### PR TITLE
[Crystal] Skip primitive types from ModelImportMap

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -360,7 +360,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
     @Override
     public String toModelImport(String name) {
         if (primitiveTypes.contains(name)) {
-            return "";
+            return null;
         } else {
             return toModelFilename(name);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -63,6 +63,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
     protected String shardAuthorEmail = "";
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
+    protected List<String> primitiveTypes = new ArrayList<String>();
 
     public static final String SHARD_NAME = "shardName";
     public static final String MODULE_NAME = "moduleName";
@@ -184,6 +185,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         instantiationTypes.put("map", "Hash");
         instantiationTypes.put("array", "Array");
         instantiationTypes.put("set", "Set");
+        primitiveTypes = new ArrayList<String>(typeMapping.values());
 
         // remove modelPackage and apiPackage added by default
         cliOptions.removeIf(opt -> CodegenConstants.MODEL_PACKAGE.equals(opt.getOpt()) ||
@@ -353,6 +355,15 @@ public class CrystalClientCodegen extends DefaultCodegen {
         }
 
         return toModelName(type);
+    }
+
+    @Override
+    public String toModelImport(String name) {
+        if (primitiveTypes.contains(name)) {
+            return "";
+        } else {
+            return toModelFilename(name);
+        }
     }
 
     @Override


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
For crystal lang, there's no need to require any file for primitive types.

This PR makes the model import for a primitive type return null.

@wing328 Please review.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
