### PR TITLE
Update Java/Feign api.mustache to accept its own convinience Map Class

### DIFF
--- a/docs/generators/fsharp-functions.md
+++ b/docs/generators/fsharp-functions.md
@@ -34,7 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |OpenAPI/src|
+|sourceFolder|source folder for generated code| |OpenAPI\src|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/fsharp-giraffe-server.md
+++ b/docs/generators/fsharp-giraffe-server.md
@@ -30,7 +30,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageVersion|F# package version.| |1.0.0|
 |returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |OpenAPI/src|
+|sourceFolder|source folder for generated code| |OpenAPI\src|
 |useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |false|

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -62,7 +62,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |src/gen/java|
+|sourceFolder|source folder for generated code| |src\gen\java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -62,7 +62,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |src/gen/java|
+|sourceFolder|source folder for generated code| |src\gen\java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGenericResponse|Use generic response| |false|

--- a/docs/generators/swift5.md
+++ b/docs/generators/swift5.md
@@ -49,13 +49,13 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |responseAs|Optionally use libraries to manage response.  Currently PromiseKit, RxSwift, Result, Combine, AsyncAwait are available.| |null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|swiftPackagePath|Set a custom source path instead of OpenAPIClient/Classes/OpenAPIs.| |null|
+|swiftPackagePath|Set a custom source path instead of OpenAPIClient\Classes\OpenAPIs.| |null|
 |swiftUseApiNamespace|Flag to make all the API classes inner-class of {{projectName}}API| |null|
 |useBacktickEscapes|Escape reserved words using backticks (default: false)| |false|
 |useClasses|Use final classes for models instead of structs (default: false)| |false|
 |useCustomDateWithoutTime|Uses a custom type to decode and encode dates without time information to support OpenAPIs date format (default: false)| |false|
 |useJsonEncodable|Make models conform to JSONEncodable protocol (default: true)| |true|
-|useSPMFileStructure|Use SPM file structure and set the source path to Sources/{{projectName}} (default: false).| |null|
+|useSPMFileStructure|Use SPM file structure and set the source path to Sources\{{projectName}} (default: false).| |null|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/api.mustache
@@ -124,7 +124,7 @@ public interface {{classname}} extends ApiClient.Api {
       "{{baseName}}: {{=<% %>=}}{<%paramName%>}<%={{ }}=%>"{{^-last}},
       {{/-last}}{{/headerParams}}
   })
-  {{#returnType}}{{{.}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}}({{#allParams}}{{^isQueryParam}}{{^isBodyParam}}{{^isFormParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isFormParam}}{{#isFormParam}}@Param("{{baseName}}") {{/isFormParam}}{{/isBodyParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}{{/allParams}}@QueryMap(encoded=true) Map<String, Object> queryParams);
+  {{#returnType}}{{{.}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}}({{#allParams}}{{^isQueryParam}}{{^isBodyParam}}{{^isFormParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isFormParam}}{{#isFormParam}}@Param("{{baseName}}") {{/isFormParam}}{{/isBodyParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}{{/allParams}}@QueryMap(encoded=true) {{operationIdCamelCase}}QueryParams queryParams);
 
   /**
   * {{summary}}
@@ -164,7 +164,7 @@ public interface {{classname}} extends ApiClient.Api {
           "{{baseName}}: {{=<% %>=}}{<%paramName%>}<%={{ }}=%>"{{^-last}},
       {{/-last}}{{/headerParams}}
       })
-   ApiResponse<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{nickname}}WithHttpInfo({{#allParams}}{{^isQueryParam}}{{^isBodyParam}}{{^isFormParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isFormParam}}{{#isFormParam}}@Param("{{baseName}}") {{/isFormParam}}{{/isBodyParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}{{/allParams}}@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{nickname}}WithHttpInfo({{#allParams}}{{^isQueryParam}}{{^isBodyParam}}{{^isFormParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isFormParam}}{{#isFormParam}}@Param("{{baseName}}") {{/isFormParam}}{{/isBodyParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}{{/allParams}}@QueryMap(encoded=true) {{operationIdCamelCase}}QueryParams queryParams);
 
 
    /**

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -242,7 +242,7 @@ public interface FakeApi extends ApiClient.Api {
   "Content-Type: application/json",
   "Accept: application/json",
   })
-  void testBodyWithQueryParams(User body, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testBodyWithQueryParams(User body, @QueryMap(encoded=true) TestBodyWithQueryParamsQueryParams queryParams);
 
   /**
   * 
@@ -261,7 +261,7 @@ public interface FakeApi extends ApiClient.Api {
     "Content-Type: application/json",
     "Accept: application/json",
       })
-   ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(User body, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(User body, @QueryMap(encoded=true) TestBodyWithQueryParamsQueryParams queryParams);
 
 
    /**
@@ -432,7 +432,7 @@ public interface FakeApi extends ApiClient.Api {
       
       "enum_header_string: {enumHeaderString}"
   })
-  void testEnumParameters(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testEnumParameters(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) TestEnumParametersQueryParams queryParams);
 
   /**
   * To test enum parameters
@@ -460,7 +460,7 @@ public interface FakeApi extends ApiClient.Api {
       
           "enum_header_string: {enumHeaderString}"
       })
-   ApiResponse<Void> testEnumParametersWithHttpInfo(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testEnumParametersWithHttpInfo(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) TestEnumParametersQueryParams queryParams);
 
 
    /**
@@ -552,7 +552,7 @@ public interface FakeApi extends ApiClient.Api {
       
       "boolean_group: {booleanGroup}"
   })
-  void testGroupParameters(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testGroupParameters(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) TestGroupParametersQueryParams queryParams);
 
   /**
   * Fake endpoint to test group parameters (optional)
@@ -577,7 +577,7 @@ public interface FakeApi extends ApiClient.Api {
       
           "boolean_group: {booleanGroup}"
       })
-   ApiResponse<Void> testGroupParametersWithHttpInfo(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testGroupParametersWithHttpInfo(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) TestGroupParametersQueryParams queryParams);
 
 
    /**
@@ -713,7 +713,7 @@ public interface FakeApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  void testQueryParameterCollectionFormat(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testQueryParameterCollectionFormat(@QueryMap(encoded=true) TestQueryParameterCollectionFormatQueryParams queryParams);
 
   /**
   * 
@@ -734,7 +734,7 @@ public interface FakeApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(@QueryMap(encoded=true) TestQueryParameterCollectionFormatQueryParams queryParams);
 
 
    /**

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/PetApi.java
@@ -120,7 +120,7 @@ public interface PetApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  List<Pet> findPetsByStatus(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  List<Pet> findPetsByStatus(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
   /**
   * Finds Pets by status
@@ -138,7 +138,7 @@ public interface PetApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
 
    /**
@@ -203,7 +203,7 @@ public interface PetApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  Set<Pet> findPetsByTags(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  Set<Pet> findPetsByTags(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
   /**
   * Finds Pets by tags
@@ -223,7 +223,7 @@ public interface PetApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
 
    /**

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
@@ -198,7 +198,7 @@ public interface UserApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  String loginUser(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  String loginUser(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 
   /**
   * Logs user into the system
@@ -217,7 +217,7 @@ public interface UserApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<String> loginUserWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<String> loginUserWithHttpInfo(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 
 
    /**

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -106,7 +106,7 @@ public interface FakeApi extends ApiClient.Api {
   "Accept: application/json",
       "header_1: {header1}"
   })
-  void fakeHttpSignatureTest(Pet pet, @Param("header1") String header1, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void fakeHttpSignatureTest(Pet pet, @Param("header1") String header1, @QueryMap(encoded=true) FakeHttpSignatureTestQueryParams queryParams);
 
   /**
   * test http signature authentication
@@ -127,7 +127,7 @@ public interface FakeApi extends ApiClient.Api {
     "Accept: application/json",
           "header_1: {header1}"
       })
-   ApiResponse<Void> fakeHttpSignatureTestWithHttpInfo(Pet pet, @Param("header1") String header1, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> fakeHttpSignatureTestWithHttpInfo(Pet pet, @Param("header1") String header1, @QueryMap(encoded=true) FakeHttpSignatureTestQueryParams queryParams);
 
 
    /**
@@ -388,7 +388,7 @@ public interface FakeApi extends ApiClient.Api {
   "Content-Type: application/json",
   "Accept: application/json",
   })
-  void testBodyWithQueryParams(User user, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testBodyWithQueryParams(User user, @QueryMap(encoded=true) TestBodyWithQueryParamsQueryParams queryParams);
 
   /**
   * 
@@ -407,7 +407,7 @@ public interface FakeApi extends ApiClient.Api {
     "Content-Type: application/json",
     "Accept: application/json",
       })
-   ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(User user, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(User user, @QueryMap(encoded=true) TestBodyWithQueryParamsQueryParams queryParams);
 
 
    /**
@@ -581,7 +581,7 @@ public interface FakeApi extends ApiClient.Api {
       
       "enum_header_string: {enumHeaderString}"
   })
-  void testEnumParameters(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testEnumParameters(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) TestEnumParametersQueryParams queryParams);
 
   /**
   * To test enum parameters
@@ -610,7 +610,7 @@ public interface FakeApi extends ApiClient.Api {
       
           "enum_header_string: {enumHeaderString}"
       })
-   ApiResponse<Void> testEnumParametersWithHttpInfo(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testEnumParametersWithHttpInfo(@Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @QueryMap(encoded=true) TestEnumParametersQueryParams queryParams);
 
 
    /**
@@ -706,7 +706,7 @@ public interface FakeApi extends ApiClient.Api {
       
       "boolean_group: {booleanGroup}"
   })
-  void testGroupParameters(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testGroupParameters(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) TestGroupParametersQueryParams queryParams);
 
   /**
   * Fake endpoint to test group parameters (optional)
@@ -731,7 +731,7 @@ public interface FakeApi extends ApiClient.Api {
       
           "boolean_group: {booleanGroup}"
       })
-   ApiResponse<Void> testGroupParametersWithHttpInfo(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testGroupParametersWithHttpInfo(@Param("requiredBooleanGroup") Boolean requiredBooleanGroup, @Param("booleanGroup") Boolean booleanGroup, @QueryMap(encoded=true) TestGroupParametersQueryParams queryParams);
 
 
    /**
@@ -873,7 +873,7 @@ public interface FakeApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  void testQueryParameterCollectionFormat(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  void testQueryParameterCollectionFormat(@QueryMap(encoded=true) TestQueryParameterCollectionFormatQueryParams queryParams);
 
   /**
   * 
@@ -896,7 +896,7 @@ public interface FakeApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(@QueryMap(encoded=true) TestQueryParameterCollectionFormatQueryParams queryParams);
 
 
    /**

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/PetApi.java
@@ -120,7 +120,7 @@ public interface PetApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  List<Pet> findPetsByStatus(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  List<Pet> findPetsByStatus(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
   /**
   * Finds Pets by status
@@ -138,7 +138,7 @@ public interface PetApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
 
    /**
@@ -203,7 +203,7 @@ public interface PetApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  Set<Pet> findPetsByTags(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  Set<Pet> findPetsByTags(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
   /**
   * Finds Pets by tags
@@ -223,7 +223,7 @@ public interface PetApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
 
    /**

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/UserApi.java
@@ -198,7 +198,7 @@ public interface UserApi extends ApiClient.Api {
   @Headers({
   "Accept: application/json",
   })
-  String loginUser(@QueryMap(encoded=true) Map<String, Object> queryParams);
+  String loginUser(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 
   /**
   * Logs user into the system
@@ -217,7 +217,7 @@ public interface UserApi extends ApiClient.Api {
       @Headers({
     "Accept: application/json",
       })
-   ApiResponse<String> loginUserWithHttpInfo(@QueryMap(encoded=true) Map<String, Object> queryParams);
+   ApiResponse<String> loginUserWithHttpInfo(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 
 
    /**


### PR DESCRIPTION
Hi, I just saw, that the generated Map Class is never used outside of tests, but it would be the perfect fit for the changed mehods, as its use-case is exactly the same.

Also a useful change to prevent problems with Collection types and their generics parameters (f.e. Map<x, y>). See: https://stackoverflow.com/questions/62823341/openapi-generator-maven-plugin-breaks-old-feign-with-querymap

Mentions:
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 

