### PR TITLE
[Spring] Fix Pascal case for java enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
@@ -3,7 +3,7 @@ package {{configPackage}};
 {{#models}}
     {{#model}}
         {{#isEnum}}
-import {{modelPackage}}.{{name}};
+import {{modelPackage}}.{{classname}};
         {{/isEnum}}
     {{/model}}
 {{/models}}
@@ -19,11 +19,11 @@ public class EnumConverterConfiguration {
 {{#model}}
 {{#isEnum}}
     @Bean
-    Converter<{{{dataType}}}, {{name}}> {{classVarName}}Converter() {
-        return new Converter<{{{dataType}}}, {{name}}>() {
+    Converter<{{{dataType}}}, {{classname}}> {{classVarName}}Converter() {
+        return new Converter<{{{dataType}}}, {{classname}}>() {
             @Override
-            public {{name}} convert({{{dataType}}} source) {
-                return {{name}}.fromValue(source);
+            public {{classname}} convert({{{dataType}}} source) {
+                return {{classname}}.fromValue(source);
             }
         };
     }


### PR DESCRIPTION
Fixes `kebab-case` or even single uncapitalized `foo` as schema name for OAS `enum` yielding compiler errors in Spring java generated `EnumConverterConfiguration.java`. E.g., both of these generate invalid java file:

```yaml
components:
  schemas:    
    # currently broken:
    fruit:
      type: string
      enum:
        - ORANGE
        - APPLE
    fruit-type:
      type: string
      enum:
        - ORANGE
        - APPLE

    # this works
    FruitType:
      type: string
      enum:
        - ORANGE
        - APPLE
```

Spring Technical Committee: @cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente @Zomzog

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
