### PR TITLE
fix(sec): upgrade urllib3 to 

### DIFF
--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -29,7 +29,7 @@ six==1.16.0
 starlette==0.14.2
 typing-extensions==3.10.0.0
 ujson==4.0.2
-urllib3==1.26.4
+urllib3==1.26.5
 uvicorn==0.13.4
 uvloop==0.14.0
 watchgod==0.7


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.26.4
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.26.4 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS