### PR TITLE
[ruby] Fix api_error.mustache to initialize message-only errors properly

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_error.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_error.mustache
@@ -24,6 +24,7 @@ module {{moduleName}}
         end
       else
         super arg
+        @message = arg
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api_error.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api_error.rb
@@ -32,6 +32,7 @@ module Petstore
         end
       else
         super arg
+        @message = arg
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_error.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_error.rb
@@ -32,6 +32,7 @@ module Petstore
         end
       else
         super arg
+        @message = arg
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/api_error.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_error.rb
@@ -32,6 +32,7 @@ module Petstore
         end
       else
         super arg
+        @message = arg
       end
     end
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_error.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_error.rb
@@ -32,6 +32,7 @@ module XAuthIDAlias
         end
       else
         super arg
+        @message = arg
       end
     end
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_error.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_error.rb
@@ -32,6 +32,7 @@ module DynamicServers
         end
       else
         super arg
+        @message = arg
       end
     end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_error.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_error.rb
@@ -32,6 +32,7 @@ module Petstore
         end
       else
         super arg
+        @message = arg
       end
     end
 


### PR DESCRIPTION
When generating message-only errors (e.g. `ApiError.new('Connection failed')`), the `@message` instance variable is not set so the `message` method returns the default message: 

https://github.com/OpenAPITools/openapi-generator/blob/d90c9a6f3bdabec92019e7a78837400c575c5735/modules/openapi-generator/src/main/resources/ruby-client/api_error.mustache#L36-L37

<img width="379" alt="Screenshot 2022-12-15 at 9 31 33 AM" src="https://user-images.githubusercontent.com/16286071/207887210-9883d0ec-b3b9-41c8-af48-cf29963feec9.png">

With this PR (setting the `@message` instance variable), the `message` method returns the expected message:

<img width="217" alt="Screenshot 2022-12-15 at 9 31 45 AM" src="https://user-images.githubusercontent.com/16286071/207887277-515d168f-4b7a-42e2-b6ee-457b1646864f.png">


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 