### PR TITLE
[typescript-nest] fixes query parameter append bug

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -76,7 +76,7 @@ export class {{classname}} {
 {{/allParams}}
 
 {{#hasQueryParams}}
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
 {{#queryParams}}
         {{#isArray}}
         if ({{paramName}}) {
@@ -93,10 +93,10 @@ export class {{classname}} {
         {{^isArray}}
         if ({{paramName}} !== undefined && {{paramName}} !== null) {
         {{#isDateTime}}
-            queryParameters['{{baseName}}'] = <any>{{paramName}}.toISOString();
+            queryParameters.append('{{baseName}}', <any>{{paramName}}.toISOString());
         {{/isDateTime}}
         {{^isDateTime}}
-            queryParameters['{{baseName}}'] = <any>{{paramName}};
+            queryParameters.append('{{baseName}}', <any>{{paramName}});
         {{/isDateTime}}
         }
         {{/isArray}}
@@ -128,10 +128,10 @@ export class {{classname}} {
 {{/isKeyInHeader}}
 {{#isKeyInQuery}}
         {{^hasQueryParams}}
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         {{/hasQueryParams}}
         if (this.configuration.apiKeys["{{keyParamName}}"]) {
-            queryParameters['{{keyParamName}}'] = this.configuration.apiKeys["{{keyParamName}}"];
+            queryParameters.append('{{keyParamName}}', this.configuration.apiKeys["{{keyParamName}}"]);
         }
 
 {{/isKeyInQuery}}

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -152,9 +152,9 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         if (status) {
-            queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('status', status.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = this.defaultHeaders;
@@ -202,9 +202,9 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         if (tags) {
-            queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = this.defaultHeaders;

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -268,12 +268,12 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         if (username !== undefined && username !== null) {
-            queryParameters['username'] = <any>username;
+            queryParameters.append('username', <any>username);
         }
         if (password !== undefined && password !== null) {
-            queryParameters['password'] = <any>password;
+            queryParameters.append('password', <any>password);
         }
 
         let headers = this.defaultHeaders;

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -153,7 +153,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         if (status) {
             queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
         }
@@ -203,9 +203,9 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         if (tags) {
-            queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = this.defaultHeaders;

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
@@ -269,12 +269,12 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
         if (username !== undefined && username !== null) {
-            queryParameters['username'] = <any>username;
+            queryParameters.append('username', <any>username);
         }
         if (password !== undefined && password !== null) {
-            queryParameters['password'] = <any>password;
+            queryParameters.append('password', <any>password);
         }
 
         let headers = this.defaultHeaders;


### PR DESCRIPTION
This pull request updates the typescript-nest client generator to use `URLSearchParams` instead of an empty object when storing and referencing query parameters. This fixes a bug where the generator would build invalid typescript. 

Using the examples described in [this issue](https://github.com/OpenAPITools/openapi-generator/issues/14134), the following typescript would be generated:

```
let queryParameters = {};
if (brandOrganizationId) {
    brandOrganizationId.forEach((element) => {
        queryParameters.append('brandOrganizationId', <any>element);
    })
}
```

The `queryParameters` object is a plain object and doesn't have the `append` method available. This change updates `queryParameters` to always be an instance of `URLSearchParams` where `append` is an available method. 

Axios (the http client in this case), accepts an instance of `URLSearchParams` or a string as the params property. This pull request updates all query params to be passed as `URLSearchParams`.

Closes https://github.com/OpenAPITools/openapi-generator/pull/13638
Closes https://github.com/OpenAPITools/openapi-generator/issues/14134

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
