### PR TITLE
[dart-dio] Add `r` before '{{MappingName}}' to handle special characters in discriminators

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_serializer.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_serializer.mustache
@@ -127,7 +127,7 @@ class _${{classname}}Serializer implements PrimitiveSerializer<{{classname}}> {
     Type oneOfType;
     switch (discValue) {
       {{#mappedModels}}
-      case '{{mappingName}}':
+      case r'{{mappingName}}':
         oneOfResult = serializers.deserialize(
           oneOfDataSrc,
           specifiedType: FullType({{modelName}}),
@@ -210,7 +210,7 @@ class _${{classname}}Serializer implements PrimitiveSerializer<{{classname}}> {
     Type anyOfType;
     switch (discValue) {
       {{#mappedModels}}
-      case '{{mappingName}}':
+      case r'{{mappingName}}':
         anyOfResult = serializers.deserialize(anyOfDataSrc, specifiedType: FullType({{modelName}})) as {{modelName}};
         anyOfType = {{modelName}};
         break;
@@ -271,7 +271,7 @@ class _${{classname}}Serializer implements PrimitiveSerializer<{{classname}}> {
     final discValue = serializers.deserialize(serializedList[discIndex], specifiedType: FullType(String)) as String;
     switch (discValue) {
       {{#mappedModels}}
-      case '{{mappingName}}':
+      case r'{{mappingName}}':
         return serializers.deserialize(serialized, specifiedType: FullType({{modelName}})) as {{modelName}};
       {{/mappedModels}}
       default:

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_ref_or_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/bar_ref_or_value.dart
@@ -82,14 +82,14 @@ class _$BarRefOrValueSerializer implements PrimitiveSerializer<BarRefOrValue> {
     Object oneOfResult;
     Type oneOfType;
     switch (discValue) {
-      case 'Bar':
+      case r'Bar':
         oneOfResult = serializers.deserialize(
           oneOfDataSrc,
           specifiedType: FullType(Bar),
         ) as Bar;
         oneOfType = Bar;
         break;
-      case 'BarRef':
+      case r'BarRef':
         oneOfResult = serializers.deserialize(
           oneOfDataSrc,
           specifiedType: FullType(BarRef),

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity.dart
@@ -125,17 +125,17 @@ class _$EntitySerializer implements PrimitiveSerializer<Entity> {
     final discIndex = serializedList.indexOf(Entity.discriminatorFieldName) + 1;
     final discValue = serializers.deserialize(serializedList[discIndex], specifiedType: FullType(String)) as String;
     switch (discValue) {
-      case 'Bar':
+      case r'Bar':
         return serializers.deserialize(serialized, specifiedType: FullType(Bar)) as Bar;
-      case 'Bar_Create':
+      case r'Bar_Create':
         return serializers.deserialize(serialized, specifiedType: FullType(BarCreate)) as BarCreate;
-      case 'Foo':
+      case r'Foo':
         return serializers.deserialize(serialized, specifiedType: FullType(Foo)) as Foo;
-      case 'Pasta':
+      case r'Pasta':
         return serializers.deserialize(serialized, specifiedType: FullType(Pasta)) as Pasta;
-      case 'Pizza':
+      case r'Pizza':
         return serializers.deserialize(serialized, specifiedType: FullType(Pizza)) as Pizza;
-      case 'PizzaSpeziale':
+      case r'PizzaSpeziale':
         return serializers.deserialize(serialized, specifiedType: FullType(PizzaSpeziale)) as PizzaSpeziale;
       default:
         return serializers.deserialize(serialized, specifiedType: FullType($Entity)) as $Entity;

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/entity_ref.dart
@@ -129,9 +129,9 @@ class _$EntityRefSerializer implements PrimitiveSerializer<EntityRef> {
     final discIndex = serializedList.indexOf(EntityRef.discriminatorFieldName) + 1;
     final discValue = serializers.deserialize(serializedList[discIndex], specifiedType: FullType(String)) as String;
     switch (discValue) {
-      case 'BarRef':
+      case r'BarRef':
         return serializers.deserialize(serialized, specifiedType: FullType(BarRef)) as BarRef;
-      case 'FooRef':
+      case r'FooRef':
         return serializers.deserialize(serialized, specifiedType: FullType(FooRef)) as FooRef;
       default:
         return serializers.deserialize(serialized, specifiedType: FullType($EntityRef)) as $EntityRef;

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo_ref_or_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/foo_ref_or_value.dart
@@ -82,14 +82,14 @@ class _$FooRefOrValueSerializer implements PrimitiveSerializer<FooRefOrValue> {
     Object oneOfResult;
     Type oneOfType;
     switch (discValue) {
-      case 'Foo':
+      case r'Foo':
         oneOfResult = serializers.deserialize(
           oneOfDataSrc,
           specifiedType: FullType(Foo),
         ) as Foo;
         oneOfType = Foo;
         break;
-      case 'FooRef':
+      case r'FooRef':
         oneOfResult = serializers.deserialize(
           oneOfDataSrc,
           specifiedType: FullType(FooRef),

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pizza.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/pizza.dart
@@ -110,7 +110,7 @@ class _$PizzaSerializer implements PrimitiveSerializer<Pizza> {
     final discIndex = serializedList.indexOf(Pizza.discriminatorFieldName) + 1;
     final discValue = serializers.deserialize(serializedList[discIndex], specifiedType: FullType(String)) as String;
     switch (discValue) {
-      case 'PizzaSpeziale':
+      case r'PizzaSpeziale':
         return serializers.deserialize(serialized, specifiedType: FullType(PizzaSpeziale)) as PizzaSpeziale;
       default:
         return serializers.deserialize(serialized, specifiedType: FullType($Pizza)) as $Pizza;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/animal.dart
@@ -85,9 +85,9 @@ class _$AnimalSerializer implements PrimitiveSerializer<Animal> {
     final discIndex = serializedList.indexOf(Animal.discriminatorFieldName) + 1;
     final discValue = serializers.deserialize(serializedList[discIndex], specifiedType: FullType(String)) as String;
     switch (discValue) {
-      case 'Cat':
+      case r'Cat':
         return serializers.deserialize(serialized, specifiedType: FullType(Cat)) as Cat;
-      case 'Dog':
+      case r'Dog':
         return serializers.deserialize(serialized, specifiedType: FullType(Dog)) as Dog;
       default:
         return serializers.deserialize(serialized, specifiedType: FullType($Animal)) as $Animal;


### PR DESCRIPTION
This is a simple PR to fix special character handling for `mappingName `

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08) @wing328 