### PR TITLE
[Java][Spring] Fix #14398 springboot 3 schema required

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom-sb3.mustache
@@ -15,7 +15,7 @@
         {{/springDocDocumentationProvider}}
         {{^springDocDocumentationProvider}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.2.0</swagger-annotations.version>
+        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{#useSwaggerUI}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -22,7 +22,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>
         {{/swagger1AnnotationLibrary}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.1.13</swagger-annotations.version>
+        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{/springFoxDocumentationProvider}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
@@ -15,7 +15,7 @@
         {{/springDocDocumentationProvider}}
         {{^springDocDocumentationProvider}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.2.0</swagger-annotations.version>
+        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
     </properties>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -22,7 +22,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>
         {{/swagger1AnnotationLibrary}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.1.13</swagger-annotations.version>
+        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{/springFoxDocumentationProvider}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -150,7 +150,7 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   {{#required}}@NotNull{{/required}}
   {{/useBeanValidation}}
   {{#swagger2AnnotationLibrary}}
-  @Schema(name = "{{{baseName}}}", {{#isReadOnly}}accessMode = Schema.AccessMode.READ_ONLY, {{/isReadOnly}}{{#example}}example = "{{{.}}}", {{/example}}{{#description}}description = "{{{.}}}", {{/description}}required = {{{required}}})
+  @Schema(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = Schema.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}, requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}})
   {{/swagger2AnnotationLibrary}}
   {{#swagger1AnnotationLibrary}}
   @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")

--- a/modules/openapi-generator/src/main/resources/java-camel-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/pom.mustache
@@ -128,7 +128,7 @@ Do not edit the class manually.
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.1.11</version>
+            <version>2.2.7</version>
         </dependency>
         {{/oas3}}
         {{#jackson}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/configuration/pom.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/configuration/pom.xml.mustache
@@ -26,7 +26,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         {{/generateSwagger1Annotations}}
         {{#generateSwagger2Annotations}}
-        <swagger-annotations-version>2.2.0</swagger-annotations-version>
+        <swagger-annotations-version>2.2.7</swagger-annotations-version>
         {{/generateSwagger2Annotations}}
     </properties>
 

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
@@ -190,7 +190,7 @@ Declare the class with extends and implements
     @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
         {{/generateSwagger1Annotations}}
         {{#generateSwagger2Annotations}}
-    @Schema(name = "{{{baseName}}}", {{#isReadOnly}}accessMode = Schema.AccessMode.READ_ONLY, {{/isReadOnly}}{{#example}}example = "{{{.}}}", {{/example}}{{#description}}description = "{{{.}}}", {{/description}}required = {{{required}}})
+    @Schema(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = Schema.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}, requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}})
         {{/generateSwagger2Annotations}}
         {{#vendorExtensions.x-extra-annotation}}
     {{{vendorExtensions.x-extra-annotation}}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceOptVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceOptVar.mustache
@@ -1,4 +1,4 @@
 {{#swagger2AnnotationLibrary}}
-        @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
+        @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}requiredMode = Schema.RequiredMode.REQUIRED, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
         @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}
         {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? {{^discriminator}}= {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}{{/discriminator}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceReqVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceReqVar.mustache
@@ -1,4 +1,4 @@
 {{#swagger2AnnotationLibrary}}
-        @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
+        @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}requiredMode = Schema.RequiredMode.REQUIRED, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
         @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}
         {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/model/Pet.java
@@ -55,7 +55,7 @@ public class Pet {
    * @return atType
   */
   @NotNull 
-  @Schema(name = "@type", required = true)
+  @Schema(name = "@type", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getAtType() {
     return atType;
   }
@@ -74,7 +74,7 @@ public class Pet {
    * @return age
   */
   
-  @Schema(name = "age", required = false)
+  @Schema(name = "age", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAge() {
     return age;
   }
@@ -93,7 +93,7 @@ public class Pet {
    * @return happy
   */
   
-  @Schema(name = "happy", required = false)
+  @Schema(name = "happy", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getHappy() {
     return happy;
   }
@@ -112,7 +112,7 @@ public class Pet {
    * @return price
   */
   @Valid 
-  @Schema(name = "price", required = false)
+  @Schema(name = "price", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrice() {
     return price;
   }
@@ -131,7 +131,7 @@ public class Pet {
    * @return lastFeed
   */
   @Valid 
-  @Schema(name = "lastFeed", required = false)
+  @Schema(name = "lastFeed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getLastFeed() {
     return lastFeed;
   }
@@ -150,7 +150,7 @@ public class Pet {
    * @return dateOfBirth
   */
   @Valid 
-  @Schema(name = "dateOfBirth", required = false)
+  @Schema(name = "dateOfBirth", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public LocalDate getDateOfBirth() {
     return dateOfBirth;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Addressable.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Addressable.java
@@ -38,7 +38,7 @@ public class Addressable {
    * @return href
   */
   
-  @Schema(name = "href", description = "Hyperlink reference", required = false)
+  @Schema(name = "href", description = "Hyperlink reference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getHref() {
     return href;
   }
@@ -57,7 +57,7 @@ public class Addressable {
    * @return id
   */
   
-  @Schema(name = "id", description = "unique identifier", required = false)
+  @Schema(name = "id", description = "unique identifier", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getId() {
     return id;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Bar.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Bar.java
@@ -49,7 +49,7 @@ public class Bar extends Entity implements BarRefOrValue {
    * @return id
   */
   @NotNull 
-  @Schema(name = "id", required = true)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getId() {
     return id;
   }
@@ -68,7 +68,7 @@ public class Bar extends Entity implements BarRefOrValue {
    * @return barPropA
   */
   
-  @Schema(name = "barPropA", required = false)
+  @Schema(name = "barPropA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBarPropA() {
     return barPropA;
   }
@@ -87,7 +87,7 @@ public class Bar extends Entity implements BarRefOrValue {
    * @return fooPropB
   */
   
-  @Schema(name = "fooPropB", required = false)
+  @Schema(name = "fooPropB", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFooPropB() {
     return fooPropB;
   }
@@ -106,7 +106,7 @@ public class Bar extends Entity implements BarRefOrValue {
    * @return foo
   */
   @Valid 
-  @Schema(name = "foo", required = false)
+  @Schema(name = "foo", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public FooRefOrValue getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarCreate.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/BarCreate.java
@@ -48,7 +48,7 @@ public class BarCreate extends Entity {
    * @return barPropA
   */
   
-  @Schema(name = "barPropA", required = false)
+  @Schema(name = "barPropA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBarPropA() {
     return barPropA;
   }
@@ -67,7 +67,7 @@ public class BarCreate extends Entity {
    * @return fooPropB
   */
   
-  @Schema(name = "fooPropB", required = false)
+  @Schema(name = "fooPropB", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFooPropB() {
     return fooPropB;
   }
@@ -86,7 +86,7 @@ public class BarCreate extends Entity {
    * @return foo
   */
   @Valid 
-  @Schema(name = "foo", required = false)
+  @Schema(name = "foo", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public FooRefOrValue getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Entity.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Entity.java
@@ -69,7 +69,7 @@ public class Entity {
    * @return href
   */
   
-  @Schema(name = "href", description = "Hyperlink reference", required = false)
+  @Schema(name = "href", description = "Hyperlink reference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getHref() {
     return href;
   }
@@ -88,7 +88,7 @@ public class Entity {
    * @return id
   */
   
-  @Schema(name = "id", description = "unique identifier", required = false)
+  @Schema(name = "id", description = "unique identifier", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getId() {
     return id;
   }
@@ -107,7 +107,7 @@ public class Entity {
    * @return atSchemaLocation
   */
   
-  @Schema(name = "@schemaLocation", description = "A URI to a JSON-Schema file that defines additional attributes and relationships", required = false)
+  @Schema(name = "@schemaLocation", description = "A URI to a JSON-Schema file that defines additional attributes and relationships", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtSchemaLocation() {
     return atSchemaLocation;
   }
@@ -126,7 +126,7 @@ public class Entity {
    * @return atBaseType
   */
   
-  @Schema(name = "@baseType", description = "When sub-classing, this defines the super-class", required = false)
+  @Schema(name = "@baseType", description = "When sub-classing, this defines the super-class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtBaseType() {
     return atBaseType;
   }
@@ -145,7 +145,7 @@ public class Entity {
    * @return atType
   */
   @NotNull 
-  @Schema(name = "@type", description = "When sub-classing, this defines the sub-class Extensible name", required = true)
+  @Schema(name = "@type", description = "When sub-classing, this defines the sub-class Extensible name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getAtType() {
     return atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/EntityRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/EntityRef.java
@@ -68,7 +68,7 @@ public class EntityRef {
    * @return name
   */
   
-  @Schema(name = "name", description = "Name of the related entity.", required = false)
+  @Schema(name = "name", description = "Name of the related entity.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }
@@ -87,7 +87,7 @@ public class EntityRef {
    * @return atReferredType
   */
   
-  @Schema(name = "@referredType", description = "The actual type of the target instance when needed for disambiguation.", required = false)
+  @Schema(name = "@referredType", description = "The actual type of the target instance when needed for disambiguation.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtReferredType() {
     return atReferredType;
   }
@@ -106,7 +106,7 @@ public class EntityRef {
    * @return href
   */
   
-  @Schema(name = "href", description = "Hyperlink reference", required = false)
+  @Schema(name = "href", description = "Hyperlink reference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getHref() {
     return href;
   }
@@ -125,7 +125,7 @@ public class EntityRef {
    * @return id
   */
   
-  @Schema(name = "id", description = "unique identifier", required = false)
+  @Schema(name = "id", description = "unique identifier", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getId() {
     return id;
   }
@@ -144,7 +144,7 @@ public class EntityRef {
    * @return atSchemaLocation
   */
   
-  @Schema(name = "@schemaLocation", description = "A URI to a JSON-Schema file that defines additional attributes and relationships", required = false)
+  @Schema(name = "@schemaLocation", description = "A URI to a JSON-Schema file that defines additional attributes and relationships", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtSchemaLocation() {
     return atSchemaLocation;
   }
@@ -163,7 +163,7 @@ public class EntityRef {
    * @return atBaseType
   */
   
-  @Schema(name = "@baseType", description = "When sub-classing, this defines the super-class", required = false)
+  @Schema(name = "@baseType", description = "When sub-classing, this defines the super-class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtBaseType() {
     return atBaseType;
   }
@@ -182,7 +182,7 @@ public class EntityRef {
    * @return atType
   */
   @NotNull 
-  @Schema(name = "@type", description = "When sub-classing, this defines the sub-class Extensible name", required = true)
+  @Schema(name = "@type", description = "When sub-classing, this defines the sub-class Extensible name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getAtType() {
     return atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Extensible.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Extensible.java
@@ -40,7 +40,7 @@ public class Extensible {
    * @return atSchemaLocation
   */
   
-  @Schema(name = "@schemaLocation", description = "A URI to a JSON-Schema file that defines additional attributes and relationships", required = false)
+  @Schema(name = "@schemaLocation", description = "A URI to a JSON-Schema file that defines additional attributes and relationships", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtSchemaLocation() {
     return atSchemaLocation;
   }
@@ -59,7 +59,7 @@ public class Extensible {
    * @return atBaseType
   */
   
-  @Schema(name = "@baseType", description = "When sub-classing, this defines the super-class", required = false)
+  @Schema(name = "@baseType", description = "When sub-classing, this defines the super-class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAtBaseType() {
     return atBaseType;
   }
@@ -78,7 +78,7 @@ public class Extensible {
    * @return atType
   */
   @NotNull 
-  @Schema(name = "@type", description = "When sub-classing, this defines the sub-class Extensible name", required = true)
+  @Schema(name = "@type", description = "When sub-classing, this defines the sub-class Extensible name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getAtType() {
     return atType;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Foo.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Foo.java
@@ -42,7 +42,7 @@ public class Foo extends Entity implements FooRefOrValue {
    * @return fooPropA
   */
   
-  @Schema(name = "fooPropA", required = false)
+  @Schema(name = "fooPropA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFooPropA() {
     return fooPropA;
   }
@@ -61,7 +61,7 @@ public class Foo extends Entity implements FooRefOrValue {
    * @return fooPropB
   */
   
-  @Schema(name = "fooPropB", required = false)
+  @Schema(name = "fooPropB", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFooPropB() {
     return fooPropB;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/FooRef.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/FooRef.java
@@ -39,7 +39,7 @@ public class FooRef extends EntityRef implements FooRefOrValue {
    * @return foorefPropA
   */
   
-  @Schema(name = "foorefPropA", required = false)
+  @Schema(name = "foorefPropA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoorefPropA() {
     return foorefPropA;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pasta.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pasta.java
@@ -39,7 +39,7 @@ public class Pasta extends Entity {
    * @return vendor
   */
   
-  @Schema(name = "vendor", required = false)
+  @Schema(name = "vendor", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getVendor() {
     return vendor;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pizza.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Pizza.java
@@ -49,7 +49,7 @@ public class Pizza extends Entity {
    * @return pizzaSize
   */
   @Valid 
-  @Schema(name = "pizzaSize", required = false)
+  @Schema(name = "pizzaSize", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPizzaSize() {
     return pizzaSize;
   }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/PizzaSpeziale.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/PizzaSpeziale.java
@@ -40,7 +40,7 @@ public class PizzaSpeziale extends Pizza {
    * @return toppings
   */
   
-  @Schema(name = "toppings", required = false)
+  @Schema(name = "toppings", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getToppings() {
     return toppings;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -110,7 +110,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -137,7 +137,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -164,7 +164,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -191,7 +191,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -218,7 +218,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -245,7 +245,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -272,7 +272,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -291,7 +291,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -310,7 +310,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -329,7 +329,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -35,7 +35,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -35,7 +35,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Animal.java
@@ -53,7 +53,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -72,7 +72,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -45,7 +45,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -45,7 +45,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ArrayTest.java
@@ -53,7 +53,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -80,7 +80,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -107,7 +107,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
@@ -78,7 +78,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -75,7 +75,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Capitalization.java
@@ -48,7 +48,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -67,7 +67,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -86,7 +86,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -105,7 +105,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -124,7 +124,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -143,7 +143,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Cat.java
@@ -47,7 +47,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/CatAllOf.java
@@ -35,7 +35,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Category.java
@@ -36,7 +36,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -55,7 +55,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ClassModel.java
@@ -34,7 +34,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Client.java
@@ -33,7 +33,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Dog.java
@@ -38,7 +38,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/DogAllOf.java
@@ -35,7 +35,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
@@ -110,7 +110,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -137,7 +137,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
@@ -193,7 +193,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -212,7 +212,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -231,7 +231,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -250,7 +250,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -269,7 +269,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/File.java
@@ -34,7 +34,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -40,7 +40,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -67,7 +67,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
@@ -84,7 +84,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -105,7 +105,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -124,7 +124,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -145,7 +145,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -166,7 +166,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -187,7 +187,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -206,7 +206,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -225,7 +225,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -244,7 +244,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -263,7 +263,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -282,7 +282,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -301,7 +301,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -320,7 +320,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -339,7 +339,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -38,7 +38,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -57,7 +57,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
@@ -92,7 +92,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -119,7 +119,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -146,7 +146,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -173,7 +173,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -66,7 +66,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -93,7 +93,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Model200Response.java
@@ -39,7 +39,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -58,7 +58,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -41,7 +41,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -60,7 +60,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -79,7 +79,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelList.java
@@ -35,7 +35,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ModelReturn.java
@@ -36,7 +36,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Name.java
@@ -43,7 +43,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -62,7 +62,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -81,7 +81,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -100,7 +100,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NumberOnly.java
@@ -34,7 +34,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
@@ -89,7 +89,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -108,7 +108,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -127,7 +127,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -146,7 +146,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -165,7 +165,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -184,7 +184,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterComposite.java
@@ -40,7 +40,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -59,7 +59,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -78,7 +78,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -95,7 +95,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -114,7 +114,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -133,7 +133,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -160,7 +160,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -188,7 +188,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -207,7 +207,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -36,7 +36,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -55,7 +55,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -35,7 +35,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Tag.java
@@ -36,7 +36,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -55,7 +55,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -49,7 +49,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -68,7 +68,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -87,7 +87,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -106,7 +106,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -133,7 +133,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -52,7 +52,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -71,7 +71,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -90,7 +90,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -109,7 +109,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -128,7 +128,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -155,7 +155,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/User.java
@@ -54,7 +54,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -73,7 +73,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -92,7 +92,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -111,7 +111,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -130,7 +130,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -149,7 +149,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -168,7 +168,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -187,7 +187,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/XmlItem.java
@@ -129,7 +129,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -148,7 +148,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -167,7 +167,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -186,7 +186,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -213,7 +213,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -232,7 +232,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -251,7 +251,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -270,7 +270,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -289,7 +289,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -316,7 +316,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -343,7 +343,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -362,7 +362,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -381,7 +381,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -400,7 +400,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -419,7 +419,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -446,7 +446,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -473,7 +473,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -492,7 +492,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -511,7 +511,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -530,7 +530,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -549,7 +549,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -576,7 +576,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -603,7 +603,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -622,7 +622,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -641,7 +641,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -660,7 +660,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -679,7 +679,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -706,7 +706,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -733,7 +733,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Category.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Category.java
@@ -38,7 +38,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Category {
    * @return name
   */
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -43,7 +43,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -62,7 +62,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -81,7 +81,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -91,7 +91,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -110,7 +110,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -129,7 +129,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -148,7 +148,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -167,7 +167,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -186,7 +186,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -94,7 +94,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -113,7 +113,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -132,7 +132,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -156,7 +156,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -183,7 +183,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -202,7 +202,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Tag.java
@@ -38,7 +38,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -57,7 +57,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/User.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/User.java
@@ -56,7 +56,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -94,7 +94,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -113,7 +113,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -132,7 +132,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -151,7 +151,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -170,7 +170,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -189,7 +189,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/server/petstore/java-camel/pom.xml
+++ b/samples/server/petstore/java-camel/pom.xml
@@ -127,7 +127,7 @@ Do not edit the class manually.
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.1.11</version>
+            <version>2.2.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Category.java
@@ -48,7 +48,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -67,7 +67,7 @@ public class Category {
    * @return name
   */
   @Pattern(regexp = "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") 
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -54,7 +54,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -73,7 +73,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -92,7 +92,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Order.java
@@ -105,7 +105,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -124,7 +124,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -143,7 +143,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -162,7 +162,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Date getShipDate() {
     return shipDate;
   }
@@ -181,7 +181,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -200,7 +200,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Pet.java
@@ -108,7 +108,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -127,7 +127,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -146,7 +146,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -170,7 +170,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -197,7 +197,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -216,7 +216,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Tag.java
@@ -48,7 +48,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -67,7 +67,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/User.java
@@ -72,7 +72,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -91,7 +91,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -110,7 +110,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -129,7 +129,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -148,7 +148,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -167,7 +167,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -186,7 +186,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -205,7 +205,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/server/petstore/java-micronaut-server/pom.xml
+++ b/samples/server/petstore/java-micronaut-server/pom.xml
@@ -22,7 +22,7 @@
         <micronaut.version>3.4.3</micronaut.version>
         <exec.mainClass>org.openapitools.Application</exec.mainClass>
         <micronaut.runtime>netty</micronaut.runtime>
-        <swagger-annotations-version>2.2.0</swagger-annotations-version>
+        <swagger-annotations-version>2.2.7</swagger-annotations-version>
     </properties>
 
     <repositories>

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Category.java
@@ -53,7 +53,7 @@ public class Category {
      * @return id
      **/
     @Nullable
-    @Schema(name = "id", required = false)
+    @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Long getId() {
@@ -77,7 +77,7 @@ public class Category {
      **/
     @Nullable
     @Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
-    @Schema(name = "name", required = false)
+    @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_NAME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getName() {

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -58,7 +58,7 @@ public class ModelApiResponse {
      * @return code
      **/
     @Nullable
-    @Schema(name = "code", required = false)
+    @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_CODE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Integer getCode() {
@@ -81,7 +81,7 @@ public class ModelApiResponse {
      * @return type
      **/
     @Nullable
-    @Schema(name = "type", required = false)
+    @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_TYPE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getType() {
@@ -104,7 +104,7 @@ public class ModelApiResponse {
      * @return message
      **/
     @Nullable
-    @Schema(name = "message", required = false)
+    @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_MESSAGE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getMessage() {

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Order.java
@@ -104,7 +104,7 @@ public class Order {
      * @return id
      **/
     @Nullable
-    @Schema(name = "id", required = false)
+    @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Long getId() {
@@ -127,7 +127,7 @@ public class Order {
      * @return petId
      **/
     @Nullable
-    @Schema(name = "petId", required = false)
+    @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_PET_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Long getPetId() {
@@ -150,7 +150,7 @@ public class Order {
      * @return quantity
      **/
     @Nullable
-    @Schema(name = "quantity", required = false)
+    @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_QUANTITY)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Integer getQuantity() {
@@ -173,7 +173,7 @@ public class Order {
      * @return shipDate
      **/
     @Nullable
-    @Schema(name = "shipDate", required = false)
+    @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_SHIP_DATE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
@@ -198,7 +198,7 @@ public class Order {
      * @return status
      **/
     @Nullable
-    @Schema(name = "status", description = "Order Status", required = false)
+    @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_STATUS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public StatusEnum getStatus() {
@@ -221,7 +221,7 @@ public class Order {
      * @return complete
      **/
     @Nullable
-    @Schema(name = "complete", required = false)
+    @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_COMPLETE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Boolean getComplete() {

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Pet.java
@@ -109,7 +109,7 @@ public class Pet {
      * @return id
      **/
     @Nullable
-    @Schema(name = "id", required = false)
+    @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Long getId() {
@@ -133,7 +133,7 @@ public class Pet {
      **/
     @Valid
     @Nullable
-    @Schema(name = "category", required = false)
+    @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_CATEGORY)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Category getCategory() {
@@ -156,7 +156,7 @@ public class Pet {
      * @return name
      **/
     @NotNull
-    @Schema(name = "name", example = "doggie", required = true)
+    @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty(JSON_PROPERTY_NAME)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public String getName() {
@@ -184,7 +184,7 @@ public class Pet {
      * @return photoUrls
      **/
     @NotNull
-    @Schema(name = "photoUrls", required = true)
+    @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public List<String> getPhotoUrls() {
@@ -215,7 +215,7 @@ public class Pet {
      * @return tags
      **/
     @Nullable
-    @Schema(name = "tags", required = false)
+    @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_TAGS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public List<Tag> getTags() {
@@ -238,7 +238,7 @@ public class Pet {
      * @return status
      **/
     @Nullable
-    @Schema(name = "status", description = "pet status in the store", required = false)
+    @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_STATUS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public StatusEnum getStatus() {

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Tag.java
@@ -53,7 +53,7 @@ public class Tag {
      * @return id
      **/
     @Nullable
-    @Schema(name = "id", required = false)
+    @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Long getId() {
@@ -76,7 +76,7 @@ public class Tag {
      * @return name
      **/
     @Nullable
-    @Schema(name = "name", required = false)
+    @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_NAME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getName() {

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/User.java
@@ -77,7 +77,7 @@ public class User {
      * @return id
      **/
     @Nullable
-    @Schema(name = "id", required = false)
+    @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Long getId() {
@@ -100,7 +100,7 @@ public class User {
      * @return username
      **/
     @Nullable
-    @Schema(name = "username", required = false)
+    @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_USERNAME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getUsername() {
@@ -123,7 +123,7 @@ public class User {
      * @return firstName
      **/
     @Nullable
-    @Schema(name = "firstName", required = false)
+    @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_FIRST_NAME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getFirstName() {
@@ -146,7 +146,7 @@ public class User {
      * @return lastName
      **/
     @Nullable
-    @Schema(name = "lastName", required = false)
+    @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_LAST_NAME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getLastName() {
@@ -169,7 +169,7 @@ public class User {
      * @return email
      **/
     @Nullable
-    @Schema(name = "email", required = false)
+    @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_EMAIL)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getEmail() {
@@ -192,7 +192,7 @@ public class User {
      * @return password
      **/
     @Nullable
-    @Schema(name = "password", required = false)
+    @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_PASSWORD)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getPassword() {
@@ -215,7 +215,7 @@ public class User {
      * @return phone
      **/
     @Nullable
-    @Schema(name = "phone", required = false)
+    @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_PHONE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getPhone() {
@@ -238,7 +238,7 @@ public class User {
      * @return userStatus
      **/
     @Nullable
-    @Schema(name = "userStatus", description = "User Status", required = false)
+    @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @JsonProperty(JSON_PROPERTY_USER_STATUS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public Integer getUserStatus() {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/File.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
@@ -73,7 +73,7 @@ public class ObjectWithUniqueItems {
    * @return nullSet
   */
   
-  @Schema(name = "nullSet", required = false)
+  @Schema(name = "nullSet", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JsonNullable<Set<String>> getNullSet() {
     return nullSet;
   }
@@ -100,7 +100,7 @@ public class ObjectWithUniqueItems {
    * @return notNullSet
   */
   
-  @Schema(name = "notNullSet", required = false)
+  @Schema(name = "notNullSet", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Set<String> getNotNullSet() {
     return notNullSet;
   }
@@ -128,7 +128,7 @@ public class ObjectWithUniqueItems {
    * @return nullList
   */
   
-  @Schema(name = "nullList", required = false)
+  @Schema(name = "nullList", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JsonNullable<List<String>> getNullList() {
     return nullList;
   }
@@ -155,7 +155,7 @@ public class ObjectWithUniqueItems {
    * @return notNullList
   */
   
-  @Schema(name = "notNullList", required = false)
+  @Schema(name = "notNullList", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getNotNullList() {
     return notNullList;
   }
@@ -174,7 +174,7 @@ public class ObjectWithUniqueItems {
    * @return notNullDateField
   */
   @Valid 
-  @Schema(name = "notNullDateField", required = false)
+  @Schema(name = "notNullDateField", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getNotNullDateField() {
     return notNullDateField;
   }
@@ -193,7 +193,7 @@ public class ObjectWithUniqueItems {
    * @return nullDateField
   */
   @Valid 
-  @Schema(name = "nullDateField", required = false)
+  @Schema(name = "nullDateField", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getNullDateField() {
     return nullDateField;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesAnyType.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesArray.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesBoolean.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
@@ -84,7 +84,7 @@ public class AdditionalPropertiesClass {
    * @return mapString
   */
   
-  @Schema(name = "map_string", required = false)
+  @Schema(name = "map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -111,7 +111,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   */
   @Valid 
-  @Schema(name = "map_number", required = false)
+  @Schema(name = "map_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -138,7 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapInteger
   */
   
-  @Schema(name = "map_integer", required = false)
+  @Schema(name = "map_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -165,7 +165,7 @@ public class AdditionalPropertiesClass {
    * @return mapBoolean
   */
   
-  @Schema(name = "map_boolean", required = false)
+  @Schema(name = "map_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -192,7 +192,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayInteger
   */
   @Valid 
-  @Schema(name = "map_array_integer", required = false)
+  @Schema(name = "map_array_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass {
    * @return mapArrayAnytype
   */
   @Valid 
-  @Schema(name = "map_array_anytype", required = false)
+  @Schema(name = "map_array_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -246,7 +246,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapString
   */
   @Valid 
-  @Schema(name = "map_map_string", required = false)
+  @Schema(name = "map_map_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -273,7 +273,7 @@ public class AdditionalPropertiesClass {
    * @return mapMapAnytype
   */
   @Valid 
-  @Schema(name = "map_map_anytype", required = false)
+  @Schema(name = "map_map_anytype", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -292,7 +292,7 @@ public class AdditionalPropertiesClass {
    * @return anytype1
   */
   
-  @Schema(name = "anytype_1", required = false)
+  @Schema(name = "anytype_1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype1() {
     return anytype1;
   }
@@ -311,7 +311,7 @@ public class AdditionalPropertiesClass {
    * @return anytype2
   */
   
-  @Schema(name = "anytype_2", required = false)
+  @Schema(name = "anytype_2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype2() {
     return anytype2;
   }
@@ -330,7 +330,7 @@ public class AdditionalPropertiesClass {
    * @return anytype3
   */
   
-  @Schema(name = "anytype_3", required = false)
+  @Schema(name = "anytype_3", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesInteger.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesNumber.java
@@ -37,7 +37,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesObject.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesString.java
@@ -36,7 +36,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
@@ -54,7 +54,7 @@ public class Animal {
    * @return className
   */
   @NotNull 
-  @Schema(name = "className", required = true)
+  @Schema(name = "className", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getClassName() {
     return className;
   }
@@ -73,7 +73,7 @@ public class Animal {
    * @return color
   */
   
-  @Schema(name = "color", required = false)
+  @Schema(name = "color", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getColor() {
     return color;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfArrayOfNumberOnly {
    * @return arrayArrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayArrayNumber", required = false)
+  @Schema(name = "ArrayArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfNumberOnly.java
@@ -46,7 +46,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   */
   @Valid 
-  @Schema(name = "ArrayNumber", required = false)
+  @Schema(name = "ArrayNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayTest.java
@@ -54,7 +54,7 @@ public class ArrayTest {
    * @return arrayOfString
   */
   
-  @Schema(name = "array_of_string", required = false)
+  @Schema(name = "array_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -81,7 +81,7 @@ public class ArrayTest {
    * @return arrayArrayOfInteger
   */
   @Valid 
-  @Schema(name = "array_array_of_integer", required = false)
+  @Schema(name = "array_array_of_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -108,7 +108,7 @@ public class ArrayTest {
    * @return arrayArrayOfModel
   */
   @Valid 
-  @Schema(name = "array_array_of_model", required = false)
+  @Schema(name = "array_array_of_model", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCat.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCat.java
@@ -79,7 +79,7 @@ public class BigCat extends Cat {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCatAllOf.java
@@ -76,7 +76,7 @@ public class BigCatAllOf {
    * @return kind
   */
   
-  @Schema(name = "kind", required = false)
+  @Schema(name = "kind", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Capitalization.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Capitalization.java
@@ -49,7 +49,7 @@ public class Capitalization {
    * @return smallCamel
   */
   
-  @Schema(name = "smallCamel", required = false)
+  @Schema(name = "smallCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -68,7 +68,7 @@ public class Capitalization {
    * @return capitalCamel
   */
   
-  @Schema(name = "CapitalCamel", required = false)
+  @Schema(name = "CapitalCamel", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -87,7 +87,7 @@ public class Capitalization {
    * @return smallSnake
   */
   
-  @Schema(name = "small_Snake", required = false)
+  @Schema(name = "small_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -106,7 +106,7 @@ public class Capitalization {
    * @return capitalSnake
   */
   
-  @Schema(name = "Capital_Snake", required = false)
+  @Schema(name = "Capital_Snake", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -125,7 +125,7 @@ public class Capitalization {
    * @return scAETHFlowPoints
   */
   
-  @Schema(name = "SCA_ETH_Flow_Points", required = false)
+  @Schema(name = "SCA_ETH_Flow_Points", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -144,7 +144,7 @@ public class Capitalization {
    * @return ATT_NAME
   */
   
-  @Schema(name = "ATT_NAME", description = "Name of the pet ", required = false)
+  @Schema(name = "ATT_NAME", description = "Name of the pet ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Cat.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Cat.java
@@ -48,7 +48,7 @@ public class Cat extends Animal {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/CatAllOf.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/CatAllOf.java
@@ -36,7 +36,7 @@ public class CatAllOf {
    * @return declawed
   */
   
-  @Schema(name = "declawed", required = false)
+  @Schema(name = "declawed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Category.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Category.java
@@ -37,7 +37,7 @@ public class Category {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Category {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ClassModel.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ClassModel.java
@@ -35,7 +35,7 @@ public class ClassModel {
    * @return propertyClass
   */
   
-  @Schema(name = "_class", required = false)
+  @Schema(name = "_class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Client.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Client.java
@@ -34,7 +34,7 @@ public class Client {
    * @return client
   */
   
-  @Schema(name = "client", required = false)
+  @Schema(name = "client", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getClient() {
     return client;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Dog.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Dog.java
@@ -39,7 +39,7 @@ public class Dog extends Animal {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/DogAllOf.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/DogAllOf.java
@@ -36,7 +36,7 @@ public class DogAllOf {
    * @return breed
   */
   
-  @Schema(name = "breed", required = false)
+  @Schema(name = "breed", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
@@ -111,7 +111,7 @@ public class EnumArrays {
    * @return justSymbol
   */
   
-  @Schema(name = "just_symbol", required = false)
+  @Schema(name = "just_symbol", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -138,7 +138,7 @@ public class EnumArrays {
    * @return arrayEnum
   */
   
-  @Schema(name = "array_enum", required = false)
+  @Schema(name = "array_enum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
@@ -194,7 +194,7 @@ public class EnumTest {
    * @return enumString
   */
   
-  @Schema(name = "enum_string", required = false)
+  @Schema(name = "enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -213,7 +213,7 @@ public class EnumTest {
    * @return enumStringRequired
   */
   @NotNull 
-  @Schema(name = "enum_string_required", required = true)
+  @Schema(name = "enum_string_required", requiredMode = Schema.RequiredMode.REQUIRED)
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -232,7 +232,7 @@ public class EnumTest {
    * @return enumInteger
   */
   
-  @Schema(name = "enum_integer", required = false)
+  @Schema(name = "enum_integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -251,7 +251,7 @@ public class EnumTest {
    * @return enumNumber
   */
   
-  @Schema(name = "enum_number", required = false)
+  @Schema(name = "enum_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -270,7 +270,7 @@ public class EnumTest {
    * @return outerEnum
   */
   @Valid 
-  @Schema(name = "outerEnum", required = false)
+  @Schema(name = "outerEnum", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/File.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/File.java
@@ -35,7 +35,7 @@ public class File {
    * @return sourceURI
   */
   
-  @Schema(name = "sourceURI", description = "Test capitalization", required = false)
+  @Schema(name = "sourceURI", description = "Test capitalization", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getSourceURI() {
     return sourceURI;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
@@ -41,7 +41,7 @@ public class FileSchemaTestClass {
    * @return file
   */
   @Valid 
-  @Schema(name = "file", required = false)
+  @Schema(name = "file", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public File getFile() {
     return file;
   }
@@ -68,7 +68,7 @@ public class FileSchemaTestClass {
    * @return files
   */
   @Valid 
-  @Schema(name = "files", required = false)
+  @Schema(name = "files", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<File> getFiles() {
     return files;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
@@ -85,7 +85,7 @@ public class FormatTest {
    * @return integer
   */
   @Min(10) @Max(100) 
-  @Schema(name = "integer", required = false)
+  @Schema(name = "integer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInteger() {
     return integer;
   }
@@ -106,7 +106,7 @@ public class FormatTest {
    * @return int32
   */
   @Min(20) @Max(200) 
-  @Schema(name = "int32", required = false)
+  @Schema(name = "int32", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getInt32() {
     return int32;
   }
@@ -125,7 +125,7 @@ public class FormatTest {
    * @return int64
   */
   
-  @Schema(name = "int64", required = false)
+  @Schema(name = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getInt64() {
     return int64;
   }
@@ -146,7 +146,7 @@ public class FormatTest {
    * @return number
   */
   @NotNull @Valid @DecimalMin("32.1") @DecimalMax("543.2") 
-  @Schema(name = "number", required = true)
+  @Schema(name = "number", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumber() {
     return number;
   }
@@ -167,7 +167,7 @@ public class FormatTest {
    * @return _float
   */
   @DecimalMin("54.3") @DecimalMax("987.6") 
-  @Schema(name = "float", required = false)
+  @Schema(name = "float", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Float getFloat() {
     return _float;
   }
@@ -188,7 +188,7 @@ public class FormatTest {
    * @return _double
   */
   @DecimalMin("67.8") @DecimalMax("123.4") 
-  @Schema(name = "double", required = false)
+  @Schema(name = "double", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Double getDouble() {
     return _double;
   }
@@ -207,7 +207,7 @@ public class FormatTest {
    * @return string
   */
   @Pattern(regexp = "/[a-z]/i") 
-  @Schema(name = "string", required = false)
+  @Schema(name = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getString() {
     return string;
   }
@@ -226,7 +226,7 @@ public class FormatTest {
    * @return _byte
   */
   @NotNull 
-  @Schema(name = "byte", required = true)
+  @Schema(name = "byte", requiredMode = Schema.RequiredMode.REQUIRED)
   public byte[] getByte() {
     return _byte;
   }
@@ -245,7 +245,7 @@ public class FormatTest {
    * @return binary
   */
   @Valid 
-  @Schema(name = "binary", required = false)
+  @Schema(name = "binary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public org.springframework.core.io.Resource getBinary() {
     return binary;
   }
@@ -264,7 +264,7 @@ public class FormatTest {
    * @return date
   */
   @NotNull @Valid 
-  @Schema(name = "date", required = true)
+  @Schema(name = "date", requiredMode = Schema.RequiredMode.REQUIRED)
   public LocalDate getDate() {
     return date;
   }
@@ -283,7 +283,7 @@ public class FormatTest {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -302,7 +302,7 @@ public class FormatTest {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", required = false)
+  @Schema(name = "uuid", example = "72f98069-206d-4f12-9f12-3d1e525a8e84", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -321,7 +321,7 @@ public class FormatTest {
    * @return password
   */
   @NotNull @Size(min = 10, max = 64) 
-  @Schema(name = "password", required = true)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -340,7 +340,7 @@ public class FormatTest {
    * @return bigDecimal
   */
   @Valid 
-  @Schema(name = "BigDecimal", required = false)
+  @Schema(name = "BigDecimal", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/HasOnlyReadOnly.java
@@ -39,7 +39,7 @@ public class HasOnlyReadOnly {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -58,7 +58,7 @@ public class HasOnlyReadOnly {
    * @return foo
   */
   
-  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "foo", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
@@ -93,7 +93,7 @@ public class MapTest {
    * @return mapMapOfString
   */
   @Valid 
-  @Schema(name = "map_map_of_string", required = false)
+  @Schema(name = "map_map_of_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -120,7 +120,7 @@ public class MapTest {
    * @return mapOfEnumString
   */
   
-  @Schema(name = "map_of_enum_string", required = false)
+  @Schema(name = "map_of_enum_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -147,7 +147,7 @@ public class MapTest {
    * @return directMap
   */
   
-  @Schema(name = "direct_map", required = false)
+  @Schema(name = "direct_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -174,7 +174,7 @@ public class MapTest {
    * @return indirectMap
   */
   
-  @Schema(name = "indirect_map", required = false)
+  @Schema(name = "indirect_map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -48,7 +48,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return uuid
   */
   @Valid 
-  @Schema(name = "uuid", required = false)
+  @Schema(name = "uuid", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public UUID getUuid() {
     return uuid;
   }
@@ -67,7 +67,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return dateTime
   */
   @Valid 
-  @Schema(name = "dateTime", required = false)
+  @Schema(name = "dateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
@@ -94,7 +94,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * @return map
   */
   @Valid 
-  @Schema(name = "map", required = false)
+  @Schema(name = "map", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Model200Response.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Model200Response.java
@@ -40,7 +40,7 @@ public class Model200Response {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -59,7 +59,7 @@ public class Model200Response {
    * @return propertyClass
   */
   
-  @Schema(name = "class", required = false)
+  @Schema(name = "class", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
@@ -42,7 +42,7 @@ public class ModelApiResponse {
    * @return code
   */
   
-  @Schema(name = "code", required = false)
+  @Schema(name = "code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getCode() {
     return code;
   }
@@ -61,7 +61,7 @@ public class ModelApiResponse {
    * @return type
   */
   
-  @Schema(name = "type", required = false)
+  @Schema(name = "type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getType() {
     return type;
   }
@@ -80,7 +80,7 @@ public class ModelApiResponse {
    * @return message
   */
   
-  @Schema(name = "message", required = false)
+  @Schema(name = "message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMessage() {
     return message;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelList.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelList.java
@@ -36,7 +36,7 @@ public class ModelList {
    * @return _123list
   */
   
-  @Schema(name = "123-list", required = false)
+  @Schema(name = "123-list", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String get123list() {
     return _123list;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelReturn.java
@@ -37,7 +37,7 @@ public class ModelReturn {
    * @return _return
   */
   
-  @Schema(name = "return", required = false)
+  @Schema(name = "return", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getReturn() {
     return _return;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Name.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Name.java
@@ -44,7 +44,7 @@ public class Name {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", required = true)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getName() {
     return name;
   }
@@ -63,7 +63,7 @@ public class Name {
    * @return snakeCase
   */
   
-  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "snake_case", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -82,7 +82,7 @@ public class Name {
    * @return property
   */
   
-  @Schema(name = "property", required = false)
+  @Schema(name = "property", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getProperty() {
     return property;
   }
@@ -101,7 +101,7 @@ public class Name {
    * @return _123number
   */
   
-  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "123Number", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer get123number() {
     return _123number;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NumberOnly.java
@@ -35,7 +35,7 @@ public class NumberOnly {
    * @return justNumber
   */
   @Valid 
-  @Schema(name = "JustNumber", required = false)
+  @Schema(name = "JustNumber", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
@@ -90,7 +90,7 @@ public class Order {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -109,7 +109,7 @@ public class Order {
    * @return petId
   */
   
-  @Schema(name = "petId", required = false)
+  @Schema(name = "petId", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getPetId() {
     return petId;
   }
@@ -128,7 +128,7 @@ public class Order {
    * @return quantity
   */
   
-  @Schema(name = "quantity", required = false)
+  @Schema(name = "quantity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getQuantity() {
     return quantity;
   }
@@ -147,7 +147,7 @@ public class Order {
    * @return shipDate
   */
   @Valid 
-  @Schema(name = "shipDate", required = false)
+  @Schema(name = "shipDate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
@@ -166,7 +166,7 @@ public class Order {
    * @return status
   */
   
-  @Schema(name = "status", description = "Order Status", required = false)
+  @Schema(name = "status", description = "Order Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   */
   
-  @Schema(name = "complete", required = false)
+  @Schema(name = "complete", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterComposite.java
@@ -41,7 +41,7 @@ public class OuterComposite {
    * @return myNumber
   */
   @Valid 
-  @Schema(name = "my_number", required = false)
+  @Schema(name = "my_number", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -60,7 +60,7 @@ public class OuterComposite {
    * @return myString
   */
   
-  @Schema(name = "my_string", required = false)
+  @Schema(name = "my_string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getMyString() {
     return myString;
   }
@@ -79,7 +79,7 @@ public class OuterComposite {
    * @return myBoolean
   */
   
-  @Schema(name = "my_boolean", required = false)
+  @Schema(name = "my_boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -96,7 +96,7 @@ public class Pet {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -115,7 +115,7 @@ public class Pet {
    * @return category
   */
   @Valid 
-  @Schema(name = "category", required = false)
+  @Schema(name = "category", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Category getCategory() {
     return category;
   }
@@ -134,7 +134,7 @@ public class Pet {
    * @return name
   */
   @NotNull 
-  @Schema(name = "name", example = "doggie", required = true)
+  @Schema(name = "name", example = "doggie", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getName() {
     return name;
   }
@@ -158,7 +158,7 @@ public class Pet {
    * @return photoUrls
   */
   @NotNull 
-  @Schema(name = "photoUrls", required = true)
+  @Schema(name = "photoUrls", requiredMode = Schema.RequiredMode.REQUIRED)
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -186,7 +186,7 @@ public class Pet {
    * @return tags
   */
   @Valid 
-  @Schema(name = "tags", required = false)
+  @Schema(name = "tags", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Tag> getTags() {
     return tags;
   }
@@ -205,7 +205,7 @@ public class Pet {
    * @return status
   */
   
-  @Schema(name = "status", description = "pet status in the store", required = false)
+  @Schema(name = "status", description = "pet status in the store", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ReadOnlyFirst.java
@@ -37,7 +37,7 @@ public class ReadOnlyFirst {
    * @return bar
   */
   
-  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, required = false)
+  @Schema(name = "bar", accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBar() {
     return bar;
   }
@@ -56,7 +56,7 @@ public class ReadOnlyFirst {
    * @return baz
   */
   
-  @Schema(name = "baz", required = false)
+  @Schema(name = "baz", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getBaz() {
     return baz;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/SpecialModelName.java
@@ -36,7 +36,7 @@ public class SpecialModelName {
    * @return $specialPropertyName
   */
   
-  @Schema(name = "$special[property.name]", required = false)
+  @Schema(name = "$special[property.name]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Tag.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -56,7 +56,7 @@ public class Tag {
    * @return name
   */
   
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderDefault.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderDefault.java
@@ -50,7 +50,7 @@ public class TypeHolderDefault {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", required = true)
+  @Schema(name = "string_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -69,7 +69,7 @@ public class TypeHolderDefault {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", required = true)
+  @Schema(name = "number_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -88,7 +88,7 @@ public class TypeHolderDefault {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", required = true)
+  @Schema(name = "integer_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -107,7 +107,7 @@ public class TypeHolderDefault {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", required = true)
+  @Schema(name = "bool_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -131,7 +131,7 @@ public class TypeHolderDefault {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", required = true)
+  @Schema(name = "array_item", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderExample.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/TypeHolderExample.java
@@ -53,7 +53,7 @@ public class TypeHolderExample {
    * @return stringItem
   */
   @NotNull 
-  @Schema(name = "string_item", example = "what", required = true)
+  @Schema(name = "string_item", example = "what", requiredMode = Schema.RequiredMode.REQUIRED)
   public String getStringItem() {
     return stringItem;
   }
@@ -72,7 +72,7 @@ public class TypeHolderExample {
    * @return numberItem
   */
   @NotNull @Valid 
-  @Schema(name = "number_item", example = "1.234", required = true)
+  @Schema(name = "number_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -91,7 +91,7 @@ public class TypeHolderExample {
    * @return floatItem
   */
   @NotNull 
-  @Schema(name = "float_item", example = "1.234", required = true)
+  @Schema(name = "float_item", example = "1.234", requiredMode = Schema.RequiredMode.REQUIRED)
   public Float getFloatItem() {
     return floatItem;
   }
@@ -110,7 +110,7 @@ public class TypeHolderExample {
    * @return integerItem
   */
   @NotNull 
-  @Schema(name = "integer_item", example = "-2", required = true)
+  @Schema(name = "integer_item", example = "-2", requiredMode = Schema.RequiredMode.REQUIRED)
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -129,7 +129,7 @@ public class TypeHolderExample {
    * @return boolItem
   */
   @NotNull 
-  @Schema(name = "bool_item", example = "true", required = true)
+  @Schema(name = "bool_item", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -153,7 +153,7 @@ public class TypeHolderExample {
    * @return arrayItem
   */
   @NotNull 
-  @Schema(name = "array_item", example = "[0, 1, 2, 3]", required = true)
+  @Schema(name = "array_item", example = "[0, 1, 2, 3]", requiredMode = Schema.RequiredMode.REQUIRED)
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/User.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/User.java
@@ -55,7 +55,7 @@ public class User {
    * @return id
   */
   
-  @Schema(name = "id", required = false)
+  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Long getId() {
     return id;
   }
@@ -74,7 +74,7 @@ public class User {
    * @return username
   */
   
-  @Schema(name = "username", required = false)
+  @Schema(name = "username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getUsername() {
     return username;
   }
@@ -93,7 +93,7 @@ public class User {
    * @return firstName
   */
   
-  @Schema(name = "firstName", required = false)
+  @Schema(name = "firstName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getFirstName() {
     return firstName;
   }
@@ -112,7 +112,7 @@ public class User {
    * @return lastName
   */
   
-  @Schema(name = "lastName", required = false)
+  @Schema(name = "lastName", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getLastName() {
     return lastName;
   }
@@ -131,7 +131,7 @@ public class User {
    * @return email
   */
   
-  @Schema(name = "email", required = false)
+  @Schema(name = "email", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getEmail() {
     return email;
   }
@@ -150,7 +150,7 @@ public class User {
    * @return password
   */
   
-  @Schema(name = "password", required = false)
+  @Schema(name = "password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPassword() {
     return password;
   }
@@ -169,7 +169,7 @@ public class User {
    * @return phone
   */
   
-  @Schema(name = "phone", required = false)
+  @Schema(name = "phone", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPhone() {
     return phone;
   }
@@ -188,7 +188,7 @@ public class User {
    * @return userStatus
   */
   
-  @Schema(name = "userStatus", description = "User Status", required = false)
+  @Schema(name = "userStatus", description = "User Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/XmlItem.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/XmlItem.java
@@ -130,7 +130,7 @@ public class XmlItem {
    * @return attributeString
   */
   
-  @Schema(name = "attribute_string", example = "string", required = false)
+  @Schema(name = "attribute_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getAttributeString() {
     return attributeString;
   }
@@ -149,7 +149,7 @@ public class XmlItem {
    * @return attributeNumber
   */
   @Valid 
-  @Schema(name = "attribute_number", example = "1.234", required = false)
+  @Schema(name = "attribute_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -168,7 +168,7 @@ public class XmlItem {
    * @return attributeInteger
   */
   
-  @Schema(name = "attribute_integer", example = "-2", required = false)
+  @Schema(name = "attribute_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -187,7 +187,7 @@ public class XmlItem {
    * @return attributeBoolean
   */
   
-  @Schema(name = "attribute_boolean", example = "true", required = false)
+  @Schema(name = "attribute_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -214,7 +214,7 @@ public class XmlItem {
    * @return wrappedArray
   */
   
-  @Schema(name = "wrapped_array", required = false)
+  @Schema(name = "wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -233,7 +233,7 @@ public class XmlItem {
    * @return nameString
   */
   
-  @Schema(name = "name_string", example = "string", required = false)
+  @Schema(name = "name_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNameString() {
     return nameString;
   }
@@ -252,7 +252,7 @@ public class XmlItem {
    * @return nameNumber
   */
   @Valid 
-  @Schema(name = "name_number", example = "1.234", required = false)
+  @Schema(name = "name_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -271,7 +271,7 @@ public class XmlItem {
    * @return nameInteger
   */
   
-  @Schema(name = "name_integer", example = "-2", required = false)
+  @Schema(name = "name_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -290,7 +290,7 @@ public class XmlItem {
    * @return nameBoolean
   */
   
-  @Schema(name = "name_boolean", example = "true", required = false)
+  @Schema(name = "name_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -317,7 +317,7 @@ public class XmlItem {
    * @return nameArray
   */
   
-  @Schema(name = "name_array", required = false)
+  @Schema(name = "name_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -344,7 +344,7 @@ public class XmlItem {
    * @return nameWrappedArray
   */
   
-  @Schema(name = "name_wrapped_array", required = false)
+  @Schema(name = "name_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -363,7 +363,7 @@ public class XmlItem {
    * @return prefixString
   */
   
-  @Schema(name = "prefix_string", example = "string", required = false)
+  @Schema(name = "prefix_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixString() {
     return prefixString;
   }
@@ -382,7 +382,7 @@ public class XmlItem {
    * @return prefixNumber
   */
   @Valid 
-  @Schema(name = "prefix_number", example = "1.234", required = false)
+  @Schema(name = "prefix_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -401,7 +401,7 @@ public class XmlItem {
    * @return prefixInteger
   */
   
-  @Schema(name = "prefix_integer", example = "-2", required = false)
+  @Schema(name = "prefix_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -420,7 +420,7 @@ public class XmlItem {
    * @return prefixBoolean
   */
   
-  @Schema(name = "prefix_boolean", example = "true", required = false)
+  @Schema(name = "prefix_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -447,7 +447,7 @@ public class XmlItem {
    * @return prefixArray
   */
   
-  @Schema(name = "prefix_array", required = false)
+  @Schema(name = "prefix_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -474,7 +474,7 @@ public class XmlItem {
    * @return prefixWrappedArray
   */
   
-  @Schema(name = "prefix_wrapped_array", required = false)
+  @Schema(name = "prefix_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -493,7 +493,7 @@ public class XmlItem {
    * @return namespaceString
   */
   
-  @Schema(name = "namespace_string", example = "string", required = false)
+  @Schema(name = "namespace_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -512,7 +512,7 @@ public class XmlItem {
    * @return namespaceNumber
   */
   @Valid 
-  @Schema(name = "namespace_number", example = "1.234", required = false)
+  @Schema(name = "namespace_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -531,7 +531,7 @@ public class XmlItem {
    * @return namespaceInteger
   */
   
-  @Schema(name = "namespace_integer", example = "-2", required = false)
+  @Schema(name = "namespace_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -550,7 +550,7 @@ public class XmlItem {
    * @return namespaceBoolean
   */
   
-  @Schema(name = "namespace_boolean", example = "true", required = false)
+  @Schema(name = "namespace_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -577,7 +577,7 @@ public class XmlItem {
    * @return namespaceArray
   */
   
-  @Schema(name = "namespace_array", required = false)
+  @Schema(name = "namespace_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -604,7 +604,7 @@ public class XmlItem {
    * @return namespaceWrappedArray
   */
   
-  @Schema(name = "namespace_wrapped_array", required = false)
+  @Schema(name = "namespace_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -623,7 +623,7 @@ public class XmlItem {
    * @return prefixNsString
   */
   
-  @Schema(name = "prefix_ns_string", example = "string", required = false)
+  @Schema(name = "prefix_ns_string", example = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -642,7 +642,7 @@ public class XmlItem {
    * @return prefixNsNumber
   */
   @Valid 
-  @Schema(name = "prefix_ns_number", example = "1.234", required = false)
+  @Schema(name = "prefix_ns_number", example = "1.234", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -661,7 +661,7 @@ public class XmlItem {
    * @return prefixNsInteger
   */
   
-  @Schema(name = "prefix_ns_integer", example = "-2", required = false)
+  @Schema(name = "prefix_ns_integer", example = "-2", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -680,7 +680,7 @@ public class XmlItem {
    * @return prefixNsBoolean
   */
   
-  @Schema(name = "prefix_ns_boolean", example = "true", required = false)
+  @Schema(name = "prefix_ns_boolean", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -707,7 +707,7 @@ public class XmlItem {
    * @return prefixNsArray
   */
   
-  @Schema(name = "prefix_ns_array", required = false)
+  @Schema(name = "prefix_ns_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -734,7 +734,7 @@ public class XmlItem {
    * @return prefixNsWrappedArray
   */
   
-  @Schema(name = "prefix_ns_wrapped_array", required = false)
+  @Schema(name = "prefix_ns_wrapped_array", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }


### PR DESCRIPTION
Fix for #14398

[`Schema#required` is deprecated since 2.2.5 and replaced by `requiredMode`](https://docs.swagger.io/swagger-core/v2.2.7/apidocs/io/swagger/v3/oas/annotations/media/Schema.html#required--).

[OAS3 `required` parameter is of type `boolean` and defaults to `false`](https://spec.openapis.org/oas/v3.0.3#parameterRequired) thus I used `Schema.RequiredMode.NOT_REQUIRED` when `required` is false.

I have checked following samples for compilation, such that min >= 2.2.5 swagger-annotations library is used.

- samples/openapi3/client/petstore/spring-cloud-3/
- samples/openapi3/client/petstore/spring-cloud-async/
- samples/openapi3/client/petstore/spring-cloud-date-time/
- samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/
- samples/openapi3/client/petstore/spring-cloud-spring-pageable/
- samples/openapi3/client/petstore/spring-cloud/
- samples/openapi3/client/petstore/spring-stubs-skip-default-interface/
- samples/openapi3/client/petstore/spring-stubs/
- samples/openapi3/server/petstore/spring-boot-oneof/
- samples/openapi3/server/petstore/spring-boot-springdoc/
- samples/openapi3/server/petstore/springboot-3/
- samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/
- samples/openapi3/server/petstore/springboot-delegate/
- samples/openapi3/server/petstore/springboot-implicitHeaders/
- samples/openapi3/server/petstore/springboot-reactive/
- samples/openapi3/server/petstore/springboot-useoptional/
- samples/openapi3/server/petstore/springboot/
- samples/server/petstore/java-camel/
- samples/server/petstore/java-micronaut-server/pom.xml
- samples/server/petstore/java-micronaut-server/
- samples/server/petstore/spring-boot-defaultInterface-unhandledException/
- samples/server/petstore/spring-boot-nullable-set/
- samples/server/petstore/springboot-virtualan/

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/java-*
  ./bin/generate-samples.sh ./bin/configs/spring-*
  ./bin/generate-samples.sh ./bin/configs/kotlin-*
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
