### PR TITLE
[Java][resttemplate] #13393 : Make queryParams known to UriComponents builder so it can properly encode them

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -674,16 +674,18 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         Map<String,Object> uriParams = new HashMap<>();
         uriParams.putAll(pathParams);
 
-        String finalUri = path;
+        String queryUri = null;
 
         if (queryParams != null && !queryParams.isEmpty()) {
             //Include queryParams in uriParams taking into account the paramName
-            String queryUri = generateQueryUri(queryParams, uriParams);
-            //Append to finalUri the templatized query string like "?param1={param1Value}&.......
-            finalUri += "?" + queryUri;
+            String query = generateQueryUri(queryParams, uriParams);
+            queryUri = expandPath("?" + query, uriParams).substring(1); //exclude the '?'
+            //queryUri is the templatized query string like "?param1={param1Value}&.......
         }
-        String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        String expandedPath = this.expandPath(path, uriParams);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath)
+                .path(expandedPath)
+                .query(queryUri);
 
         URI uri;
         try {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -597,16 +597,18 @@ public class ApiClient extends JavaTimeFormatter {
         Map<String,Object> uriParams = new HashMap<>();
         uriParams.putAll(pathParams);
 
-        String finalUri = path;
+        String queryUri = null;
 
         if (queryParams != null && !queryParams.isEmpty()) {
             //Include queryParams in uriParams taking into account the paramName
-            String queryUri = generateQueryUri(queryParams, uriParams);
-            //Append to finalUri the templatized query string like "?param1={param1Value}&.......
-            finalUri += "?" + queryUri;
+            String query = generateQueryUri(queryParams, uriParams);
+            queryUri = expandPath("?" + query, uriParams).substring(1); //exclude the '?'
+            //queryUri is the templatized query string like "?param1={param1Value}&.......
         }
-        String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        String expandedPath = this.expandPath(path, uriParams);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath)
+                .path(expandedPath)
+                .query(queryUri);
 
         URI uri;
         try {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -634,16 +634,18 @@ public class ApiClient extends JavaTimeFormatter {
         Map<String,Object> uriParams = new HashMap<>();
         uriParams.putAll(pathParams);
 
-        String finalUri = path;
+        String queryUri = null;
 
         if (queryParams != null && !queryParams.isEmpty()) {
             //Include queryParams in uriParams taking into account the paramName
-            String queryUri = generateQueryUri(queryParams, uriParams);
-            //Append to finalUri the templatized query string like "?param1={param1Value}&.......
-            finalUri += "?" + queryUri;
+            String query = generateQueryUri(queryParams, uriParams);
+            queryUri = expandPath("?" + query, uriParams).substring(1); //exclude the '?'
+            //queryUri is the templatized query string like "?param1={param1Value}&.......
         }
-        String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        String expandedPath = this.expandPath(path, uriParams);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath)
+                .path(expandedPath)
+                .query(queryUri);
 
         URI uri;
         try {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -629,16 +629,18 @@ public class ApiClient extends JavaTimeFormatter {
         Map<String,Object> uriParams = new HashMap<>();
         uriParams.putAll(pathParams);
 
-        String finalUri = path;
+        String queryUri = null;
 
         if (queryParams != null && !queryParams.isEmpty()) {
             //Include queryParams in uriParams taking into account the paramName
-            String queryUri = generateQueryUri(queryParams, uriParams);
-            //Append to finalUri the templatized query string like "?param1={param1Value}&.......
-            finalUri += "?" + queryUri;
+            String query = generateQueryUri(queryParams, uriParams);
+            queryUri = expandPath("?" + query, uriParams).substring(1); //exclude the '?'
+            //queryUri is the templatized query string like "?param1={param1Value}&.......
         }
-        String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        String expandedPath = this.expandPath(path, uriParams);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath)
+                .path(expandedPath)
+                .query(queryUri);
 
         URI uri;
         try {


### PR DESCRIPTION
Make queryParams known to UriComponents builder so it can properly encode them

To close https://github.com/OpenAPITools/openapi-generator/issues/13393


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
