### PR TITLE
fix(typescript-axios): adds support for anyOf in typescript-axios generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
@@ -12,5 +12,5 @@ import { {{class}} } from './{{filename}}';{{/oneOf}}{{/hasOneOf}}{{^hasAllOf}}{
 // @ts-ignore
 import { {{class}} } from './{{filename}}';{{/imports}}{{/hasOneOf}}{{/hasAllOf}}{{/withSeparateModelsAndApi}}
 {{#models}}{{#model}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{#allOf}}{{#-first}}{{>modelAllOf}}{{/-first}}{{/allOf}}{{^isEnum}}{{^oneOf}}{{^allOf}}{{>modelGeneric}}{{/allOf}}{{/oneOf}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{#allOf}}{{#-first}}{{>modelAllOf}}{{/-first}}{{/allOf}}{{#anyOf}}{{#-first}}{{>modelAnyOf}}{{/-first}}{{/anyOf}}{{^isEnum}}{{^oneOf}}{{^allOf}}{{^anyOf}}{{>modelGeneric}}{{/anyOf}}{{/allOf}}{{/oneOf}}{{/isEnum}}
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelAnyOf.mustache
@@ -1,0 +1,15 @@
+/**
+ * @type {{classname}}{{#description}}
+ * {{{.}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#discriminator}}{{!
+
+discriminator with mapped models - TypeScript discriminating union
+}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{!
+
+discriminator only - fallback to not use the discriminator. Default model names are available but possibility of having null/nullable values could introduce more edge cases
+}}{{^mappedModels}}{{#anyOf}}{{{.}}}{{^-last}} | {{/-last}}{{/anyOf}}{{/mappedModels}}{{/discriminator}}{{!
+
+plain anyOf
+}}{{^discriminator}}{{#anyOf}}{{{.}}}{{^-last}} | {{/-last}}{{/anyOf}}{{/discriminator}};


### PR DESCRIPTION
Added support to render `anyOf` schemas into typescript-axios generator.
In scope of this MR the following files were modified/added:
-  `modules/openapi-generator/src/main/resources/typescript-axios/model.mustache` extended so it renders modelAnyOf template in case model contains `anyOf` declaration
- `modules/openapi-generator/src/main/resources/typescript-axios/modelAnyOf.mustache` a template to render models that contain `anyOf` declaration. It follows the same pattern as `oneOf` and `allOf` declarations.

Exmple of schema that had an issue:
```
{
    "type": "object",
    "anyOf": [
        {
            "additionalProperties": false,
            "required": ["type"],
            "properties": {
                "type": {
                    "type": "string",
                    "enum": ["audience"]
                },
                "uid": {
                    "type": "string"
                },
                "attributes": {
                    "type": "object",
                    "additionalProperties": false,
                    "properties": {
                        "name": {
                            "type": "string"
                        }
                    }
                }
            }
        },
        {
            "additionalProperties": false,
            "required": ["type"],
            "properties": {
                "type": {
                    "type": "string",
                    "enum": ["creative"]
                },
                "uid": {
                    "type": "string"
                },
                "attributes": {
                    "type": "object",
                    "additionalProperties": false,
                    "properties": {
                        "name": {
                            "type": "string"
                        },
                        "media_type": {
                            "type": "string",
                            "enum": ["video", "banner"]
                        }
                    }
                }
            }
        },
        {
            "additionalProperties": false,
            "required": ["type"],
            "properties": {
                "type": {
                    "type": "string",
                    "enum": ["set"]
                },
                "uid": {
                    "type": "string"
                },
                "attributes": {
                    "type": "object",
                    "additionalProperties": false,
                    "properties": {
                        "name": {
                            "type": "string"
                        },
                        "set_type": {
                            "type": "string",
                            "enum": ["geo.set.postal_code"]
                        },
                        "created_at": {
                            "type": "string"
                        },
                        "updated_at": {
                            "type": "string"
                        }
                    }
                }
            }
        }
    ]
}

```


@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
