### PR TITLE
Fix query parameters encoding in Java apache-httpclient

### DIFF
--- a/.github/workflows/samples-java-client-echo-api-jdk11.yaml
+++ b/.github/workflows/samples-java-client-echo-api-jdk11.yaml
@@ -17,6 +17,7 @@ jobs:
         sample:
           # clients
           - samples/client/echo_api/java/native
+          - samples/client/echo_api/java/apache-httpclient
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -580,9 +580,11 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     List<Pair> params = new ArrayList<Pair>();
 
     // preconditions
-    if (name == null || name.isEmpty() || value == null || value instanceof Collection) return params;
+    if (name == null || name.isEmpty() || value == null || value instanceof Collection) {
+      return params;
+    }
 
-    params.add(new Pair(name, parameterToString(value)));
+    params.add(new Pair(name, escapeString(parameterToString(value))));
     return params;
   }
 
@@ -829,6 +831,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     if (mimeType == null || isJsonMime(mimeType)) {
       // Assume json if no mime type
       return objectMapper.readValue(entity.getContent(), valueType);
+    } else if ("text/plain".equalsIgnoreCase(mimeType)) {
+      // convert input stream to string
+      java.util.Scanner s = new java.util.Scanner(entity.getContent()).useDelimiter("\\A");
+      return (T) (s.hasNext() ? s.next() : "");
     } else {
       throw new ApiException(
           "Deserialization for content type '" + mimeType + "' not supported for type '" + valueType + "'",
@@ -917,7 +923,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             url.append("&");
           }
           String value = parameterToString(param.getValue());
-          url.append(escapeString(param.getName())).append("=").append(escapeString(value));
+          // query parameter value already escaped as part of parameterToPair
+          url.append(escapeString(param.getName())).append("=").append(value);
         }
       }
     }

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -26,6 +26,66 @@ info:
 servers:
   - url: http://localhost:3000/
 paths:
+  # path parameter tests
+  /path/string/{path_string}/integer/{path_integer}:
+    get:
+      tags:
+        - path 
+      summary: Test path parameter(s)
+      description: Test path parameter(s)
+      operationId: tests/path/string/{path_string}/integer/{path_integer}
+      parameters:
+      - in: path 
+        name: path_string
+        required: true
+        schema:
+          type: string
+      - in: path 
+        name: path_integer
+        required: true
+        schema:
+          type: integer 
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # query parameter tests
+  /query/integer/boolean/string:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/integer/boolean/string
+      parameters:
+      - in: query
+        name: integer_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: integer
+      - in: query
+        name: boolean_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: boolean
+      - in: query
+        name: string_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
   /query/style_form/explode_true/array_string:
     get:
       tags:

--- a/samples/client/echo_api/java/native/.openapi-generator/FILES
+++ b/samples/client/echo_api/java/native/.openapi-generator/FILES
@@ -6,6 +6,7 @@ api/openapi.yaml
 build.gradle
 build.sbt
 docs/Category.md
+docs/PathApi.md
 docs/Pet.md
 docs/QueryApi.md
 docs/Tag.md
@@ -28,6 +29,7 @@ src/main/java/org/openapitools/client/Pair.java
 src/main/java/org/openapitools/client/RFC3339DateFormat.java
 src/main/java/org/openapitools/client/ServerConfiguration.java
 src/main/java/org/openapitools/client/ServerVariable.java
+src/main/java/org/openapitools/client/api/PathApi.java
 src/main/java/org/openapitools/client/api/QueryApi.java
 src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
 src/main/java/org/openapitools/client/model/Category.java

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -74,21 +74,22 @@ Please follow the [installation](#installation) instruction and execute the foll
 
 import org.openapitools.client.*;
 import org.openapitools.client.model.*;
-import org.openapitools.client.api.QueryApi;
+import org.openapitools.client.api.PathApi;
 
-public class QueryApiExample {
+public class PathApiExample {
 
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         // Configure clients using the `defaultClient` object, such as
         // overriding the host and port, timeout, etc.
-        QueryApi apiInstance = new QueryApi(defaultClient);
-        TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter queryObject = new HashMap(); // TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter | 
+        PathApi apiInstance = new PathApi(defaultClient);
+        String pathString = "pathString_example"; // String | 
+        Integer pathInteger = 56; // Integer | 
         try {
-            String result = apiInstance.testQueryStyleFormExplodeTrueArrayString(queryObject);
+            String result = apiInstance.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling QueryApi#testQueryStyleFormExplodeTrueArrayString");
+            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathInteger");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -105,6 +106,10 @@ All URIs are relative to *http://localhost:3000*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*PathApi* | [**testsPathStringPathStringIntegerPathIntegerWithHttpInfo**](docs/PathApi.md#testsPathStringPathStringIntegerPathIntegerWithHttpInfo) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*QueryApi* | [**testQueryIntegerBooleanString**](docs/QueryApi.md#testQueryIntegerBooleanString) | **GET** /query/integer/boolean/string | Test query parameter(s)
+*QueryApi* | [**testQueryIntegerBooleanStringWithHttpInfo**](docs/QueryApi.md#testQueryIntegerBooleanStringWithHttpInfo) | **GET** /query/integer/boolean/string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayStringWithHttpInfo**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayStringWithHttpInfo) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -11,6 +11,73 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
+  /path/string/{path_string}/integer/{path_integer}:
+    get:
+      description: Test path parameter(s)
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      parameters:
+      - explode: false
+        in: path
+        name: path_string
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: path_integer
+        required: true
+        schema:
+          type: integer
+        style: simple
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test path parameter(s)
+      tags:
+      - path
+      x-accepts: text/plain
+  /query/integer/boolean/string:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/integer/boolean/string
+      parameters:
+      - explode: true
+        in: query
+        name: integer_query
+        required: false
+        schema:
+          type: integer
+        style: form
+      - explode: true
+        in: query
+        name: boolean_query
+        required: false
+        schema:
+          type: boolean
+        style: form
+      - explode: true
+        in: query
+        name: string_query
+        required: false
+        schema:
+          type: string
+        style: form
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts: text/plain
   /query/style_form/explode_true/array_string:
     get:
       description: Test query parameter(s)

--- a/samples/client/echo_api/java/native/docs/QueryApi.md
+++ b/samples/client/echo_api/java/native/docs/QueryApi.md
@@ -4,11 +4,155 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**testQueryIntegerBooleanString**](QueryApi.md#testQueryIntegerBooleanString) | **GET** /query/integer/boolean/string | Test query parameter(s) |
+| [**testQueryIntegerBooleanStringWithHttpInfo**](QueryApi.md#testQueryIntegerBooleanStringWithHttpInfo) | **GET** /query/integer/boolean/string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueArrayStringWithHttpInfo**](QueryApi.md#testQueryStyleFormExplodeTrueArrayStringWithHttpInfo) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectWithHttpInfo**](QueryApi.md#testQueryStyleFormExplodeTrueObjectWithHttpInfo) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 
+
+
+## testQueryIntegerBooleanString
+
+> String testQueryIntegerBooleanString(integerQuery, booleanQuery, stringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Integer integerQuery = 56; // Integer | 
+        Boolean booleanQuery = true; // Boolean | 
+        String stringQuery = "stringQuery_example"; // String | 
+        try {
+            String result = apiInstance.testQueryIntegerBooleanString(integerQuery, booleanQuery, stringQuery);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryIntegerBooleanString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **integerQuery** | **Integer**|  | [optional] |
+| **booleanQuery** | **Boolean**|  | [optional] |
+| **stringQuery** | **String**|  | [optional] |
+
+### Return type
+
+**String**
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testQueryIntegerBooleanStringWithHttpInfo
+
+> ApiResponse<String> testQueryIntegerBooleanString testQueryIntegerBooleanStringWithHttpInfo(integerQuery, booleanQuery, stringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Integer integerQuery = 56; // Integer | 
+        Boolean booleanQuery = true; // Boolean | 
+        String stringQuery = "stringQuery_example"; // String | 
+        try {
+            ApiResponse<String> response = apiInstance.testQueryIntegerBooleanStringWithHttpInfo(integerQuery, booleanQuery, stringQuery);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryIntegerBooleanString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **integerQuery** | **Integer**|  | [optional] |
+| **booleanQuery** | **Boolean**|  | [optional] |
+| **stringQuery** | **String**|  | [optional] |
+
+### Return type
+
+ApiResponse<**String**>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
 
 
 ## testQueryStyleFormExplodeTrueArrayString

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -78,6 +78,97 @@ public class QueryApi {
   /**
    * Test query parameter(s)
    * Test query parameter(s)
+   * @param integerQuery  (optional)
+   * @param booleanQuery  (optional)
+   * @param stringQuery  (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testQueryIntegerBooleanString(Integer integerQuery, Boolean booleanQuery, String stringQuery) throws ApiException {
+    ApiResponse<String> localVarResponse = testQueryIntegerBooleanStringWithHttpInfo(integerQuery, booleanQuery, stringQuery);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param integerQuery  (optional)
+   * @param booleanQuery  (optional)
+   * @param stringQuery  (optional)
+   * @return ApiResponse&lt;String&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<String> testQueryIntegerBooleanStringWithHttpInfo(Integer integerQuery, Boolean booleanQuery, String stringQuery) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testQueryIntegerBooleanStringRequestBuilder(integerQuery, booleanQuery, stringQuery);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testQueryIntegerBooleanString", localVarResponse);
+        }
+        // for plain text response
+        InputStream responseBody = localVarResponse.body();
+        if (localVarResponse.headers().map().containsKey("Content-Type") &&
+                "text/plain".equalsIgnoreCase(localVarResponse.headers().map().get("Content-Type").get(0))) {
+          java.util.Scanner s = new java.util.Scanner(responseBody).useDelimiter("\\A");
+          String responseBodyText = s.hasNext() ? s.next() : "";
+          return new ApiResponse<String>(
+                  localVarResponse.statusCode(),
+                  localVarResponse.headers().map(),
+                  responseBodyText
+          );
+        } else {
+            throw new RuntimeException("Error! The response Content-Type is supposed to be `text/plain` but it's not: " + localVarResponse);
+        }
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testQueryIntegerBooleanStringRequestBuilder(Integer integerQuery, Boolean booleanQuery, String stringQuery) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/query/integer/boolean/string";
+
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("integer_query", integerQuery));
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("boolean_query", booleanQuery));
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("string_query", stringQuery));
+
+    if (!localVarQueryParams.isEmpty()) {
+      StringJoiner queryJoiner = new StringJoiner("&");
+      localVarQueryParams.forEach(p -> queryJoiner.add(p.getName() + '=' + p.getValue()));
+      localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath + '?' + queryJoiner.toString()));
+    } else {
+      localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+    }
+
+    localVarRequestBuilder.header("Accept", "text/plain");
+
+    localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
    * @param queryObject  (optional)
    * @return String
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -596,9 +596,11 @@ public class ApiClient extends JavaTimeFormatter {
     List<Pair> params = new ArrayList<Pair>();
 
     // preconditions
-    if (name == null || name.isEmpty() || value == null || value instanceof Collection) return params;
+    if (name == null || name.isEmpty() || value == null || value instanceof Collection) {
+      return params;
+    }
 
-    params.add(new Pair(name, parameterToString(value)));
+    params.add(new Pair(name, escapeString(parameterToString(value))));
     return params;
   }
 
@@ -845,6 +847,10 @@ public class ApiClient extends JavaTimeFormatter {
     if (mimeType == null || isJsonMime(mimeType)) {
       // Assume json if no mime type
       return objectMapper.readValue(entity.getContent(), valueType);
+    } else if ("text/plain".equalsIgnoreCase(mimeType)) {
+      // convert input stream to string
+      java.util.Scanner s = new java.util.Scanner(entity.getContent()).useDelimiter("\\A");
+      return (T) (s.hasNext() ? s.next() : "");
     } else {
       throw new ApiException(
           "Deserialization for content type '" + mimeType + "' not supported for type '" + valueType + "'",
@@ -933,7 +939,8 @@ public class ApiClient extends JavaTimeFormatter {
             url.append("&");
           }
           String value = parameterToString(param.getValue());
-          url.append(escapeString(param.getName())).append("=").append(escapeString(value));
+          // query parameter value already escaped as part of parameterToPair
+          url.append(escapeString(param.getName())).append("=").append(value);
         }
       }
     }


### PR DESCRIPTION
- Fixed query parameters (array, non-array) encoding in Java apache-httpclient
- Added tests

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

