### PR TITLE
[Go] [Client] Don't Explode Query Params

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -225,8 +225,16 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			valuesMap.Add( keyPrefix, value )
-			break
+		if collectionType == "csv" {
+			if valuesMap.Has(keyPrefix){
+				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
+			} else {
+				valuesMap.Add(keyPrefix, value)
+			}
+		} else {
+			valuesMap.Add(keyPrefix, value)
+		}
+		break
 		case map[string]string:
 			valuesMap[keyPrefix] = value
 			break

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -225,16 +225,12 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-		if collectionType == "csv" {
-			if valuesMap.Has(keyPrefix){
+			if collectionType == "csv" && valuesMap.Has(keyPrefix){
 				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
 			} else {
 				valuesMap.Add(keyPrefix, value)
 			}
-		} else {
-			valuesMap.Add(keyPrefix, value)
-		}
-		break
+			break
 		case map[string]string:
 			valuesMap[keyPrefix] = value
 			break

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -225,7 +225,7 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+			if collectionType == "csv" && valuesMap.Get(keyPrefix) != "" {
 				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
 			} else {
 				valuesMap.Add(keyPrefix, value)

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -231,7 +231,7 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+			if collectionType == "csv" && valuesMap.Get(keyPrefix) != "" {
 				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
 			} else {
 				valuesMap.Add(keyPrefix, value)
@@ -241,7 +241,6 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 			valuesMap[keyPrefix] = value
 			break
 	}
-	
 }
 
 // helper for converting interface{} parameters to json strings

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -231,12 +231,17 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			valuesMap.Add( keyPrefix, value )
+			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
+			} else {
+				valuesMap.Add(keyPrefix, value)
+			}
 			break
 		case map[string]string:
 			valuesMap[keyPrefix] = value
 			break
 	}
+	
 }
 
 // helper for converting interface{} parameters to json strings

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -215,12 +215,17 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			valuesMap.Add( keyPrefix, value )
+			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
+			} else {
+				valuesMap.Add(keyPrefix, value)
+			}
 			break
 		case map[string]string:
 			valuesMap[keyPrefix] = value
 			break
 	}
+	
 }
 
 // helper for converting interface{} parameters to json strings

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -215,7 +215,7 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+			if collectionType == "csv" && valuesMap.Get(keyPrefix) != "" {
 				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
 			} else {
 				valuesMap.Add(keyPrefix, value)
@@ -225,7 +225,6 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 			valuesMap[keyPrefix] = value
 			break
 	}
-	
 }
 
 // helper for converting interface{} parameters to json strings

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -234,12 +234,17 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			valuesMap.Add( keyPrefix, value )
+			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
+			} else {
+				valuesMap.Add(keyPrefix, value)
+			}
 			break
 		case map[string]string:
 			valuesMap[keyPrefix] = value
 			break
 	}
+	
 }
 
 // helper for converting interface{} parameters to json strings

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -234,7 +234,7 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 
 	switch valuesMap := queryParams.(type) {
 		case url.Values:
-			if collectionType == "csv" && valuesMap.Has(keyPrefix){
+			if collectionType == "csv" && valuesMap.Get(keyPrefix) != "" {
 				valuesMap.Set(keyPrefix, valuesMap.Get(keyPrefix) + "," + value)
 			} else {
 				valuesMap.Add(keyPrefix, value)
@@ -244,7 +244,6 @@ func parameterAddToQuery(queryParams interface{}, keyPrefix string, obj interfac
 			valuesMap[keyPrefix] = value
 			break
 	}
-	
 }
 
 // helper for converting interface{} parameters to json strings


### PR DESCRIPTION
Query params were incorrectly being exploded all the time, regardless of the setting in the spec.
This was introduced with https://github.com/OpenAPITools/openapi-generator/pull/13909/files and addresses https://github.com/OpenAPITools/openapi-generator/issues/14089

I think there are a lot of different ways to fix this issue, but this was a minimal way to get a slice of query params to be comma separated.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @wing328