### PR TITLE
[swift5][client] - simplify async await

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -211,34 +211,7 @@ extension {{projectName}}API {
     {{/isDeprecated}}
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) async throws{{#returnType}} -> {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{/returnType}} {
-        let requestBuilder = {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    {{#returnType}}
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    {{/returnType}}
-                    {{^returnType}}
-                    case .success:
-                        continuation.resume(returning: ())
-                    {{/returnType}}
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).execute().body
     }
 {{/useAsyncAwait}}
 {{#useResult}}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -20,28 +20,7 @@ open class AnotherFakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func call123testSpecialTags(body: Client) async throws -> Client {
-        let requestBuilder = call123testSpecialTagsWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await call123testSpecialTagsWithRequestBuilder(body: body).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -19,28 +19,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterBooleanSerialize(body: Bool? = nil) async throws -> Bool {
-        let requestBuilder = fakeOuterBooleanSerializeWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -74,28 +53,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil) async throws -> OuterComposite {
-        let requestBuilder = fakeOuterCompositeSerializeWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await fakeOuterCompositeSerializeWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -129,28 +87,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterNumberSerialize(body: Double? = nil) async throws -> Double {
-        let requestBuilder = fakeOuterNumberSerializeWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await fakeOuterNumberSerializeWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -184,28 +121,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterStringSerialize(body: String? = nil) async throws -> String {
-        let requestBuilder = fakeOuterStringSerializeWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await fakeOuterStringSerializeWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -239,28 +155,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testBodyWithFileSchema(body: FileSchemaTestClass) async throws {
-        let requestBuilder = testBodyWithFileSchemaWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testBodyWithFileSchemaWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -295,28 +190,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testBodyWithQueryParams(query: String, body: User) async throws {
-        let requestBuilder = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testBodyWithQueryParamsWithRequestBuilder(query: query, body: body).execute().body
     }
 
     /**
@@ -354,28 +228,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testClientModel(body: Client) async throws -> Client {
-        let requestBuilder = testClientModelWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testClientModelWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -424,28 +277,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) async throws {
-        let requestBuilder = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute().body
     }
 
     /**
@@ -589,28 +421,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) async throws {
-        let requestBuilder = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute().body
     }
 
     /**
@@ -672,28 +483,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) async throws {
-        let requestBuilder = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute().body
     }
 
     /**
@@ -741,28 +531,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testInlineAdditionalProperties(param: [String: String]) async throws {
-        let requestBuilder = testInlineAdditionalPropertiesWithRequestBuilder(param: param)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testInlineAdditionalPropertiesWithRequestBuilder(param: param).execute().body
     }
 
     /**
@@ -798,28 +567,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testJsonFormData(param: String, param2: String) async throws {
-        let requestBuilder = testJsonFormDataWithRequestBuilder(param: param, param2: param2)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -20,28 +20,7 @@ open class FakeClassnameTags123API {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testClassname(body: Client) async throws -> Client {
-        let requestBuilder = testClassnameWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await testClassnameWithRequestBuilder(body: body).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -20,28 +20,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func addPet(body: Pet) async throws {
-        let requestBuilder = addPetWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await addPetWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -83,28 +62,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deletePet(petId: Int64, apiKey: String? = nil) async throws {
-        let requestBuilder = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute().body
     }
 
     /**
@@ -155,28 +113,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func findPetsByStatus(status: [Status_findPetsByStatus]) async throws -> [Pet] {
-        let requestBuilder = findPetsByStatusWithRequestBuilder(status: status)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await findPetsByStatusWithRequestBuilder(status: status).execute().body
     }
 
     /**
@@ -219,28 +156,7 @@ open class PetAPI {
     @available(*, deprecated, message: "This operation is deprecated.")
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func findPetsByTags(tags: [String]) async throws -> [Pet] {
-        let requestBuilder = findPetsByTagsWithRequestBuilder(tags: tags)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await findPetsByTagsWithRequestBuilder(tags: tags).execute().body
     }
 
     /**
@@ -283,28 +199,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getPetById(petId: Int64) async throws -> Pet {
-        let requestBuilder = getPetByIdWithRequestBuilder(petId: petId)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await getPetByIdWithRequestBuilder(petId: petId).execute().body
     }
 
     /**
@@ -346,28 +241,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updatePet(body: Pet) async throws {
-        let requestBuilder = updatePetWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await updatePetWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -407,28 +281,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) async throws {
-        let requestBuilder = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute().body
     }
 
     /**
@@ -479,28 +332,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) async throws -> ApiResponse {
-        let requestBuilder = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute().body
     }
 
     /**
@@ -551,28 +383,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) async throws -> ApiResponse {
-        let requestBuilder = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -20,28 +20,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deleteOrder(orderId: String) async throws {
-        let requestBuilder = deleteOrderWithRequestBuilder(orderId: orderId)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await deleteOrderWithRequestBuilder(orderId: orderId).execute().body
     }
 
     /**
@@ -79,28 +58,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getInventory() async throws -> [String: Int] {
-        let requestBuilder = getInventoryWithRequestBuilder()
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await getInventoryWithRequestBuilder().execute().body
     }
 
     /**
@@ -138,28 +96,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getOrderById(orderId: Int64) async throws -> Order {
-        let requestBuilder = getOrderByIdWithRequestBuilder(orderId: orderId)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await getOrderByIdWithRequestBuilder(orderId: orderId).execute().body
     }
 
     /**
@@ -198,28 +135,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func placeOrder(body: Order) async throws -> Order {
-        let requestBuilder = placeOrderWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await placeOrderWithRequestBuilder(body: body).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -20,28 +20,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUser(body: User) async throws {
-        let requestBuilder = createUserWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await createUserWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -77,28 +56,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUsersWithArrayInput(body: [User]) async throws {
-        let requestBuilder = createUsersWithArrayInputWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await createUsersWithArrayInputWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -133,28 +91,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUsersWithListInput(body: [User]) async throws {
-        let requestBuilder = createUsersWithListInputWithRequestBuilder(body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await createUsersWithListInputWithRequestBuilder(body: body).execute().body
     }
 
     /**
@@ -189,28 +126,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deleteUser(username: String) async throws {
-        let requestBuilder = deleteUserWithRequestBuilder(username: username)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await deleteUserWithRequestBuilder(username: username).execute().body
     }
 
     /**
@@ -249,28 +165,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getUserByName(username: String) async throws -> User {
-        let requestBuilder = getUserByNameWithRequestBuilder(username: username)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await getUserByNameWithRequestBuilder(username: username).execute().body
     }
 
     /**
@@ -309,28 +204,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func loginUser(username: String, password: String) async throws -> String {
-        let requestBuilder = loginUserWithRequestBuilder(username: username, password: password)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case let .success(response):
-                        continuation.resume(returning: response.body)
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await loginUserWithRequestBuilder(username: username, password: password).execute().body
     }
 
     /**
@@ -370,28 +244,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func logoutUser() async throws {
-        let requestBuilder = logoutUserWithRequestBuilder()
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await logoutUserWithRequestBuilder().execute().body
     }
 
     /**
@@ -426,28 +279,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updateUser(username: String, body: User) async throws {
-        let requestBuilder = updateUserWithRequestBuilder(username: username, body: body)
-        let requestTask = requestBuilder.requestTask
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                  continuation.resume(throwing: CancellationError())
-                  return
-                }
-
-                requestBuilder.execute { result in
-                    switch result {
-                    case .success:
-                        continuation.resume(returning: ())
-                    case let .failure(error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            requestTask.cancel()
-        }
+        return try await updateUserWithRequestBuilder(username: username, body: body).execute().body
     }
 
     /**

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/.gitignore
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/.gitignore
@@ -1,0 +1,105 @@
+# Created by https://www.toptal.com/developers/gitignore/api/swift,xcode
+# Edit at https://www.toptal.com/developers/gitignore?templates=swift,xcode
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Add this lines if you are using Accio dependency management (Deprecated since Xcode 12)
+# Dependencies/
+# .accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+## Gcc Patch
+/*.gcno
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/swift,xcode

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcodeproj/project.pbxproj
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcodeproj/project.pbxproj
@@ -1,0 +1,496 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A5782C732664FABF00CAA106 /* PetstoreClient in Frameworks */ = {isa = PBXBuildFile; productRef = A5782C722664FABF00CAA106 /* PetstoreClient */; };
+		A5EA12582419390400E30FC3 /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EA12562419390400E30FC3 /* FileUtils.swift */; };
+		A5EA12592419390400E30FC3 /* UIImage+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EA12572419390400E30FC3 /* UIImage+Extras.swift */; };
+		B596E4BD205657A500B46F03 /* APIHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B596E4BC205657A500B46F03 /* APIHelperTests.swift */; };
+		EAEC0BC21D4E30CE00C908A3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEC0BC11D4E30CE00C908A3 /* AppDelegate.swift */; };
+		EAEC0BC41D4E30CE00C908A3 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEC0BC31D4E30CE00C908A3 /* ViewController.swift */; };
+		EAEC0BC71D4E30CE00C908A3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EAEC0BC51D4E30CE00C908A3 /* Main.storyboard */; };
+		EAEC0BC91D4E30CE00C908A3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EAEC0BC81D4E30CE00C908A3 /* Assets.xcassets */; };
+		EAEC0BCC1D4E30CE00C908A3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EAEC0BCA1D4E30CE00C908A3 /* LaunchScreen.storyboard */; };
+		EAEC0BE41D4E330700C908A3 /* PetAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEC0BE31D4E330700C908A3 /* PetAPITests.swift */; };
+		EAEC0BE61D4E379000C908A3 /* StoreAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEC0BE51D4E379000C908A3 /* StoreAPITests.swift */; };
+		EAEC0BE81D4E38CB00C908A3 /* UserAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEC0BE71D4E38CB00C908A3 /* UserAPITests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		EAEC0BD31D4E30CE00C908A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EAEC0BB61D4E30CE00C908A3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EAEC0BBD1D4E30CE00C908A3;
+			remoteInfo = SwaggerClient;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A5EA12562419390400E30FC3 /* FileUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
+		A5EA12572419390400E30FC3 /* UIImage+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extras.swift"; sourceTree = "<group>"; };
+		B596E4BC205657A500B46F03 /* APIHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelperTests.swift; sourceTree = "<group>"; };
+		EAEC0BBE1D4E30CE00C908A3 /* SwaggerClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwaggerClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAEC0BC11D4E30CE00C908A3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		EAEC0BC31D4E30CE00C908A3 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		EAEC0BC61D4E30CE00C908A3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		EAEC0BC81D4E30CE00C908A3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		EAEC0BCB1D4E30CE00C908A3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		EAEC0BCD1D4E30CE00C908A3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EAEC0BD21D4E30CE00C908A3 /* SwaggerClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwaggerClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAEC0BD81D4E30CE00C908A3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EAEC0BE31D4E330700C908A3 /* PetAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetAPITests.swift; sourceTree = "<group>"; };
+		EAEC0BE51D4E379000C908A3 /* StoreAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreAPITests.swift; sourceTree = "<group>"; };
+		EAEC0BE71D4E38CB00C908A3 /* UserAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAPITests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		EAEC0BBB1D4E30CE00C908A3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A5782C732664FABF00CAA106 /* PetstoreClient in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEC0BCF1D4E30CE00C908A3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A5782C712664FABE00CAA106 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EAEC0BB51D4E30CE00C908A3 = {
+			isa = PBXGroup;
+			children = (
+				EAEC0BC01D4E30CE00C908A3 /* SwaggerClient */,
+				EAEC0BD51D4E30CE00C908A3 /* SwaggerClientTests */,
+				EAEC0BBF1D4E30CE00C908A3 /* Products */,
+				A5782C712664FABE00CAA106 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		EAEC0BBF1D4E30CE00C908A3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EAEC0BBE1D4E30CE00C908A3 /* SwaggerClient.app */,
+				EAEC0BD21D4E30CE00C908A3 /* SwaggerClientTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EAEC0BC01D4E30CE00C908A3 /* SwaggerClient */ = {
+			isa = PBXGroup;
+			children = (
+				EAEC0BC11D4E30CE00C908A3 /* AppDelegate.swift */,
+				EAEC0BC31D4E30CE00C908A3 /* ViewController.swift */,
+				EAEC0BC51D4E30CE00C908A3 /* Main.storyboard */,
+				EAEC0BC81D4E30CE00C908A3 /* Assets.xcassets */,
+				EAEC0BCA1D4E30CE00C908A3 /* LaunchScreen.storyboard */,
+				EAEC0BCD1D4E30CE00C908A3 /* Info.plist */,
+			);
+			path = SwaggerClient;
+			sourceTree = "<group>";
+		};
+		EAEC0BD51D4E30CE00C908A3 /* SwaggerClientTests */ = {
+			isa = PBXGroup;
+			children = (
+				EAEC0BD81D4E30CE00C908A3 /* Info.plist */,
+				EAEC0BE31D4E330700C908A3 /* PetAPITests.swift */,
+				EAEC0BE51D4E379000C908A3 /* StoreAPITests.swift */,
+				EAEC0BE71D4E38CB00C908A3 /* UserAPITests.swift */,
+				B596E4BC205657A500B46F03 /* APIHelperTests.swift */,
+				A5EA12562419390400E30FC3 /* FileUtils.swift */,
+				A5EA12572419390400E30FC3 /* UIImage+Extras.swift */,
+			);
+			path = SwaggerClientTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		EAEC0BBD1D4E30CE00C908A3 /* SwaggerClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EAEC0BDB1D4E30CE00C908A3 /* Build configuration list for PBXNativeTarget "SwaggerClient" */;
+			buildPhases = (
+				EAEC0BBA1D4E30CE00C908A3 /* Sources */,
+				EAEC0BBB1D4E30CE00C908A3 /* Frameworks */,
+				EAEC0BBC1D4E30CE00C908A3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwaggerClient;
+			packageProductDependencies = (
+				A5782C722664FABF00CAA106 /* PetstoreClient */,
+			);
+			productName = SwaggerClient;
+			productReference = EAEC0BBE1D4E30CE00C908A3 /* SwaggerClient.app */;
+			productType = "com.apple.product-type.application";
+		};
+		EAEC0BD11D4E30CE00C908A3 /* SwaggerClientTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EAEC0BDE1D4E30CE00C908A3 /* Build configuration list for PBXNativeTarget "SwaggerClientTests" */;
+			buildPhases = (
+				EAEC0BCE1D4E30CE00C908A3 /* Sources */,
+				EAEC0BCF1D4E30CE00C908A3 /* Frameworks */,
+				EAEC0BD01D4E30CE00C908A3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EAEC0BD41D4E30CE00C908A3 /* PBXTargetDependency */,
+			);
+			name = SwaggerClientTests;
+			productName = SwaggerClientTests;
+			productReference = EAEC0BD21D4E30CE00C908A3 /* SwaggerClientTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EAEC0BB61D4E30CE00C908A3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 1130;
+				ORGANIZATIONNAME = Swagger;
+				TargetAttributes = {
+					EAEC0BBD1D4E30CE00C908A3 = {
+						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1130;
+					};
+					EAEC0BD11D4E30CE00C908A3 = {
+						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1130;
+						TestTargetID = EAEC0BBD1D4E30CE00C908A3;
+					};
+				};
+			};
+			buildConfigurationList = EAEC0BB91D4E30CE00C908A3 /* Build configuration list for PBXProject "SwaggerClient" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EAEC0BB51D4E30CE00C908A3;
+			productRefGroup = EAEC0BBF1D4E30CE00C908A3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EAEC0BBD1D4E30CE00C908A3 /* SwaggerClient */,
+				EAEC0BD11D4E30CE00C908A3 /* SwaggerClientTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EAEC0BBC1D4E30CE00C908A3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EAEC0BCC1D4E30CE00C908A3 /* LaunchScreen.storyboard in Resources */,
+				EAEC0BC91D4E30CE00C908A3 /* Assets.xcassets in Resources */,
+				EAEC0BC71D4E30CE00C908A3 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEC0BD01D4E30CE00C908A3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		EAEC0BBA1D4E30CE00C908A3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EAEC0BC41D4E30CE00C908A3 /* ViewController.swift in Sources */,
+				EAEC0BC21D4E30CE00C908A3 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEC0BCE1D4E30CE00C908A3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B596E4BD205657A500B46F03 /* APIHelperTests.swift in Sources */,
+				EAEC0BE81D4E38CB00C908A3 /* UserAPITests.swift in Sources */,
+				A5EA12592419390400E30FC3 /* UIImage+Extras.swift in Sources */,
+				EAEC0BE61D4E379000C908A3 /* StoreAPITests.swift in Sources */,
+				EAEC0BE41D4E330700C908A3 /* PetAPITests.swift in Sources */,
+				A5EA12582419390400E30FC3 /* FileUtils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EAEC0BD41D4E30CE00C908A3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EAEC0BBD1D4E30CE00C908A3 /* SwaggerClient */;
+			targetProxy = EAEC0BD31D4E30CE00C908A3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		EAEC0BC51D4E30CE00C908A3 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EAEC0BC61D4E30CE00C908A3 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		EAEC0BCA1D4E30CE00C908A3 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EAEC0BCB1D4E30CE00C908A3 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		EAEC0BD91D4E30CE00C908A3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		EAEC0BDA1D4E30CE00C908A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		EAEC0BDC1D4E30CE00C908A3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = SwaggerClient/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swagger.SwaggerClient;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EAEC0BDD1D4E30CE00C908A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = SwaggerClient/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swagger.SwaggerClient;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		EAEC0BDF1D4E30CE00C908A3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				INFOPLIST_FILE = SwaggerClientTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swagger.SwaggerClientTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwaggerClient.app/SwaggerClient";
+			};
+			name = Debug;
+		};
+		EAEC0BE01D4E30CE00C908A3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				INFOPLIST_FILE = SwaggerClientTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swagger.SwaggerClientTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwaggerClient.app/SwaggerClient";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		EAEC0BB91D4E30CE00C908A3 /* Build configuration list for PBXProject "SwaggerClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EAEC0BD91D4E30CE00C908A3 /* Debug */,
+				EAEC0BDA1D4E30CE00C908A3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EAEC0BDB1D4E30CE00C908A3 /* Build configuration list for PBXNativeTarget "SwaggerClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EAEC0BDC1D4E30CE00C908A3 /* Debug */,
+				EAEC0BDD1D4E30CE00C908A3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EAEC0BDE1D4E30CE00C908A3 /* Build configuration list for PBXNativeTarget "SwaggerClientTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EAEC0BDF1D4E30CE00C908A3 /* Debug */,
+				EAEC0BE01D4E30CE00C908A3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A5782C722664FABF00CAA106 /* PetstoreClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PetstoreClient;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = EAEC0BB61D4E30CE00C908A3 /* Project object */;
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcodeproj/xcshareddata/xcschemes/SwaggerClient.xcscheme
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcodeproj/xcshareddata/xcschemes/SwaggerClient.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EAEC0BBD1D4E30CE00C908A3"
+               BuildableName = "SwaggerClient.app"
+               BlueprintName = "SwaggerClient"
+               ReferencedContainer = "container:SwaggerClient.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EAEC0BBD1D4E30CE00C908A3"
+            BuildableName = "SwaggerClient.app"
+            BlueprintName = "SwaggerClient"
+            ReferencedContainer = "container:SwaggerClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EAEC0BD11D4E30CE00C908A3"
+               BuildableName = "SwaggerClientTests.xctest"
+               BlueprintName = "SwaggerClientTests"
+               ReferencedContainer = "container:SwaggerClient.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EAEC0BBD1D4E30CE00C908A3"
+            BuildableName = "SwaggerClient.app"
+            BlueprintName = "SwaggerClient"
+            ReferencedContainer = "container:SwaggerClient.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EAEC0BBD1D4E30CE00C908A3"
+            BuildableName = "SwaggerClient.app"
+            BlueprintName = "SwaggerClient"
+            ReferencedContainer = "container:SwaggerClient.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcworkspace/contents.xcworkspacedata
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:..">
+   </FileRef>
+   <FileRef
+      location = "group:SwaggerClient.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AnyCodable",
+        "repositoryURL": "https://github.com/Flight-School/AnyCodable",
+        "state": {
+          "branch": null,
+          "revision": "b1a7a8a6186f2fcb28f7bda67cfc545de48b3c80",
+          "version": "0.6.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/AppDelegate.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/AppDelegate.swift
@@ -1,0 +1,43 @@
+//
+//  AppDelegate.swift
+//  SwaggerClient
+//
+//  Created by Tony Wang on 7/31/16.
+//  Copyright © 2016 Swagger. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Base.lproj/LaunchScreen.storyboard
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Base.lproj/Main.storyboard
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Info.plist
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/Info.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>petstore.swagger.io</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/ViewController.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClient/ViewController.swift
@@ -1,0 +1,23 @@
+//
+//  ViewController.swift
+//  SwaggerClient
+//
+//  Created by Tony Wang on 7/31/16.
+//  Copyright © 2016 Swagger. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
@@ -1,0 +1,55 @@
+//
+//  APIHelperTests.swift
+//  SwaggerClientTests
+//
+//  Created by Daiki Matsudate on 2018/03/12.
+//  Copyright © 2018 Swagger. All rights reserved.
+//
+
+import XCTest
+import PetstoreClient
+@testable import SwaggerClient
+
+class APIHelperTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testRejectNil() {
+        let source: [String: Any?] = ["a": 1, "b": nil, "c": ["1", nil, "2"], "d": true, "e": false]
+        let expected: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": true, "e": false]
+        let actual: [String: Any] = APIHelper.rejectNil(source)!
+        XCTAssert(NSDictionary(dictionary: actual).isEqual(to: expected))
+    }
+
+    func testRejectNilHeaders() {
+        let source: [String: Any?] = ["a": 1, "b": nil, "c": ["1", nil, "2"], "d": true, "e": false]
+        let expected: [String: String] = ["a": "1", "c": "1,2", "d": "true", "e": "false"]
+        let actual: [String: String] = APIHelper.rejectNilHeaders(source)
+        XCTAssert(NSDictionary(dictionary: actual).isEqual(to: expected))
+    }
+
+    func testConvertBoolToString() {
+        let source: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": true, "e": false]
+        let expected: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": "true", "e": "false"]
+        let actual: [String: Any] = APIHelper.convertBoolToString(source)!
+        XCTAssert(NSDictionary(dictionary: actual).isEqual(to: expected))
+    }
+
+    func testMapValuesToQueryItems() {
+        let source: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": true, "e": false]
+        let expected: [URLQueryItem] = [URLQueryItem(name: "a", value: "1"),
+                                      URLQueryItem(name: "c", value: "1,2"),
+                                      URLQueryItem(name: "d", value: "true"),
+                                      URLQueryItem(name: "e", value: "false")].sorted(by: { $0.name > $1.name })
+        let actual: [URLQueryItem] = APIHelper.mapValuesToQueryItems(source)!.sorted(by: { $0.name > $1.name })
+        XCTAssert(actual == expected)
+    }
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/FileUtils.swift
@@ -1,0 +1,49 @@
+//
+//  FileUtils.swift
+//  SwaggerClientTests
+//
+//  Created by Bruno Coelho on 11/03/2020.
+//  Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+//
+
+import UIKit
+
+class FileUtils {
+    static func saveImage(imageName: String, image: UIImage) -> URL? {
+        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+
+        let fileName = imageName
+        let fileURL = documentsDirectory.appendingPathComponent(fileName)
+        guard let data = image.jpegData(compressionQuality: 1) else { return nil }
+
+        // Checks if file exists, removes it if so.
+        deleteFile(fileURL: fileURL)
+
+        do {
+            try data.write(to: fileURL)
+        } catch let error {
+            print("error saving file with error", error)
+            return nil
+        }
+
+        return fileURL
+    }
+
+    @discardableResult
+    static func deleteFile(fileURL: URL) -> Bool {
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            do {
+                try FileManager.default.removeItem(atPath: fileURL.path)
+                print("Removed old image")
+                return true
+            } catch let removeError {
+                print("couldn't remove file at path", removeError)
+                return false
+            }
+        }
+        return false
+    }
+
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/Info.plist
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>petstore.swagger.io</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -1,0 +1,91 @@
+//
+//  PetAPITests.swift
+//  SwaggerClient
+//
+//  Created by Tony Wang on 7/31/16.
+//  Copyright © 2016 Swagger. All rights reserved.
+//
+
+import PetstoreClient
+import XCTest
+@testable import SwaggerClient
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class PetAPITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func test1CreatePet() async throws {
+        let category = Category(id: 1234, name: "eyeColor")
+        let tags = [Tag(id: 1234, name: "New York"), Tag(id: 124321, name: "Jose")]
+        let newPet = Pet(id: 1000, category: category, name: "Fluffy", photoUrls: ["https://petstore.com/sample/photo1.jpg", "https://petstore.com/sample/photo2.jpg"], tags: tags, status: .encodeValue(.available))
+
+        try await PetAPI.addPet(body: newPet)
+    }
+
+    func test2GetPet() async throws {
+        let pet = try await PetAPI.getPetById(petId: 1000)
+        
+        XCTAssert(pet.id == 1000, "invalid id")
+        XCTAssert(pet.name == "Fluffy", "invalid name")
+        XCTAssert(pet.category!.id == 1234, "invalid category id")
+        XCTAssert(pet.category!.name == "eyeColor", "invalid category name")
+        
+        let tag1 = pet.tags![0]
+        XCTAssert(tag1.id == 1234, "invalid tag id")
+        XCTAssert(tag1.name == "New York", "invalid tag name")
+        
+        let tag2 = pet.tags![1]
+        XCTAssert(tag2.id == 124321, "invalid tag id")
+        XCTAssert(tag2.name == "Jose", "invalid tag name")
+        
+        XCTAssert(pet.photoUrls[0] == "https://petstore.com/sample/photo1.jpg")
+        XCTAssert(pet.photoUrls[1] == "https://petstore.com/sample/photo2.jpg")
+    }
+
+    func test3UploadFile() async throws {
+        let imageName = UUID().uuidString + ".png"
+
+        guard
+            let image = UIImage(color: .red, size: CGSize(width: 10, height: 10)),
+            let imageURL = FileUtils.saveImage(imageName: imageName, image: image)
+        else {
+            fatalError()
+        }
+
+        do {
+            let _ = try await PetAPI.uploadFile(petId: 1000, additionalMetadata: "additionalMetadata", file: imageURL)
+            
+            FileUtils.deleteFile(fileURL: imageURL)
+        } catch {
+            FileUtils.deleteFile(fileURL: imageURL)
+            XCTFail("error uploading file")
+        }
+    }
+
+    func test4DeletePet() async throws {
+        do {
+            try await PetAPI.deletePet(petId: 1000)
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting pet")
+            }
+        }
+    }
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
@@ -1,0 +1,77 @@
+//
+//  StoreAPITests.swift
+//  SwaggerClient
+//
+//  Created by Tony Wang on 7/31/16.
+//  Copyright © 2016 Swagger. All rights reserved.
+//
+
+import PetstoreClient
+import Combine
+import XCTest
+@testable import SwaggerClient
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class StoreAPITests: XCTestCase {
+
+    let isoDateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+
+    func test1PlaceOrder() async throws {
+        // use explicit naming to reference the enum so that we test we don't regress on enum naming
+        let shipDate = Date()
+        let order = Order(id: 1000, petId: 1000, quantity: 10, shipDate: shipDate, status: .placed, complete: true)
+        let placedOrder = try await StoreAPI.placeOrder(body: order)
+                    
+        XCTAssert(placedOrder.id == 1000, "invalid id")
+        XCTAssert(placedOrder.quantity == 10, "invalid quantity")
+        XCTAssert(placedOrder.status == .placed, "invalid status")
+        XCTAssert(placedOrder.shipDate!.isEqual(shipDate, format: self.isoDateFormat),
+                  "Date should be idempotent")
+        XCTAssert(placedOrder.complete == true, "invalid complete")
+    }
+
+    func test2GetOrder() async throws {
+        let order = try await StoreAPI.getOrderById(orderId: 1000)
+        XCTAssert(order.id == 1000, "invalid id")
+        XCTAssert(order.quantity == 10, "invalid quantity")
+        XCTAssert(order.status == .placed, "invalid status")
+        XCTAssert(order.complete == true, "invalid complete")
+    }
+
+    func test3DeleteOrder() async throws {
+        do {
+            try await StoreAPI.deleteOrder(orderId: "1000")
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting order")
+            }
+        }
+    }
+
+}
+
+private extension Date {
+
+    /**
+     Returns true if the dates are equal given the format string.
+     
+     - parameter date:   The date to compare to.
+     - parameter format: The format string to use to compare.
+     
+     - returns: true if the dates are equal, given the format string.
+     */
+    func isEqual(_ date: Date, format: String) -> Bool {
+        let fmt = DateFormatter()
+        fmt.dateFormat = format
+        return fmt.string(from: self).isEqual(fmt.string(from: date))
+    }
+
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/UIImage+Extras.swift
@@ -1,0 +1,23 @@
+//
+//  UIImage+Extras.swift
+//  SwaggerClientTests
+//
+//  Created by Bruno Coelho on 11/03/2020.
+//  Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+//
+
+import UIKit
+
+extension UIImage {
+    convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
+        let rect = CGRect(origin: .zero, size: size)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
+        color.setFill()
+        UIRectFill(rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        guard let cgImage = image?.cgImage else { return nil }
+        self.init(cgImage: cgImage)
+    }
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
@@ -1,0 +1,111 @@
+//
+//  UserAPITests.swift
+//  SwaggerClient
+//
+//  Created by Tony Wang on 7/31/16.
+//  Copyright © 2016 Swagger. All rights reserved.
+//
+
+import PetstoreClient
+import Combine
+import XCTest
+@testable import SwaggerClient
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class UserAPITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testLogin() async throws {
+        do {
+            let _ = try await UserAPI.loginUser(username: "swiftTester", password: "swift")
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting order")
+            }
+        }
+    }
+
+    func testLogout() async throws {
+        do {
+            try await UserAPI.logoutUser()
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting order")
+            }
+        }        
+    }
+
+    func test1CreateUser() async throws {
+        let newUser = User(id: 1000, username: "test@test.com", firstName: "Test", lastName: "Tester", email: "test@test.com", password: "test!", phone: "867-5309", userStatus: 0)
+        
+        do {
+            try await UserAPI.createUser(body: newUser)
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error creating user")
+            }
+        }
+    }
+
+    func test2GetUser() async throws {
+        let user = try await UserAPI.getUserByName(username: "test@test.com")
+        XCTAssert(user.userStatus == 0, "invalid userStatus")
+        XCTAssert(user.email == "test@test.com", "invalid email")
+        XCTAssert(user.firstName == "Test", "invalid firstName")
+        XCTAssert(user.lastName == "Tester", "invalid lastName")
+        XCTAssert(user.password == "test!", "invalid password")
+        XCTAssert(user.phone == "867-5309", "invalid phone")
+    }
+
+    func test3DeleteUser() async throws {
+        do {
+            try await UserAPI.deleteUser(username: "test@test.com")
+        } catch let errorType {
+            // The server gives us no data back so alamofire parsing fails - at least
+            // verify that is the error we get here
+            // Error Domain=com.alamofire.error Code=-6006 "JSON could not be serialized. Input data was nil or zero
+            // length." UserInfo={NSLocalizedFailureReason=JSON could not be serialized. Input data was nil or zero
+            // length.}
+            let error = errorType as NSError
+            if error.code == -6006 {
+                // Everything ok!
+            } else {
+                XCTFail("error deleting user")
+            }
+        }
+    }
+
+}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/pom.xml
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/pom.xml
@@ -1,0 +1,43 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.swagger</groupId>
+    <artifactId>Swift5RxSwiftPetstoreClientTests</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Swift5 RxSwift Swagger Petstore Client</name>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>xcodebuild-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>./run_xcodebuild.sh</executable>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/swift5_test_all.sh
+++ b/samples/client/petstore/swift5/swift5_test_all.sh
@@ -6,6 +6,7 @@ DIRECTORY=`dirname $0`
 
 # example project with unit tests
 mvn -f $DIRECTORY/alamofireLibrary/SwaggerClientTests/pom.xml integration-test
+mvn -f $DIRECTORY/asyncAwaitLibrary/SwaggerClientTests/pom.xml integration-test
 mvn -f $DIRECTORY/combineLibrary/SwaggerClientTests/pom.xml integration-test
 mvn -f $DIRECTORY/default/SwaggerClientTests/pom.xml integration-test
 mvn -f $DIRECTORY/promisekitLibrary/SwaggerClientTests/pom.xml integration-test


### PR DESCRIPTION
Since https://github.com/OpenAPITools/openapi-generator/pull/14416 got merged, we can now simplify the async/await implementation.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)