### PR TITLE
Support GSON Decoder for Java Feign Generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -503,7 +503,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         }
 
         if (FEIGN.equals(getLibrary())) {
-            forceSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);
             supportingFiles.add(new SupportingFile("ParamExpander.mustache", invokerFolder, "ParamExpander.java"));
             supportingFiles.add(new SupportingFile("EncodingUtils.mustache", invokerFolder, "EncodingUtils.java"));
             supportingFiles.add(new SupportingFile("auth/DefaultApi20Impl.mustache", authFolder, "DefaultApi20Impl.java"));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -5,14 +5,15 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+{{#jackson}}
 import feign.okhttp.OkHttpClient;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 {{#openApiNullable}}
 import org.openapitools.jackson.nullable.JsonNullableModule;
 {{/openApiNullable}}
+{{/jackson}}
 {{#joda}}
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 {{/joda}}
@@ -21,8 +22,14 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.Feign;
 import feign.RequestInterceptor;
 import feign.form.FormEncoder;
+{{#jackson}}
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+{{/jackson}}
+{{#gson}}
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+{{/gson}}
 import feign.slf4j.Slf4jLogger;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.HttpBearerAuth;
@@ -53,6 +60,7 @@ public class ApiClient {
   public ApiClient() {
     objectMapper = createObjectMapper();
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
+    {{#gson}}
     feignBuilder = Feign.builder()
                 .client(new OkHttpClient())
                 .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
@@ -62,6 +70,17 @@ public class ApiClient {
                 .retryer(new Retryer.Default(0, 0, 2))
                 {{/hasOAuthMethods}}
                 .logger(new Slf4jLogger());
+    {{/jackson}}
+    {{#gson}}
+    feignBuilder = Feign.builder()
+        .encoder(new FormEncoder(new GsonEncoder()))
+        .decoder(new GsonDecoder())
+        {{#hasOAuthMethods}}
+        .errorDecoder(new ApiErrorDecoder())
+        .retryer(new Retryer.Default(0, 0, 2))
+        {{/hasOAuthMethods}}
+        .logger(new Slf4jLogger());
+    {{/gson}}
   }
 
   public ApiClient(String[] authNames) {


### PR DESCRIPTION
Adds an option for the feign generator to use the Gson Decoder instead of Jackson. Light touch.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov  @cbornet @jeff9finger  @karismann  @Zomzog @lwlee2608 
