### PR TITLE
typescript-nestjs / Ensure default headers remain unmodified

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -103,7 +103,7 @@ export class {{classname}} {
 {{/queryParams}}
 
 {{/hasQueryParams}}
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 {{#headerParams}}
         {{#isArray}}
         if ({{paramName}}) {

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -54,7 +54,7 @@ export class PetService {
             throw new Error('Required parameter pet was null or undefined when calling addPet.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -107,7 +107,7 @@ export class PetService {
         }
 
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
         if (apiKey !== undefined && apiKey !== null) {
             headers['api_key'] = String(apiKey);
         }
@@ -157,7 +157,7 @@ export class PetService {
             queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -207,7 +207,7 @@ export class PetService {
             queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -252,7 +252,7 @@ export class PetService {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -293,7 +293,7 @@ export class PetService {
             throw new Error('Required parameter pet was null or undefined when calling updatePet.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -348,7 +348,7 @@ export class PetService {
 
 
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -416,7 +416,7 @@ export class PetService {
 
 
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
@@ -53,7 +53,7 @@ export class StoreService {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -82,7 +82,7 @@ export class StoreService {
     public getInventory(): Observable<AxiosResponse<{ [key: string]: number; }>>;
     public getInventory(): Observable<any> {
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -122,7 +122,7 @@ export class StoreService {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -158,7 +158,7 @@ export class StoreService {
             throw new Error('Required parameter order was null or undefined when calling placeOrder.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -53,7 +53,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling createUser.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -98,7 +98,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -143,7 +143,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithListInput.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -188,7 +188,7 @@ export class UserService {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -227,7 +227,7 @@ export class UserService {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -276,7 +276,7 @@ export class UserService {
             queryParameters.append('password', <any>password);
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -308,7 +308,7 @@ export class UserService {
     public logoutUser(): Observable<AxiosResponse<any>>;
     public logoutUser(): Observable<any> {
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -352,7 +352,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling updateUser.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -55,7 +55,7 @@ export class PetService {
             throw new Error('Required parameter pet was null or undefined when calling addPet.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -108,7 +108,7 @@ export class PetService {
         }
 
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
         if (apiKey !== undefined && apiKey !== null) {
             headers['api_key'] = String(apiKey);
         }
@@ -158,7 +158,7 @@ export class PetService {
             queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -208,7 +208,7 @@ export class PetService {
             queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -253,7 +253,7 @@ export class PetService {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -294,7 +294,7 @@ export class PetService {
             throw new Error('Required parameter pet was null or undefined when calling updatePet.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -349,7 +349,7 @@ export class PetService {
 
 
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {
@@ -417,7 +417,7 @@ export class PetService {
 
 
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (petstore_auth) required
         if (this.configuration.accessToken) {

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
@@ -54,7 +54,7 @@ export class StoreService {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -83,7 +83,7 @@ export class StoreService {
     public getInventory(): Observable<AxiosResponse<{ [key: string]: number; }>>;
     public getInventory(): Observable<any> {
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -123,7 +123,7 @@ export class StoreService {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -159,7 +159,7 @@ export class StoreService {
             throw new Error('Required parameter order was null or undefined when calling placeOrder.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
@@ -54,7 +54,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling createUser.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -99,7 +99,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -144,7 +144,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithListInput.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -189,7 +189,7 @@ export class UserService {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -228,7 +228,7 @@ export class UserService {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -277,7 +277,7 @@ export class UserService {
             queryParameters.append('password', <any>password);
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // to determine the Accept header
         let httpHeaderAccepts: string[] = [
@@ -309,7 +309,7 @@ export class UserService {
     public logoutUser(): Observable<AxiosResponse<any>>;
     public logoutUser(): Observable<any> {
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -353,7 +353,7 @@ export class UserService {
             throw new Error('Required parameter user was null or undefined when calling updateUser.');
         }
 
-        let headers = this.defaultHeaders;
+        let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {


### PR DESCRIPTION
When sending a request with a client generated by typescript-nestjs, the default headers are modified. This occurs when headers such as "Accept" are appended by the client.
The root of the issue is that a reference to the default headers is stored instead of a clone.

Previously the code would have been generated like this:
```
    public deletePet(petId: number, apiKey?: string, ): Observable<any> {
        /* ... */
        let headers = this.defaultHeaders;$
        if (apiKey !== undefined && apiKey !== null) {$
            headers['api_key'] = String(apiKey);$
        }
```
This adds the `api_key` to the default headers, which then leaks to all following requests, until another request might change the `api_key` header.

This PR changes the generated code to:
```
    public deletePet(petId: number, apiKey?: string, ): Observable<any> {
        /* ... */
        let headers = {...this.defaultHeaders};
        if (apiKey !== undefined && apiKey !== null) {
            headers['api_key'] = String(apiKey);
        }
```

Instead of changing the default headers, the headers are copied and the header is only set in the scope of the single request.

Mentioning technical comittee for typescript: @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
