### PR TITLE
Add optional property for C# codegen to generate optional properties as nullable

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -189,6 +189,9 @@ public class CodegenConstants {
     public static final String OPTIONAL_CONDITIONAL_SERIALIZATION = "conditionalSerialization";
     public static final String OPTIONAL_CONDITIONAL_SERIALIZATION_DESC = "Serialize only those properties which are initialized by user, accepted values are true or false, default value is false.";
 
+    public static final String OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE = "optionalGenerateOptionalPropertiesAsNullable";
+    public static final String OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE_DESC = "Generate optional properties as nullable.";
+    
     public static final String NETCORE_PROJECT_FILE = "netCoreProjectFile";
     public static final String NETCORE_PROJECT_FILE_DESC = "Use the new format (.NET Core) for .NET project files (.csproj).";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -48,6 +48,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     protected boolean optionalAssemblyInfoFlag = true;
     protected boolean optionalEmitDefaultValuesFlag = false;
+    protected boolean optionalGenerateOptionalPropertiesAsNullableFlag = false;
     protected boolean conditionalSerialization = false;
     protected boolean optionalProjectFileFlag = true;
     protected boolean optionalMethodArgumentFlag = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -207,6 +207,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         addSwitch(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES,
                 CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES_DESC,
                 this.optionalEmitDefaultValuesFlag);
+        
+        addSwitch(CodegenConstants.OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE,
+                CodegenConstants.OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE_DESC,
+                this.optionalGenerateOptionalPropertiesAsNullableFlag);
 
         addSwitch(CodegenConstants.OPTIONAL_PROJECT_FILE,
                 CodegenConstants.OPTIONAL_PROJECT_FILE_DESC,
@@ -404,6 +408,12 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         } else {
             additionalProperties.put(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES, optionalEmitDefaultValuesFlag);
         }
+        
+         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE)) {
+            setOptionalGenerateOptionalPropertiesAsNullableFlag(convertPropertyToBooleanAndWriteBack(CodegenConstants.OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE));
+        } else {
+            additionalProperties.put(CodegenConstants.OPTIONAL_GENERATE_OPTIONAL_PROPERTIES_AS_NULLABLE, optionalGenerateOptionalPropertiesAsNullableFlag);
+        }
 
         if (additionalProperties.containsKey(CodegenConstants.NON_PUBLIC_API)) {
             setNonPublicApi(convertPropertyToBooleanAndWriteBack(CodegenConstants.NON_PUBLIC_API));
@@ -559,6 +569,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     public void setOptionalEmitDefaultValuesFlag(boolean flag) {
         this.optionalEmitDefaultValuesFlag = flag;
     }
+    
+    public void setOptionalGenerateOptionalPropertiesAsNullableFlag(boolean flag) {
+        this.optionalGenerateOptionalPropertiesAsNullableFlag = flag;
+    }
 
     @Override
     public CodegenModel fromModel(String name, Schema model) {
@@ -640,8 +654,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         postProcessPattern(property.pattern, property.vendorExtensions);
         postProcessEmitDefaultValue(property.vendorExtensions);
         super.postProcessModelProperty(model, property);
-
-        if (!property.isContainer && (nullableType.contains(property.dataType) || property.isEnum)) {
+        
+        if(nullableType.contains(property.dataType)) { //optional
+            property.dataType = property.dataType + "?";
+        } else if (!property.isContainer && (nullableType.contains(property.dataType) || property.isEnum)) {
             property.vendorExtensions.put("x-csharp-value-type", true);
         }
     }


### PR DESCRIPTION
@wing328 , I'm trying to add a feature to address [this ](https://github.com/OpenAPITools/openapi-generator/issues/4816) issue. Can you please advise on what I'm missing? I know I didn't complete the necessary updates, I need some direction. Thanks!