### PR TITLE
[GO][Client] Use a `*os.File` for the API Client when uploading and downloading

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -121,9 +121,9 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         typeMapping.put("date", "string");
         typeMapping.put("DateTime", "time.Time");
         typeMapping.put("password", "string");
-        typeMapping.put("File", "os.File");
-        typeMapping.put("file", "os.File");
-        typeMapping.put("binary", "os.File");
+        typeMapping.put("File", "*os.File");
+        typeMapping.put("file", "*os.File");
+        typeMapping.put("binary", "*os.File");
         typeMapping.put("ByteArray", "string");
         typeMapping.put("null", "nil");
         // A 'type: object' OAS schema without any declared property is
@@ -505,13 +505,13 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         boolean addedReflectImport = false;
         for (CodegenOperation operation : operations) {
             // import "os" if the operation uses files
-            if (!addedOSImport && "os.File".equals(operation.returnType)) {
+            if (!addedOSImport && "*os.File".equals(operation.returnType)) {
                 imports.add(createMapping("import", "os"));
                 addedOSImport = true;
             }
             for (CodegenParameter param : operation.allParams) {
                 // import "os" if the operation uses files
-                if (!addedOSImport && "os.File".equals(param.dataType)) {
+                if (!addedOSImport && "*os.File".equals(param.dataType)) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }
@@ -665,8 +665,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                     imports.add(createMapping("import", "time"));
                     addedTimeImport = true;
                 }
-                if (!addedOSImport && ("os.File".equals(cp.dataType) ||
-                        (cp.items != null && "os.File".equals(cp.items.dataType)))) {
+                if (!addedOSImport && ("*os.File".equals(cp.dataType) ||
+                        (cp.items != null && "*os.File".equals(cp.items.dataType)))) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -305,7 +305,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
         for (CodegenOperation operation : operations) {
             for (CodegenParameter param : operation.allParams) {
                 // import "os" if the operation uses files
-                if (!addedOSImport && ("os.File".equals(param.dataType) || ("[]os.File".equals(param.dataType)))) {
+                if (!addedOSImport && ("*os.File".equals(param.dataType) || ("[]*os.File".equals(param.dataType)))) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -112,22 +112,22 @@ func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} heade
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
-func ReadFormFileToTempFile(r *http.Request, key string) (os.File, error) {
+func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	_, fileHeader, err := r.FormFile(key)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	return readFileHeaderToTempFile(fileHeader)
 }
 
 // ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
-func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
+func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		return nil, err
 	}
 
-	files := make([]os.File, 0, len(r.MultipartForm.File[key]))
+	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
 
 	for _, fileHeader := range r.MultipartForm.File[key] {
 		file, err := readFileHeaderToTempFile(fileHeader)
@@ -142,29 +142,29 @@ func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
 }
 
 // readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
-func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (os.File, error) {
+func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
 	formFile, err := fileHeader.Open()
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer formFile.Close()
 
 	fileBytes, err := ioutil.ReadAll(formFile)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	file, err := ioutil.TempFile("", fileHeader.Filename)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer file.Close()
 
 	file.Write(fileBytes)
 
-	return *file, nil
+	return file, nil
 }
 
 // parseInt64Parameter parses a string parameter to an int64.

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -39,7 +39,7 @@ type {{classname}} interface {
 	{{#isDeprecated}}
 	// Deprecated
 	{{/isDeprecated}}
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
+	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -74,7 +74,7 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/s
 
 {{/isPathParam}}
 {{/allParams}}
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) Execute() ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) Execute() ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -108,13 +108,13 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#pathParams
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.Method{{httpMethod}}
 		localVarPostBody     interface{}
 		formFiles            []formFile
 		{{#returnType}}
-		localVarReturnValue  {{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}
+		localVarReturnValue  {{^isArray}}{{^returnTypeIsPrimitive}}{{^isResponseFile}}*{{/isResponseFile}}{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}
 		{{/returnType}}
 	)
 

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -55,7 +55,7 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/stru
 	ApiService *{{classname}}Service
 {{/generateInterfaces}}
 {{#allParams}}
-	{{paramName}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}
+	{{paramName}} {{^isPathParam}}{{^isFile}}*{{/isFile}}{{/isPathParam}}{{{dataType}}}
 {{/allParams}}
 }
 
@@ -68,7 +68,7 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/stru
 // Deprecated
 {{/isDeprecated}}
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request {
-	r.{{paramName}} = &{{paramName}}
+	r.{{paramName}} = {{^isFile}}&{{/isFile}}{{paramName}}
 	return r
 }
 
@@ -258,27 +258,17 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 	{{paramName}}LocalVarFormFileName = "{{baseName}}"
 
-{{#required}}
+
 	{{paramName}}LocalVarFile := r.{{paramName}}
-{{/required}}
-{{^required}}
-	var {{paramName}}LocalVarFile *{{dataType}}
-	if r.{{paramName}} != nil {
-		{{paramName}}LocalVarFile = r.{{paramName}}
-	}
+
 	if {{paramName}}LocalVarFile != nil {
 		fbs, _ := ioutil.ReadAll({{paramName}}LocalVarFile)
-		{{/required}}
-		{{#required}}
-				fbs, _ := ioutil.ReadAll({{paramName}}LocalVarFile)
-		{{/required}}
+
 		{{paramName}}LocalVarFileBytes = fbs
 		{{paramName}}LocalVarFileName = {{paramName}}LocalVarFile.Name()
 		{{paramName}}LocalVarFile.Close()
-	{{^required}}
+		formFiles = append(formFiles, formFile{fileBytes: {{paramName}}LocalVarFileBytes, fileName: {{paramName}}LocalVarFileName, formFileName: {{paramName}}LocalVarFormFileName})
 	}
-	{{/required}}
-	formFiles = append(formFiles, formFile{fileBytes: {{paramName}}LocalVarFileBytes, fileName: {{paramName}}LocalVarFileName, formFileName: {{paramName}}LocalVarFormFileName})
 {{/isFile}}
 {{^isFile}}
 {{#required}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -262,8 +262,8 @@ public class GoModelTest {
     public void filePropertyTest() {
         final DefaultCodegen codegen = new GoClientCodegen();
         final Schema model1 = new Schema().type("file");
-        Assert.assertEquals(codegen.getSchemaType(model1), "os.File");
-        Assert.assertEquals(codegen.getTypeDeclaration(model1), "os.File");
+        Assert.assertEquals(codegen.getSchemaType(model1), "*os.File");
+        Assert.assertEquals(codegen.getTypeDeclaration(model1), "*os.File");
 
         final Schema model2 = new Schema().$ref("#/definitions/File");
         Assert.assertEquals(codegen.getSchemaType(model2), "File");

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -1135,8 +1135,8 @@ func (r ApiTestEndpointParametersRequest) String_(string_ string) ApiTestEndpoin
 }
 
 // None
-func (r ApiTestEndpointParametersRequest) Binary(binary os.File) ApiTestEndpointParametersRequest {
-	r.binary = &binary
+func (r ApiTestEndpointParametersRequest) Binary(binary *os.File) ApiTestEndpointParametersRequest {
+	r.binary = binary
 	return r
 }
 
@@ -1271,17 +1271,17 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 
 	binaryLocalVarFormFileName = "binary"
 
-	var binaryLocalVarFile *os.File
-	if r.binary != nil {
-		binaryLocalVarFile = r.binary
-	}
+
+	binaryLocalVarFile := r.binary
+
 	if binaryLocalVarFile != nil {
 		fbs, _ := ioutil.ReadAll(binaryLocalVarFile)
+
 		binaryLocalVarFileBytes = fbs
 		binaryLocalVarFileName = binaryLocalVarFile.Name()
 		binaryLocalVarFile.Close()
+		formFiles = append(formFiles, formFile{fileBytes: binaryLocalVarFileBytes, fileName: binaryLocalVarFileName, formFileName: binaryLocalVarFormFileName})
 	}
-	formFiles = append(formFiles, formFile{fileBytes: binaryLocalVarFileBytes, fileName: binaryLocalVarFileName, formFileName: binaryLocalVarFormFileName})
 	if r.date != nil {
 		parameterAddToQuery(localVarFormParams, "date", r.date, "")
 	}

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -905,8 +905,8 @@ func (r ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) ApiU
 }
 
 // file to upload
-func (r ApiUploadFileRequest) File(file os.File) ApiUploadFileRequest {
-	r.file = &file
+func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
+	r.file = file
 	return r
 }
 
@@ -977,17 +977,17 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (*ApiResponse,
 
 	fileLocalVarFormFileName = "file"
 
-	var fileLocalVarFile *os.File
-	if r.file != nil {
-		fileLocalVarFile = r.file
-	}
+
+	fileLocalVarFile := r.file
+
 	if fileLocalVarFile != nil {
 		fbs, _ := ioutil.ReadAll(fileLocalVarFile)
+
 		fileLocalVarFileBytes = fbs
 		fileLocalVarFileName = fileLocalVarFile.Name()
 		fileLocalVarFile.Close()
+		formFiles = append(formFiles, formFile{fileBytes: fileLocalVarFileBytes, fileName: fileLocalVarFileName, formFileName: fileLocalVarFormFileName})
 	}
-	formFiles = append(formFiles, formFile{fileBytes: fileLocalVarFileBytes, fileName: fileLocalVarFileName, formFileName: fileLocalVarFormFileName})
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1034,8 +1034,8 @@ type ApiUploadFileWithRequiredFileRequest struct {
 }
 
 // file to upload
-func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile os.File) ApiUploadFileWithRequiredFileRequest {
-	r.requiredFile = &requiredFile
+func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) ApiUploadFileWithRequiredFileRequest {
+	r.requiredFile = requiredFile
 	return r
 }
 
@@ -1115,12 +1115,17 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 
 	requiredFileLocalVarFormFileName = "requiredFile"
 
+
 	requiredFileLocalVarFile := r.requiredFile
-				fbs, _ := ioutil.ReadAll(requiredFileLocalVarFile)
+
+	if requiredFileLocalVarFile != nil {
+		fbs, _ := ioutil.ReadAll(requiredFileLocalVarFile)
+
 		requiredFileLocalVarFileBytes = fbs
 		requiredFileLocalVarFileName = requiredFileLocalVarFile.Name()
 		requiredFileLocalVarFile.Close()
-	formFiles = append(formFiles, formFile{fileBytes: requiredFileLocalVarFileBytes, fileName: requiredFileLocalVarFileName, formFileName: requiredFileLocalVarFormFileName})
+		formFiles = append(formFiles, formFile{fileBytes: requiredFileLocalVarFileBytes, fileName: requiredFileLocalVarFileName, formFileName: requiredFileLocalVarFormFileName})
+	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -574,7 +574,7 @@ func main() {
     int64_ := int64(789) // int64 | None (optional)
     float := float32(3.4) // float32 | None (optional)
     string_ := "string__example" // string | None (optional)
-    binary := os.NewFile(1234, "some_file") // os.File | None (optional)
+    binary := os.NewFile(1234, "some_file") // *os.File | None (optional)
     date := time.Now() // string | None (optional)
     dateTime := time.Now() // time.Time | None (optional)
     password := "password_example" // string | None (optional)
@@ -610,7 +610,7 @@ Name | Type | Description  | Notes
  **int64_** | **int64** | None | 
  **float** | **float32** | None | 
  **string_** | **string** | None | 
- **binary** | **os.File** | None | 
+ **binary** | ***os.File** | None | 
  **date** | **string** | None | 
  **dateTime** | **time.Time** | None | 
  **password** | **string** | None | 

--- a/samples/client/petstore/go/go-petstore/docs/FormatTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/FormatTest.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **Double** | Pointer to **float64** |  | [optional] 
 **String** | Pointer to **string** |  | [optional] 
 **Byte** | **string** |  | 
-**Binary** | Pointer to **os.File** |  | [optional] 
+**Binary** | Pointer to ***os.File** |  | [optional] 
 **Date** | **string** |  | 
 **DateTime** | Pointer to **time.Time** |  | [optional] 
 **Uuid** | Pointer to **string** |  | [optional] 
@@ -230,20 +230,20 @@ SetByte sets Byte field to given value.
 
 ### GetBinary
 
-`func (o *FormatTest) GetBinary() os.File`
+`func (o *FormatTest) GetBinary() *os.File`
 
 GetBinary returns the Binary field if non-nil, zero value otherwise.
 
 ### GetBinaryOk
 
-`func (o *FormatTest) GetBinaryOk() (*os.File, bool)`
+`func (o *FormatTest) GetBinaryOk() (**os.File, bool)`
 
 GetBinaryOk returns a tuple with the Binary field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetBinary
 
-`func (o *FormatTest) SetBinary(v os.File)`
+`func (o *FormatTest) SetBinary(v *os.File)`
 
 SetBinary sets Binary field to given value.
 

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -501,7 +501,7 @@ import (
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
-    file := os.NewFile(1234, "some_file") // os.File | file to upload (optional)
+    file := os.NewFile(1234, "some_file") // *os.File | file to upload (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -532,7 +532,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
  **additionalMetadata** | **string** | Additional data to pass to server | 
- **file** | **os.File** | file to upload | 
+ **file** | ***os.File** | file to upload | 
 
 ### Return type
 
@@ -572,7 +572,7 @@ import (
 
 func main() {
     petId := int64(789) // int64 | ID of pet to update
-    requiredFile := os.NewFile(1234, "some_file") // os.File | file to upload
+    requiredFile := os.NewFile(1234, "some_file") // *os.File | file to upload
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
 
     configuration := openapiclient.NewConfiguration()
@@ -603,7 +603,7 @@ Other parameters are passed through a pointer to a apiUploadFileWithRequiredFile
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **requiredFile** | **os.File** | file to upload | 
+ **requiredFile** | ***os.File** | file to upload | 
  **additionalMetadata** | **string** | Additional data to pass to server | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -29,7 +29,7 @@ type FormatTest struct {
 	Double *float64 `json:"double,omitempty"`
 	String *string `json:"string,omitempty"`
 	Byte string `json:"byte"`
-	Binary *os.File `json:"binary,omitempty"`
+	Binary **os.File `json:"binary,omitempty"`
 	Date string `json:"date"`
 	DateTime *time.Time `json:"dateTime,omitempty"`
 	Uuid *string `json:"uuid,omitempty"`
@@ -299,9 +299,9 @@ func (o *FormatTest) SetByte(v string) {
 }
 
 // GetBinary returns the Binary field value if set, zero value otherwise.
-func (o *FormatTest) GetBinary() os.File {
+func (o *FormatTest) GetBinary() *os.File {
 	if o == nil || isNil(o.Binary) {
-		var ret os.File
+		var ret *os.File
 		return ret
 	}
 	return *o.Binary
@@ -309,7 +309,7 @@ func (o *FormatTest) GetBinary() os.File {
 
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
+func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || isNil(o.Binary) {
 		return nil, false
 	}
@@ -325,8 +325,8 @@ func (o *FormatTest) HasBinary() bool {
 	return false
 }
 
-// SetBinary gets a reference to the given os.File and assigns it to the Binary field.
-func (o *FormatTest) SetBinary(v os.File) {
+// SetBinary gets a reference to the given *os.File and assigns it to the Binary field.
+func (o *FormatTest) SetBinary(v *os.File) {
 	o.Binary = &v
 }
 

--- a/samples/client/petstore/go/pet_api_test.go
+++ b/samples/client/petstore/go/pet_api_test.go
@@ -154,7 +154,7 @@ func TestUploadFile(t *testing.T) {
 		t.Fatalf("Error opening file: %v", err1)
 	}
 
-	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(*file).Execute()
+	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
@@ -172,7 +172,7 @@ func TestUploadFileRequired(t *testing.T) {
 		t.Fatalf("Error opening file: %v", err1)
 	}
 
-	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(*file).AdditionalMetadata("golang").Execute()
+	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
 	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
@@ -70,6 +70,35 @@ pub fn urlencode<T: AsRef<str>>(s: T) -> String {
     ::url::form_urlencoded::byte_serialize(s.as_ref().as_bytes()).collect()
 }
 
+pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String, String)> {
+    if let serde_json::Value::Object(object) = value {
+        let mut params = vec![];
+
+        for (key, value) in object {
+            match value {
+                serde_json::Value::Object(_) => params.append(&mut parse_deep_object(
+                    &format!("{}[{}]", prefix, key),
+                    value,
+                )),
+                serde_json::Value::Array(array) => {
+                    for (i, value) in array.iter().enumerate() {
+                        params.append(&mut parse_deep_object(
+                            &format!("{}[{}][{}]", prefix, key, i),
+                            value,
+                        ));
+                    }
+                },
+                serde_json::Value::String(s) => params.push((format!("{}[{}]", prefix, key), s.clone())),
+                _ => params.push((format!("{}[{}]", prefix, key), value.to_string())),
+            }
+        }
+
+        return params;
+    }
+
+    unimplemented!("Only objects are supported with style=deepObject")
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -1161,8 +1161,8 @@ func (r ApiTestEndpointParametersRequest) String_(string_ string) ApiTestEndpoin
 }
 
 // None
-func (r ApiTestEndpointParametersRequest) Binary(binary os.File) ApiTestEndpointParametersRequest {
-	r.binary = &binary
+func (r ApiTestEndpointParametersRequest) Binary(binary *os.File) ApiTestEndpointParametersRequest {
+	r.binary = binary
 	return r
 }
 
@@ -1298,17 +1298,17 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 
 	binaryLocalVarFormFileName = "binary"
 
-	var binaryLocalVarFile *os.File
-	if r.binary != nil {
-		binaryLocalVarFile = r.binary
-	}
+
+	binaryLocalVarFile := r.binary
+
 	if binaryLocalVarFile != nil {
 		fbs, _ := ioutil.ReadAll(binaryLocalVarFile)
+
 		binaryLocalVarFileBytes = fbs
 		binaryLocalVarFileName = binaryLocalVarFile.Name()
 		binaryLocalVarFile.Close()
+		formFiles = append(formFiles, formFile{fileBytes: binaryLocalVarFileBytes, fileName: binaryLocalVarFileName, formFileName: binaryLocalVarFormFileName})
 	}
-	formFiles = append(formFiles, formFile{fileBytes: binaryLocalVarFileBytes, fileName: binaryLocalVarFileName, formFileName: binaryLocalVarFormFileName})
 	if r.date != nil {
 		parameterAddToQuery(localVarFormParams, "date", r.date, "")
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -926,8 +926,8 @@ func (r ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) ApiU
 }
 
 // file to upload
-func (r ApiUploadFileRequest) File(file os.File) ApiUploadFileRequest {
-	r.file = &file
+func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
+	r.file = file
 	return r
 }
 
@@ -1000,17 +1000,17 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (*ApiResponse,
 
 	fileLocalVarFormFileName = "file"
 
-	var fileLocalVarFile *os.File
-	if r.file != nil {
-		fileLocalVarFile = r.file
-	}
+
+	fileLocalVarFile := r.file
+
 	if fileLocalVarFile != nil {
 		fbs, _ := ioutil.ReadAll(fileLocalVarFile)
+
 		fileLocalVarFileBytes = fbs
 		fileLocalVarFileName = fileLocalVarFile.Name()
 		fileLocalVarFile.Close()
+		formFiles = append(formFiles, formFile{fileBytes: fileLocalVarFileBytes, fileName: fileLocalVarFileName, formFileName: fileLocalVarFormFileName})
 	}
-	formFiles = append(formFiles, formFile{fileBytes: fileLocalVarFileBytes, fileName: fileLocalVarFileName, formFileName: fileLocalVarFormFileName})
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -1057,8 +1057,8 @@ type ApiUploadFileWithRequiredFileRequest struct {
 }
 
 // file to upload
-func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile os.File) ApiUploadFileWithRequiredFileRequest {
-	r.requiredFile = &requiredFile
+func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) ApiUploadFileWithRequiredFileRequest {
+	r.requiredFile = requiredFile
 	return r
 }
 
@@ -1140,12 +1140,17 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 
 	requiredFileLocalVarFormFileName = "requiredFile"
 
+
 	requiredFileLocalVarFile := r.requiredFile
-				fbs, _ := ioutil.ReadAll(requiredFileLocalVarFile)
+
+	if requiredFileLocalVarFile != nil {
+		fbs, _ := ioutil.ReadAll(requiredFileLocalVarFile)
+
 		requiredFileLocalVarFileBytes = fbs
 		requiredFileLocalVarFileName = requiredFileLocalVarFile.Name()
 		requiredFileLocalVarFile.Close()
-	formFiles = append(formFiles, formFile{fileBytes: requiredFileLocalVarFileBytes, fileName: requiredFileLocalVarFileName, formFileName: requiredFileLocalVarFormFileName})
+		formFiles = append(formFiles, formFile{fileBytes: requiredFileLocalVarFileBytes, fileName: requiredFileLocalVarFileName, formFileName: requiredFileLocalVarFormFileName})
+	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -571,7 +571,7 @@ func main() {
     int64_ := int64(789) // int64 | None (optional)
     float := float32(3.4) // float32 | None (optional)
     string_ := "string__example" // string | None (optional)
-    binary := os.NewFile(1234, "some_file") // os.File | None (optional)
+    binary := os.NewFile(1234, "some_file") // *os.File | None (optional)
     date := time.Now() // string | None (optional)
     dateTime := time.Now() // time.Time | None (optional)
     password := "password_example" // string | None (optional)
@@ -607,7 +607,7 @@ Name | Type | Description  | Notes
  **int64_** | **int64** | None | 
  **float** | **float32** | None | 
  **string_** | **string** | None | 
- **binary** | **os.File** | None | 
+ **binary** | ***os.File** | None | 
  **date** | **string** | None | 
  **dateTime** | **time.Time** | None | 
  **password** | **string** | None | 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FormatTest.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **Double** | Pointer to **float64** |  | [optional] 
 **String** | Pointer to **string** |  | [optional] 
 **Byte** | **string** |  | 
-**Binary** | Pointer to **os.File** |  | [optional] 
+**Binary** | Pointer to ***os.File** |  | [optional] 
 **Date** | **string** |  | 
 **DateTime** | Pointer to **time.Time** |  | [optional] 
 **Uuid** | Pointer to **string** |  | [optional] 
@@ -231,20 +231,20 @@ SetByte sets Byte field to given value.
 
 ### GetBinary
 
-`func (o *FormatTest) GetBinary() os.File`
+`func (o *FormatTest) GetBinary() *os.File`
 
 GetBinary returns the Binary field if non-nil, zero value otherwise.
 
 ### GetBinaryOk
 
-`func (o *FormatTest) GetBinaryOk() (*os.File, bool)`
+`func (o *FormatTest) GetBinaryOk() (**os.File, bool)`
 
 GetBinaryOk returns a tuple with the Binary field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetBinary
 
-`func (o *FormatTest) SetBinary(v os.File)`
+`func (o *FormatTest) SetBinary(v *os.File)`
 
 SetBinary sets Binary field to given value.
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/MapOfFileTest.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/MapOfFileTest.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**PropTest** | Pointer to **map[string]os.File** | a property to test map of file | [optional] 
+**PropTest** | Pointer to **map[string]*os.File** | a property to test map of file | [optional] 
 
 ## Methods
 
@@ -27,20 +27,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetPropTest
 
-`func (o *MapOfFileTest) GetPropTest() map[string]os.File`
+`func (o *MapOfFileTest) GetPropTest() map[string]*os.File`
 
 GetPropTest returns the PropTest field if non-nil, zero value otherwise.
 
 ### GetPropTestOk
 
-`func (o *MapOfFileTest) GetPropTestOk() (*map[string]os.File, bool)`
+`func (o *MapOfFileTest) GetPropTestOk() (*map[string]*os.File, bool)`
 
 GetPropTestOk returns a tuple with the PropTest field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPropTest
 
-`func (o *MapOfFileTest) SetPropTest(v map[string]os.File)`
+`func (o *MapOfFileTest) SetPropTest(v map[string]*os.File)`
 
 SetPropTest sets PropTest field to given value.
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -511,7 +511,7 @@ import (
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
-    file := os.NewFile(1234, "some_file") // os.File | file to upload (optional)
+    file := os.NewFile(1234, "some_file") // *os.File | file to upload (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
@@ -542,7 +542,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
  **additionalMetadata** | **string** | Additional data to pass to server | 
- **file** | **os.File** | file to upload | 
+ **file** | ***os.File** | file to upload | 
 
 ### Return type
 
@@ -584,7 +584,7 @@ import (
 
 func main() {
     petId := int64(789) // int64 | ID of pet to update
-    requiredFile := os.NewFile(1234, "some_file") // os.File | file to upload
+    requiredFile := os.NewFile(1234, "some_file") // *os.File | file to upload
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
 
     configuration := openapiclient.NewConfiguration()
@@ -615,7 +615,7 @@ Other parameters are passed through a pointer to a apiUploadFileWithRequiredFile
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **requiredFile** | **os.File** | file to upload | 
+ **requiredFile** | ***os.File** | file to upload | 
  **additionalMetadata** | **string** | Additional data to pass to server | 
 
 ### Return type

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -29,7 +29,7 @@ type FormatTest struct {
 	Double *float64 `json:"double,omitempty"`
 	String *string `json:"string,omitempty"`
 	Byte string `json:"byte"`
-	Binary *os.File `json:"binary,omitempty"`
+	Binary **os.File `json:"binary,omitempty"`
 	Date string `json:"date"`
 	DateTime *time.Time `json:"dateTime,omitempty"`
 	Uuid *string `json:"uuid,omitempty"`
@@ -305,9 +305,9 @@ func (o *FormatTest) SetByte(v string) {
 }
 
 // GetBinary returns the Binary field value if set, zero value otherwise.
-func (o *FormatTest) GetBinary() os.File {
+func (o *FormatTest) GetBinary() *os.File {
 	if o == nil || isNil(o.Binary) {
-		var ret os.File
+		var ret *os.File
 		return ret
 	}
 	return *o.Binary
@@ -315,7 +315,7 @@ func (o *FormatTest) GetBinary() os.File {
 
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetBinaryOk() (*os.File, bool) {
+func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || isNil(o.Binary) {
 		return nil, false
 	}
@@ -331,8 +331,8 @@ func (o *FormatTest) HasBinary() bool {
 	return false
 }
 
-// SetBinary gets a reference to the given os.File and assigns it to the Binary field.
-func (o *FormatTest) SetBinary(v os.File) {
+// SetBinary gets a reference to the given *os.File and assigns it to the Binary field.
+func (o *FormatTest) SetBinary(v *os.File) {
 	o.Binary = &v
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
@@ -21,7 +21,7 @@ var _ MappedNullable = &MapOfFileTest{}
 // MapOfFileTest test map of file in a property
 type MapOfFileTest struct {
 	// a property to test map of file
-	PropTest *map[string]os.File `json:"prop_test,omitempty"`
+	PropTest *map[string]*os.File `json:"prop_test,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -45,9 +45,9 @@ func NewMapOfFileTestWithDefaults() *MapOfFileTest {
 }
 
 // GetPropTest returns the PropTest field value if set, zero value otherwise.
-func (o *MapOfFileTest) GetPropTest() map[string]os.File {
+func (o *MapOfFileTest) GetPropTest() map[string]*os.File {
 	if o == nil || isNil(o.PropTest) {
-		var ret map[string]os.File
+		var ret map[string]*os.File
 		return ret
 	}
 	return *o.PropTest
@@ -55,7 +55,7 @@ func (o *MapOfFileTest) GetPropTest() map[string]os.File {
 
 // GetPropTestOk returns a tuple with the PropTest field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *MapOfFileTest) GetPropTestOk() (*map[string]os.File, bool) {
+func (o *MapOfFileTest) GetPropTestOk() (*map[string]*os.File, bool) {
 	if o == nil || isNil(o.PropTest) {
 		return nil, false
 	}
@@ -71,8 +71,8 @@ func (o *MapOfFileTest) HasPropTest() bool {
 	return false
 }
 
-// SetPropTest gets a reference to the given map[string]os.File and assigns it to the PropTest field.
-func (o *MapOfFileTest) SetPropTest(v map[string]os.File) {
+// SetPropTest gets a reference to the given map[string]*os.File and assigns it to the PropTest field.
+func (o *MapOfFileTest) SetPropTest(v map[string]*os.File) {
 	o.PropTest = &v
 }
 

--- a/samples/openapi3/client/petstore/go/pet_api_test.go
+++ b/samples/openapi3/client/petstore/go/pet_api_test.go
@@ -144,7 +144,7 @@ func TestUploadFile(t *testing.T) {
 		t.Fatalf("Error opening file: %v", err1)
 	}
 
-	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(*file).Execute()
+	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
@@ -162,7 +162,7 @@ func TestUploadFileRequired(t *testing.T) {
 		t.Fatalf("Error opening file: %v", err1)
 	}
 
-	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(*file).AdditionalMetadata("golang").Execute()
+	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
 	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -68,7 +68,7 @@ type PetApiServicer interface {
 	GetPetById(context.Context, int64) (ImplResponse, error)
 	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
-	UploadFile(context.Context, int64, string, os.File) (ImplResponse, error)
+	UploadFile(context.Context, int64, string, *os.File) (ImplResponse, error)
 }
 
 

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -130,7 +130,7 @@ func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name
 }
 
 // UploadFile - uploads an image
-func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file os.File) (ImplResponse, error) {
+func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (ImplResponse, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -80,22 +80,22 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
-func ReadFormFileToTempFile(r *http.Request, key string) (os.File, error) {
+func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	_, fileHeader, err := r.FormFile(key)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	return readFileHeaderToTempFile(fileHeader)
 }
 
 // ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
-func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
+func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		return nil, err
 	}
 
-	files := make([]os.File, 0, len(r.MultipartForm.File[key]))
+	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
 
 	for _, fileHeader := range r.MultipartForm.File[key] {
 		file, err := readFileHeaderToTempFile(fileHeader)
@@ -110,29 +110,29 @@ func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
 }
 
 // readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
-func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (os.File, error) {
+func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
 	formFile, err := fileHeader.Open()
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer formFile.Close()
 
 	fileBytes, err := ioutil.ReadAll(formFile)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	file, err := ioutil.TempFile("", fileHeader.Filename)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer file.Close()
 
 	file.Write(fileBytes)
 
-	return *file, nil
+	return file, nil
 }
 
 // parseInt64Parameter parses a string parameter to an int64.

--- a/samples/server/petstore/go-chi-server/go/api.go
+++ b/samples/server/petstore/go-chi-server/go/api.go
@@ -68,7 +68,7 @@ type PetApiServicer interface {
 	GetPetById(context.Context, int64) (ImplResponse, error)
 	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
-	UploadFile(context.Context, int64, string, os.File) (ImplResponse, error)
+	UploadFile(context.Context, int64, string, *os.File) (ImplResponse, error)
 }
 
 

--- a/samples/server/petstore/go-chi-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet_service.go
@@ -130,7 +130,7 @@ func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name
 }
 
 // UploadFile - uploads an image
-func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file os.File) (ImplResponse, error) {
+func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (ImplResponse, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -76,22 +76,22 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
-func ReadFormFileToTempFile(r *http.Request, key string) (os.File, error) {
+func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	_, fileHeader, err := r.FormFile(key)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	return readFileHeaderToTempFile(fileHeader)
 }
 
 // ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
-func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
+func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		return nil, err
 	}
 
-	files := make([]os.File, 0, len(r.MultipartForm.File[key]))
+	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
 
 	for _, fileHeader := range r.MultipartForm.File[key] {
 		file, err := readFileHeaderToTempFile(fileHeader)
@@ -106,29 +106,29 @@ func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
 }
 
 // readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
-func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (os.File, error) {
+func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
 	formFile, err := fileHeader.Open()
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer formFile.Close()
 
 	fileBytes, err := ioutil.ReadAll(formFile)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	file, err := ioutil.TempFile("", fileHeader.Filename)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer file.Close()
 
 	file.Write(fileBytes)
 
-	return *file, nil
+	return file, nil
 }
 
 // parseInt64Parameter parses a string parameter to an int64.

--- a/samples/server/petstore/go-server-required/go/api.go
+++ b/samples/server/petstore/go-server-required/go/api.go
@@ -68,7 +68,7 @@ type PetApiServicer interface {
 	GetPetById(context.Context, int64) (ImplResponse, error)
 	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
-	UploadFile(context.Context, int64, string, os.File) (ImplResponse, error)
+	UploadFile(context.Context, int64, string, *os.File) (ImplResponse, error)
 }
 
 

--- a/samples/server/petstore/go-server-required/go/api_pet_service.go
+++ b/samples/server/petstore/go-server-required/go/api_pet_service.go
@@ -130,7 +130,7 @@ func (s *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, name
 }
 
 // UploadFile - uploads an image
-func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file os.File) (ImplResponse, error) {
+func (s *PetApiService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (ImplResponse, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-server-required/go/routers.go
+++ b/samples/server/petstore/go-server-required/go/routers.go
@@ -76,22 +76,22 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
-func ReadFormFileToTempFile(r *http.Request, key string) (os.File, error) {
+func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
 	_, fileHeader, err := r.FormFile(key)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	return readFileHeaderToTempFile(fileHeader)
 }
 
 // ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
-func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
+func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		return nil, err
 	}
 
-	files := make([]os.File, 0, len(r.MultipartForm.File[key]))
+	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
 
 	for _, fileHeader := range r.MultipartForm.File[key] {
 		file, err := readFileHeaderToTempFile(fileHeader)
@@ -106,29 +106,29 @@ func ReadFormFilesToTempFiles(r *http.Request, key string) ([]os.File, error) {
 }
 
 // readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
-func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (os.File, error) {
+func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
 	formFile, err := fileHeader.Open()
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer formFile.Close()
 
 	fileBytes, err := ioutil.ReadAll(formFile)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	file, err := ioutil.TempFile("", fileHeader.Filename)
 	if err != nil {
-		return os.File{}, err
+		return nil, err
 	}
 
 	defer file.Close()
 
 	file.Write(fileBytes)
 
-	return *file, nil
+	return file, nil
 }
 
 // parseInt64Parameter parses a string parameter to an int64.


### PR DESCRIPTION
Downloading and uploading files for the Go Client were broken recently but then fixed with https://github.com/OpenAPITools/openapi-generator/pull/14046. However this fix breaks the pattern of the API returning pointers to things.

This change makes the API return `*os.File` and accept `*os.File` for uploading and downloading.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 