### PR TITLE
[csharp-netcore] Added new pipeline to build standard

### DIFF
--- a/.github/workflows/samples-dotnet-standard.yaml
+++ b/.github/workflows/samples-dotnet-standard.yaml
@@ -1,0 +1,30 @@
+name: Samples C# .Net Standard
+
+on:
+  push:
+    paths:
+      - 'samples/client/petstore/csharp-netcore/**netstandard**/'
+  pull_request:
+    paths:
+      - 'samples/client/petstore/csharp-netcore/**netstandard**/'
+jobs:
+  build:
+    name: Build .Net projects
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sample:
+          # clients
+          - samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: 2.1.*
+      - name: Build
+        working-directory: ${{ matrix.sample }}
+        run: dotnet build Org.OpenAPITools.sln
+      - name: Test
+        working-directory: ${{ matrix.sample }}
+        run: dotnet test Org.OpenAPITools.sln


### PR DESCRIPTION
The other pipeline to build dotnet samples was ignoring standard. It looks like to include standard we need to use another dotnet-version property.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05)