### PR TITLE
[C][Client] Allow cJSON_IsNull() for a string if it is not mandatory

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -635,7 +635,7 @@ fail:
     {{^isEnum}}
     {{#isString}}
     {{^required}}if ({{{name}}}) { {{/required}}
-    if(!cJSON_IsString({{{name}}}))
+    if(!cJSON_IsString({{{name}}}){{^required}} && !cJSON_IsNull({{{name}}}){{/required}})
     {
     goto end; //String
     }
@@ -880,7 +880,7 @@ fail:
         {{/isEnum}}
         {{^isEnum}}
         {{#isString}}
-        {{^required}}{{{name}}} ? {{/required}}strdup({{{name}}}->valuestring){{^required}} : NULL{{/required}}{{^-last}},{{/-last}}
+        {{^required}}{{{name}}} && !cJSON_IsNull({{{name}}}) ? {{/required}}strdup({{{name}}}->valuestring){{^required}} : NULL{{/required}}{{^-last}},{{/-last}}
         {{/isString}}
         {{/isEnum}}
         {{#isByteArray}}

--- a/samples/client/petstore/c/model/api_response.c
+++ b/samples/client/petstore/c/model/api_response.c
@@ -88,7 +88,7 @@ api_response_t *api_response_parseFromJSON(cJSON *api_responseJSON){
     // api_response->type
     cJSON *type = cJSON_GetObjectItemCaseSensitive(api_responseJSON, "type");
     if (type) { 
-    if(!cJSON_IsString(type))
+    if(!cJSON_IsString(type) && !cJSON_IsNull(type))
     {
     goto end; //String
     }
@@ -97,7 +97,7 @@ api_response_t *api_response_parseFromJSON(cJSON *api_responseJSON){
     // api_response->message
     cJSON *message = cJSON_GetObjectItemCaseSensitive(api_responseJSON, "message");
     if (message) { 
-    if(!cJSON_IsString(message))
+    if(!cJSON_IsString(message) && !cJSON_IsNull(message))
     {
     goto end; //String
     }
@@ -106,8 +106,8 @@ api_response_t *api_response_parseFromJSON(cJSON *api_responseJSON){
 
     api_response_local_var = api_response_create (
         code ? code->valuedouble : 0,
-        type ? strdup(type->valuestring) : NULL,
-        message ? strdup(message->valuestring) : NULL
+        type && !cJSON_IsNull(type) ? strdup(type->valuestring) : NULL,
+        message && !cJSON_IsNull(message) ? strdup(message->valuestring) : NULL
         );
 
     return api_response_local_var;

--- a/samples/client/petstore/c/model/category.c
+++ b/samples/client/petstore/c/model/category.c
@@ -74,7 +74,7 @@ category_t *category_parseFromJSON(cJSON *categoryJSON){
     // category->name
     cJSON *name = cJSON_GetObjectItemCaseSensitive(categoryJSON, "name");
     if (name) { 
-    if(!cJSON_IsString(name))
+    if(!cJSON_IsString(name) && !cJSON_IsNull(name))
     {
     goto end; //String
     }
@@ -83,7 +83,7 @@ category_t *category_parseFromJSON(cJSON *categoryJSON){
 
     category_local_var = category_create (
         id ? id->valuedouble : 0,
-        name ? strdup(name->valuestring) : NULL
+        name && !cJSON_IsNull(name) ? strdup(name->valuestring) : NULL
         );
 
     return category_local_var;

--- a/samples/client/petstore/c/model/tag.c
+++ b/samples/client/petstore/c/model/tag.c
@@ -74,7 +74,7 @@ tag_t *tag_parseFromJSON(cJSON *tagJSON){
     // tag->name
     cJSON *name = cJSON_GetObjectItemCaseSensitive(tagJSON, "name");
     if (name) { 
-    if(!cJSON_IsString(name))
+    if(!cJSON_IsString(name) && !cJSON_IsNull(name))
     {
     goto end; //String
     }
@@ -83,7 +83,7 @@ tag_t *tag_parseFromJSON(cJSON *tagJSON){
 
     tag_local_var = tag_create (
         id ? id->valuedouble : 0,
-        name ? strdup(name->valuestring) : NULL
+        name && !cJSON_IsNull(name) ? strdup(name->valuestring) : NULL
         );
 
     return tag_local_var;

--- a/samples/client/petstore/c/model/user.c
+++ b/samples/client/petstore/c/model/user.c
@@ -154,7 +154,7 @@ user_t *user_parseFromJSON(cJSON *userJSON){
     // user->username
     cJSON *username = cJSON_GetObjectItemCaseSensitive(userJSON, "username");
     if (username) { 
-    if(!cJSON_IsString(username))
+    if(!cJSON_IsString(username) && !cJSON_IsNull(username))
     {
     goto end; //String
     }
@@ -163,7 +163,7 @@ user_t *user_parseFromJSON(cJSON *userJSON){
     // user->first_name
     cJSON *first_name = cJSON_GetObjectItemCaseSensitive(userJSON, "firstName");
     if (first_name) { 
-    if(!cJSON_IsString(first_name))
+    if(!cJSON_IsString(first_name) && !cJSON_IsNull(first_name))
     {
     goto end; //String
     }
@@ -172,7 +172,7 @@ user_t *user_parseFromJSON(cJSON *userJSON){
     // user->last_name
     cJSON *last_name = cJSON_GetObjectItemCaseSensitive(userJSON, "lastName");
     if (last_name) { 
-    if(!cJSON_IsString(last_name))
+    if(!cJSON_IsString(last_name) && !cJSON_IsNull(last_name))
     {
     goto end; //String
     }
@@ -181,7 +181,7 @@ user_t *user_parseFromJSON(cJSON *userJSON){
     // user->email
     cJSON *email = cJSON_GetObjectItemCaseSensitive(userJSON, "email");
     if (email) { 
-    if(!cJSON_IsString(email))
+    if(!cJSON_IsString(email) && !cJSON_IsNull(email))
     {
     goto end; //String
     }
@@ -190,7 +190,7 @@ user_t *user_parseFromJSON(cJSON *userJSON){
     // user->password
     cJSON *password = cJSON_GetObjectItemCaseSensitive(userJSON, "password");
     if (password) { 
-    if(!cJSON_IsString(password))
+    if(!cJSON_IsString(password) && !cJSON_IsNull(password))
     {
     goto end; //String
     }
@@ -199,7 +199,7 @@ user_t *user_parseFromJSON(cJSON *userJSON){
     // user->phone
     cJSON *phone = cJSON_GetObjectItemCaseSensitive(userJSON, "phone");
     if (phone) { 
-    if(!cJSON_IsString(phone))
+    if(!cJSON_IsString(phone) && !cJSON_IsNull(phone))
     {
     goto end; //String
     }
@@ -217,12 +217,12 @@ user_t *user_parseFromJSON(cJSON *userJSON){
 
     user_local_var = user_create (
         id ? id->valuedouble : 0,
-        username ? strdup(username->valuestring) : NULL,
-        first_name ? strdup(first_name->valuestring) : NULL,
-        last_name ? strdup(last_name->valuestring) : NULL,
-        email ? strdup(email->valuestring) : NULL,
-        password ? strdup(password->valuestring) : NULL,
-        phone ? strdup(phone->valuestring) : NULL,
+        username && !cJSON_IsNull(username) ? strdup(username->valuestring) : NULL,
+        first_name && !cJSON_IsNull(first_name) ? strdup(first_name->valuestring) : NULL,
+        last_name && !cJSON_IsNull(last_name) ? strdup(last_name->valuestring) : NULL,
+        email && !cJSON_IsNull(email) ? strdup(email->valuestring) : NULL,
+        password && !cJSON_IsNull(password) ? strdup(password->valuestring) : NULL,
+        phone && !cJSON_IsNull(phone) ? strdup(phone->valuestring) : NULL,
         user_status ? user_status->valuedouble : 0
         );
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Hi @wing328 @zhemant @michelealbano

This PR is similar to https://github.com/OpenAPITools/openapi-generator/pull/13884

Sometimes, the value of `string` data type in the JSON/YAML string is null

e.g.
```yaml
{
  "kind": "NodeList",
  "apiVersion": "v1",
  "metadata": {
    "continue": ""
  },
  "items": [
    {
      "kind": "Node",
 ...
      "status": {
 ...
        "phase": null  <---- Here !
      }
    }
  ]
}
```

Currently `openapi-generator/c-libcurl` doesn't allow this case, so parsing JSON strings into cJSON objects will fail.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
