### PR TITLE
[Go] Exclude test files with additionalProperties

### DIFF
--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -20,7 +20,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |enumClassPrefix|Prefix enum with class name| |false|
-|excludeTests|Skip test files during code generation| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |isGoSubmodule|whether the generated Go module is a submodule| |false|

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -20,6 +20,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |enumClassPrefix|Prefix enum with class name| |false|
+|excludeTests|Skip test files during code generation| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |isGoSubmodule|whether the generated Go module is a submodule| |false|

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -20,6 +20,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |enumClassPrefix|Prefix enum with class name| |false|
+|excludeTests|Specifies that no tests are to be generated.| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |isGoSubmodule|whether the generated Go module is a submodule| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -255,6 +255,11 @@ public class GoClientCodegen extends AbstractGoCodegen {
                     .get(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT).toString()));
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.EXCLUDE_TESTS)) {
+            // skip tests generation
+            apiTestTemplateFiles.remove("api_test.mustache");
+        }
+
         // add lambda for mustache templates to handle oneOf/anyOf naming
         // e.g. []string => ArrayOfString
         additionalProperties.put("lambda.type-to-name", (Mustache.Lambda) (fragment, writer) -> writer.write(typeToName(fragment.execute())));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -58,6 +58,8 @@ public class GoClientCodegen extends AbstractGoCodegen {
     protected boolean isGoSubmodule = false;
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
 
+    protected boolean excludeTests = false;
+
     // A cache to efficiently lookup schema `toModelName()` based on the schema Key
     private Map<String, String> schemaKeyToModelNameCache = new HashMap<>();
 
@@ -134,6 +136,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
         disallowAdditionalPropertiesIfNotPresentOpt.setEnum(disallowAdditionalPropertiesIfNotPresentOpts);
         cliOptions.add(disallowAdditionalPropertiesIfNotPresentOpt);
         this.setDisallowAdditionalPropertiesIfNotPresent(true);
+
+        cliOptions.add(new CliOption(CodegenConstants.EXCLUDE_TESTS, CodegenConstants.EXCLUDE_TESTS_DESC)
+                .defaultValue(Boolean.FALSE.toString()));
+
     }
 
     /**
@@ -257,6 +263,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
 
         if (additionalProperties.containsKey(CodegenConstants.EXCLUDE_TESTS)) {
             // skip tests generation
+            setExcludeTests(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.EXCLUDE_TESTS).toString()));
             apiTestTemplateFiles.remove("api_test.mustache");
         }
 
@@ -295,6 +302,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
 
     public void setIsGoSubmodule(boolean isGoSubmodule) {
         this.isGoSubmodule = isGoSubmodule;
+    }
+
+    public void setExcludeTests(boolean excludeTests) {
+        this.excludeTests = excludeTests;
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -244,6 +244,26 @@ public class GoClientCodegenTest {
     }
 
     @Test
+    public void verifyExcludeTests() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .addAdditionalProperty("excludeTests", "true")
+                .setGeneratorName("go")
+                .setGitUserId("OpenAPITools")
+                .setGitRepoId("openapi-generator")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileNotExists(Paths.get(output + "/test/api_pet_test.go"));
+    }
+
+    @Test
     public void verifyFormatErrorMessageInUse() throws IOException {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
@@ -51,5 +51,6 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setStructPrefix(GoClientOptionsProvider.STRUCT_PREFIX_VALUE);
         verify(clientCodegen).setWithAWSV4Signature(GoClientOptionsProvider.WITH_AWSV4_SIGNATURE);
         verify(clientCodegen).setUseOneOfDiscriminatorLookup(GoClientOptionsProvider.USE_ONE_OF_DISCRIMINATOR_LOOKUP_VALUE);
+        verify(clientCodegen).setExcludeTests(GoClientOptionsProvider.EXCLUDE_TESTS);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
@@ -36,6 +36,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
     public static final boolean GENERATE_INTERFACES_VALUE = true;
     public static final boolean DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT_VALUE = true;
     public static final boolean USE_ONE_OF_DISCRIMINATOR_LOOKUP_VALUE = true;
+    public static final boolean EXCLUDE_TESTS = false;
 
     @Override
     public String getLanguage() {
@@ -58,6 +59,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, "true")
                 .put("generateInterfaces", "true")
                 .put("structPrefix", "true")
+                .put(CodegenConstants.EXCLUDE_TESTS, "false")
                 .build();
     }
 


### PR DESCRIPTION
Fix #14085 

Allow developers to skip the generation of test files (adding `excludeTests=true` in the additionalProperties)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04)