### PR TITLE
Fix enum generation for php-symfony generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model.mustache
@@ -35,5 +35,6 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package {{modelPackage}}
  * @author  OpenAPI Generator team
  */
-{{>model_generic}}
+{{#isEnum}}{{>model_enum}}{{/isEnum}}
+{{^isEnum}}{{>model_generic}}{{/isEnum}}
 {{/model}}{{/models}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/ApiResponse.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/ApiResponse.php
@@ -41,6 +41,7 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
+
 class ApiResponse 
 {
         /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Category.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Category.php
@@ -41,6 +41,7 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
+
 class Category 
 {
         /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/EnumStringModel.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/EnumStringModel.php
@@ -41,15 +41,28 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
-class EnumStringModel 
+class EnumStringModel
 {
-        /**
-     * Constructor
-     * @param array|null $data Associated array of property values initializing the model
+    /**
+     * Possible values of this enum
      */
-    public function __construct(array $data = null)
+    const AVAILABLE = "available";
+    const PENDING = "pending";
+    const SOLD = "sold";
+    
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
     {
+        return [
+            self::AVAILABLE,
+            self::PENDING,
+            self::SOLD,
+        ];
     }
 }
+
 
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -41,6 +41,7 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
+
 class Order 
 {
         /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -41,6 +41,7 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
+
 class Pet 
 {
         /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Tag.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Tag.php
@@ -41,6 +41,7 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
+
 class Tag 
 {
         /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php
@@ -41,6 +41,7 @@ use JMS\Serializer\Annotation\SerializedName;
  * @package OpenAPI\Server\Model
  * @author  OpenAPI Generator team
  */
+
 class User 
 {
         /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)

Currently, the `model generic` template is used to generate all DTO classes including enums.
This results in empty classes for enums.

This PR just make use of the existing `model enum` template to generate enum DTOs.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
