### PR TITLE
Fixed typescript codegen pattern compiler

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -1144,43 +1144,11 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
                     return fullPrefix + example + closeChars;
                 } else if (StringUtils.isNotBlank(schema.getPattern())) {
                     String pattern = schema.getPattern();
-                    /*
-                    RxGen does not support our ECMA dialect https://github.com/curious-odd-man/RgxGen/issues/56
-                    So strip off the leading / and trailing / and turn on ignore case if we have it
-                     */
-                    Pattern valueExtractor = Pattern.compile("^/?(.+?)/?(.?)$");
-                    Matcher m = valueExtractor.matcher(pattern);
-                    RgxGen rgxGen = null;
-                    if (m.find()) {
-                        int groupCount = m.groupCount();
-                        if (groupCount == 1) {
-                            // only pattern found
-                            String isolatedPattern = m.group(1);
-                            rgxGen = new RgxGen(isolatedPattern);
-                        } else if (groupCount == 2) {
-                            // patterns and flag found
-                            String isolatedPattern = m.group(1);
-                            String flags = m.group(2);
-                            if (flags.contains("i")) {
-                                rgxGen = new RgxGen(isolatedPattern);
-                                RgxGenProperties properties = new RgxGenProperties();
-                                RgxGenOption.CASE_INSENSITIVE.setInProperties(properties, true);
-                                rgxGen.setProperties(properties);
-                            } else {
-                                rgxGen = new RgxGen(isolatedPattern);
-                            }
-                        }
-                    } else {
-                        rgxGen = new RgxGen(pattern);
-                    }
+                    RgxGen rgxGen = new RgxGen(pattern);
 
                     // this seed makes it so if we have [a-z] we pick a
                     Random random = new Random(18);
-                    if (rgxGen != null){
-                        example = rgxGen.generate(random);
-                    } else {
-                        throw new RuntimeException("rgxGen cannot be null. Please open an issue in the openapi-generator github repo.");
-                    }
+                    example = rgxGen.generate(random);
                 } else if (schema.getMinLength() != null) {
                     example = "";
                     int len = schema.getMinLength().intValue();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -141,4 +141,21 @@ public class TypeScriptClientCodegenTest {
         Assert.assertEquals(tsImports.get(0).get("filename"), mappedName);
         Assert.assertEquals(tsImports.get(0).get("classname"), "ApiResponse");
     }
+
+    @Test
+    public void testCompilePattern() {
+        final DefaultCodegen codegen = new TypeScriptClientCodegen();
+        final StringSchema prop = new StringSchema();
+        prop.setPattern("[A-Z]{3}");
+        final Schema root = new ObjectSchema().addProperty("stringPattern", prop);
+        final OpenAPI openApi = TestUtils.createOpenAPIWithOneSchema("sample", root);
+        codegen.setOpenAPI(openApi);
+
+        try {
+            final CodegenModel model = codegen.fromModel("sample", root);
+            Assert.assertEquals(model.getAllVars().get(0).getPattern(), "/[A-Z]{3}/");
+        } catch (Exception ex) {
+            Assert.fail("Exception was thrown.");
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes an issue with the Typescript client code generator when compiling a regular expression pattern:

```
  Exception: Unbalanced '{' - missing '}' at 
'[A-Z]{3'
      ^

Caused by: com.github.curiousoddman.rgxgen.parsing.dflt.RgxGenParseException: Unbalanced '{' - missing '}' at 
'[A-Z]{3'
      ^
```

This PR supersedes #13655, as its author seems inactive. It also implements a suggestion made in this previous PR, of removing the non-standard support for leading/trailing slashes when parsing regular expressions (see https://github.com/OpenAPITools/openapi-generator/pull/13655#discussion_r992232977)

Fixes #13390

Mentioning the Typescript technical commitee: @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
