### PR TITLE
[Go] Trim Client Error Message White Space

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -633,5 +633,5 @@ func formatErrorMessage(status string, v interface{}) string {
 	}
 
 	// status title (detail)
-	return fmt.Sprintf("%s %s", status, str)
+	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
 }

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -593,5 +593,5 @@ func formatErrorMessage(status string, v interface{}) string {
 	}
 
 	// status title (detail)
-	return fmt.Sprintf("%s %s", status, str)
+	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
 }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -578,5 +578,5 @@ func formatErrorMessage(status string, v interface{}) string {
 	}
 
 	// status title (detail)
-	return fmt.Sprintf("%s %s", status, str)
+	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -606,5 +606,5 @@ func formatErrorMessage(status string, v interface{}) string {
 	}
 
 	// status title (detail)
-	return fmt.Sprintf("%s %s", status, str)
+	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
 }


### PR DESCRIPTION
A trailing whitespace gets included if the error is not a RFC7807 model. Not a huge issue but still nice to have cleaner error message

This was introduced with https://github.com/OpenAPITools/openapi-generator/pull/13680

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @wing328