### PR TITLE
14432: Do not add @Valid to Java types in "jaxrs-spec" generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidation.mustache
@@ -1,4 +1,1 @@
-{{#required}}
-  @NotNull
-{{/required}}
-{{>beanValidationCore}}
+{{#required}}{{^isReadOnly}}@NotNull {{/isReadOnly}}{{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}@Valid {{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}@Valid {{/isPrimitiveType}}{{/isContainer}}{{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -35,7 +35,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
   private {{#useBeanValidation}}@Valid {{/useBeanValidation}}{{{datatypeWithEnum}}} {{name}}{{#required}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}}{{#isNullable}} = null{{/isNullable}}{{/required}}{{^required}} = null{{/required}};
   {{/isContainer}}
   {{^isContainer}}
-  private {{#useBeanValidation}}@Valid {{/useBeanValidation}}{{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
   {{/isContainer}}
   {{/vars}}
   {{#generateBuilders}}

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,9 +30,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = null;
   private @Valid Map<String, Map<String, String>> mapMapString = null;
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = null;
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   /**
    **/
@@ -79,7 +79,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+@Valid   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -184,7 +184,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+@Valid   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+@Valid   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -254,7 +254,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+@Valid   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -289,7 +289,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+@Valid   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   /**
    **/
@@ -40,8 +40,7 @@ public class Animal  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+@NotNull   public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -33,7 +33,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+@Valid   public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -33,7 +33,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+@Valid   public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -70,7 +70,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+@Valid   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -105,7 +105,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+@Valid   public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
@@ -66,7 +66,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCatAllOf.java
@@ -66,7 +66,7 @@ public class BigCatAllOf  implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat_allOf")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class CatAllOf  implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   /**
    **/
@@ -50,8 +50,7 @@ public class Category  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+@NotNull   public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog_allOf")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class DogAllOf  implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -67,7 +67,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -67,7 +67,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -115,7 +115,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -163,7 +163,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -211,8 +211,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   /**
    **/
@@ -243,8 +243,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+@NotNull   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -301,7 +300,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+@Valid   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<ModelFile> files = null;
 
   /**
@@ -34,7 +34,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+@Valid   public ModelFile getFile() {
     return _file;
   }
 
@@ -53,7 +53,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+@Valid   public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
@@ -25,20 +25,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid Date dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private Date dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   /**
    * minimum: 10
@@ -113,8 +113,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+@NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
   }
 
@@ -194,8 +193,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+@NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
     return _byte;
   }
 
@@ -214,7 +212,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
-  public File getBinary() {
+@Valid   public File getBinary() {
     return binary;
   }
 
@@ -233,8 +231,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+@NotNull @Valid   public LocalDate getDate() {
     return date;
   }
 
@@ -253,7 +250,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+@Valid   public Date getDateTime() {
     return dateTime;
   }
 
@@ -272,7 +269,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+@Valid   public UUID getUuid() {
     return uuid;
   }
 
@@ -291,8 +288,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+@NotNull  @Size(min=10,max=64)  public String getPassword() {
     return password;
   }
 
@@ -311,7 +307,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+@Valid   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -82,7 +82,7 @@ public class MapTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+@Valid   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid Date dateTime;
+  private UUID uuid;
+  private Date dateTime;
   private @Valid Map<String, Animal> map = null;
 
   /**
@@ -37,7 +37,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+@Valid   public UUID getUuid() {
     return uuid;
   }
 
@@ -56,7 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+@Valid   public Date getDateTime() {
     return dateTime;
   }
 
@@ -75,7 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+@Valid   public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelFile.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   /**
    * Test capitalization

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelList.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   /**
    **/
@@ -35,8 +35,7 @@ public class Name  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+@NotNull   public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   /**
    **/
@@ -31,7 +31,7 @@ public class NumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+@Valid   public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid Date shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private Date shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -70,8 +70,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   /**
    **/
@@ -140,7 +140,7 @@ public class Order  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
-  public Date getShipDate() {
+@Valid   public Date getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   /**
    **/
@@ -33,7 +33,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+@Valid   public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<Tag> tags = null;
   public enum StatusEnum {
@@ -77,7 +77,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   /**
    **/
@@ -108,7 +108,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
-  public Category getCategory() {
+@Valid   public Category getCategory() {
     return category;
   }
 
@@ -127,8 +127,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+@NotNull   public String getName() {
     return name;
   }
 
@@ -147,8 +146,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+@NotNull   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -184,7 +182,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+@Valid   public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   /**
@@ -37,8 +37,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+@NotNull   public String getStringItem() {
     return stringItem;
   }
 
@@ -57,8 +56,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+@NotNull @Valid   public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -77,8 +75,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+@NotNull   public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -97,8 +94,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+@NotNull   public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -117,8 +113,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+@NotNull   public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -21,11 +21,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   /**
@@ -38,8 +38,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+@NotNull   public String getStringItem() {
     return stringItem;
   }
 
@@ -58,8 +57,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+@NotNull @Valid   public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -78,8 +76,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+@NotNull   public Float getFloatItem() {
     return floatItem;
   }
 
@@ -98,8 +95,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+@NotNull   public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -118,8 +114,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+@NotNull   public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -138,8 +133,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+@NotNull   public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
@@ -18,14 +18,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
@@ -21,33 +21,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = null;
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = null;
   private @Valid List<Integer> nameWrappedArray = null;
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = null;
   private @Valid List<Integer> prefixWrappedArray = null;
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = null;
   private @Valid List<Integer> namespaceWrappedArray = null;
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = null;
   private @Valid List<Integer> prefixNsWrappedArray = null;
 
@@ -80,7 +80,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+@Valid   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -191,7 +191,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+@Valid   public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -337,7 +337,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+@Valid   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -483,7 +483,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+@Valid   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -629,7 +629,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+@Valid   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,9 +30,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = null;
   private @Valid Map<String, Map<String, String>> mapMapString = null;
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = null;
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   protected AdditionalPropertiesClass(AdditionalPropertiesClassBuilder<?, ?> b) {
     this.mapString = b.mapString;
@@ -96,7 +96,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+@Valid   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -201,7 +201,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+@Valid   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -236,7 +236,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+@Valid   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -271,7 +271,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+@Valid   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -306,7 +306,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+@Valid   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   protected Animal(AnimalBuilder<?, ?> b) {
     this.className = b.className;
@@ -48,8 +48,7 @@ public class Animal  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+@NotNull   public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -40,7 +40,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+@Valid   public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -40,7 +40,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+@Valid   public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -79,7 +79,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+@Valid   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -114,7 +114,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+@Valid   public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
@@ -66,7 +66,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   protected BigCat(BigCatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCatAllOf.java
@@ -66,7 +66,7 @@ public class BigCatAllOf  implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   protected BigCatAllOf(BigCatAllOfBuilder<?, ?> b) {
     this.kind = b.kind;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   protected Capitalization(CapitalizationBuilder<?, ?> b) {
     this.smallCamel = b.smallCamel;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   protected Cat(CatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat_allOf")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class CatAllOf  implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   protected CatAllOf(CatAllOfBuilder<?, ?> b) {
     this.declawed = b.declawed;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   protected Category(CategoryBuilder<?, ?> b) {
     this.id = b.id;
@@ -58,8 +58,7 @@ public class Category  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+@NotNull   public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   protected ClassModel(ClassModelBuilder<?, ?> b) {
     this.propertyClass = b.propertyClass;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   protected Client(ClientBuilder<?, ?> b) {
     this.client = b.client;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   protected Dog(DogBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog_allOf")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class DogAllOf  implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   protected DogAllOf(DogAllOfBuilder<?, ?> b) {
     this.breed = b.breed;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -67,7 +67,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -67,7 +67,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -115,7 +115,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -163,7 +163,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -211,8 +211,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   protected EnumTest(EnumTestBuilder<?, ?> b) {
     this.enumString = b.enumString;
@@ -254,8 +254,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+@NotNull   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -312,7 +311,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+@Valid   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<ModelFile> files = null;
 
   protected FileSchemaTestClass(FileSchemaTestClassBuilder<?, ?> b) {
@@ -42,7 +42,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+@Valid   public ModelFile getFile() {
     return _file;
   }
 
@@ -61,7 +61,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+@Valid   public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
@@ -25,20 +25,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid Date dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private Date dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   protected FormatTest(FormatTestBuilder<?, ?> b) {
     this.integer = b.integer;
@@ -133,8 +133,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+@NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
   }
 
@@ -214,8 +213,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+@NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
     return _byte;
   }
 
@@ -234,7 +232,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
-  public File getBinary() {
+@Valid   public File getBinary() {
     return binary;
   }
 
@@ -253,8 +251,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+@NotNull @Valid   public LocalDate getDate() {
     return date;
   }
 
@@ -273,7 +270,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+@Valid   public Date getDateTime() {
     return dateTime;
   }
 
@@ -292,7 +289,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+@Valid   public UUID getUuid() {
     return uuid;
   }
 
@@ -311,8 +308,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+@NotNull  @Size(min=10,max=64)  public String getPassword() {
     return password;
   }
 
@@ -331,7 +327,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+@Valid   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   protected HasOnlyReadOnly(HasOnlyReadOnlyBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -92,7 +92,7 @@ public class MapTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+@Valid   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid Date dateTime;
+  private UUID uuid;
+  private Date dateTime;
   private @Valid Map<String, Animal> map = null;
 
   protected MixedPropertiesAndAdditionalPropertiesClass(MixedPropertiesAndAdditionalPropertiesClassBuilder<?, ?> b) {
@@ -46,7 +46,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+@Valid   public UUID getUuid() {
     return uuid;
   }
 
@@ -65,7 +65,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+@Valid   public Date getDateTime() {
     return dateTime;
   }
 
@@ -84,7 +84,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+@Valid   public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   protected Model200Response(Model200ResponseBuilder<?, ?> b) {
     this.name = b.name;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   protected ModelApiResponse(ModelApiResponseBuilder<?, ?> b) {
     this.code = b.code;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelFile.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   protected ModelFile(ModelFileBuilder<?, ?> b) {
     this.sourceURI = b.sourceURI;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelList.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   protected ModelList(ModelListBuilder<?, ?> b) {
     this._123list = b._123list;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   protected ModelReturn(ModelReturnBuilder<?, ?> b) {
     this._return = b._return;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   protected Name(NameBuilder<?, ?> b) {
     this.name = b.name;
@@ -45,8 +45,7 @@ public class Name  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+@NotNull   public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   protected NumberOnly(NumberOnlyBuilder<?, ?> b) {
     this.justNumber = b.justNumber;
@@ -38,7 +38,7 @@ public class NumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+@Valid   public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid Date shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private Date shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -70,8 +70,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   protected Order(OrderBuilder<?, ?> b) {
     this.id = b.id;
@@ -152,7 +152,7 @@ public class Order  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
-  public Date getShipDate() {
+@Valid   public Date getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   protected OuterComposite(OuterCompositeBuilder<?, ?> b) {
     this.myNumber = b.myNumber;
@@ -42,7 +42,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+@Valid   public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<Tag> tags = null;
   public enum StatusEnum {
@@ -77,7 +77,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   protected Pet(PetBuilder<?, ?> b) {
     this.id = b.id;
@@ -120,7 +120,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
-  public Category getCategory() {
+@Valid   public Category getCategory() {
     return category;
   }
 
@@ -139,8 +139,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+@NotNull   public String getName() {
     return name;
   }
 
@@ -159,8 +158,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+@NotNull   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -196,7 +194,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+@Valid   public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   protected ReadOnlyFirst(ReadOnlyFirstBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   protected SpecialModelName(SpecialModelNameBuilder<?, ?> b) {
     this.$specialPropertyName = b.$specialPropertyName;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   protected Tag(TagBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderDefault(TypeHolderDefaultBuilder<?, ?> b) {
@@ -48,8 +48,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+@NotNull   public String getStringItem() {
     return stringItem;
   }
 
@@ -68,8 +67,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+@NotNull @Valid   public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -88,8 +86,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+@NotNull   public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -108,8 +105,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+@NotNull   public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -128,8 +124,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+@NotNull   public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -21,11 +21,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderExample(TypeHolderExampleBuilder<?, ?> b) {
@@ -50,8 +50,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+@NotNull   public String getStringItem() {
     return stringItem;
   }
 
@@ -70,8 +69,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+@NotNull @Valid   public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -90,8 +88,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+@NotNull   public Float getFloatItem() {
     return floatItem;
   }
 
@@ -110,8 +107,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+@NotNull   public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -130,8 +126,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+@NotNull   public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -150,8 +145,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+@NotNull   public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
@@ -18,14 +18,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   protected User(UserBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
@@ -21,33 +21,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = null;
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = null;
   private @Valid List<Integer> nameWrappedArray = null;
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = null;
   private @Valid List<Integer> prefixWrappedArray = null;
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = null;
   private @Valid List<Integer> namespaceWrappedArray = null;
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = null;
   private @Valid List<Integer> prefixNsWrappedArray = null;
 
@@ -115,7 +115,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+@Valid   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -226,7 +226,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+@Valid   public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -372,7 +372,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+@Valid   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -518,7 +518,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+@Valid   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -664,7 +664,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+@Valid   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 


### PR DESCRIPTION
`@Valid` annotation is only needed for objects, where the cascading
validation is required. For standard Java types and enums it is useless.
Moreover, when those annotations are there for those types - Hibernate
Validator's performance degrades significantly (see:
https://hibernate.atlassian.net/browse/HV-1928 and
https://hibernate.atlassian.net/browse/HV-1933). I've checked other
available generators, and it looks like `spring` generates those
annotations properly. So I took the content of the modified files from
that generator and placed to the `jaxrs-spec` one.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @bbdouglas @sreeshas  @jfiala  @lukoyanov @cbornet @jeff9finger @karismann 
@Zomzog @lwlee2608 @cachescrubber @welshm @MelleD @atextor @manedev79  @javisst  @borsch  @banlevente @Zomzog 
