### PR TITLE
[BUG][Swift] fix decimal encoding referencing not existing extension method "encodeToJSON" 

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
@@ -35,6 +35,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -34,6 +34,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Extensions.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -33,6 +33,10 @@ extension Double: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }
 
+extension Decimal: JSONEncodable {
+    func encodeToJSON() -> Any { self }
+}
+
 extension String: JSONEncodable {
     func encodeToJSON() -> Any { self }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fixes https://github.com/OpenAPITools/openapi-generator/issues/14306

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
