### PR TITLE
[JAVA][RETROFIT2] Include java.util.Set in fullJavaUtil imports

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 {{/fullJavaUtil}}
 
 {{#operations}}

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface AnotherFakeApi {
   /**

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface FakeApi {
   /**

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface FakeClassnameTags123Api {
   /**

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface PetApi {
   /**

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface StoreApi {
   /**

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface UserApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface AnotherFakeApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface FakeApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface FakeClassnameTags123Api {
   /**

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface PetApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface StoreApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface UserApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface AnotherFakeApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface FakeApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface FakeClassnameTags123Api {
   /**

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/PetApi.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface PetApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface StoreApi {
   /**

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/UserApi.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface UserApi {
   /**


### PR DESCRIPTION
When generating a client that requires a set, the interface is not including the import of java.util.Set.

The proposal is to include it in the same group as the rest of the collections.

Related issue: https://github.com/OpenAPITools/openapi-generator/issues/14047

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]:
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
