### PR TITLE
Fix build warning in Java Apache client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -181,6 +181,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Sets the object mapper.
+   *
+   * @param objectMapper object mapper
    * @return API client
    */
   public ApiClient setObjectMapper(ObjectMapper objectMapper) {
@@ -193,6 +196,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Sets the HTTP client.
+   *
+   * @param httpClient HTTP client
    * @return API client
    */
   public ApiClient setHttpClient(CloseableHttpClient httpClient) {
@@ -205,6 +211,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Sets the base path.
+   *
+   * @param basePath base path
    * @return API client
    */
   public ApiClient setBasePath(String basePath) {
@@ -218,6 +227,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Sets the server.
+   *
+   * @param servers a list of server configuration
    * @return API client
    */
   public ApiClient setServers(List<ServerConfiguration> servers) {
@@ -230,6 +242,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Sets the server index.
+   *
+   * @param serverIndex server index
    * @return API client
    */
   public ApiClient setServerIndex(Integer serverIndex) {
@@ -242,6 +257,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Sets the server variables.
+   *
+   * @param serverVariables server variables
    * @return API client
    */
   public ApiClient setServerVariables(Map<String, String> serverVariables) {
@@ -251,6 +269,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
   /**
    * Gets the status code of the previous request
+   *
    * @return Status code
    */
   public int getStatusCode() {
@@ -688,7 +707,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
-   * Transform response headers into map
+   * Transforms response headers into map.
+   *
+   * @param headers HTTP headers
+   * @return a map of string array
    */
   protected Map<String, List<String>> transformResponseHeaders(Header[] headers) {
     Map<String, List<String>> headersMap = new HashMap<>();

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -205,6 +205,9 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Sets the object mapper.
+   *
+   * @param objectMapper object mapper
    * @return API client
    */
   public ApiClient setObjectMapper(ObjectMapper objectMapper) {
@@ -217,6 +220,9 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Sets the HTTP client.
+   *
+   * @param httpClient HTTP client
    * @return API client
    */
   public ApiClient setHttpClient(CloseableHttpClient httpClient) {
@@ -229,6 +235,9 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Sets the base path.
+   *
+   * @param basePath base path
    * @return API client
    */
   public ApiClient setBasePath(String basePath) {
@@ -242,6 +251,9 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Sets the server.
+   *
+   * @param servers a list of server configuration
    * @return API client
    */
   public ApiClient setServers(List<ServerConfiguration> servers) {
@@ -254,6 +266,9 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Sets the server index.
+   *
+   * @param serverIndex server index
    * @return API client
    */
   public ApiClient setServerIndex(Integer serverIndex) {
@@ -266,6 +281,9 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Sets the server variables.
+   *
+   * @param serverVariables server variables
    * @return API client
    */
   public ApiClient setServerVariables(Map<String, String> serverVariables) {
@@ -275,6 +293,7 @@ public class ApiClient extends JavaTimeFormatter {
 
   /**
    * Gets the status code of the previous request
+   *
    * @return Status code
    */
   public int getStatusCode() {
@@ -704,7 +723,10 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
-   * Transform response headers into map
+   * Transforms response headers into map.
+   *
+   * @param headers HTTP headers
+   * @return a map of string array
    */
   protected Map<String, List<String>> transformResponseHeaders(Header[] headers) {
     Map<String, List<String>> headersMap = new HashMap<>();


### PR DESCRIPTION
Fix build warning in Java Apache client
```
> Task :javadoc
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:210: warning: no @param for objectMapper
  public ApiClient setObjectMapper(ObjectMapper objectMapper) {
                   ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:222: warning: no @param for httpClient
  public ApiClient setHttpClient(CloseableHttpClient httpClient) {
                   ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:234: warning: no @param for basePath
  public ApiClient setBasePath(String basePath) {
                   ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:247: warning: no @param for servers
  public ApiClient setServers(List<ServerConfiguration> servers) {
                   ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:259: warning: no @param for serverIndex
  public ApiClient setServerIndex(Integer serverIndex) {
                   ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:271: warning: no @param for serverVariables
  public ApiClient setServerVariables(Map<String, String> serverVariables) {
                   ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:709: warning: no @param for headers
  protected Map<String, List<String>> transformResponseHeaders(Header[] headers) {
                                      ^
/Users/williamcheng/Code/openapi-generator3/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java:709: warning: no @return
  protected Map<String, List<String>> transformResponseHeaders(Header[] headers) {
                                      ^
8 warnings
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
