### PR TITLE
[Java] internal config option to use jakarta or javax package

### DIFF
--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -94,7 +94,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useFeignClientUrl|Whether to generate Feign client with url parameter.| |true|
 |useOptional|Use Optional container for optional parameters| |false|
-|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |true|
+|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |false|
 |useSpringController|Annotate the generated API as a Spring Controller| |false|
 |useSwaggerUI|Open the OpenApi specification in swagger-ui. Will also import and configure needed dependencies| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -87,7 +87,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useFeignClientUrl|Whether to generate Feign client with url parameter.| |true|
 |useOptional|Use Optional container for optional parameters| |false|
-|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |true|
+|useSpringBoot3|Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).| |false|
 |useSpringController|Annotate the generated API as a Spring Controller| |false|
 |useSwaggerUI|Open the OpenApi specification in swagger-ui. Will also import and configure needed dependencies| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6455,7 +6455,7 @@ public class DefaultCodegen implements CodegenConfig {
         return result;
     }
 
-    public void writePropertyBack(String propertyKey, boolean value) {
+    public void writePropertyBack(String propertyKey, Object value) {
         additionalProperties.put(propertyKey, value);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -83,6 +83,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String TEST_OUTPUT = "testOutput";
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
     public static final String IMPLICIT_HEADERS_REGEX = "implicitHeadersRegex";
+    public static final String JAVAX_PACKAGE = "javaxPackage";
 
     public static final String CAMEL_CASE_DOLLAR_SIGN = "camelCaseDollarSign";
 
@@ -670,6 +671,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (additionalProperties.containsKey(TEST_OUTPUT)) {
             setOutputTestFolder(additionalProperties.get(TEST_OUTPUT).toString());
         }
+
+        applyJavaxPackage();
     }
 
     @Override
@@ -719,6 +722,14 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             this.additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         }
+    }
+
+    protected void applyJavaxPackage() {
+        writePropertyBack(JAVAX_PACKAGE, "javax");
+    }
+
+    protected void applyJakartaPackage() {
+        writePropertyBack(JAVAX_PACKAGE, "jakarta");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -576,7 +576,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             // The flag below should be set for all Java libraries, but the templates need to be ported
             // one by one for each library.
             supportsAdditionalPropertiesWithComposedSchema = true;
-
+            applyJakartaPackage();
         } else if (NATIVE.equals(getLibrary())) {
             supportingFiles.add(new SupportingFile("ApiResponse.mustache", invokerFolder, "ApiResponse.java"));
             supportingFiles.add(new SupportingFile("JSON.mustache", invokerFolder, "JSON.java"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -105,7 +105,6 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String RETURN_SUCCESS_CODE = "returnSuccessCode";
     public static final String UNHANDLED_EXCEPTION_HANDLING = "unhandledException";
     public static final String USE_SPRING_BOOT3 = "useSpringBoot3";
-    public static final String USE_JAKARTA_EE = "useJakartaEe";
     public static final String REQUEST_MAPPING_OPTION = "requestMappingMode";
     public static final String USE_REQUEST_MAPPING_ON_CONTROLLER = "useRequestMappingOnController";
     public static final String USE_REQUEST_MAPPING_ON_INTERFACE = "useRequestMappingOnInterface";
@@ -243,7 +242,7 @@ public class SpringCodegen extends AbstractJavaCodegen
             useSwaggerUI));
         cliOptions.add(CliOption.newBoolean(USE_SPRING_BOOT3,
             "Generate code and provide dependencies for use with Spring Boot 3.x. (Use jakarta instead of javax in imports).",
-            useSwaggerUI));
+            useSpringBoot3));
 
         supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application.");
         supportedLibraries.put(SPRING_CLOUD_LIBRARY,
@@ -474,9 +473,7 @@ public class SpringCodegen extends AbstractJavaCodegen
             if (AnnotationLibrary.SWAGGER1.equals(getAnnotationLibrary())) {
                 throw new IllegalArgumentException(AnnotationLibrary.SWAGGER1.getPropertyName() + " is not supported with Spring Boot > 3.x");
             }
-            writePropertyBack(USE_JAKARTA_EE, true);
-        } else {
-            writePropertyBack(USE_JAKARTA_EE, false);
+            applyJakartaPackage();
         }
         writePropertyBack(USE_SPRING_BOOT3, isUseSpringBoot3());
 

--- a/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
@@ -21,9 +21,9 @@ import com.sun.jersey.api.client.WebResource.Builder;
 import com.sun.jersey.multipart.FormDataMultiPart;
 import com.sun.jersey.multipart.file.FileDataBodyPart;
 
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.core.Cookie;
+import {{javaxPackage}}.ws.rs.core.Response.Status.Family;
+import {{javaxPackage}}.ws.rs.core.MediaType;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/modules/openapi-generator/src/main/resources/Java/BeanValidationException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/BeanValidationException.mustache
@@ -2,8 +2,8 @@ package {{invokerPackage}};
 
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ValidationException;
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.ValidationException;
 
 public class BeanValidationException extends ValidationException {
     /**

--- a/modules/openapi-generator/src/main/resources/Java/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/api.mustache
@@ -14,7 +14,7 @@ import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.json.Json;
 
-import javax.ws.rs.core.UriBuilder;
+import {{javaxPackage}}.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
@@ -6,7 +6,7 @@ import {{invokerPackage}}.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1,15 +1,15 @@
 package {{invokerPackage}};
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.client.Client;
+import {{javaxPackage}}.ws.rs.client.ClientBuilder;
+import {{javaxPackage}}.ws.rs.client.Entity;
+import {{javaxPackage}}.ws.rs.client.Invocation;
+import {{javaxPackage}}.ws.rs.client.WebTarget;
+import {{javaxPackage}}.ws.rs.core.Form;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
 
 {{#hasOAuthMethods}}
 import com.github.scribejava.core.model.OAuth2AccessToken;
@@ -27,9 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.net.URI;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import {{javaxPackage}}.net.ssl.SSLContext;
+import {{javaxPackage}}.net.ssl.TrustManager;
+import {{javaxPackage}}.net.ssl.X509TrustManager;
 import java.security.cert.X509Certificate;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -251,7 +251,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Getter for the field <code>httpClient</code>.</p>
    *
-   * @return a {@link javax.ws.rs.client.Client} object.
+   * @return a {@link {{javaxPackage}}.ws.rs.client.Client} object.
    */
   public Client getHttpClient() {
     return httpClient;
@@ -260,7 +260,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Setter for the field <code>httpClient</code>.</p>
    *
-   * @param httpClient a {@link javax.ws.rs.client.Client} object.
+   * @param httpClient a {@link {{javaxPackage}}.ws.rs.client.Client} object.
    * @return a {@link org.openapitools.client.ApiClient} object.
    */
   public ApiClient setHttpClient(Client httpClient) {
@@ -1098,7 +1098,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Prepare the file for download from the response.</p>
    *
-   * @param response a {@link javax.ws.rs.core.Response} object.
+   * @param response a {@link {{javaxPackage}}.ws.rs.core.Response} object.
    * @return a {@link java.io.File} object.
    * @throws java.io.IOException if any.
    */
@@ -1387,7 +1387,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * To completely disable certificate validation (at your own risk), you can
    * override this method and invoke disableCertificateValidation(clientBuilder).
    *
-   * @param clientBuilder a {@link javax.ws.rs.client.ClientBuilder} object.
+   * @param clientBuilder a {@link {{javaxPackage}}.ws.rs.client.ClientBuilder} object.
    */
   protected void customizeClientBuilder(ClientBuilder clientBuilder) {
     // No-op extension point
@@ -1399,7 +1399,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * Please note that trusting all certificates is extremely risky.
    * This may be useful in a development environment with self-signed certificates.
    *
-   * @param clientBuilder a {@link javax.ws.rs.client.ClientBuilder} object.
+   * @param clientBuilder a {@link {{javaxPackage}}.ws.rs.client.ClientBuilder} object.
    * @throws java.security.KeyManagementException if any.
    * @throws java.security.NoSuchAlgorithmException if any.
    */
@@ -1426,7 +1426,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Build the response headers.</p>
    *
-   * @param response a {@link javax.ws.rs.core.Response} object.
+   * @param response a {@link {{javaxPackage}}.ws.rs.core.Response} object.
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/JSON.mustache
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.ext.ContextResolver;
 
 {{>generatedAnnotation}}
 public class JSON implements ContextResolver<ObjectMapper> {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -1,5 +1,5 @@
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -6,7 +6,7 @@ import {{invokerPackage}}.ApiResponse;
 import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 {{#imports}}import {{import}};
 {{/imports}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/OAuth.mustache
@@ -10,7 +10,7 @@ import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.oauth.OAuth20Service;
 
-import javax.ws.rs.core.UriBuilder;
+import {{javaxPackage}}.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/model.mustache
@@ -36,15 +36,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jackson}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 {{#parcelableModel}}
 import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -1,5 +1,5 @@
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -206,14 +206,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{/deprecated}}
 {{#required}}
 {{#isNullable}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/isNullable}}
 {{^isNullable}}
-  @javax.annotation.Nonnull
+  @{{javaxPackage}}.annotation.Nonnull
 {{/isNullable}}
 {{/required}}
 {{^required}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/required}}
 {{#useBeanValidation}}
 {{>beanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/AbstractOpenApiSchema.mustache
@@ -6,7 +6,7 @@ import {{invokerPackage}}.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import jakarta.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -1,15 +1,15 @@
 package {{invokerPackage}};
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Form;
-import jakarta.ws.rs.core.GenericType;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.client.Client;
+import {{javaxPackage}}.ws.rs.client.ClientBuilder;
+import {{javaxPackage}}.ws.rs.client.Entity;
+import {{javaxPackage}}.ws.rs.client.Invocation;
+import {{javaxPackage}}.ws.rs.client.WebTarget;
+import {{javaxPackage}}.ws.rs.core.Form;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
 
 {{#hasOAuthMethods}}
 import com.github.scribejava.core.model.OAuth2AccessToken;
@@ -251,7 +251,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Getter for the field <code>httpClient</code>.</p>
    *
-   * @return a {@link jakarta.ws.rs.client.Client} object.
+   * @return a {@link {{javaxPackage}}.ws.rs.client.Client} object.
    */
   public Client getHttpClient() {
     return httpClient;
@@ -260,7 +260,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Setter for the field <code>httpClient</code>.</p>
    *
-   * @param httpClient a {@link jakarta.ws.rs.client.Client} object.
+   * @param httpClient a {@link {{javaxPackage}}.ws.rs.client.Client} object.
    * @return a {@link org.openapitools.client.ApiClient} object.
    */
   public ApiClient setHttpClient(Client httpClient) {
@@ -1098,7 +1098,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Prepare the file for download from the response.</p>
    *
-   * @param response a {@link jakarta.ws.rs.core.Response} object.
+   * @param response a {@link {{javaxPackage}}.ws.rs.core.Response} object.
    * @return a {@link java.io.File} object.
    * @throws java.io.IOException if any.
    */
@@ -1382,7 +1382,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * To completely disable certificate validation (at your own risk), you can
    * override this method and invoke disableCertificateValidation(clientBuilder).
    *
-   * @param clientBuilder a {@link jakarta.ws.rs.client.ClientBuilder} object.
+   * @param clientBuilder a {@link {{javaxPackage}}.ws.rs.client.ClientBuilder} object.
    */
   protected void customizeClientBuilder(ClientBuilder clientBuilder) {
     // No-op extension point
@@ -1394,7 +1394,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * Please note that trusting all certificates is extremely risky.
    * This may be useful in a development environment with self-signed certificates.
    *
-   * @param clientBuilder a {@link jakarta.ws.rs.client.ClientBuilder} object.
+   * @param clientBuilder a {@link {{javaxPackage}}.ws.rs.client.ClientBuilder} object.
    * @throws java.security.KeyManagementException if any.
    * @throws java.security.NoSuchAlgorithmException if any.
    */
@@ -1421,7 +1421,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * <p>Build the response headers.</p>
    *
-   * @param response a {@link jakarta.ws.rs.core.Response} object.
+   * @param response a {@link {{javaxPackage}}.ws.rs.core.Response} object.
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/JSON.mustache
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import jakarta.ws.rs.core.GenericType;
-import jakarta.ws.rs.ext.ContextResolver;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.ext.ContextResolver;
 
 {{>generatedAnnotation}}
 public class JSON implements ContextResolver<ObjectMapper> {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
@@ -1,5 +1,5 @@
-import jakarta.ws.rs.core.GenericType;
-import jakarta.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -6,7 +6,7 @@ import {{invokerPackage}}.ApiResponse;
 import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 
-import jakarta.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 {{#imports}}import {{import}};
 {{/imports}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/auth/OAuth.mustache
@@ -10,7 +10,7 @@ import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.oauth.OAuth20Service;
 
-import jakarta.ws.rs.core.UriBuilder;
+import {{javaxPackage}}.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@jakarta.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/model.mustache
@@ -36,15 +36,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jackson}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 {{#parcelableModel}}
 import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/oneof_model.mustache
@@ -1,5 +1,5 @@
-import jakarta.ws.rs.core.GenericType;
-import jakarta.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -206,14 +206,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{/deprecated}}
 {{#required}}
 {{#isNullable}}
-  @jakarta.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/isNullable}}
 {{^isNullable}}
-  @jakarta.annotation.Nonnull
+  @{{javaxPackage}}.annotation.Nonnull
 {{/isNullable}}
 {{/required}}
 {{^required}}
-  @jakarta.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/required}}
 {{#useBeanValidation}}
 {{>beanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -17,8 +17,8 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 {{/disableMultipart}}
 
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.processing.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.processing.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/model.mustache
@@ -36,15 +36,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jackson}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 {{#parcelableModel}}
 import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -206,14 +206,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{/deprecated}}
 {{#required}}
 {{#isNullable}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/isNullable}}
 {{^isNullable}}
-  @javax.annotation.Nonnull
+  @{{javaxPackage}}.annotation.Nonnull
 {{/isNullable}}
 {{/required}}
 {{^required}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/required}}
 {{#useBeanValidation}}
 {{>beanValidation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/AbstractOpenApiSchema.mustache
@@ -6,7 +6,7 @@ import {{invokerPackage}}.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 //import com.fasterxml.jackson.annotation.JsonValue;
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -1,4 +1,4 @@
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -26,13 +26,13 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import java.io.IOException;
 
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
-import javax.validation.executable.ExecutableValidator;
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.Validation;
+import {{javaxPackage}}.validation.ValidatorFactory;
+import {{javaxPackage}}.validation.executable.ExecutableValidator;
 import java.util.Set;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -51,7 +51,7 @@ import java.util.Map;
 import java.io.InputStream;
 {{/supportStreaming}}
 {{/fullJavaUtil}}
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 {{#operations}}
 public class {{classname}} {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -9,7 +9,7 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 {{/caseInsensitiveResponseHeaders}}
 
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 /**
  * <p>ApiException class.</p>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/model.mustache
@@ -25,21 +25,21 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jackson}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 {{#jsonb}}
 import java.lang.reflect.Type;
-import javax.json.bind.annotation.JsonbTypeDeserializer;
-import javax.json.bind.annotation.JsonbTypeSerializer;
-import javax.json.bind.serializer.DeserializationContext;
-import javax.json.bind.serializer.JsonbDeserializer;
-import javax.json.bind.serializer.JsonbSerializer;
-import javax.json.bind.serializer.SerializationContext;
-import javax.json.stream.JsonGenerator;
-import javax.json.stream.JsonParser;
-import javax.json.bind.annotation.JsonbProperty;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeDeserializer;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeSerializer;
+import {{javaxPackage}}.json.bind.serializer.DeserializationContext;
+import {{javaxPackage}}.json.bind.serializer.JsonbDeserializer;
+import {{javaxPackage}}.json.bind.serializer.JsonbSerializer;
+import {{javaxPackage}}.json.bind.serializer.SerializationContext;
+import {{javaxPackage}}.json.stream.JsonGenerator;
+import {{javaxPackage}}.json.stream.JsonParser;
+import {{javaxPackage}}.json.bind.annotation.JsonbProperty;
 {{#vendorExtensions.x-has-readonly-properties}}
-import javax.json.bind.annotation.JsonbCreator;
+import {{javaxPackage}}.json.bind.annotation.JsonbCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jsonb}}
 {{#parcelableModel}}
@@ -47,8 +47,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
@@ -1,4 +1,4 @@
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
@@ -223,14 +223,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{/deprecated}}
 {{#required}}
 {{#isNullable}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/isNullable}}
 {{^isNullable}}
-  @javax.annotation.Nonnull
+  @{{javaxPackage}}.annotation.Nonnull
 {{/isNullable}}
 {{/required}}
 {{^required}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/required}}
 {{#jsonb}}
   @JsonbProperty("{{baseName}}")

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -27,16 +27,16 @@ import java.util.regex.Pattern;
 import java.time.OffsetDateTime;
 {{/jsr310}}
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.client.Client;
+import {{javaxPackage}}.ws.rs.client.ClientBuilder;
+import {{javaxPackage}}.ws.rs.client.Entity;
+import {{javaxPackage}}.ws.rs.client.Invocation;
+import {{javaxPackage}}.ws.rs.client.WebTarget;
+import {{javaxPackage}}.ws.rs.core.Form;
+import {{javaxPackage}}.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/JSON.mustache
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.*;
 
 import java.text.DateFormat;
 
-import javax.ws.rs.ext.ContextResolver;
+import {{javaxPackage}}.ws.rs.ext.ContextResolver;
 
 {{>generatedAnnotation}}
 public class JSON implements ContextResolver<ObjectMapper> {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/api.mustache
@@ -5,7 +5,7 @@ import {{invokerPackage}}.ApiClient;
 import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 
-import javax.ws.rs.core.GenericType;
+import {{javaxPackage}}.ws.rs.core.GenericType;
 
 {{#imports}}import {{import}};
 {{/imports}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -62,7 +62,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
-import javax.annotation.Nullable;
+import {{javaxPackage}}.annotation.Nullable;
 
 {{#jsr310}}
 import java.time.OffsetDateTime;

--- a/modules/openapi-generator/src/main/resources/Java/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/model.mustache
@@ -25,23 +25,23 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jackson}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.adapters.*;
 import io.github.threetenjaxb.core.*;
 {{/withXml}}
 {{#jsonb}}
 import java.lang.reflect.Type;
-import javax.json.bind.annotation.JsonbTypeDeserializer;
-import javax.json.bind.annotation.JsonbTypeSerializer;
-import javax.json.bind.serializer.DeserializationContext;
-import javax.json.bind.serializer.JsonbDeserializer;
-import javax.json.bind.serializer.JsonbSerializer;
-import javax.json.bind.serializer.SerializationContext;
-import javax.json.stream.JsonGenerator;
-import javax.json.stream.JsonParser;
-import javax.json.bind.annotation.JsonbProperty;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeDeserializer;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeSerializer;
+import {{javaxPackage}}.json.bind.serializer.DeserializationContext;
+import {{javaxPackage}}.json.bind.serializer.JsonbDeserializer;
+import {{javaxPackage}}.json.bind.serializer.JsonbSerializer;
+import {{javaxPackage}}.json.bind.serializer.SerializationContext;
+import {{javaxPackage}}.json.stream.JsonGenerator;
+import {{javaxPackage}}.json.stream.JsonParser;
+import {{javaxPackage}}.json.bind.annotation.JsonbProperty;
 {{#vendorExtensions.x-has-readonly-properties}}
-import javax.json.bind.annotation.JsonbCreator;
+import {{javaxPackage}}.json.bind.annotation.JsonbCreator;
 {{/vendorExtensions.x-has-readonly-properties}}
 {{/jsonb}}
 {{#parcelableModel}}
@@ -49,8 +49,8 @@ import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -204,14 +204,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{/deprecated}}
 {{#required}}
 {{#isNullable}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/isNullable}}
 {{^isNullable}}
-  @javax.annotation.Nonnull
+  @{{javaxPackage}}.annotation.Nonnull
 {{/isNullable}}
 {{/required}}
 {{^required}}
-  @javax.annotation.Nullable
+  @{{javaxPackage}}.annotation.Nullable
 {{/required}}
 {{#jsonb}}
   @JsonbProperty("{{baseName}}")

--- a/modules/openapi-generator/src/main/resources/JavaInflector/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/api.mustache
@@ -2,7 +2,7 @@ package {{invokerPackage}};
 
 import io.swagger.inflector.models.RequestContext;
 import io.swagger.inflector.models.ResponseContext;
-import javax.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
 
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import java.io.File;

--- a/modules/openapi-generator/src/main/resources/JavaInflector/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiOriginFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiOriginFilter.mustache
@@ -2,11 +2,11 @@ package {{apiPackage}};
 
 import java.io.IOException;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletResponse;
+import {{javaxPackage}}.servlet.*;
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 
 {{>generatedAnnotation}}
-public class ApiOriginFilter implements javax.servlet.Filter {
+public class ApiOriginFilter implements {{javaxPackage}}.servlet.Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {
         HttpServletResponse res = (HttpServletResponse) response;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiResponseMessage.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiResponseMessage.mustache
@@ -1,11 +1,11 @@
 package {{apiPackage}};
 
 {{#withXml}}
-import javax.xml.bind.annotation.XmlTransient;
+import {{javaxPackage}}.xml.bind.annotation.XmlTransient;
 {{/withXml}}
 
 {{#withXml}}
-@javax.xml.bind.annotation.XmlRootElement
+@{{javaxPackage}}.xml.bind.annotation.XmlRootElement
 {{/withXml}}
 {{>generatedAnnotation}}
 public class ApiResponseMessage {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/JodaDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/JodaDateTimeProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import org.joda.time.DateTime;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/JodaLocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/JodaLocalDateProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import org.joda.time.LocalDate;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
@@ -21,14 +21,14 @@ import java.io.InputStream;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
-import javax.servlet.ServletConfig;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.*;
+import {{javaxPackage}}.servlet.ServletConfig;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.*;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 @Path("{{commonPath}}")
@@ -62,7 +62,7 @@ public class {{classname}}  {
    }
 
 {{#operation}}
-    @javax.ws.rs.{{httpMethod}}
+    @{{javaxPackage}}.ws.rs.{{httpMethod}}
     {{#subresourceOperation}}@Path("{{{path}}}"){{/subresourceOperation}}
     {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}
     {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/apiService.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/apiService.mustache
@@ -15,10 +15,10 @@ import {{package}}.NotFoundException;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/apiServiceImpl.mustache
@@ -14,10 +14,10 @@ import java.io.InputStream;
 
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/bootstrap.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/bootstrap.mustache
@@ -5,10 +5,10 @@ import io.swagger.models.*;
 
 import io.swagger.models.auth.*;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
+import {{javaxPackage}}.servlet.http.HttpServlet;
+import {{javaxPackage}}.servlet.ServletContext;
+import {{javaxPackage}}.servlet.ServletConfig;
+import {{javaxPackage}}.servlet.ServletException;
 
 public class Bootstrap extends HttpServlet {
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/RestApplication.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/RestApplication.mustache
@@ -1,7 +1,7 @@
 package {{invokerPackage}};
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import {{javaxPackage}}.ws.rs.ApplicationPath;
+import {{javaxPackage}}.ws.rs.core.Application;
 
 @ApplicationPath("{{{contextPath}}}")
 public class RestApplication extends Application {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/api.mustache
@@ -4,12 +4,12 @@ package {{package}};
 {{/imports}}
 import {{package}}.{{classname}}Service;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.enterprise.context.RequestScoped;
+import {{javaxPackage}}.inject.Inject;
 
 import io.swagger.annotations.*;
 import java.io.InputStream;
@@ -21,7 +21,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.util.Map;
 import java.util.List;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 @Path("{{commonPath}}")
 @RequestScoped

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/apiService.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/apiService.mustache
@@ -13,8 +13,8 @@ import java.util.List;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/apiServiceImpl.mustache
@@ -12,9 +12,9 @@ import java.util.List;
 
 import java.io.InputStream;
 
-import javax.enterprise.context.RequestScoped;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.enterprise.context.RequestScoped;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 @RequestScoped
 {{>generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumOuterClass.mustache
@@ -1,7 +1,7 @@
 {{#withXml}}
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import {{javaxPackage}}.xml.bind.annotation.XmlType;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnum;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
 {{/withXml}}
 
 {{>enumClass}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/model.mustache
@@ -6,7 +6,7 @@ package {{package}};
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}{{#description}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -2,7 +2,7 @@ import io.swagger.annotations.*;
 import java.util.Objects;
 
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 
 {{#description}}@ApiModel(description = "{{{.}}}"){{/description}}{{>additionalModelTypeAnnotations}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/CXF2InterfaceComparator.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/CXF2InterfaceComparator.mustache
@@ -5,8 +5,8 @@ import java.lang.reflect.Method;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.Path;
+import {{javaxPackage}}.ws.rs.HttpMethod;
+import {{javaxPackage}}.ws.rs.Path;
 
 import org.apache.cxf.jaxrs.ext.ResourceComparator;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
@@ -60,7 +60,7 @@ public class CXFInterfaceComparator implements ResourceComparator {
       Method[] methods = cri.getServiceClass().getInterfaces()[0].getMethods();
       // Java reflexion. Check all the methods of an interface.
       for (Method method : methods) {
-         Path pathAnnotation = method.getAnnotation(javax.ws.rs.Path.class);
+         Path pathAnnotation = method.getAnnotation({{javaxPackage}}.ws.rs.Path.class);
          if (pathAnnotation != null && pathAnnotation.value() != null) {
             String pathValue = pathAnnotation.value();
             String methodHttpVerb = getMethodHttpVerb(method);
@@ -79,17 +79,17 @@ public class CXFInterfaceComparator implements ResourceComparator {
    }
 
    private static String getMethodHttpVerb(Method method) {
-      if (method.getAnnotation(javax.ws.rs.POST.class) != null) {
+      if (method.getAnnotation({{javaxPackage}}.ws.rs.POST.class) != null) {
          return HttpMethod.POST;
-      } else if (method.getAnnotation(javax.ws.rs.GET.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.GET.class) != null) {
          return HttpMethod.GET;
-      } else if (method.getAnnotation(javax.ws.rs.PUT.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.PUT.class) != null) {
          return HttpMethod.PUT;
-      } else if (method.getAnnotation(javax.ws.rs.OPTIONS.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.OPTIONS.class) != null) {
          return HttpMethod.OPTIONS;
-      } else if (method.getAnnotation(javax.ws.rs.DELETE.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.DELETE.class) != null) {
          return HttpMethod.DELETE;
-      } else if (method.getAnnotation(javax.ws.rs.HEAD.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.HEAD.class) != null) {
          return HttpMethod.HEAD;
       }
       assert false;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/api.mustache
@@ -7,9 +7,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.MediaType;
 import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
@@ -18,8 +18,8 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 {{#appName}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/apiServiceImpl.mustache
@@ -17,8 +17,8 @@ import org.openapitools.codegen.utils.JsonCache;
 import org.openapitools.codegen.utils.JsonCache.CacheException;
 {{/loadTestDataFromFile}}
 {{/generateOperationBody}}
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.model.wadl.Description;
 import org.apache.cxf.jaxrs.model.wadl.DocTarget;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/api_test.mustache
@@ -8,8 +8,8 @@ import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
@@ -47,10 +47,10 @@ import java.io.File;
 {{^fullJavaUtil}}
 import java.util.Set;
 {{/fullJavaUtil}}
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.Validation;
+import {{javaxPackage}}.validation.Validator;
+import {{javaxPackage}}.validation.ValidatorFactory;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.BeforeClass;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/model.mustache
@@ -6,8 +6,8 @@ package {{package}};
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 {{#models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
@@ -1,12 +1,12 @@
 import io.swagger.annotations.ApiModelProperty;
 {{#withXml}}
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import {{javaxPackage}}.xml.bind.annotation.XmlElement;
+import {{javaxPackage}}.xml.bind.annotation.XmlRootElement;
+import {{javaxPackage}}.xml.bind.annotation.XmlAccessType;
+import {{javaxPackage}}.xml.bind.annotation.XmlAccessorType;
+import {{javaxPackage}}.xml.bind.annotation.XmlType;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnum;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
 {{/withXml}}
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/CXF2InterfaceComparator.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/CXF2InterfaceComparator.mustache
@@ -5,8 +5,8 @@ import java.lang.reflect.Method;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.Path;
+import {{javaxPackage}}.ws.rs.HttpMethod;
+import {{javaxPackage}}.ws.rs.Path;
 
 import org.apache.cxf.jaxrs.ext.ResourceComparator;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
@@ -60,7 +60,7 @@ public class CXFInterfaceComparator implements ResourceComparator {
       Method[] methods = cri.getServiceClass().getInterfaces()[0].getMethods();
       // Java reflexion. Check all the methods of an interface.
       for (Method method : methods) {
-         Path pathAnnotation = method.getAnnotation(javax.ws.rs.Path.class);
+         Path pathAnnotation = method.getAnnotation({{javaxPackage}}.ws.rs.Path.class);
          if (pathAnnotation != null && pathAnnotation.value() != null) {
             String pathValue = pathAnnotation.value();
             String methodHttpVerb = getMethodHttpVerb(method);
@@ -79,17 +79,17 @@ public class CXFInterfaceComparator implements ResourceComparator {
    }
 
    private static String getMethodHttpVerb(Method method) {
-      if (method.getAnnotation(javax.ws.rs.POST.class) != null) {
+      if (method.getAnnotation({{javaxPackage}}.ws.rs.POST.class) != null) {
          return HttpMethod.POST;
-      } else if (method.getAnnotation(javax.ws.rs.GET.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.GET.class) != null) {
          return HttpMethod.GET;
-      } else if (method.getAnnotation(javax.ws.rs.PUT.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.PUT.class) != null) {
          return HttpMethod.PUT;
-      } else if (method.getAnnotation(javax.ws.rs.OPTIONS.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.OPTIONS.class) != null) {
          return HttpMethod.OPTIONS;
-      } else if (method.getAnnotation(javax.ws.rs.DELETE.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.DELETE.class) != null) {
          return HttpMethod.DELETE;
-      } else if (method.getAnnotation(javax.ws.rs.HEAD.class) != null) {
+      } else if (method.getAnnotation({{javaxPackage}}.ws.rs.HEAD.class) != null) {
          return HttpMethod.HEAD;
       }
       assert false;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api.mustache
@@ -7,9 +7,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.MediaType;
 import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
@@ -18,8 +18,8 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 {{#appName}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/apiServiceImpl.mustache
@@ -8,8 +8,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.model.wadl.Description;
 import org.apache.cxf.jaxrs.model.wadl.DocTarget;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_test.mustache
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
 
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/model.mustache
@@ -6,8 +6,8 @@ package {{package}};
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 {{#models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -1,13 +1,13 @@
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 {{#withXml}}
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
+import {{javaxPackage}}.xml.bind.annotation.XmlElement;
+import {{javaxPackage}}.xml.bind.annotation.XmlRootElement;
+import {{javaxPackage}}.xml.bind.annotation.XmlAccessType;
+import {{javaxPackage}}.xml.bind.annotation.XmlAccessorType;
+import {{javaxPackage}}.xml.bind.annotation.XmlType;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnum;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
 {{/withXml}}
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/jacksonJsonProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/jacksonJsonProvider.mustache
@@ -8,9 +8,9 @@ import com.fasterxml.jackson.datatype.jsr310.*;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.Produces;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 
 @Provider
 @Produces({MediaType.APPLICATION_JSON})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/LocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/LocalDateProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.time.LocalDate;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/OffsetDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/OffsetDateTimeProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.time.OffsetDateTime;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/api.mustache
@@ -19,13 +19,13 @@ import java.io.InputStream;
 import com.sun.jersey.multipart.FormDataParam;
 import com.sun.jersey.multipart.FormDataBodyPart;
 
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.*;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 @Path("{{commonPath}}")

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/apiService.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/apiService.mustache
@@ -16,10 +16,10 @@ import java.io.InputStream;
 import com.sun.jersey.multipart.FormDataParam;
 import com.sun.jersey.multipart.FormDataBodyPart;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey1/apiServiceImpl.mustache
@@ -16,10 +16,10 @@ import java.io.InputStream;
 import com.sun.jersey.multipart.FormDataParam;
 import com.sun.jersey.multipart.FormDataBodyPart;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey2/LocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey2/LocalDateProvider.mustache
@@ -1,8 +1,8 @@
 package {{apiPackage}};
 
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ParamConverter;
+import {{javaxPackage}}.ws.rs.ext.ParamConverterProvider;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.LocalDate;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey2/OffsetDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/libraries/jersey2/OffsetDateTimeProvider.mustache
@@ -1,8 +1,8 @@
 package {{apiPackage}};
 
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ParamConverter;
+import {{javaxPackage}}.ws.rs.ext.ParamConverterProvider;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.OffsetDateTime;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/model.mustache
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 {{#models}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiOriginFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiOriginFilter.mustache
@@ -2,11 +2,11 @@ package {{apiPackage}};
 
 import java.io.IOException;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletResponse;
+import {{javaxPackage}}.servlet.*;
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 
 {{>generatedAnnotation}}
-public class ApiOriginFilter implements javax.servlet.Filter {
+public class ApiOriginFilter implements {{javaxPackage}}.servlet.Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {
         HttpServletResponse res = (HttpServletResponse) response;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiResponseMessage.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiResponseMessage.mustache
@@ -1,8 +1,8 @@
 package {{apiPackage}};
 
-import javax.xml.bind.annotation.XmlTransient;
+import {{javaxPackage}}.xml.bind.annotation.XmlTransient;
 
-@javax.xml.bind.annotation.XmlRootElement
+@{{javaxPackage}}.xml.bind.annotation.XmlRootElement
 {{>generatedAnnotation}}
 public class ApiResponseMessage {
     public static final int ERROR = 1;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/JacksonConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/JacksonConfig.mustache
@@ -3,8 +3,8 @@ package {{invokerPackage}};
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ContextResolver;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.io.IOException;
 
 @Provider

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/JodaDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/JodaDateTimeProvider.mustache
@@ -1,13 +1,13 @@
 package {{apiPackage}};
 
 import org.joda.time.DateTime;
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ParamConverter;
+import {{javaxPackage}}.ws.rs.ext.ParamConverterProvider;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Response;
 
 
 @Provider

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/JodaLocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/JodaLocalDateProvider.mustache
@@ -1,13 +1,13 @@
 package {{apiPackage}};
 
 import org.joda.time.LocalDate;
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ParamConverter;
+import {{javaxPackage}}.ws.rs.ext.ParamConverterProvider;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Response;
 
 
 @Provider

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/LocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/LocalDateProvider.mustache
@@ -1,9 +1,9 @@
 package {{apiPackage}};
 
 import java.time.LocalDate;
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ParamConverter;
+import {{javaxPackage}}.ws.rs.ext.ParamConverterProvider;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/OffsetDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/OffsetDateTimeProvider.mustache
@@ -1,9 +1,9 @@
 package {{apiPackage}};
 
 import java.time.OffsetDateTime;
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.ext.ParamConverter;
+import {{javaxPackage}}.ws.rs.ext.ParamConverterProvider;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/RestApplication.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/RestApplication.mustache
@@ -1,7 +1,7 @@
 package {{invokerPackage}};
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import {{javaxPackage}}.ws.rs.ApplicationPath;
+import {{javaxPackage}}.ws.rs.core.Application;
 
 @ApplicationPath("{{{contextPath}}}")
 public class RestApplication extends Application {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/api.mustache
@@ -15,15 +15,15 @@ import {{package}}.NotFoundException;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.*;
-import javax.inject.Inject;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.inject.Inject;
 
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#operations}}{{#operation}}{{#isMultipart}}import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 {{/isMultipart}}{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiService.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiService.mustache
@@ -13,8 +13,8 @@ import {{package}}.NotFoundException;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/apiServiceImpl.mustache
@@ -13,9 +13,9 @@ import {{package}}.NotFoundException;
 
 import java.io.InputStream;
 
-import javax.enterprise.context.RequestScoped;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.enterprise.context.RequestScoped;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 @RequestScoped
 {{>generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/JacksonConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/JacksonConfig.mustache
@@ -1,9 +1,9 @@
 package {{invokerPackage}};
 
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.Produces;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.ext.ContextResolver;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/RestApplication.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/RestApplication.mustache
@@ -1,7 +1,7 @@
 package {{invokerPackage}};
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import {{javaxPackage}}.ws.rs.ApplicationPath;
+import {{javaxPackage}}.ws.rs.core.Application;
 
 import java.util.Set;
 import java.util.HashSet;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/api.mustache
@@ -13,13 +13,13 @@ import java.util.Map;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.*;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 {{#operations}}{{#operation}}{{#isMultipart}}import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 {{/isMultipart}}{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/apiServiceImpl.mustache
@@ -12,8 +12,8 @@ import java.util.List;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/model.mustache
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/model.mustache
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/RestApplication.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/RestApplication.mustache
@@ -1,7 +1,7 @@
 package {{invokerPackage}};
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import {{javaxPackage}}.ws.rs.ApplicationPath;
+import {{javaxPackage}}.ws.rs.core.Application;
 
 @ApplicationPath(RestResourceRoot.APPLICATION_PATH)
 public class RestApplication extends Application {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
@@ -3,8 +3,8 @@ package {{package}};
 {{#imports}}import {{import}};
 {{/imports}}
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
 
 {{#useSwaggerAnnotations}}
 import io.swagger.annotations.*;
@@ -17,8 +17,8 @@ import java.util.concurrent.CompletableFuture;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.List;
-{{#useBeanValidation}}import javax.validation.constraints.*;
-import javax.validation.Valid;{{/useBeanValidation}}
+{{#useBeanValidation}}import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;{{/useBeanValidation}}
 
 @Path("{{commonPath}}"){{#useSwaggerAnnotations}}
 @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/api.mustache
@@ -3,8 +3,8 @@ package {{package}};
 {{#imports}}import {{import}};
 {{/imports}}
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
 
 {{#useGzipFeature}}
 import org.jboss.resteasy.annotations.GZIP;
@@ -21,8 +21,8 @@ import java.util.concurrent.CompletableFuture;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.List;
-{{#useBeanValidation}}import javax.validation.constraints.*;
-import javax.validation.Valid;{{/useBeanValidation}}
+{{#useBeanValidation}}import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;{{/useBeanValidation}}
 
 @Path("{{commonPath}}"){{#useSwaggerAnnotations}}
 @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/model.mustache
@@ -6,8 +6,8 @@ package {{package}};
 import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 {{#models}}

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/apiDocController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/apiDocController.mustache
@@ -1,6 +1,6 @@
 package {{apiPackage}};
 
-import javax.inject.*;
+import {{javaxPackage}}.inject.*;
 import play.mvc.*;
 
 public class ApiDocController extends Controller {

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/errorHandler.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/errorHandler.mustache
@@ -10,7 +10,7 @@ import play.http.DefaultHttpErrorHandler;
 import play.mvc.Http.*;
 import play.mvc.*;
 
-import javax.inject.*;
+import {{javaxPackage}}.inject.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import static play.mvc.Results.*;

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/model.mustache
@@ -7,7 +7,7 @@ import java.io.Serializable;
 {{/serializableModel}}
 import com.fasterxml.jackson.annotation.*;
 import java.util.Set;
-import javax.validation.*;
+import {{javaxPackage}}.validation.*;
 {{#models}}
 {{#model}}
 {{#isEnum}}

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApi.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApi.mustache
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 {{/supportAsync}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiController.mustache
@@ -31,7 +31,7 @@ import java.util.concurrent.CompletableFuture;
 {{/supportAsync}}
 
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 import com.typesafe.config.Config;
 {{/useBeanValidation}}
 

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiInterface.mustache
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 {{/supportAsync}}
 
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/openapiUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/openapiUtils.mustache
@@ -10,10 +10,10 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 {{#useBeanValidation}}
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import {{javaxPackage}}.validation.ConstraintViolation;
+import {{javaxPackage}}.validation.Validation;
+import {{javaxPackage}}.validation.Validator;
+import {{javaxPackage}}.validation.ValidatorFactory;
 {{/useBeanValidation}}
 
 public class OpenAPIUtils {

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
@@ -1,6 +1,6 @@
 import java.util.Objects;
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 /**
  * {{description}}{{^description}}{{classname}}{{/description}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -50,14 +50,8 @@ import org.springframework.http.codec.multipart.Part;
 {{/reactive}}
 
 {{#useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.Valid;
-import javax.validation.constraints.*;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 import java.util.List;
 import java.util.Map;
@@ -72,12 +66,7 @@ import java.util.Optional;
 {{#async}}
 import java.util.concurrent.CompletableFuture;
 {{/async}}
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{>generatedAnnotation}}
 {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -36,25 +36,14 @@ import org.springframework.web.context.request.NativeWebRequest;
 {{/isDelegate}}
 
 {{#useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{>generatedAnnotation}}
 @Controller

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -20,12 +20,7 @@ import java.util.Optional;
 {{#async}}
 import java.util.concurrent.CompletableFuture;
 {{/async}}
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{#operations}}
 /**

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
@@ -1,11 +1,6 @@
 package {{apiPackage}};
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 /**
  * The exception that can be used to store the HTTP status code returned by an API response.

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiOriginFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiOriginFilter.mustache
@@ -2,17 +2,12 @@ package {{apiPackage}};
 
 import java.io.IOException;
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-import jakarta.servlet.*;
-import jakarta.servlet.http.HttpServletResponse;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
+import {{javaxPackage}}.servlet.*;
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 
 {{>generatedAnnotation}}
-public class ApiOriginFilter implements javax.servlet.Filter {
+public class ApiOriginFilter implements {{javaxPackage}}.servlet.Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiResponseMessage.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiResponseMessage.mustache
@@ -1,15 +1,10 @@
 package {{apiPackage}};
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
-import javax.xml.bind.annotation.XmlTransient;
+import {{javaxPackage}}.annotation.Generated;
+import {{javaxPackage}}.xml.bind.annotation.XmlTransient;
 
 {{>generatedAnnotation}}
-@javax.xml.bind.annotation.XmlRootElement
+@{{javaxPackage}}.xml.bind.annotation.XmlRootElement
 public class ApiResponseMessage {
     public static final int ERROR = 1;
     public static final int WARNING = 2;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
@@ -12,12 +12,7 @@ import reactor.core.publisher.Mono;
 {{^reactive}}
 import org.springframework.web.context.request.NativeWebRequest;
 
-{{#useJakartaEe}}
-import jakarta.servlet.http.HttpServletResponse;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.servlet.http.HttpServletResponse;
-{{/useJakartaEe}}
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 import java.io.IOException;
 {{/reactive}}
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
@@ -12,22 +12,11 @@ import java.io.Serializable;
 {{/serializableModel}}
 import java.time.OffsetDateTime;
 {{#useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.Valid;
-import javax.validation.constraints.*;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{^useBeanValidation}}
-{{#useJakartaEe}}
-import jakarta.validation.constraints.NotNull;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.validation.constraints.NotNull;
-{{/useJakartaEe}}
+import {{javaxPackage}}.validation.constraints.NotNull;
 {{/useBeanValidation}}
 {{#performBeanValidation}}
 import org.hibernate.validator.constraints.*;
@@ -43,7 +32,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 {{/swagger2AnnotationLibrary}}
 
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 {{^parent}}
 {{#hateoas}}
@@ -52,12 +41,7 @@ import org.springframework.hateoas.RepresentationModel;
 {{/parent}}
 
 import java.util.*;
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/notFoundException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/notFoundException.mustache
@@ -1,11 +1,6 @@
 package {{apiPackage}};
 
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
 
 {{>generatedAnnotation}}
 public class NotFoundException extends ApiException {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/openapiDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/openapiDocumentationConfig.mustache
@@ -18,14 +18,8 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 {{#useOptional}}
 import java.util.Optional;
 {{/useOptional}}
-{{#useJakartaEe}}
-import jakarta.annotation.Generated;
-import jakarta.servlet.ServletContext;
-{{/useJakartaEe}}
-{{^useJakartaEe}}
-import javax.annotation.Generated;
-import javax.servlet.ServletContext;
-{{/useJakartaEe}}
+import {{javaxPackage}}.annotation.Generated;
+import {{javaxPackage}}.servlet.ServletContext;
 
 {{>generatedAnnotation}}
 @Configuration

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/api.mustache
@@ -17,15 +17,15 @@ import io.micronaut.http.HttpResponse;
 {{#imports}}
 import {{import}};
 {{/imports}}
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 {{^fullJavaUtil}}
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 {{/fullJavaUtil}}{{#useBeanValidation}}
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#generateSwagger1Annotations}}
 import io.swagger.annotations.*;

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/Authorization.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/Authorization.mustache
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/AuthorizationBinder.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/AuthorizationBinder.mustache
@@ -13,7 +13,7 @@ import io.micronaut.http.client.bind.ClientRequestUriContext;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/AuthorizationFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/AuthorizationFilter.mustache
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/Authorizations.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/Authorizations.mustache
@@ -8,7 +8,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/configuration/ApiKeyAuthConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/configuration/ApiKeyAuthConfiguration.mustache
@@ -7,7 +7,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.cookie.Cookie;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/configuration/ConfigurableAuthorization.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/configuration/ConfigurableAuthorization.mustache
@@ -3,7 +3,7 @@ package {{invokerPackage}}.auth.configuration;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpRequest;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/configuration/HttpBasicAuthConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/auth/configuration/HttpBasicAuthConfiguration.mustache
@@ -6,7 +6,7 @@ import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpRequest;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 
 
 {{>common/generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/model.mustache
@@ -22,17 +22,17 @@ import com.fasterxml.jackson.dataformat.xml.annotation.*;
 import com.fasterxml.jackson.annotation.*;
 {{/withXml}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 {{#parcelableModel}}
 import android.os.Parcelable;
 import android.os.Parcel;
 {{/parcelableModel}}{{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 import io.micronaut.core.annotation.*;
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 {{#generateSwagger1Annotations}}
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/modules/openapi-generator/src/main/resources/java-micronaut/server/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/server/controller.mustache
@@ -21,7 +21,7 @@ import io.micronaut.http.exceptions.HttpStatusException;
 {{#imports}}
 import {{import}};
 {{/imports}}
-import javax.annotation.Generated;
+import {{javaxPackage}}.annotation.Generated;
 {{^fullJavaUtil}}
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,8 +32,8 @@ import java.util.Arrays;
 {{/generateControllerFromExamples}}
 {{/fullJavaUtil}}
 {{#useBeanValidation}}
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#generateSwagger1Annotations}}
 import io.swagger.annotations.*;

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiOriginFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiOriginFilter.mustache
@@ -2,11 +2,11 @@ package {{apiPackage}};
 
 import java.io.IOException;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletResponse;
+import {{javaxPackage}}.servlet.*;
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 
 {{>generatedAnnotation}}
-public class ApiOriginFilter implements javax.servlet.Filter {
+public class ApiOriginFilter implements {{javaxPackage}}.servlet.Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {
         HttpServletResponse res = (HttpServletResponse) response;

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiResponseMessage.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiResponseMessage.mustache
@@ -1,8 +1,8 @@
 package {{apiPackage}};
 
-import javax.xml.bind.annotation.XmlTransient;
+import {{javaxPackage}}.xml.bind.annotation.XmlTransient;
 
-@javax.xml.bind.annotation.XmlRootElement
+@{{javaxPackage}}.xml.bind.annotation.XmlRootElement
 {{>generatedAnnotation}}
 public class ApiResponseMessage {
     public static final int ERROR = 1;

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/JodaDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/JodaDateTimeProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import org.joda.time.DateTime;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/JodaLocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/JodaLocalDateProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import org.joda.time.LocalDate;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/LocalDateProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/LocalDateProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.time.LocalDate;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/OffsetDateTimeProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/OffsetDateTimeProvider.mustache
@@ -4,13 +4,13 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.QueryParam;
+import {{javaxPackage}}.ws.rs.WebApplicationException;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.Response.Status;
+import {{javaxPackage}}.ws.rs.core.UriInfo;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 import java.time.OffsetDateTime;
 import java.util.List;
 

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/api.mustache
@@ -18,10 +18,10 @@ import java.io.InputStream;
 import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Context;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.*;
 
 @Path("{{commonPath}}")
 {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/apiService.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/apiService.mustache
@@ -14,8 +14,8 @@ import {{package}}.NotFoundException;
 
 import java.io.InputStream;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/apiServiceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/apiServiceImpl.mustache
@@ -14,8 +14,8 @@ import java.io.InputStream;
 import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.SecurityContext;
 
 {{>generatedAnnotation}}
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/bootstrap.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/bootstrap.mustache
@@ -5,10 +5,10 @@ import io.swagger.models.*;
 
 import io.swagger.models.auth.*;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
+import {{javaxPackage}}.servlet.http.HttpServlet;
+import {{javaxPackage}}.servlet.ServletContext;
+import {{javaxPackage}}.servlet.ServletConfig;
+import {{javaxPackage}}.servlet.ServletException;
 
 public class Bootstrap extends HttpServlet {
   @Override

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/jacksonJsonProvider.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/jacksonJsonProvider.mustache
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import {{javaxPackage}}.ws.rs.Produces;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import {{javaxPackage}}.ws.rs.ext.Provider;
 
 @Provider
 @Produces({MediaType.APPLICATION_JSON})

--- a/modules/openapi-generator/src/main/resources/java-pkmst/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/api.mustache
@@ -28,8 +28,8 @@ import java.util.concurrent.{{^jdk8}}Callable{{/jdk8}}{{#jdk8}}CompletableFuture
 {{/async}}
 {{#useBeanValidation}}
 import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 /**
  * Provides the info about api methods

--- a/modules/openapi-generator/src/main/resources/java-pkmst/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/apiController.mustache
@@ -32,8 +32,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 {{/useSpringCloudClient}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
 {{/useBeanValidation}}
 /**
  * Api implementation

--- a/modules/openapi-generator/src/main/resources/java-pkmst/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/java-pkmst/logging/httpLoggingFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/logging/httpLoggingFilter.mustache
@@ -14,27 +14,27 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ReadListener;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.WriteListener;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
+import {{javaxPackage}}.servlet.Filter;
+import {{javaxPackage}}.servlet.FilterChain;
+import {{javaxPackage}}.servlet.FilterConfig;
+import {{javaxPackage}}.servlet.ReadListener;
+import {{javaxPackage}}.servlet.ServletException;
+import {{javaxPackage}}.servlet.ServletInputStream;
+import {{javaxPackage}}.servlet.ServletOutputStream;
+import {{javaxPackage}}.servlet.ServletRequest;
+import {{javaxPackage}}.servlet.ServletResponse;
+import {{javaxPackage}}.servlet.WriteListener;
+import {{javaxPackage}}.servlet.http.Cookie;
+import {{javaxPackage}}.servlet.http.HttpServletRequest;
+import {{javaxPackage}}.servlet.http.HttpServletRequestWrapper;
+import {{javaxPackage}}.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 /**
- * Implements javax.servlet.Filter and dump the request/response to syslog
+ * Implements {{javaxPackage}}.servlet.Filter and dump the request/response to syslog
  * @author pkmst
  *
  */

--- a/modules/openapi-generator/src/main/resources/java-pkmst/model.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/model.mustache
@@ -8,8 +8,8 @@ import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
 import org.springframework.validation.annotation.Validated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+import {{javaxPackage}}.validation.constraints.*;
 {{/useBeanValidation}}
 {{#jackson}}
 {{#withXml}}
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 {{/withXml}}
 {{/jackson}}
 {{#withXml}}
-import javax.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.*;
 {{/withXml}}
 /**
  * Response class to be returned by Api

--- a/modules/openapi-generator/src/main/resources/java-undertow-server/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-undertow-server/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{{generatorClass}}}"{{^hideGenerationTimestamp}}, date = "{{{generatedDate}}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = "{{{generatorClass}}}"{{^hideGenerationTimestamp}}, date = "{{{generatedDate}}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/java-undertow-server/handler.mustache
+++ b/modules/openapi-generator/src/main/resources/java-undertow-server/handler.mustache
@@ -33,7 +33,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
     /**
      * Returns the default base path to access this server.
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     public String getBasePath() {
         return "{{{basePathWithoutHost}}}";
     }
@@ -52,7 +52,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
      *
      * @return an {@link HttpHandler} of type {@link RoutingHandler}
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     @Override
     public HttpHandler getHandler() {
         return getHandler(false);
@@ -67,7 +67,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
      * @param withBasePath if true, all endpoints would start with "{{{basePathWithoutHost}}}"
      * @return an {@link HttpHandler} of type {@link RoutingHandler}
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     public HttpHandler getHandler(final boolean withBasePath) {
         return getHandler(withBasePath ? getBasePath() : "");
     }
@@ -82,7 +82,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
      * @return an {@link HttpHandler} of type {@link RoutingHandler}
      */
     @SuppressWarnings("Convert2Lambda")
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     public HttpHandler getHandler(final String basePath) {
         return Handlers.routing()
 {{#apiInfo}}
@@ -116,7 +116,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
      *
      * @return an {@link HttpHandler} of type {@link RoutingHandler}
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     public HttpHandler getStatefulHandler() {
         return getStatefulHandler(false);
     }
@@ -130,7 +130,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
      * @param withBasePath if true, all endpoints would start with "{{{basePathWithoutHost}}}"
      * @return an {@link HttpHandler} of type {@link RoutingHandler}
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     public HttpHandler getStatefulHandler(final boolean withBasePath) {
         return getStatefulHandler(withBasePath ? getBasePath() : "");
     }
@@ -144,7 +144,7 @@ abstract public class PathHandlerProvider implements HandlerProvider, PathHandle
      * @param basePath base path to set for all endpoints
      * @return an {@link HttpHandler} of type {@link RoutingHandler}
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
     public HttpHandler getStatefulHandler(final String basePath) {
         return Handlers.routing()
 {{#apiInfo}}

--- a/modules/openapi-generator/src/main/resources/java-undertow-server/interface.mustache
+++ b/modules/openapi-generator/src/main/resources/java-undertow-server/interface.mustache
@@ -65,7 +65,7 @@ public interface PathHandlerInterface {
 {{/responses}}
      * </ul>
      */
-    @javax.annotation.Nonnull
+    @{{javaxPackage}}.annotation.Nonnull
 {{#isDeprecated}}    @Deprecated
 {{/isDeprecated}}
     HttpHandler {{{operationId}}}();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1523,7 +1523,6 @@ public class SpringCodegenTest {
         codegen.additionalProperties().put(SpringCodegen.USE_BEANVALIDATION, "false");
         codegen.additionalProperties().put(SpringCodegen.PERFORM_BEANVALIDATION, "false");
         codegen.additionalProperties().put(SpringCodegen.USE_SPRING_BOOT3, "true");
-        codegen.additionalProperties().put(SpringCodegen.USE_JAKARTA_EE, "true");
         codegen.additionalProperties().put(SpringCodegen.OPENAPI_NULLABLE, "false");
         codegen.additionalProperties().put(SpringCodegen.UNHANDLED_EXCEPTION_HANDLING, "false");
         codegen.additionalProperties().put(CodegenConstants.SORT_MODEL_PROPERTIES_BY_REQUIRED_FLAG, "false");

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApiController.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApiController.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApiController.java
@@ -20,8 +20,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.context.request.NativeWebRequest;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Internal option to control whether `javax` or `jakarta` package should be used. This option will allow much easier transition to never version of dependencies with `jakarta` support.

Example - https://github.com/OpenAPITools/openapi-generator/issues/14276 rest-template to be migrated to `jakarta` while other libraries might still use `javax` packages in common templates 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<html><body>
<!--StartFragment-->

Java | @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala  (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)  @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
-- | --
Java Spring | @cachescrubber (2022/02) @welshm (2022/02) @MelleD  (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02)  @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09)

<!--EndFragment-->
</body>
</html>