### PR TITLE
typescript-angular: Fixed path parameter encoding for date-time dataFormat

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
@@ -196,7 +196,7 @@ export class {{configurationClassName}} {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/configuration.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/configuration.ts
@@ -157,7 +157,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/configuration.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/configuration.ts
@@ -157,7 +157,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/configuration.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/configuration.ts
@@ -157,7 +157,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/configuration.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/configuration.ts
@@ -157,7 +157,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/configuration.ts
@@ -157,7 +157,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/configuration.ts
@@ -177,7 +177,7 @@ export class Configuration {
         //
         // But: if that's all you need (i.e.: the most common use-case): no need for customization!
 
-        const value = param.dataFormat === 'date-time'
+        const value = param.dataFormat === 'date-time' && param.value instanceof Date
             ? (param.value as Date).toISOString()
             : param.value;
 


### PR DESCRIPTION
In https://github.com/OpenAPITools/openapi-generator/pull/13132 `defaultEncodeParam` method has been introduced. This method is used in every API client call to encode the path variables. By default openapi-generator uses `string` type for date-time params, but this encoder misses the type check and tries to call `toISOString()` on it.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov  @davidgamero @mkusaka