### PR TITLE
feat(typescript-axios): set `name` in constructor

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
@@ -54,8 +54,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/base.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/default/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/es6-target/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/base.ts
@@ -65,8 +65,8 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        this.name = "RequiredError"
     }
 }


### PR DESCRIPTION
### Introducing the following changes
- Sets the  `name` property inside class constructor
- Updated samples

### Motivation
The setting `noImplicitOverride` leads to a more robust codebase. However, setting this option resulted in an error since the class was overriding the `name` property without marking it as override.


### References
- [TS Documentation noImplicitOverride](https://www.typescriptlang.org/tsconfig#noImplicitOverride)
- https://github.com/OpenAPITools/openapi-generator/pull/14225 (First attempt to solve this issue)


### Pinging the commitee for visibility
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx  @macjohnny  @topce @akehir  @petejohansonxo @amakhrov  @davidgamero  @mkusaka 


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
