### PR TITLE
Fix invalid Python import for qualified package name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -889,7 +889,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen {
     @Override
     public String toModelImport(String name) {
         // name looks like Cat
-        return "from " + packagePath() + "." +  modelPackage() + "." + toModelFilename(name) + " import " + toModelName(name);
+        return "from " + packageName + "." +  modelPackage() + "." + toModelFilename(name) + " import " + toModelName(name);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -224,4 +224,13 @@ public class PythonClientTest {
         Assert.assertEquals(enumVars.get(0).get("name"), "DIGIT_THREE_67B9C");
         Assert.assertEquals(enumVars.get(1).get("name"), "FFA5A4");
     }
+
+    @Test(description = "format imports of models using a package containing dots")
+    public void testImportWithQualifiedPackageName() throws Exception {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        codegen.setPackageName("openapi.client");
+
+        String importValue = codegen.toModelImport("model_name");
+        Assert.assertEquals(importValue, "from openapi.client.model.model_name import ModelName");
+    }
 }


### PR DESCRIPTION
Fix #13648

Change from `packagePath()` to `packageName` when generating the Python `import` statement.

@spacether 

**Test command:**
```shell
$ java -jar ./modules/openapi-generator-cli/target/openapi-generator-cli.jar \
    generate \
        -i ./modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
        -g python \
        --additional-properties packageName='my.openapi' \
        -o /tmp/issue-13648
```

**Before:**
```shell
$ tail -n2 /tmp/issue-13648/my/openapi/model/pet.py
from my/openapi.model.category import Category
from my/openapi.model.tag import Tag
```

**After:**
```shell
$ tail -n2 /tmp/issue-13648/my/openapi/model/pet.py
from my.openapi.model.category import Category
from my.openapi.model.tag import Tag
```

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
