### PR TITLE
[GO] fix: correctly use oneOf path parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -558,6 +558,14 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                     sb.setCharAt(0, Character.toUpperCase(nameFirstChar));
                     param.vendorExtensions.put("x-export-param-name", sb.toString());
                 }
+
+                // set x-is-param-oneof
+                param.vendorExtensions.put("x-is-param-oneof", param.getComposedSchemas() != null && param.getComposedSchemas().getOneOf() != null);
+            }
+
+            for (CodegenParameter param : operation.pathParams) {
+                // set x-is-param-oneof
+                param.vendorExtensions.put("x-is-param-oneof", param.getComposedSchemas() != null && param.getComposedSchemas().getOneOf() != null);
             }
 
             setExportParameterName(operation.queryParams);
@@ -600,6 +608,9 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 sb.setCharAt(0, Character.toUpperCase(nameFirstChar));
                 param.vendorExtensions.put("x-export-param-name", sb.toString());
             }
+
+            // set x-is-param-oneof
+            param.vendorExtensions.put("x-is-param-oneof", param.getComposedSchemas() != null && param.getComposedSchemas().getOneOf() != null);
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -124,7 +124,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", url.PathEscape(parameterToString(r.{{paramName}}, "{{collectionFormat}}")), -1){{/pathParams}}
+	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", url.PathEscape(parameterToString(r.{{paramName}}{{#vendorExtensions.x-is-param-oneof}}.GetActualInstance(){{/vendorExtensions.x-is-param-oneof}}, "{{collectionFormat}}")), -1){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -147,10 +147,16 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		delimiter = ","
 	}
 
-	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+	objType := reflect.TypeOf(obj)
+	switch objType.Kind() {
+	case reflect.Slice:
 		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
-	} else if t, ok := obj.(time.Time); ok {
-		return t.Format(time.RFC3339)
+	case reflect.Ptr:
+		return fmt.Sprintf("%v", reflect.ValueOf(obj).Elem().Interface())
+	default:
+		if t, ok := obj.(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
 	}
 
 	return fmt.Sprintf("%v", obj)

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -155,10 +155,16 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		delimiter = ","
 	}
 
-	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+	objType := reflect.TypeOf(obj)
+	switch objType.Kind() {
+	case reflect.Slice:
 		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
-	} else if t, ok := obj.(time.Time); ok {
-		return t.Format(time.RFC3339)
+	case reflect.Ptr:
+		return fmt.Sprintf("%v", reflect.ValueOf(obj).Elem().Interface())
+	default:
+		if t, ok := obj.(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
 	}
 
 	return fmt.Sprintf("%v", obj)

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -140,10 +140,16 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		delimiter = ","
 	}
 
-	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+	objType := reflect.TypeOf(obj)
+	switch objType.Kind() {
+	case reflect.Slice:
 		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
-	} else if t, ok := obj.(time.Time); ok {
-		return t.Format(time.RFC3339)
+	case reflect.Ptr:
+		return fmt.Sprintf("%v", reflect.ValueOf(obj).Elem().Interface())
+	default:
+		if t, ok := obj.(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
 	}
 
 	return fmt.Sprintf("%v", obj)

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -158,10 +158,16 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		delimiter = ","
 	}
 
-	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+	objType := reflect.TypeOf(obj)
+	switch objType.Kind() {
+	case reflect.Slice:
 		return strings.Trim(strings.Replace(fmt.Sprint(obj), " ", delimiter, -1), "[]")
-	} else if t, ok := obj.(time.Time); ok {
-		return t.Format(time.RFC3339)
+	case reflect.Ptr:
+		return fmt.Sprintf("%v", reflect.ValueOf(obj).Elem().Interface())
+	default:
+		if t, ok := obj.(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
 	}
 
 	return fmt.Sprintf("%v", obj)


### PR DESCRIPTION
Fixes #14028

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04)
