### PR TITLE
fix removing dollar sign for name sanitization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -448,7 +448,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         name = name.replaceAll("[^\\w\\\\]+", "_"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         // remove dollar sign
-        name = name.replaceAll("$", "");
+        name = name.replace("$", "");
 
         // model name cannot use reserved keyword
         if (isReservedWord(name)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -178,7 +178,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         // remove dollar sign
-        name = name.replaceAll("$", "");
+        name = name.replace("$", "");
 
         // if it's all upper case, convert to lower case
         if (name.matches("^[A-Z_]*$")) {
@@ -639,7 +639,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
         String sanitizedName = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         // remove dollar sign
-        sanitizedName = sanitizedName.replaceAll("$", "");
+        sanitizedName = sanitizedName.replace("$", "");
         // remove whitespace
         sanitizedName = sanitizedName.replaceAll("\\s+", "");
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -505,7 +505,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
     public String toModelName(String name) {
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         // remove dollar sign
-        name = name.replaceAll("$", "");
+        name = name.replace("$", "");
 
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientCodegenTest.java
@@ -17,8 +17,11 @@
 
 package org.openapitools.codegen.php;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.languages.PhpClientCodegen;
+import org.openapitools.codegen.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -76,4 +79,15 @@ public class PhpClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "Xinvoker");
     }
 
+    @Test(description = "convert a model with dollar signs")
+    public void modelTest() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/dollar-in-names-pull14359.yaml");
+        final PhpClientCodegen codegen = new PhpClientCodegen();
+
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel simpleName = codegen.fromModel("$DollarModel$", openAPI.getComponents().getSchemas().get("$DollarModel$"));
+        Assert.assertEquals(simpleName.name, "$DollarModel$");
+        Assert.assertEquals(simpleName.classname, "DollarModel");
+        Assert.assertEquals(simpleName.classVarName, "dollar_model");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/protobuf/ProtobufSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/protobuf/ProtobufSchemaCodegenTest.java
@@ -16,7 +16,9 @@
 
 package org.openapitools.codegen.protobuf;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
@@ -78,5 +80,17 @@ public class ProtobufSchemaCodegenTest {
             .replace("\n", "").replace("\r", "");
 
         assertEquals(generatedFile, expectedFile);
+    }
+
+    @Test(description = "convert a model with dollar signs")
+    public void modelTest() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/dollar-in-names-pull14359.yaml");
+        final ProtobufSchemaCodegen codegen = new ProtobufSchemaCodegen();
+
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel simpleName = codegen.fromModel("$DollarModel$", openAPI.getComponents().getSchemas().get("$DollarModel$"));
+        Assert.assertEquals(simpleName.name, "$DollarModel$");
+        Assert.assertEquals(simpleName.classname, "DollarModel");
+        Assert.assertEquals(simpleName.classVarName, "$DollarModel$");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonNextgenClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonNextgenClientCodegenTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class PythonNextgenClientCodegenTest {
 
@@ -126,7 +127,7 @@ public class PythonNextgenClientCodegenTest {
     }
 
     @Test(description = "convert a python model with dots")
-    public void modelTest() {
+    public void modelTestDots() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/v1beta3.yaml");
         final DefaultCodegen codegen = new PythonNextgenClientCodegen();
         codegen.setOpenAPI(openAPI);
@@ -148,6 +149,23 @@ public class PythonNextgenClientCodegenTest {
         final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
         Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
         Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
+    }
+
+    @Test(description = "convert a model with dollar signs")
+    public void modelTestDollarSign() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/dollar-in-names-pull14359.yaml");
+        final DefaultCodegen codegen = new PythonNextgenClientCodegen();
+
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel simpleName = codegen.fromModel("$DollarModel$", openAPI.getComponents().getSchemas().get("$DollarModel$"));
+        Assert.assertEquals(simpleName.name, "$DollarModel$");
+        Assert.assertEquals(simpleName.classname, "DollarModel");
+        Assert.assertEquals(simpleName.classVarName, "dollar_model");
+
+        List<CodegenProperty> vars = simpleName.getVars();
+        Assert.assertEquals(vars.size(), 1);
+        CodegenProperty property = vars.get(0);
+        Assert.assertEquals(property.name, "dollar_value");
     }
 
     @Test(description = "convert a simple java model")

--- a/modules/openapi-generator/src/test/resources/3_0/dollar-in-names-pull14359.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dollar-in-names-pull14359.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  title: Pull 14359 - Dollar escaping
+  description: "Dollar sign in names"
+  version: "1.0.0"
+components:
+  schemas:
+    $DollarModel$:
+      type: object
+      properties:
+        $dollarValue$:
+          type: integer
+          format: int64


### PR DESCRIPTION
String#replaceAll uses RegEx. In RegEx the $ matches the end.
So `name.replaceAll("$", "");` doesn't remove the dollar sign instead it does nothing.
The correct way to do it would be to use `String#replace` which doesn't treat the first argument as RegEx.