### PR TITLE
[csharp-netcore][generichost] Fixes a bug in serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/EnumValueDataType.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/EnumValueDataType.mustache
@@ -1,0 +1,1 @@
+{{#isString}}{{^isNumeric}}string{{/isNumeric}}{{/isString}}{{#isNumeric}}{{#isLong}}long{{/isLong}}{{#isFloat}}float{{/isFloat}}{{#isDouble}}double{{/isDouble}}{{#isDecimal}}decimal{{/isDecimal}}{{^isLong}}{{^isFloat}}{{^isDouble}}{{^isDecimal}}int{{/isDecimal}}{{/isDouble}}{{/isFloat}}{{/isLong}}{{/isNumeric}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
@@ -194,17 +194,19 @@
             writer.WriteBoolean("{{baseName}}", {{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}});
             {{/isNullable}}
             {{/isBoolean}}
+            {{^isEnum}}
             {{#isNumeric}}
             {{#isNullable}}
             if ({{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}} != null)
-                writer.WriteNumber("{{baseName}}", (int){{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}}.Value);
+                writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}}.Value);
             else
                 writer.WriteNull("{{baseName}}");
             {{/isNullable}}
             {{^isNullable}}
-            writer.WriteNumber("{{baseName}}", (int){{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}});
+            writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}});
             {{/isNullable}}
             {{/isNumeric}}
+            {{/isEnum}}
             {{#isDate}}
             writer.WritePropertyName("{{baseName}}");
             JsonSerializer.Serialize(writer, {{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}}, options);
@@ -214,6 +216,9 @@
             JsonSerializer.Serialize(writer, {{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}}, options);
             {{/isDateTime}}
             {{#isEnum}}
+            {{#isNumeric}}
+            writer.WriteNumber("{{baseName}}", {{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}}ToJsonValue({{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}.{{name}}));
+            {{/isNumeric}}
             {{^isMap}}
             {{^isNumeric}}
             {{#isInnerEnum}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelEnum.mustache
@@ -67,7 +67,7 @@
             return null;
         }
 
-        public static {{#isString}}string{{/isString}}{{^isString}}int{{/isString}} ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
+        public static {{>EnumValueDataType}} ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
         {
             {{^isString}}
             return (int) value;
@@ -76,7 +76,7 @@
             {{#allowableValues}}
             {{#enumVars}}
             if (value == {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.{{name}})
-                return "{{value}}";
+                return {{^isNumeric}}"{{/isNumeric}}{{value}}{{^isNumeric}}"{{/isNumeric}};
 
             {{/enumVars}}
             {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
@@ -57,7 +57,7 @@
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public static {{#isString}}string{{/isString}}{{^isString}}int{{/isString}} {{datatypeWithEnum}}ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
+        public static {{>EnumValueDataType}} {{datatypeWithEnum}}ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
         {
             {{^isString}}
             return (int) value;
@@ -66,7 +66,7 @@
             {{#allowableValues}}
             {{#enumVars}}
             if (value == {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.{{name}})
-                return "{{value}}";
+                return {{^isNumeric}}"{{/isNumeric}}{{value}}{{^isNumeric}}"{{/isNumeric}};
 
             {{/enumVars}}
             {{/allowableValues}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("code", (int)apiResponse.Code);
+            writer.WriteNumber("code", apiResponse.Code);
             writer.WriteString("message", apiResponse.Message);
             writer.WriteString("type", apiResponse.Type);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("lengthCm", (int)banana.LengthCm);
+            writer.WriteNumber("lengthCm", banana.LengthCm);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("lengthCm", (int)bananaReq.LengthCm);
+            writer.WriteNumber("lengthCm", bananaReq.LengthCm);
             writer.WriteBoolean("sweet", bananaReq.Sweet);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
@@ -163,7 +163,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)category.Id);
+            writer.WriteNumber("id", category.Id);
             writer.WriteString("name", category.Name);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -225,13 +225,13 @@ namespace Org.OpenAPITools.Model
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public static string EnumNumberEnumToJsonValue(EnumNumberEnum value)
+        public static double EnumNumberEnumToJsonValue(EnumNumberEnum value)
         {
             if (value == EnumNumberEnum.NUMBER_1_DOT_1)
-                return "1.1";
+                return 1.1;
 
             if (value == EnumNumberEnum.NUMBER_MINUS_1_DOT_2)
-                return "-1.2";
+                return -1.2;
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
@@ -538,9 +538,9 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("enum_integer", (int)enumTest.EnumInteger);
-            writer.WriteNumber("enum_integer_only", (int)enumTest.EnumIntegerOnly);
-            writer.WriteNumber("enum_number", (int)enumTest.EnumNumber);
+            writer.WriteNumber("enum_integer", EnumTest.EnumIntegerEnumToJsonValue(enumTest.EnumInteger));
+            writer.WriteNumber("enum_integer_only", EnumTest.EnumIntegerOnlyEnumToJsonValue(enumTest.EnumIntegerOnly));
+            writer.WriteNumber("enum_number", EnumTest.EnumNumberEnumToJsonValue(enumTest.EnumNumber));
             var enumStringRawValue = EnumTest.EnumStringEnumToJsonValue(enumTest.EnumString);
             if (enumStringRawValue != null)
                 writer.WriteString("enum_string", enumStringRawValue);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -492,12 +492,12 @@ namespace Org.OpenAPITools.Model
             JsonSerializer.Serialize(writer, formatTest.DateTime, options);
             writer.WritePropertyName("decimal");
             JsonSerializer.Serialize(writer, formatTest.DecimalProperty, options);
-            writer.WriteNumber("double", (int)formatTest.DoubleProperty);
-            writer.WriteNumber("float", (int)formatTest.FloatProperty);
-            writer.WriteNumber("int32", (int)formatTest.Int32);
-            writer.WriteNumber("int64", (int)formatTest.Int64);
-            writer.WriteNumber("integer", (int)formatTest.Integer);
-            writer.WriteNumber("number", (int)formatTest.Number);
+            writer.WriteNumber("double", formatTest.DoubleProperty);
+            writer.WriteNumber("float", formatTest.FloatProperty);
+            writer.WriteNumber("int32", formatTest.Int32);
+            writer.WriteNumber("int64", formatTest.Int64);
+            writer.WriteNumber("integer", formatTest.Integer);
+            writer.WriteNumber("number", formatTest.Number);
             writer.WriteString("password", formatTest.Password);
             writer.WriteString("pattern_with_digits", formatTest.PatternWithDigits);
             writer.WriteString("pattern_with_digits_and_delimiter", formatTest.PatternWithDigitsAndDelimiter);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteString("class", model200Response.ClassProperty);
-            writer.WriteNumber("name", (int)model200Response.Name);
+            writer.WriteNumber("name", model200Response.Name);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
@@ -232,10 +232,10 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("name", (int)name.NameProperty);
+            writer.WriteNumber("name", name.NameProperty);
             writer.WriteString("property", name.Property);
-            writer.WriteNumber("snake_case", (int)name.SnakeCase);
-            writer.WriteNumber("123Number", (int)name._123Number);
+            writer.WriteNumber("snake_case", name.SnakeCase);
+            writer.WriteNumber("123Number", name._123Number);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -306,11 +306,11 @@ namespace Org.OpenAPITools.Model
             writer.WritePropertyName("datetime_prop");
             JsonSerializer.Serialize(writer, nullableClass.DatetimeProp, options);
             if (nullableClass.IntegerProp != null)
-                writer.WriteNumber("integer_prop", (int)nullableClass.IntegerProp.Value);
+                writer.WriteNumber("integer_prop", nullableClass.IntegerProp.Value);
             else
                 writer.WriteNull("integer_prop");
             if (nullableClass.NumberProp != null)
-                writer.WriteNumber("number_prop", (int)nullableClass.NumberProp.Value);
+                writer.WriteNumber("number_prop", nullableClass.NumberProp.Value);
             else
                 writer.WriteNull("number_prop");
             writer.WritePropertyName("object_and_items_nullable_prop");

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("JustNumber", (int)numberOnly.JustNumber);
+            writer.WriteNumber("JustNumber", numberOnly.JustNumber);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -202,7 +202,7 @@ namespace Org.OpenAPITools.Model
             JsonSerializer.Serialize(writer, objectWithDeprecatedFields.Bars, options);
             writer.WritePropertyName("deprecatedRef");
             JsonSerializer.Serialize(writer, objectWithDeprecatedFields.DeprecatedRef, options);
-            writer.WriteNumber("id", (int)objectWithDeprecatedFields.Id);
+            writer.WriteNumber("id", objectWithDeprecatedFields.Id);
             writer.WriteString("uuid", objectWithDeprecatedFields.Uuid);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
@@ -291,9 +291,9 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)order.Id);
-            writer.WriteNumber("petId", (int)order.PetId);
-            writer.WriteNumber("quantity", (int)order.Quantity);
+            writer.WriteNumber("id", order.Id);
+            writer.WriteNumber("petId", order.PetId);
+            writer.WriteNumber("quantity", order.Quantity);
             writer.WritePropertyName("shipDate");
             JsonSerializer.Serialize(writer, order.ShipDate, options);
             var statusRawValue = Order.StatusEnumToJsonValue(order.Status);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -180,7 +180,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteBoolean("my_boolean", outerComposite.MyBoolean);
-            writer.WriteNumber("my_number", (int)outerComposite.MyNumber);
+            writer.WriteNumber("my_number", outerComposite.MyNumber);
             writer.WriteString("my_string", outerComposite.MyString);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
@@ -293,7 +293,7 @@ namespace Org.OpenAPITools.Model
 
             writer.WritePropertyName("category");
             JsonSerializer.Serialize(writer, pet.Category, options);
-            writer.WriteNumber("id", (int)pet.Id);
+            writer.WriteNumber("id", pet.Id);
             writer.WriteString("name", pet.Name);
             writer.WritePropertyName("photoUrls");
             JsonSerializer.Serialize(writer, pet.PhotoUrls, options);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
@@ -147,7 +147,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("return", (int)_return.ReturnProperty);
+            writer.WriteNumber("return", _return.ReturnProperty);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -164,7 +164,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteString("_special_model.name_", specialModelName.SpecialModelNameProperty);
-            writer.WriteNumber("$special[property.name]", (int)specialModelName.SpecialPropertyName);
+            writer.WriteNumber("$special[property.name]", specialModelName.SpecialPropertyName);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
@@ -163,7 +163,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)tag.Id);
+            writer.WriteNumber("id", tag.Id);
             writer.WriteString("name", tag.Name);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
@@ -321,13 +321,13 @@ namespace Org.OpenAPITools.Model
 
             writer.WriteString("email", user.Email);
             writer.WriteString("firstName", user.FirstName);
-            writer.WriteNumber("id", (int)user.Id);
+            writer.WriteNumber("id", user.Id);
             writer.WriteString("lastName", user.LastName);
             writer.WritePropertyName("objectWithNoDeclaredProps");
             JsonSerializer.Serialize(writer, user.ObjectWithNoDeclaredProps, options);
             writer.WriteString("password", user.Password);
             writer.WriteString("phone", user.Phone);
-            writer.WriteNumber("userStatus", (int)user.UserStatus);
+            writer.WriteNumber("userStatus", user.UserStatus);
             writer.WriteString("username", user.Username);
             writer.WritePropertyName("anyTypeProp");
             JsonSerializer.Serialize(writer, user.AnyTypeProp, options);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("code", (int)apiResponse.Code);
+            writer.WriteNumber("code", apiResponse.Code);
             writer.WriteString("message", apiResponse.Message);
             writer.WriteString("type", apiResponse.Type);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("lengthCm", (int)banana.LengthCm);
+            writer.WriteNumber("lengthCm", banana.LengthCm);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("lengthCm", (int)bananaReq.LengthCm);
+            writer.WriteNumber("lengthCm", bananaReq.LengthCm);
             writer.WriteBoolean("sweet", bananaReq.Sweet);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)category.Id);
+            writer.WriteNumber("id", category.Id);
             writer.WriteString("name", category.Name);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -223,13 +223,13 @@ namespace Org.OpenAPITools.Model
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public static string EnumNumberEnumToJsonValue(EnumNumberEnum value)
+        public static double EnumNumberEnumToJsonValue(EnumNumberEnum value)
         {
             if (value == EnumNumberEnum.NUMBER_1_DOT_1)
-                return "1.1";
+                return 1.1;
 
             if (value == EnumNumberEnum.NUMBER_MINUS_1_DOT_2)
-                return "-1.2";
+                return -1.2;
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
@@ -536,9 +536,9 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("enum_integer", (int)enumTest.EnumInteger);
-            writer.WriteNumber("enum_integer_only", (int)enumTest.EnumIntegerOnly);
-            writer.WriteNumber("enum_number", (int)enumTest.EnumNumber);
+            writer.WriteNumber("enum_integer", EnumTest.EnumIntegerEnumToJsonValue(enumTest.EnumInteger));
+            writer.WriteNumber("enum_integer_only", EnumTest.EnumIntegerOnlyEnumToJsonValue(enumTest.EnumIntegerOnly));
+            writer.WriteNumber("enum_number", EnumTest.EnumNumberEnumToJsonValue(enumTest.EnumNumber));
             var enumStringRawValue = EnumTest.EnumStringEnumToJsonValue(enumTest.EnumString);
             if (enumStringRawValue != null)
                 writer.WriteString("enum_string", enumStringRawValue);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -490,12 +490,12 @@ namespace Org.OpenAPITools.Model
             JsonSerializer.Serialize(writer, formatTest.DateTime, options);
             writer.WritePropertyName("decimal");
             JsonSerializer.Serialize(writer, formatTest.DecimalProperty, options);
-            writer.WriteNumber("double", (int)formatTest.DoubleProperty);
-            writer.WriteNumber("float", (int)formatTest.FloatProperty);
-            writer.WriteNumber("int32", (int)formatTest.Int32);
-            writer.WriteNumber("int64", (int)formatTest.Int64);
-            writer.WriteNumber("integer", (int)formatTest.Integer);
-            writer.WriteNumber("number", (int)formatTest.Number);
+            writer.WriteNumber("double", formatTest.DoubleProperty);
+            writer.WriteNumber("float", formatTest.FloatProperty);
+            writer.WriteNumber("int32", formatTest.Int32);
+            writer.WriteNumber("int64", formatTest.Int64);
+            writer.WriteNumber("integer", formatTest.Integer);
+            writer.WriteNumber("number", formatTest.Number);
             writer.WriteString("password", formatTest.Password);
             writer.WriteString("pattern_with_digits", formatTest.PatternWithDigits);
             writer.WriteString("pattern_with_digits_and_delimiter", formatTest.PatternWithDigitsAndDelimiter);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteString("class", model200Response.ClassProperty);
-            writer.WriteNumber("name", (int)model200Response.Name);
+            writer.WriteNumber("name", model200Response.Name);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
@@ -230,10 +230,10 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("name", (int)name.NameProperty);
+            writer.WriteNumber("name", name.NameProperty);
             writer.WriteString("property", name.Property);
-            writer.WriteNumber("snake_case", (int)name.SnakeCase);
-            writer.WriteNumber("123Number", (int)name._123Number);
+            writer.WriteNumber("snake_case", name.SnakeCase);
+            writer.WriteNumber("123Number", name._123Number);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -304,11 +304,11 @@ namespace Org.OpenAPITools.Model
             writer.WritePropertyName("datetime_prop");
             JsonSerializer.Serialize(writer, nullableClass.DatetimeProp, options);
             if (nullableClass.IntegerProp != null)
-                writer.WriteNumber("integer_prop", (int)nullableClass.IntegerProp.Value);
+                writer.WriteNumber("integer_prop", nullableClass.IntegerProp.Value);
             else
                 writer.WriteNull("integer_prop");
             if (nullableClass.NumberProp != null)
-                writer.WriteNumber("number_prop", (int)nullableClass.NumberProp.Value);
+                writer.WriteNumber("number_prop", nullableClass.NumberProp.Value);
             else
                 writer.WriteNull("number_prop");
             writer.WritePropertyName("object_and_items_nullable_prop");

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("JustNumber", (int)numberOnly.JustNumber);
+            writer.WriteNumber("JustNumber", numberOnly.JustNumber);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
             JsonSerializer.Serialize(writer, objectWithDeprecatedFields.Bars, options);
             writer.WritePropertyName("deprecatedRef");
             JsonSerializer.Serialize(writer, objectWithDeprecatedFields.DeprecatedRef, options);
-            writer.WriteNumber("id", (int)objectWithDeprecatedFields.Id);
+            writer.WriteNumber("id", objectWithDeprecatedFields.Id);
             writer.WriteString("uuid", objectWithDeprecatedFields.Uuid);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
@@ -289,9 +289,9 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)order.Id);
-            writer.WriteNumber("petId", (int)order.PetId);
-            writer.WriteNumber("quantity", (int)order.Quantity);
+            writer.WriteNumber("id", order.Id);
+            writer.WriteNumber("petId", order.PetId);
+            writer.WriteNumber("quantity", order.Quantity);
             writer.WritePropertyName("shipDate");
             JsonSerializer.Serialize(writer, order.ShipDate, options);
             var statusRawValue = Order.StatusEnumToJsonValue(order.Status);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteBoolean("my_boolean", outerComposite.MyBoolean);
-            writer.WriteNumber("my_number", (int)outerComposite.MyNumber);
+            writer.WriteNumber("my_number", outerComposite.MyNumber);
             writer.WriteString("my_string", outerComposite.MyString);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -291,7 +291,7 @@ namespace Org.OpenAPITools.Model
 
             writer.WritePropertyName("category");
             JsonSerializer.Serialize(writer, pet.Category, options);
-            writer.WriteNumber("id", (int)pet.Id);
+            writer.WriteNumber("id", pet.Id);
             writer.WriteString("name", pet.Name);
             writer.WritePropertyName("photoUrls");
             JsonSerializer.Serialize(writer, pet.PhotoUrls, options);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("return", (int)_return.ReturnProperty);
+            writer.WriteNumber("return", _return.ReturnProperty);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteString("_special_model.name_", specialModelName.SpecialModelNameProperty);
-            writer.WriteNumber("$special[property.name]", (int)specialModelName.SpecialPropertyName);
+            writer.WriteNumber("$special[property.name]", specialModelName.SpecialPropertyName);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)tag.Id);
+            writer.WriteNumber("id", tag.Id);
             writer.WriteString("name", tag.Name);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
@@ -319,13 +319,13 @@ namespace Org.OpenAPITools.Model
 
             writer.WriteString("email", user.Email);
             writer.WriteString("firstName", user.FirstName);
-            writer.WriteNumber("id", (int)user.Id);
+            writer.WriteNumber("id", user.Id);
             writer.WriteString("lastName", user.LastName);
             writer.WritePropertyName("objectWithNoDeclaredProps");
             JsonSerializer.Serialize(writer, user.ObjectWithNoDeclaredProps, options);
             writer.WriteString("password", user.Password);
             writer.WriteString("phone", user.Phone);
-            writer.WriteNumber("userStatus", (int)user.UserStatus);
+            writer.WriteNumber("userStatus", user.UserStatus);
             writer.WriteString("username", user.Username);
             writer.WritePropertyName("anyTypeProp");
             JsonSerializer.Serialize(writer, user.AnyTypeProp, options);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("code", (int)apiResponse.Code);
+            writer.WriteNumber("code", apiResponse.Code);
             writer.WriteString("message", apiResponse.Message);
             writer.WriteString("type", apiResponse.Type);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("lengthCm", (int)banana.LengthCm);
+            writer.WriteNumber("lengthCm", banana.LengthCm);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("lengthCm", (int)bananaReq.LengthCm);
+            writer.WriteNumber("lengthCm", bananaReq.LengthCm);
             writer.WriteBoolean("sweet", bananaReq.Sweet);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)category.Id);
+            writer.WriteNumber("id", category.Id);
             writer.WriteString("name", category.Name);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -223,13 +223,13 @@ namespace Org.OpenAPITools.Model
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public static string EnumNumberEnumToJsonValue(EnumNumberEnum value)
+        public static double EnumNumberEnumToJsonValue(EnumNumberEnum value)
         {
             if (value == EnumNumberEnum.NUMBER_1_DOT_1)
-                return "1.1";
+                return 1.1;
 
             if (value == EnumNumberEnum.NUMBER_MINUS_1_DOT_2)
-                return "-1.2";
+                return -1.2;
 
             throw new NotImplementedException($"Value could not be handled: '{value}'");
         }
@@ -536,9 +536,9 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("enum_integer", (int)enumTest.EnumInteger);
-            writer.WriteNumber("enum_integer_only", (int)enumTest.EnumIntegerOnly);
-            writer.WriteNumber("enum_number", (int)enumTest.EnumNumber);
+            writer.WriteNumber("enum_integer", EnumTest.EnumIntegerEnumToJsonValue(enumTest.EnumInteger));
+            writer.WriteNumber("enum_integer_only", EnumTest.EnumIntegerOnlyEnumToJsonValue(enumTest.EnumIntegerOnly));
+            writer.WriteNumber("enum_number", EnumTest.EnumNumberEnumToJsonValue(enumTest.EnumNumber));
             var enumStringRawValue = EnumTest.EnumStringEnumToJsonValue(enumTest.EnumString);
             if (enumStringRawValue != null)
                 writer.WriteString("enum_string", enumStringRawValue);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -490,12 +490,12 @@ namespace Org.OpenAPITools.Model
             JsonSerializer.Serialize(writer, formatTest.DateTime, options);
             writer.WritePropertyName("decimal");
             JsonSerializer.Serialize(writer, formatTest.DecimalProperty, options);
-            writer.WriteNumber("double", (int)formatTest.DoubleProperty);
-            writer.WriteNumber("float", (int)formatTest.FloatProperty);
-            writer.WriteNumber("int32", (int)formatTest.Int32);
-            writer.WriteNumber("int64", (int)formatTest.Int64);
-            writer.WriteNumber("integer", (int)formatTest.Integer);
-            writer.WriteNumber("number", (int)formatTest.Number);
+            writer.WriteNumber("double", formatTest.DoubleProperty);
+            writer.WriteNumber("float", formatTest.FloatProperty);
+            writer.WriteNumber("int32", formatTest.Int32);
+            writer.WriteNumber("int64", formatTest.Int64);
+            writer.WriteNumber("integer", formatTest.Integer);
+            writer.WriteNumber("number", formatTest.Number);
             writer.WriteString("password", formatTest.Password);
             writer.WriteString("pattern_with_digits", formatTest.PatternWithDigits);
             writer.WriteString("pattern_with_digits_and_delimiter", formatTest.PatternWithDigitsAndDelimiter);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteString("class", model200Response.ClassProperty);
-            writer.WriteNumber("name", (int)model200Response.Name);
+            writer.WriteNumber("name", model200Response.Name);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
@@ -230,10 +230,10 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("name", (int)name.NameProperty);
+            writer.WriteNumber("name", name.NameProperty);
             writer.WriteString("property", name.Property);
-            writer.WriteNumber("snake_case", (int)name.SnakeCase);
-            writer.WriteNumber("123Number", (int)name._123Number);
+            writer.WriteNumber("snake_case", name.SnakeCase);
+            writer.WriteNumber("123Number", name._123Number);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -304,11 +304,11 @@ namespace Org.OpenAPITools.Model
             writer.WritePropertyName("datetime_prop");
             JsonSerializer.Serialize(writer, nullableClass.DatetimeProp, options);
             if (nullableClass.IntegerProp != null)
-                writer.WriteNumber("integer_prop", (int)nullableClass.IntegerProp.Value);
+                writer.WriteNumber("integer_prop", nullableClass.IntegerProp.Value);
             else
                 writer.WriteNull("integer_prop");
             if (nullableClass.NumberProp != null)
-                writer.WriteNumber("number_prop", (int)nullableClass.NumberProp.Value);
+                writer.WriteNumber("number_prop", nullableClass.NumberProp.Value);
             else
                 writer.WriteNull("number_prop");
             writer.WritePropertyName("object_and_items_nullable_prop");

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("JustNumber", (int)numberOnly.JustNumber);
+            writer.WriteNumber("JustNumber", numberOnly.JustNumber);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -200,7 +200,7 @@ namespace Org.OpenAPITools.Model
             JsonSerializer.Serialize(writer, objectWithDeprecatedFields.Bars, options);
             writer.WritePropertyName("deprecatedRef");
             JsonSerializer.Serialize(writer, objectWithDeprecatedFields.DeprecatedRef, options);
-            writer.WriteNumber("id", (int)objectWithDeprecatedFields.Id);
+            writer.WriteNumber("id", objectWithDeprecatedFields.Id);
             writer.WriteString("uuid", objectWithDeprecatedFields.Uuid);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
@@ -289,9 +289,9 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)order.Id);
-            writer.WriteNumber("petId", (int)order.PetId);
-            writer.WriteNumber("quantity", (int)order.Quantity);
+            writer.WriteNumber("id", order.Id);
+            writer.WriteNumber("petId", order.PetId);
+            writer.WriteNumber("quantity", order.Quantity);
             writer.WritePropertyName("shipDate");
             JsonSerializer.Serialize(writer, order.ShipDate, options);
             var statusRawValue = Order.StatusEnumToJsonValue(order.Status);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteBoolean("my_boolean", outerComposite.MyBoolean);
-            writer.WriteNumber("my_number", (int)outerComposite.MyNumber);
+            writer.WriteNumber("my_number", outerComposite.MyNumber);
             writer.WriteString("my_string", outerComposite.MyString);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -291,7 +291,7 @@ namespace Org.OpenAPITools.Model
 
             writer.WritePropertyName("category");
             JsonSerializer.Serialize(writer, pet.Category, options);
-            writer.WriteNumber("id", (int)pet.Id);
+            writer.WriteNumber("id", pet.Id);
             writer.WriteString("name", pet.Name);
             writer.WritePropertyName("photoUrls");
             JsonSerializer.Serialize(writer, pet.PhotoUrls, options);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("return", (int)_return.ReturnProperty);
+            writer.WriteNumber("return", _return.ReturnProperty);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
             writer.WriteStartObject();
 
             writer.WriteString("_special_model.name_", specialModelName.SpecialModelNameProperty);
-            writer.WriteNumber("$special[property.name]", (int)specialModelName.SpecialPropertyName);
+            writer.WriteNumber("$special[property.name]", specialModelName.SpecialPropertyName);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         {
             writer.WriteStartObject();
 
-            writer.WriteNumber("id", (int)tag.Id);
+            writer.WriteNumber("id", tag.Id);
             writer.WriteString("name", tag.Name);
 
             writer.WriteEndObject();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
@@ -319,13 +319,13 @@ namespace Org.OpenAPITools.Model
 
             writer.WriteString("email", user.Email);
             writer.WriteString("firstName", user.FirstName);
-            writer.WriteNumber("id", (int)user.Id);
+            writer.WriteNumber("id", user.Id);
             writer.WriteString("lastName", user.LastName);
             writer.WritePropertyName("objectWithNoDeclaredProps");
             JsonSerializer.Serialize(writer, user.ObjectWithNoDeclaredProps, options);
             writer.WriteString("password", user.Password);
             writer.WriteString("phone", user.Phone);
-            writer.WriteNumber("userStatus", (int)user.UserStatus);
+            writer.WriteNumber("userStatus", user.UserStatus);
             writer.WriteString("username", user.Username);
             writer.WritePropertyName("anyTypeProp");
             JsonSerializer.Serialize(writer, user.AnyTypeProp, options);


### PR DESCRIPTION
Number types were being cast to integer while serializing, causing undesired rounding.
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
