### PR TITLE
[Go] Fix generated client tests when there is no response body

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_test.mustache
@@ -39,7 +39,7 @@ func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 		var {{paramName}} {{{dataType}}}
 		{{/pathParams}}
 
-		resp, httpRes, err := apiClient.{{classname}}.{{operationId}}(context.Background(){{#pathParams}}, {{paramName}}{{/pathParams}}).Execute()
+		{{#returnType}}resp, {{/returnType}}httpRes, err := apiClient.{{classname}}.{{operationId}}(context.Background(){{#pathParams}}, {{paramName}}{{/pathParams}}).Execute()
 
 		require.Nil(t, err)
 		require.NotNil(t, resp)

--- a/modules/openapi-generator/src/main/resources/go/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_test.mustache
@@ -42,7 +42,9 @@ func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 		{{#returnType}}resp, {{/returnType}}httpRes, err := apiClient.{{classname}}.{{operationId}}(context.Background(){{#pathParams}}, {{paramName}}{{/pathParams}}).Execute()
 
 		require.Nil(t, err)
+		{{#returnType}}
 		require.NotNil(t, resp)
+		{{/returnType}}
 		assert.Equal(t, 200, httpRes.StatusCode)
 
 	})

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -261,4 +261,29 @@ public class GoClientCodegenTest {
         TestUtils.assertFileContains(Paths.get(output + "/api_pet.go"),
                 "newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)");
     }
+
+    @Test
+    public void verifyApiTestWithNullResponse() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setGitUserId("OpenAPITools")
+                .setGitRepoId("openapi-generator")
+                .setInputSpec("src/test/resources/3_0/go/petstore-with-no-response-body.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/test/api_pet_test.go"));
+        TestUtils.assertFileNotContains(Paths.get(output + "/test/api_pet_test.go"),
+                "require.NotNil(t, resp)");
+        TestUtils.assertFileNotContains(Paths.get(output + "/test/api_pet_test.go"),
+                "resp, httpRes, err := apiClient.PetApi.PetDelete(context.Background()).Execute()");
+        TestUtils.assertFileContains(Paths.get(output + "/test/api_pet_test.go"),
+                "httpRes, err := apiClient.PetApi.PetDelete(context.Background()).Execute()");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/go/petstore-with-no-response-body.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/petstore-with-no-response-body.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  description: >-
+    This spec is mainly for testing Petstore server and contains fake endpoints,
+    models. Please do not use this for any other purpose. Special characters: "
+    \
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+paths:
+  /pet:
+    delete:
+      tags:
+        - pet
+      responses:
+        '204':
+          description: OK


### PR DESCRIPTION
Closes #14079 

Currently, the Go client generator produces tests that are incorrect when an API endpoint response does not include a response body.  This updates the `api_test` template to remove the expectation for a response body if the API endpoint under test does not produce a response body.  A unit test is also added to the Go generator to validate that the `api_test` file is generated correctly for those API endpoints.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @wing328