### PR TITLE
[cpp-restsdk] Update CMake to fix cpprest linking for UNIX and few enhancements

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/cmake-lists.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/cmake-lists.mustache
@@ -12,6 +12,7 @@ cmake_minimum_required (VERSION 3.1)
 
 project({{{packageName}}})
 
+# Force -fPIC even if the project is configured for building a static library.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CXX_STANDARD_REQUIRED ON)
 
@@ -46,19 +47,20 @@ target_include_directories(${PROJECT_NAME}
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_directories(${PROJECT_NAME}
-    PRIVATE
-        ${Boost_LIBRARY_DIRS}
-)
-
 if (UNIX)
     message(STATUS "Building client library for Linux/Unix")
-
-    target_link_libraries(${PROJECT_NAME} PUBLIC cpprest ${Boost_LIBRARIES} crypto)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest)
+    else()
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest crypto)
+    endif()
 else()
     message(STATUS "Building client library for Windows")
-
-    target_link_libraries(${PROJECT_NAME} PUBLIC cpprestsdk::cpprest ${Boost_LIBRARIES} bcrypt)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest)
+    else()
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest bcrypt)
+    endif()
 endif()
 
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in

--- a/samples/client/petstore/cpp-restsdk/client/CMakeLists.txt
+++ b/samples/client/petstore/cpp-restsdk/client/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_minimum_required (VERSION 3.1)
 
 project(CppRestPetstoreClient)
 
+# Force -fPIC even if the project is configured for building a static library.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CXX_STANDARD_REQUIRED ON)
 
@@ -46,19 +47,20 @@ target_include_directories(${PROJECT_NAME}
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_directories(${PROJECT_NAME}
-    PRIVATE
-        ${Boost_LIBRARY_DIRS}
-)
-
 if (UNIX)
     message(STATUS "Building client library for Linux/Unix")
-
-    target_link_libraries(${PROJECT_NAME} PUBLIC cpprest ${Boost_LIBRARIES} crypto)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest)
+    else()
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest crypto)
+    endif()
 else()
     message(STATUS "Building client library for Windows")
-
-    target_link_libraries(${PROJECT_NAME} PUBLIC cpprestsdk::cpprest ${Boost_LIBRARIES} bcrypt)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest)
+    else()
+        target_link_libraries(${PROJECT_NAME} PUBLIC Boost::headers cpprestsdk::cpprest bcrypt)
+    endif()
 endif()
 
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi,

This fixes the generated CMakeLists.txt when used with [cpprestsdk](https://github.com/microsoft/cpprestsdk) framework (see the details below).

---------

The generated CMakeFiles.txt contains the following issues (tested with the latest cpprestsdk version available: `2.10.18`):
1. The public dependency on CppRestSDK is not matching the one from the generated CMake config files on Unix, but is correct for Windows.
Name mismatch: `cpprest` instead of `cpprestsdk::cpprest`.

2. The library links against the whole Boost libraries (usage of `Boost_LIBRARIES`) whereas it only needs `boost/algorithm/*.hpp` and `boost/uuid/*.hpp` which are headers-only. Boost CMake finder provides different targets (see more details in https://cmake.org/cmake/help/latest/module/FindBoost.html). The one for the headers is `Boost::headers`.

3. The project does not provide an option to build either a dynamic or static library. When compiling as shared libraries, `crypto` for Unix (and `bcrypt` for Windows) are not needed. Those are dependencies of CppRestSDK and should not even be here.

4. Regarding 3), in my experience, dynamic libraries are the most common way to distribute C++ libraries. I would recommend to set the default build to a shared library instead of a static one. Please let me know if you think that could be an issue, and why.

### Testing:

I tested the build of a OpenAPI C++ client with the dynamic and static configuration, and it succeeded without any error.

***
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Kindly review it! @ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd

Regards,
Sanjay