### PR TITLE
Enable access token refresh

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
@@ -70,13 +70,17 @@ require '{{{gemName}}}'
   config.username = 'YOUR_USERNAME'
   config.password = 'YOUR_PASSWORD'{{/isBasicBasic}}{{#isBasicBearer}}
   # Configure Bearer authorization{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}: {{{name}}}
-  config.access_token = 'YOUR_BEARER_TOKEN'{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+  config.access_token = 'YOUR_BEARER_TOKEN'
+  # Configure a proc to get access tokens in lieu of the static access_token configuration
+  config.access_token_getter = -> { 'YOUR TOKEN GETTER PROC' } {{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
   # Configure API key authorization: {{{name}}}
   config.api_key['{{{name}}}'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
   # config.api_key_prefix['{{{name}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
   # Configure OAuth2 access token for authorization: {{{name}}}
-  config.access_token = 'YOUR ACCESS TOKEN'{{/isOAuth}}
+  config.access_token = 'YOUR ACCESS TOKEN'
+  # Configure a proc to get access tokens in lieu of the static access_token configuration
+  config.access_token_getter = -> { 'YOUR TOKEN GETTER PROC' } {{/isOAuth}}
 {{/authMethods}}end
 {{/hasAuthMethods}}
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -54,6 +54,11 @@ module {{moduleName}}
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -178,6 +183,12 @@ module {{moduleName}}
       end
     end
 
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
+    end
+
     # Gets Basic Auth token string
     def basic_auth_token
       'Basic ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
@@ -215,7 +226,7 @@ module {{moduleName}}
             format: '{{{.}}}',
             {{/bearerFormat}}
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
 {{/isBasicBearer}}
 {{/isBasic}}
@@ -225,7 +236,7 @@ module {{moduleName}}
             type: 'oauth2',
             in: 'header',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
 {{/isOAuth}}
 {{/authMethods}}

--- a/samples/client/petstore/ruby-autoload/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/configuration.rb
@@ -62,6 +62,11 @@ module Petstore
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -208,6 +213,12 @@ module Petstore
       end
     end
 
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
+    end
+
     # Gets Basic Auth token string
     def basic_auth_token
       'Basic ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
@@ -236,7 +247,7 @@ module Petstore
             in: 'header',
             format: 'JWT',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
         'http_basic_test' =>
           {
@@ -250,7 +261,7 @@ module Petstore
             type: 'oauth2',
             in: 'header',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
       }
     end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -62,6 +62,11 @@ module Petstore
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -211,6 +216,12 @@ module Petstore
       end
     end
 
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
+    end
+
     # Gets Basic Auth token string
     def basic_auth_token
       'Basic ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
@@ -239,7 +250,7 @@ module Petstore
             in: 'header',
             format: 'JWT',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
         'http_basic_test' =>
           {
@@ -253,7 +264,7 @@ module Petstore
             type: 'oauth2',
             in: 'header',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
       }
     end

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -62,6 +62,11 @@ module Petstore
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -208,6 +213,12 @@ module Petstore
       end
     end
 
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
+    end
+
     # Gets Basic Auth token string
     def basic_auth_token
       'Basic ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
@@ -236,7 +247,7 @@ module Petstore
             in: 'header',
             format: 'JWT',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
         'http_basic_test' =>
           {
@@ -250,7 +261,7 @@ module Petstore
             type: 'oauth2',
             in: 'header',
             key: 'Authorization',
-            value: "Bearer #{access_token}"
+            value: "Bearer #{access_token_with_refresh}"
           },
       }
     end

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/configuration.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/configuration.rb
@@ -62,6 +62,11 @@ module XAuthIDAlias
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -206,6 +211,12 @@ module XAuthIDAlias
       else
         key
       end
+    end
+
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
     end
 
     # Gets Basic Auth token string

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/configuration.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/configuration.rb
@@ -62,6 +62,11 @@ module DynamicServers
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -206,6 +211,12 @@ module DynamicServers
       else
         key
       end
+    end
+
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
     end
 
     # Gets Basic Auth token string

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
@@ -62,6 +62,11 @@ module Petstore
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
+    # Defines a Proc used to fetch or refresh access tokens (Bearer) used with OAuth2.
+    # Overrides the access_token if set
+    # @return [Proc]
+    attr_accessor :access_token_getter
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.
@@ -206,6 +211,12 @@ module Petstore
       else
         key
       end
+    end
+
+    # Gets access_token using access_token_getter or uses the static access_token
+    def access_token_with_refresh
+        return access_token if access_token_getter.nil?
+        access_token_getter.call
     end
 
     # Gets Basic Auth token string


### PR DESCRIPTION
- The client can now be optionally configured with an access token getter proc
- The proc overrides the the static access token if it is set
See: https://github.com/OpenAPITools/openapi-generator/issues/14068
ruby technical committee: @cliffano @zlx @autopp @wing328 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
