### PR TITLE
[JAVA][SPRING] - fix Api class files generation uses only first tag

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -733,10 +733,7 @@ public class SpringCodegen extends AbstractJavaCodegen
                                 value.put("tag", tag);
                                 tags.add(value);
                             }
-                            if (operation.getTags().size() > 0) {
-                                final String tag = operation.getTags().get(0);
-                                operation.setTags(Arrays.asList(tag));
-                            }
+
                             operation.addExtension("x-tags", tags);
                         }
                     }

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -154,7 +154,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (status) {
-            queryParameters.append('status', status.join(COLLECTION_FORMATS['csv']));
+            queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
         }
 
         let headers = this.defaultHeaders;
@@ -204,7 +204,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (tags) {
-            queryParameters.append('tags', tags.join(COLLECTION_FORMATS['csv']));
+            queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
         }
 
         let headers = this.defaultHeaders;

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -205,7 +205,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (tags) {
-            queryParameters.append('tags', tags.join(COLLECTION_FORMATS['csv']));
+            queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
         }
 
         let headers = this.defaultHeaders;


### PR DESCRIPTION
References:  https://github.com/OpenAPITools/openapi-generator/issues/6405

if we have `useTags=true` and in openapi we have:
```
tags:
    - first
    - second
 ```

Spring generator will generate only `FirstApi.java` class with that operation - instead it should generate `FirstApi.java` and `SecondApi.java` with operation duplicated...

This is non-breaking change as it will cause only duplication of code for people who have multiple tags

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]

@welshm @MelleD 👋 