### PR TITLE
Migrate python-prior/tests_manual/ to pathlib

### DIFF
--- a/samples/openapi3/client/petstore/python-prior/tests_manual/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python-prior/tests_manual/test_api_validation.py
@@ -9,7 +9,6 @@ $ cd OpenAPIetstore-python
 $ nosetests -v
 """
 
-import os
 import time
 import atexit
 import datetime

--- a/samples/openapi3/client/petstore/python-prior/tests_manual/test_deserialization.py
+++ b/samples/openapi3/client/petstore/python-prior/tests_manual/test_deserialization.py
@@ -10,7 +10,6 @@ $ nosetests -v
 """
 from collections import namedtuple
 import json
-import os
 import time
 import unittest
 import datetime

--- a/samples/openapi3/client/petstore/python-prior/tests_manual/test_fake_api.py
+++ b/samples/openapi3/client/petstore/python-prior/tests_manual/test_fake_api.py
@@ -11,7 +11,6 @@
 
 import sys
 from collections import namedtuple
-import os
 import json
 import unittest
 from pathlib import Path
@@ -381,9 +380,7 @@ class TestFakeApi(unittest.TestCase):
 
     def test_upload_file(self):
         # uploads a file
-        test_file_dir = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "..", "testfiles"))
-        file_path1 = os.path.join(test_file_dir, "1px_pic1.png")
+        file_path1 = Path(__file__, "..", "..", "testfiles",  "1px_pic1.png").resolve()
 
         headers = {}
         def get_headers():
@@ -439,10 +436,8 @@ class TestFakeApi(unittest.TestCase):
             self.api.upload_file(file=file)
 
     def test_upload_files(self):
-        test_file_dir = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "..", "testfiles"))
-        file_path1 = os.path.join(test_file_dir, "1px_pic1.png")
-        file_path2 = os.path.join(test_file_dir, "1px_pic2.png")
+        file_path1 = Path(__file__, "..", "..", "testfiles",  "1px_pic1.png").resolve()
+        file_path2 = Path(__file__, "..", "..", "testfiles",  "1px_pic2.png").resolve()
 
         headers = {}
         def get_headers():
@@ -579,12 +574,10 @@ class TestFakeApi(unittest.TestCase):
                     self.assertEqual(file_object.read(), file_data.encode('utf-8'))
                 finally:
                     file_object.close()
-                    os.unlink(file_object.name)
+                    Path(file_object.name).unlink()
 
     def test_upload_download_file(self):
-        test_file_dir = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "..", "testfiles"))
-        file_path1 = os.path.join(test_file_dir, "1px_pic1.png")
+        file_path1 = Path(__file__, "..", "..", "testfiles", "1px_pic1.png").resolve()
 
         with open(file_path1, "rb") as f:
             expected_file_data = f.read()
@@ -623,7 +616,7 @@ class TestFakeApi(unittest.TestCase):
         finally:
             file1.close()
             downloaded_file.close()
-            os.unlink(downloaded_file.name)
+            Path(downloaded_file.name).unlink()
 
     def test_test_body_with_file_schema(self):
         """Test case for test_body_with_file_schema

--- a/samples/openapi3/client/petstore/python-prior/tests_manual/test_http_signature.py
+++ b/samples/openapi3/client/petstore/python-prior/tests_manual/test_http_signature.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import unittest
+from pathlib import Path
 from urllib.parse import urlencode, urlparse
 
 from Crypto.Hash import SHA256, SHA512
@@ -205,7 +206,7 @@ class PetApiTests(unittest.TestCase):
             cls.ec_p521_key_path,
         ]
         for file_path in file_paths:
-            os.unlink(file_path)
+            Path(file_path).unlink()
 
     @classmethod
     def setUpModels(cls):
@@ -226,22 +227,19 @@ class PetApiTests(unittest.TestCase):
 
     @classmethod
     def setUpFiles(cls):
-        cls.test_file_dir = os.path.join(
-            os.path.dirname(__file__), "..", "testfiles")
-        cls.test_file_dir = os.path.realpath(cls.test_file_dir)
-        if not os.path.exists(cls.test_file_dir):
-            os.mkdir(cls.test_file_dir)
+        cls.test_file_dir = Path(__file__, "..", "..", "testfiles").resolve()
+        cls.test_file_dir.mkdir(exist_ok=True)
 
-        cls.private_key_passphrase = 'test-passphrase'
-        cls.rsa_key_path = os.path.join(cls.test_file_dir, 'rsa.pem')
-        cls.rsa4096_key_path = os.path.join(cls.test_file_dir, 'rsa4096.pem')
-        cls.ec_p521_key_path = os.path.join(cls.test_file_dir, 'ecP521.pem')
+        cls.private_key_passphrase = "test-passphrase"
+        cls.rsa_key_path = cls.test_file_dir / "rsa.pem"
+        cls.rsa4096_key_path = cls.test_file_dir / "rsa4096.pem"
+        cls.ec_p521_key_path = cls.test_file_dir / "ecP521.pem"
 
-        if not os.path.exists(cls.rsa_key_path):
+        if not cls.rsa_key_path.exists():
             with open(cls.rsa_key_path, 'w') as f:
                 f.write(RSA_TEST_PRIVATE_KEY)
 
-        if not os.path.exists(cls.rsa4096_key_path):
+        if not cls.rsa4096_key_path.exists():
             key = RSA.generate(4096)
             private_key = key.export_key(
                 passphrase=cls.private_key_passphrase,
@@ -250,7 +248,7 @@ class PetApiTests(unittest.TestCase):
             with open(cls.rsa4096_key_path, "wb") as f:
                 f.write(private_key)
 
-        if not os.path.exists(cls.ec_p521_key_path):
+        if not cls.ec_p521_key_path.exists():
             key = ECC.generate(curve='P-521')
             private_key = key.export_key(
                 format='PEM',


### PR DESCRIPTION
This change has no functional impact. In my view, `pathlib` has a more pleasant API than `os.path`.  Incidentally, this slightly reduces line count.

cc @spacether