### PR TITLE
Modify Java ApiException to have a more informative message.

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/apiException.mustache
@@ -37,7 +37,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     }
 
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
+        this("Response Code: " + code + " Response Body: " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     public ApiException(int code, String message) {

--- a/modules/openapi-generator/src/main/resources/Java/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/apiException.mustache
@@ -37,7 +37,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     }
 
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     public ApiException(int code, String message) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -101,7 +101,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
+        this("Response Code: " + code + " Response Body: " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -101,7 +101,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
@@ -99,7 +99,7 @@ public class ApiException extends Exception {
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
@@ -48,7 +48,7 @@ public class ApiException extends Exception {
     }
 
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     public ApiException(int code, String message) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ApiException.java
@@ -48,7 +48,7 @@ public class ApiException extends Exception {
     }
 
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     public ApiException(int code, String message) {

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
@@ -99,7 +99,7 @@ public class ApiException extends Exception {
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiException.java
@@ -99,7 +99,7 @@ public class ApiException extends Exception {
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
@@ -99,7 +99,7 @@ public class ApiException extends Exception {
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiException.java
@@ -99,7 +99,7 @@ public class ApiException extends Exception {
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
@@ -99,7 +99,7 @@ public class ApiException extends Exception {
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     /**

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
@@ -48,7 +48,7 @@ public class ApiException extends Exception {
     }
 
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+        this(code + " " + responseBody, (Throwable) null, code, responseHeaders, responseBody);
     }
 
     public ApiException(int code, String message) {


### PR DESCRIPTION
Improves the implementation of Java ApiException for okhttp3 and top level in cases where there is a status code and a response body, but there is no message passed to the exception constructor.

See: https://github.com/kubernetes-client/java/issues/2066

cc @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
