### PR TITLE
#14141 Add externalDocs to @Operation to the JavaSpring generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 public class CodegenOperation {
     public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();
-    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams, hasRequiredParams, hasExternalDocs,
+    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams, hasRequiredParams,
             returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
             isArray, isMultipart,
             isResponseBinary = false, isResponseFile = false, isResponseOptional = false, hasReference = false, defaultReturnType = false,
@@ -316,7 +316,6 @@ public class CodegenOperation {
         sb.append(", hasParams=").append(hasParams);
         sb.append(", hasOptionalParams=").append(hasOptionalParams);
         sb.append(", hasRequiredParams=").append(hasRequiredParams);
-        sb.append(", hasExternalDocs=").append(hasExternalDocs);
         sb.append(", returnTypeIsPrimitive=").append(returnTypeIsPrimitive);
         sb.append(", returnSimpleType=").append(returnSimpleType);
         sb.append(", subresourceOperation=").append(subresourceOperation);
@@ -394,7 +393,6 @@ public class CodegenOperation {
                 hasParams == that.hasParams &&
                 hasOptionalParams == that.hasOptionalParams &&
                 hasRequiredParams == that.hasRequiredParams &&
-                hasExternalDocs == that.hasExternalDocs &&
                 returnTypeIsPrimitive == that.returnTypeIsPrimitive &&
                 returnSimpleType == that.returnSimpleType &&
                 subresourceOperation == that.subresourceOperation &&
@@ -464,7 +462,7 @@ public class CodegenOperation {
     public int hashCode() {
 
         return Objects.hash(responseHeaders, hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams,
-                hasRequiredParams, hasExternalDocs, returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
+                hasRequiredParams, returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
                 isArray, isMultipart, isResponseBinary, isResponseFile, isResponseOptional, hasReference,
                 hasDefaultResponse, isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
                 isRestful, isDeprecated, isCallbackRequest, uniqueItems, path, operationId, returnType, httpMethod,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 public class CodegenOperation {
     public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();
-    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams, hasRequiredParams,
+    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams, hasRequiredParams, hasExternalDocs,
             returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
             isArray, isMultipart,
             isResponseBinary = false, isResponseFile = false, isResponseOptional = false, hasReference = false, defaultReturnType = false,
@@ -316,6 +316,7 @@ public class CodegenOperation {
         sb.append(", hasParams=").append(hasParams);
         sb.append(", hasOptionalParams=").append(hasOptionalParams);
         sb.append(", hasRequiredParams=").append(hasRequiredParams);
+        sb.append(", hasExternalDocs=").append(hasExternalDocs);
         sb.append(", returnTypeIsPrimitive=").append(returnTypeIsPrimitive);
         sb.append(", returnSimpleType=").append(returnSimpleType);
         sb.append(", subresourceOperation=").append(subresourceOperation);
@@ -393,6 +394,7 @@ public class CodegenOperation {
                 hasParams == that.hasParams &&
                 hasOptionalParams == that.hasOptionalParams &&
                 hasRequiredParams == that.hasRequiredParams &&
+                hasExternalDocs == that.hasExternalDocs &&
                 returnTypeIsPrimitive == that.returnTypeIsPrimitive &&
                 returnSimpleType == that.returnSimpleType &&
                 subresourceOperation == that.subresourceOperation &&
@@ -462,7 +464,7 @@ public class CodegenOperation {
     public int hashCode() {
 
         return Objects.hash(responseHeaders, hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams,
-                hasRequiredParams, returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
+                hasRequiredParams, hasExternalDocs, returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
                 isArray, isMultipart, isResponseBinary, isResponseFile, isResponseOptional, hasReference,
                 hasDefaultResponse, isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
                 isRestful, isDeprecated, isCallbackRequest, uniqueItems, path, operationId, returnType, httpMethod,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4478,6 +4478,7 @@ public class DefaultCodegen implements CodegenConfig {
         op.requiredParams = requiredParams;
         op.optionalParams = optionalParams;
         op.externalDocs = operation.getExternalDocs();
+        op.hasExternalDocs = op.externalDocs != null;
         // legacy support
         op.nickname = op.operationId;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4478,7 +4478,6 @@ public class DefaultCodegen implements CodegenConfig {
         op.requiredParams = requiredParams;
         op.optionalParams = optionalParams;
         op.externalDocs = operation.getExternalDocs();
-        op.hasExternalDocs = op.externalDocs != null;
         // legacy support
         op.nickname = op.operationId;
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -8,6 +8,7 @@ package {{package}};
 {{#imports}}import {{import}};
 {{/imports}}
 {{#swagger2AnnotationLibrary}}
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -16,9 +17,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-{{#externalDocs}}
-import io.swagger.v3.oas.annotations.ExternalDocumentation;
-{{/externalDocs}}
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -174,8 +174,7 @@ public interface {{classname}} {
             @SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes={ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }{{/isOAuth}}){{^-last}},{{/-last}}
             {{/authMethods}}
         }{{/hasAuthMethods}}{{#hasExternalDocs}},
-        externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}")
-        {{/hasExternalDocs}}
+        externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}"){{/hasExternalDocs}}
     )
     {{/swagger2AnnotationLibrary}}
     {{#swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -16,9 +16,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-{{#hasAuthMethods}}
+{{#hasExternalDocs}}
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
-{{/hasAuthMethods}}
+{{/hasExternalDocs}}
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -16,6 +16,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+{{#hasAuthMethods}}
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+{{/hasAuthMethods}}
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;
@@ -170,7 +173,9 @@ public interface {{classname}} {
             {{#authMethods}}
             @SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes={ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }{{/isOAuth}}){{^-last}},{{/-last}}
             {{/authMethods}}
-        }{{/hasAuthMethods}}
+        }{{/hasAuthMethods}}{{#hasExternalDocs}},
+            externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}")
+        {{/hasExternalDocs}}
     )
     {{/swagger2AnnotationLibrary}}
     {{#swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -16,9 +16,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-{{#hasExternalDocs}}
+{{#externalDocs}}
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
-{{/hasExternalDocs}}
+{{/externalDocs}}
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;
@@ -173,8 +173,8 @@ public interface {{classname}} {
             {{#authMethods}}
             @SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes={ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }{{/isOAuth}}){{^-last}},{{/-last}}
             {{/authMethods}}
-        }{{/hasAuthMethods}}{{#hasExternalDocs}},
-        externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}"){{/hasExternalDocs}}
+        }{{/hasAuthMethods}}{{#externalDocs}},
+        externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}"){{/externalDocs}}
     )
     {{/swagger2AnnotationLibrary}}
     {{#swagger1AnnotationLibrary}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -174,7 +174,7 @@ public interface {{classname}} {
             @SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes={ {{#scopes}}"{{scope}}"{{^-last}}, {{/-last}}{{/scopes}} }{{/isOAuth}}){{^-last}},{{/-last}}
             {{/authMethods}}
         }{{/hasAuthMethods}}{{#hasExternalDocs}},
-            externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}")
+        externalDocs = @ExternalDocumentation(description = "{{externalDocs.description}}", url = "{{externalDocs.url}}")
         {{/hasExternalDocs}}
     )
     {{/swagger2AnnotationLibrary}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1273,6 +1273,7 @@ public class SpringCodegenTest {
 
         JavaFileAssert.assertThat(files.get("PetApi.java"))
             .printFileContent()
+            .hasImports("io.swagger.v3.oas.annotations.ExternalDocumentation")
             .assertMethod("updatePet")
             .assertMethodAnnotations()
             .containsWithName("Operation")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1245,6 +1245,47 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void shouldGenerateExternalDocs() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+            .readLocation("src/test/resources/3_0/petstore.yaml", null, new ParseOptions()).getOpenAPI();
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setLibrary(SPRING_BOOT);
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(SpringCodegen.USE_TAGS, "true");
+        codegen.additionalProperties().put(BeanValidationFeatures.USE_BEANVALIDATION, "true");
+
+        ClientOptInput input = new ClientOptInput()
+            .openAPI(openAPI)
+            .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+        Map<String, File> files = generator.opts(input).generate().stream()
+            .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("PetApi.java"))
+            .printFileContent()
+            .assertMethod("updatePet")
+            .assertMethodAnnotations()
+            .containsWithName("Operation")
+            .containsWithNameAndAttributes("Operation",
+                ImmutableMap.of(
+                    "operationId", "\"updatePet\"",
+                    //"security", "{ @SecurityRequirement(name = \"petstore_auth\", scopes = { \"write:pets\", \"read:pets\" }) }",
+                    "externalDocs", "@ExternalDocumentation(description = \"API documentation for the updatePet operation\", url = \"http://petstore.swagger.io/v2/doc/updatePet\")"
+                )
+                );
+    }
+
+    @Test
     public void testHandleDefaultValue_issue8535() throws Exception {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -49,6 +49,9 @@ paths:
       summary: Update an existing pet
       description: ''
       operationId: updatePet
+      externalDocs:
+        url: "http://petstore.swagger.io/v2/doc/updatePet"
+        description: "API documentation for the updatePet operation"
       responses:
         '200':
           description: successful operation

--- a/samples/client/petstore/java/okhttp-gson-swagger1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/api/openapi.yaml
@@ -49,6 +49,9 @@ paths:
       x-accepts: application/json
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -747,6 +747,8 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     public okhttp3.Call updatePetCall(Pet pet, final ApiCallback _callback) throws ApiException {
         String basePath = null;
@@ -820,6 +822,8 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     public Pet updatePet(Pet pet) throws ApiException {
         ApiResponse<Pet> localVarResp = updatePetWithHttpInfo(pet);
@@ -840,6 +844,8 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     public ApiResponse<Pet> updatePetWithHttpInfo(Pet pet) throws ApiException {
         okhttp3.Call localVarCall = updatePetValidateBeforeCall(pet, null);
@@ -862,6 +868,8 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     public okhttp3.Call updatePetAsync(Pet pet, final ApiCallback<Pet> _callback) throws ApiException {
 

--- a/samples/client/petstore/java/resttemplate-swagger1/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-swagger1/api/openapi.yaml
@@ -49,6 +49,9 @@ paths:
       x-accepts: application/json
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -317,6 +317,8 @@ public class PetApi {
      * @param pet Pet object that needs to be added to the store (required)
      * @return Pet
      * @throws RestClientException if an error occurs while attempting to invoke the API
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     public Pet updatePet(Pet pet) throws RestClientException {
         return updatePetWithHttpInfo(pet).getBody();
@@ -332,6 +334,8 @@ public class PetApi {
      * @param pet Pet object that needs to be added to the store (required)
      * @return ResponseEntity&lt;Pet&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     public ResponseEntity<Pet> updatePetWithHttpInfo(Pet pet) throws RestClientException {
         Object localVarPostBody = pet;

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApi.java
@@ -212,6 +212,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @ApiOperation(
         tags = { "pet" },

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -212,6 +212,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @ApiOperation(
         tags = { "pet" },

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/api/openapi.yaml
@@ -49,6 +49,9 @@ paths:
       x-accepts: application/json
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -415,6 +415,8 @@ public class PetApi {
        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
+   * API documentation for the updatePet operation
+   * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
    */
   public Pet updatePet(Pet pet) throws ApiException {
     return updatePetWithHttpInfo(pet).getData();
@@ -434,6 +436,8 @@ public class PetApi {
        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
+   * API documentation for the updatePet operation
+   * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
    */
   public ApiResponse<Pet> updatePetWithHttpInfo(Pet pet) throws ApiException {
     Object localVarPostBody = pet;

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
@@ -215,6 +215,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @Operation(
         operationId = "updatePet",
@@ -232,7 +234,8 @@ public interface PetApi {
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })
-        }
+        },
+        externalDocs = @ExternalDocumentation(description = "API documentation for the updatePet operation", url = "http://petstore.swagger.io/v2/doc/updatePet")
     )
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/api/DefaultApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
@@ -15,6 +15,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
@@ -9,6 +9,7 @@ import org.openapitools.model.ModelApiResponse;
 import org.springframework.data.domain.Pageable;
 import org.springdoc.api.annotations.ParameterObject;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -215,6 +215,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @Operation(
         operationId = "updatePet",
@@ -232,7 +234,8 @@ public interface PetApi {
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })
-        }
+        },
+        externalDocs = @ExternalDocumentation(description = "API documentation for the updatePet operation", url = "http://petstore.swagger.io/v2/doc/updatePet")
     )
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.Bar;
 import org.openapitools.model.BarCreate;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.Foo;
 import org.openapitools.model.FooRefOrValue;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
@@ -290,6 +290,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @Operation(
         operationId = "updatePet",
@@ -307,7 +309,8 @@ public interface PetApi {
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })
-        }
+        },
+        externalDocs = @ExternalDocumentation(description = "API documentation for the updatePet operation", url = "http://petstore.swagger.io/v2/doc/updatePet")
     )
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/resources/openapi.yaml
@@ -51,6 +51,9 @@ paths:
       - tag: pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApi.java
@@ -290,6 +290,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @Operation(
         operationId = "updatePet",
@@ -307,7 +309,8 @@ public interface PetApi {
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })
-        }
+        },
+        externalDocs = @ExternalDocumentation(description = "API documentation for the updatePet operation", url = "http://petstore.swagger.io/v2/doc/updatePet")
     )
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/resources/openapi.yaml
@@ -51,6 +51,9 @@ paths:
       - tag: pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/api/PetApi.java
@@ -204,6 +204,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/openapi3/server/petstore/springboot-source/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/resources/openapi.yaml
@@ -51,6 +51,9 @@ paths:
       - tag: pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -291,6 +291,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @Operation(
         operationId = "updatePet",
@@ -308,7 +310,8 @@ public interface PetApi {
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })
-        }
+        },
+        externalDocs = @ExternalDocumentation(description = "API documentation for the updatePet operation", url = "http://petstore.swagger.io/v2/doc/updatePet")
     )
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/openapi3/server/petstore/springboot/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot/src/main/resources/openapi.yaml
@@ -51,6 +51,9 @@ paths:
       - tag: pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/erlang-server/priv/openapi.json
+++ b/samples/server/petstore/erlang-server/priv/openapi.json
@@ -62,6 +62,10 @@
       },
       "put" : {
         "description" : "",
+        "externalDocs" : {
+          "description" : "API documentation for the updatePet operation",
+          "url" : "http://petstore.swagger.io/v2/doc/updatePet"
+        },
         "operationId" : "updatePet",
         "requestBody" : {
           "$ref" : "#/components/requestBodies/Pet"

--- a/samples/server/petstore/go-api-server/api/openapi.yaml
+++ b/samples/server/petstore/go-api-server/api/openapi.yaml
@@ -47,6 +47,9 @@ paths:
       - pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/go-chi-server/api/openapi.yaml
+++ b/samples/server/petstore/go-chi-server/api/openapi.yaml
@@ -47,6 +47,9 @@ paths:
       - pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/go-echo-server/.docs/api/openapi.yaml
+++ b/samples/server/petstore/go-echo-server/.docs/api/openapi.yaml
@@ -47,6 +47,9 @@ paths:
       - pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/go-gin-api-server/api/openapi.yaml
+++ b/samples/server/petstore/go-gin-api-server/api/openapi.yaml
@@ -47,6 +47,9 @@ paths:
       - pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/PetController.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/PetController.java
@@ -217,6 +217,8 @@ public class PetController {
      *
      * @param pet Pet object that needs to be added to the store (required)
      * @return Pet
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @Operation(
         operationId = "updatePet",

--- a/samples/server/petstore/java-vertx-web/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/java-vertx-web/src/main/resources/openapi.yaml
@@ -49,6 +49,9 @@ paths:
       x-accepts: application/json
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/resources/openapi.yaml
@@ -47,6 +47,9 @@ paths:
       - pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/python-fastapi/openapi.yaml
+++ b/samples/server/petstore/python-fastapi/openapi.yaml
@@ -47,6 +47,9 @@ paths:
       - pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.api;
 
 import java.util.Map;
 import org.openapitools.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/api/NullableApi.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/api/NullableApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import org.openapitools.model.ObjectWithUniqueItems;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/api/PetApi.java
@@ -202,6 +202,8 @@ public interface PetApi {
      *         or Invalid ID supplied (status code 400)
      *         or Pet not found (status code 404)
      *         or Validation exception (status code 405)
+     * API documentation for the updatePet operation
+     * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
      */
     @RequestMapping(
         method = RequestMethod.PUT,

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/resources/openapi.yaml
@@ -51,6 +51,9 @@ paths:
       - tag: pet
     put:
       description: ""
+      externalDocs:
+        description: API documentation for the updatePet operation
+        url: http://petstore.swagger.io/v2/doc/updatePet
       operationId: updatePet
       requestBody:
         $ref: '#/components/requestBodies/Pet'

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.virtualan.api;
 
 import org.openapitools.virtualan.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import org.openapitools.virtualan.model.OuterComposite;
 import org.openapitools.virtualan.model.User;
 import org.openapitools.virtualan.model.XmlItem;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.virtualan.api;
 
 import org.openapitools.virtualan.model.Client;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/PetApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/PetApi.java
@@ -8,6 +8,7 @@ package org.openapitools.virtualan.api;
 import org.openapitools.virtualan.model.ModelApiResponse;
 import org.openapitools.virtualan.model.Pet;
 import java.util.Set;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/StoreApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/StoreApi.java
@@ -7,6 +7,7 @@ package org.openapitools.virtualan.api;
 
 import java.util.Map;
 import org.openapitools.virtualan.model.Order;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
@@ -8,6 +8,7 @@ package org.openapitools.virtualan.api;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.openapitools.virtualan.model.User;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This Pull Request implements the feature describe in https://github.com/OpenAPITools/openapi-generator/issues/14141 with a TDD approach.
It adds an `externalDocs` attribute to the `@Operation` annotation regarding the operation yaml specification.


<!-- Please check the completed items below -->

### PR checklist
 
- [ X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
For JavaSpring comitttee 
@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09)
Core Team : @wing328 @jimschubert @cbornet @jmini @etherealjoy @spacether
