### PR TITLE
[Java][Spring] config option to use Jakarta EE package

### DIFF
--- a/bin/configs/spring-boot-beanvalidation.yaml
+++ b/bin/configs/spring-boot-beanvalidation.yaml
@@ -10,3 +10,4 @@ additionalProperties:
   useBeanValidation: true
   artifactId: spring-boot-beanvalidation
   hideGenerationTimestamp: "true"
+  useJakartaEe: "true"

--- a/docs/generators/groovy.md
+++ b/docs/generators/groovy.md
@@ -63,6 +63,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/groovy|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -93,8 +93,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |unhandledException|Declare operation methods to throw a generic exception and allow unhandled exceptions (useful for Spring `@ControllerAdvice` directives).| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useFeignClientUrl|Whether to generate Feign client with url parameter.| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useOptional|Use Optional container for optional parameters| |false|
-|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |true|
+|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |false|
 |useSpringController|Annotate the generated API as a Spring Controller| |false|
 |useSwaggerUI|Open the OpenApi specification in swagger-ui. Will also import and configure needed dependencies| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/java-helidon-client.md
+++ b/docs/generators/java-helidon-client.md
@@ -60,6 +60,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-helidon-server.md
+++ b/docs/generators/java-helidon-server.md
@@ -63,6 +63,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |useAbstractClass|Whether to generate abstract classes for REST API instead of interfaces.| |false|
 |useBeanValidation|Use Bean Validation| |false|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -65,6 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -80,6 +80,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|Client service name| |null|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useOptional|Use Optional container for optional parameters| |false|
 |visitable|Generate visitor for subtypes with a discriminator| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -82,6 +82,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |title|Client service name| |null|
 |useAuth|Whether to import authorization and to annotate controller methods accordingly| |true|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useOptional|Use Optional container for optional parameters| |false|
 |visitable|Generate visitor for subtypes with a discriminator| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|

--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -70,6 +70,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useTags|use tags for creating interface and controller classnames| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/java-pkmst.md
+++ b/docs/generators/java-pkmst.md
@@ -71,6 +71,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |springBootAdminUri|Spring-Boot URI| |null|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|server title name or client service name| |null|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |zipkinUri|Zipkin URI| |null|
 

--- a/docs/generators/java-play-framework.md
+++ b/docs/generators/java-play-framework.md
@@ -73,6 +73,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |title|server title name or client service name| |openapi-java-playframework|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useInterfaces|Makes the controllerImp implements an interface to facilitate automatic completion when updating from version x to y of your spec| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useSwaggerUI|Add a route to /api which show your documentation in swagger-ui. Will also import needed dependencies| |true|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |wrapCalls|Add a wrapper to each controller function to handle things like metrics, response modification, etc..| |true|

--- a/docs/generators/java-undertow-server.md
+++ b/docs/generators/java-undertow-server.md
@@ -65,6 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-vertx-web.md
+++ b/docs/generators/java-vertx-web.md
@@ -65,6 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-vertx.md
+++ b/docs/generators/java-vertx.md
@@ -67,6 +67,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |vertxSwaggerRouterVersion|Specify the version of the swagger router library| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -83,6 +83,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useAbstractionForFiles|Use alternative types instead of java.io.File to allow passing bytes without a file on disk. Available on resttemplate, webclient, libraries| |false|
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGzipFeature|Send gzip-encoded requests| |false|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped. Only jersey2, jersey3, native, okhttp-gson support this option.| |false|
 |usePlayWS|Use Play! Async HTTP client (Play WS API)| |false|
 |useReflectionEqualsHashCode|Use org.apache.commons.lang3.builder for equals and hashCode in the models. WARNING: This will fail under a security manager, unless the appropriate permissions are set up correctly and also there's potential performance impact.| |false|

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -76,6 +76,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
 |useTags|use tags for creating interface and controller classnames| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -68,6 +68,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGenericResponse|Use generic response| |false|
 |useGzipFeatureForTests|Use Gzip Feature for tests| |false|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useLoggingFeatureForTests|Use Logging Feature for tests| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -84,6 +84,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useGenericResponse|Use generic response| |false|
 |useGzipFeature|Use Gzip Feature| |false|
 |useGzipFeatureForTests|Use Gzip Feature for tests| |false|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useLoggingFeature|Use Logging Feature| |false|
 |useLoggingFeatureForTests|Use Logging Feature for tests| |false|
 |useMultipartFeature|Use Multipart Feature| |false|

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -79,6 +79,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useGenericResponse|Use generic response| |false|
 |useGzipFeature|Use Gzip Feature| |false|
 |useGzipFeatureForTests|Use Gzip Feature for tests| |false|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useLoggingFeature|Use Logging Feature| |false|
 |useLoggingFeatureForTests|Use Logging Feature for tests| |false|
 |useMultipartFeature|Use Multipart Feature| |false|

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -71,6 +71,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useTags|use tags for creating interface and controller classnames| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -70,6 +70,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useSwaggerFeature|Use dynamic Swagger generator| |false|
 |useTags|use tags for creating interface and controller classnames| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -70,6 +70,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useTags|use tags for creating interface and controller classnames| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -76,6 +76,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
 |useTags|use tags for creating interface and controller classnames| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -86,8 +86,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |unhandledException|Declare operation methods to throw a generic exception and allow unhandled exceptions (useful for Spring `@ControllerAdvice` directives).| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useFeignClientUrl|Whether to generate Feign client with url parameter.| |true|
+|useJakartaEe|Whether to use Jakarta EE or not| |false|
 |useOptional|Use Optional container for optional parameters| |false|
-|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |true|
+|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |false|
 |useSpringController|Annotate the generated API as a Spring Controller| |false|
 |useSwaggerUI|Open the OpenApi specification in swagger-ui. Will also import and configure needed dependencies| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6440,7 +6440,7 @@ public class DefaultCodegen implements CodegenConfig {
         return result;
     }
 
-    public void writePropertyBack(String propertyKey, boolean value) {
+    public void writePropertyBack(String propertyKey, Object value) {
         additionalProperties.put(propertyKey, value);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -83,6 +83,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String TEST_OUTPUT = "testOutput";
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
     public static final String IMPLICIT_HEADERS_REGEX = "implicitHeadersRegex";
+    public static final String USE_JAKARTA_EE = "useJakartaEe";
+    public static final String JAVAX_PACKAGE = "javaxPackage";
 
     public static final String CAMEL_CASE_DOLLAR_SIGN = "camelCaseDollarSign";
 
@@ -135,6 +137,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected AnnotationLibrary annotationLibrary;
     protected boolean implicitHeaders = false;
     protected String implicitHeadersRegex = null;
+    protected boolean useJakartaEe = false;
 
     protected boolean camelCaseDollarSign = false;
 
@@ -252,6 +255,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(CliOption.newBoolean(DISCRIMINATOR_CASE_SENSITIVE, "Whether the discriminator value lookup should be case-sensitive or not. This option only works for Java API client", discriminatorCaseSensitive));
         cliOptions.add(CliOption.newBoolean(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC, this.isHideGenerationTimestamp()));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
+        cliOptions.add(CliOption.newBoolean(USE_JAKARTA_EE, "Whether to use Jakarta EE or not", useJakartaEe));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use").defaultValue(this.getDateLibrary());
         Map<String, String> dateOptions = new HashMap<>();
@@ -385,6 +389,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             String additionalAnnotationsList = additionalProperties.get(ADDITIONAL_ENUM_TYPE_ANNOTATIONS).toString();
 
             this.setAdditionalEnumTypeAnnotations(Arrays.asList(additionalAnnotationsList.split(";")));
+        }
+
+        if (additionalProperties.containsKey(USE_JAKARTA_EE)) {
+            this.setUseJakartaEe(Boolean.parseBoolean(additionalProperties.get(USE_JAKARTA_EE).toString()));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
@@ -670,6 +678,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (additionalProperties.containsKey(TEST_OUTPUT)) {
             setOutputTestFolder(additionalProperties.get(TEST_OUTPUT).toString());
         }
+
+        applyJavaxPackage();
     }
 
     @Override
@@ -719,6 +729,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             this.additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         }
+    }
+
+    protected void applyJavaxPackage() {
+        writePropertyBack(JAVAX_PACKAGE, useJakartaEe ? "jakarta" : "javax");
     }
 
     @Override
@@ -2088,6 +2102,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     public void setAdditionalModelTypeAnnotations(final List<String> additionalModelTypeAnnotations) {
         this.additionalModelTypeAnnotations = additionalModelTypeAnnotations;
+    }
+
+    public void setUseJakartaEe(final boolean useJakartaEe) {
+        this.useJakartaEe = useJakartaEe;
     }
 
     public List<String> getAdditionalOneOfTypeAnnotations() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -105,7 +105,6 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String RETURN_SUCCESS_CODE = "returnSuccessCode";
     public static final String UNHANDLED_EXCEPTION_HANDLING = "unhandledException";
     public static final String USE_SPRING_BOOT3 = "useSpringBoot3";
-    public static final String USE_JAKARTA_EE = "useJakartaEe";
     public static final String REQUEST_MAPPING_OPTION = "requestMappingMode";
     public static final String USE_REQUEST_MAPPING_ON_CONTROLLER = "useRequestMappingOnController";
     public static final String USE_REQUEST_MAPPING_ON_INTERFACE = "useRequestMappingOnInterface";
@@ -243,7 +242,7 @@ public class SpringCodegen extends AbstractJavaCodegen
             useSwaggerUI));
         cliOptions.add(CliOption.newBoolean(USE_SPRING_BOOT3,
             "Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).",
-            useSwaggerUI));
+            useSpringBoot3));
 
         supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application.");
         supportedLibraries.put(SPRING_CLOUD_LIBRARY,
@@ -475,8 +474,8 @@ public class SpringCodegen extends AbstractJavaCodegen
                 throw new IllegalArgumentException(AnnotationLibrary.SWAGGER1.getPropertyName() + " is not supported with Spring Boot > 3.x");
             }
             writePropertyBack(USE_JAKARTA_EE, true);
-        } else {
-            writePropertyBack(USE_JAKARTA_EE, false);
+            setUseJakartaEe(true);
+            applyJavaxPackage();
         }
         writePropertyBack(USE_SPRING_BOOT3, isUseSpringBoot3());
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -50,14 +50,8 @@ import org.springframework.http.codec.multipart.Part;
 {{/reactive}}
 
 {{#useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.Valid;
-import javax.validation.constraints.*;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 import java.util.List;
 import java.util.Map;
@@ -72,12 +66,7 @@ import java.util.Optional;
 {{#async}}
 import java.util.concurrent.CompletableFuture;
 {{/async}}
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{>generatedAnnotation}}
 {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -36,25 +36,14 @@ import org.springframework.web.context.request.NativeWebRequest;
 {{/isDelegate}}
 
 {{#useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{>generatedAnnotation}}
 @Controller

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -20,12 +20,7 @@ import java.util.Optional;
 {{#async}}
 import java.util.concurrent.CompletableFuture;
 {{/async}}
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{#operations}}
 /**

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
@@ -1,11 +1,6 @@
 package {{apiPackage}};
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 /**
  * The exception that can be used to store the HTTP status code returned by an API response.

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiOriginFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiOriginFilter.mustache
@@ -2,17 +2,12 @@ package {{apiPackage}};
 
 import java.io.IOException;
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-import jakarta.servlet.*;
-import jakarta.servlet.http.HttpServletResponse;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
+import {{javaxPackage}}.servlet.*;
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 
 {{>generatedAnnotation}}
-public class ApiOriginFilter implements javax.servlet.Filter {
+public class ApiOriginFilter implements {{javaxPackage}}.servlet.Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiResponseMessage.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiResponseMessage.mustache
@@ -1,11 +1,6 @@
 package {{apiPackage}};
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 import javax.xml.bind.annotation.XmlTransient;
 
 {{>generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
@@ -12,12 +12,7 @@ import reactor.core.publisher.Mono;
 {{^reactive}}
 import org.springframework.web.context.request.NativeWebRequest;
 
-{{#useJakartaEe}}
-import jakarta.servlet.http.HttpServletResponse;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.servlet.http.HttpServletResponse;
-{{/useJakartaEe}}
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 import java.io.IOException;
 {{/reactive}}
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
@@ -12,22 +12,11 @@ import java.io.Serializable;
 {{/serializableModel}}
 import java.time.OffsetDateTime;
 {{#useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.Valid;
-import javax.validation.constraints.*;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{^useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.constraints.NotNull;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.constraints.NotNull;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.constraints.NotNull;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;
@@ -52,12 +41,7 @@ import org.springframework.hateoas.RepresentationModel;
 {{/parent}}
 
 import java.util.*;
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/notFoundException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/notFoundException.mustache
@@ -1,11 +1,6 @@
 package {{apiPackage}};
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{>generatedAnnotation}}
 public class NotFoundException extends ApiException {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/openapiDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/openapiDocumentationConfig.mustache
@@ -18,14 +18,8 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 {{#useOptional}}
 import java.util.Optional;
 {{/useOptional}}
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-import jakarta.servlet.ServletContext;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-import javax.servlet.ServletContext;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
+import {{javaxPackage}}.servlet.ServletContext;
 
 {{>generatedAnnotation}}
 @Configuration

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApiController.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApiController.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApiController.java
@@ -20,8 +20,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -15,12 +15,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Controller

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/ApiUtil.java
@@ -2,7 +2,7 @@ package org.openapitools.api;
 
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class ApiUtil {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApi.java
@@ -25,12 +25,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApiController.java
@@ -28,13 +28,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Controller

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -15,12 +15,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Controller

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApi.java
@@ -17,12 +17,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApiController.java
@@ -20,13 +20,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Controller

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApi.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApiController.java
@@ -19,13 +19,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Controller

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApi.java
@@ -17,12 +17,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApiController.java
@@ -20,13 +20,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Controller

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/SpringFoxConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/SpringFoxConfiguration.java
@@ -15,8 +15,8 @@ import springfox.documentation.spring.web.paths.RelativePathProvider;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import javax.annotation.Generated;
-import javax.servlet.ServletContext;
+import jakarta.annotation.Generated;
+import jakarta.servlet.ServletContext;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Configuration

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesAnyType

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesArray

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesBoolean

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -12,12 +12,12 @@ import java.util.List;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesClass

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesInteger

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -11,12 +11,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesNumber

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesObject

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * AdditionalPropertiesString

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
@@ -14,12 +14,12 @@ import org.openapitools.model.Cat;
 import org.openapitools.model.Dog;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Animal

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ArrayOfArrayOfNumberOnly

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ArrayOfNumberOnly

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayTest.java
@@ -11,12 +11,12 @@ import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ArrayTest

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCat.java
@@ -13,12 +13,12 @@ import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Cat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * BigCat

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -10,12 +10,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * BigCatAllOf

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Capitalization.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Capitalization

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
@@ -13,12 +13,12 @@ import org.openapitools.model.Animal;
 import org.openapitools.model.BigCat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Cat

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/CatAllOf.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * CatAllOf

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Category.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Category

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ClassModel.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Model for testing model with \&quot;_class\&quot; property

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Client.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Client

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Dog.java
@@ -12,12 +12,12 @@ import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Dog

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/DogAllOf.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * DogAllOf

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * EnumArrays

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
@@ -5,12 +5,12 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
@@ -11,12 +11,12 @@ import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * EnumTest

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/File.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Must be named &#x60;File&#x60; for test.

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * FileSchemaTestClass

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
@@ -15,12 +15,12 @@ import java.util.UUID;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * FormatTest

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * HasOnlyReadOnly

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
@@ -11,12 +11,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * MapTest

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -14,12 +14,12 @@ import org.openapitools.model.Animal;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * MixedPropertiesAndAdditionalPropertiesClass

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Model200Response.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Model for testing model name starting with number

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ModelApiResponse

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelList.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ModelList

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelReturn.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Model for testing reserved words

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Name.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Model for testing model name same as property name

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NumberOnly.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * NumberOnly

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
@@ -11,12 +11,12 @@ import java.time.OffsetDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Order

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * OuterComposite

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
@@ -5,12 +5,12 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -16,12 +16,12 @@ import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Pet

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * ReadOnlyFirst

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -9,12 +9,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * SpecialModelName

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Tag.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * Tag

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * TypeHolderDefault

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * TypeHolderExample

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/User.java
@@ -8,12 +8,12 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * User

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/XmlItem.java
@@ -11,12 +11,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.time.OffsetDateTime;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 
 import java.util.*;
-import javax.annotation.Generated;
+import jakarta.annotation.Generated;
 
 /**
  * XmlItem


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
New configuration option `useJakartaEe` to control whether to use `javax` or `jakarta` package. 

Please note that as for now this option is in `AbstractJavaCodegen` since should be applied to all java generators, but only Spring templates are updated to use it. I did this 1) to reduce scope of changes 2) so that reviewers can confirm whether this approach is fine


Should resolve https://github.com/OpenAPITools/openapi-generator/issues/14143

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
