### PR TITLE
Don't cast list to tuple in python-prior binding

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-prior/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-prior/api_client.mustache
@@ -298,8 +298,10 @@ class ApiClient(object):
             return obj.isoformat()
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [cls.sanitize_for_serialization(item) for item in obj]
+        elif isinstance(obj, tuple):
+            return tuple(cls.sanitize_for_serialization(item) for item in obj)
         if isinstance(obj, dict):
             return {key: cls.sanitize_for_serialization(val) for key, val in obj.items()}
         raise ApiValueError(

--- a/samples/client/petstore/python-prior/petstore_api/api_client.py
+++ b/samples/client/petstore/python-prior/petstore_api/api_client.py
@@ -286,8 +286,10 @@ class ApiClient(object):
             return obj.isoformat()
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [cls.sanitize_for_serialization(item) for item in obj]
+        elif isinstance(obj, tuple):
+            return tuple(cls.sanitize_for_serialization(item) for item in obj)
         if isinstance(obj, dict):
             return {key: cls.sanitize_for_serialization(val) for key, val in obj.items()}
         raise ApiValueError(

--- a/samples/client/petstore/python-prior_disallowAdditionalPropertiesIfNotPresent/petstore_api/api_client.py
+++ b/samples/client/petstore/python-prior_disallowAdditionalPropertiesIfNotPresent/petstore_api/api_client.py
@@ -286,8 +286,10 @@ class ApiClient(object):
             return obj.isoformat()
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [cls.sanitize_for_serialization(item) for item in obj]
+        elif isinstance(obj, tuple):
+            return tuple(cls.sanitize_for_serialization(item) for item in obj)
         if isinstance(obj, dict):
             return {key: cls.sanitize_for_serialization(val) for key, val in obj.items()}
         raise ApiValueError(

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-prior/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-prior/x_auth_id_alias/api_client.py
@@ -286,8 +286,10 @@ class ApiClient(object):
             return obj.isoformat()
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [cls.sanitize_for_serialization(item) for item in obj]
+        elif isinstance(obj, tuple):
+            return tuple(cls.sanitize_for_serialization(item) for item in obj)
         if isinstance(obj, dict):
             return {key: cls.sanitize_for_serialization(val) for key, val in obj.items()}
         raise ApiValueError(

--- a/samples/openapi3/client/petstore/python-prior/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-prior/petstore_api/api_client.py
@@ -286,8 +286,10 @@ class ApiClient(object):
             return obj.isoformat()
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [cls.sanitize_for_serialization(item) for item in obj]
+        elif isinstance(obj, tuple):
+            return tuple(cls.sanitize_for_serialization(item) for item in obj)
         if isinstance(obj, dict):
             return {key: cls.sanitize_for_serialization(val) for key, val in obj.items()}
         raise ApiValueError(


### PR DESCRIPTION
Tweak the python-prior API bindings, so that they no longer cast lists to tuples when making a POST request with a multipart/form-data content-type. This fixes an interaction with
`urllib3.request_encode_body`, whose `fields` parameter expects tuples, not lists.

cc @spacether

See: https://urllib3.readthedocs.io/en/stable/reference/urllib3.request.html

Fix: https://github.com/OpenAPITools/openapi-generator/issues/14012