### PR TITLE
[swift5][client] - enable swift unit tests

### DIFF
--- a/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
@@ -46,7 +46,8 @@ class APIHelperTests: XCTestCase {
     func testMapValuesToQueryItems() {
         let source: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": true, "e": false]
         let expected: [URLQueryItem] = [URLQueryItem(name: "a", value: "1"),
-                                      URLQueryItem(name: "c", value: "1,2"),
+                                      URLQueryItem(name: "c", value: "1"),
+                                      URLQueryItem(name: "c", value: "2"),
                                       URLQueryItem(name: "d", value: "true"),
                                       URLQueryItem(name: "e", value: "false")].sorted(by: { $0.name > $1.name })
         let actual: [URLQueryItem] = APIHelper.mapValuesToQueryItems(source)!.sorted(by: { $0.name > $1.name })

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
+++ b/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
@@ -46,7 +46,8 @@ class APIHelperTests: XCTestCase {
     func testMapValuesToQueryItems() {
         let source: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": true, "e": false]
         let expected: [URLQueryItem] = [URLQueryItem(name: "a", value: "1"),
-                                      URLQueryItem(name: "c", value: "1,2"),
+                                      URLQueryItem(name: "c", value: "1"),
+                                      URLQueryItem(name: "c", value: "2"),
                                       URLQueryItem(name: "d", value: "true"),
                                       URLQueryItem(name: "e", value: "false")].sorted(by: { $0.name > $1.name })
         let actual: [URLQueryItem] = APIHelper.mapValuesToQueryItems(source)!.sorted(by: { $0.name > $1.name })

--- a/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/combineLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/default/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/default/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/promisekitLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/SwaggerClientTests/APIHelperTests.swift
@@ -46,7 +46,8 @@ class APIHelperTests: XCTestCase {
     func testMapValuesToQueryItems() {
         let source: [String: Any] = ["a": 1, "c": ["1", nil, "2"], "d": true, "e": false]
         let expected: [URLQueryItem] = [URLQueryItem(name: "a", value: "1"),
-                                      URLQueryItem(name: "c", value: "1,2"),
+                                      URLQueryItem(name: "c", value: "1"),
+                                      URLQueryItem(name: "c", value: "2"),
                                       URLQueryItem(name: "d", value: "true"),
                                       URLQueryItem(name: "e", value: "false")].sorted(by: { $0.name > $1.name })
         let actual: [URLQueryItem] = APIHelper.mapValuesToQueryItems(source)!.sorted(by: { $0.name > $1.name })

--- a/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/rxswiftLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}

--- a/samples/client/petstore/swift5/urlsessionLibrary/SwaggerClientTests/run_xcodebuild.sh
+++ b/samples/client/petstore/swift5/urlsessionLibrary/SwaggerClientTests/run_xcodebuild.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}
+xcodebuild clean build-for-testing -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" && xcodebuild test-without-building -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
This PR, enables the unit tests in the Swift sample projects.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)