### PR TITLE
[Java] fix JsonTypeName import

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1345,6 +1345,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             codegenModel.imports.add("JsonTypeInfo");
             codegenModel.imports.add("JsonIgnoreProperties");
         }
+        if (codegenModel.getIsClassnameSanitized() && additionalProperties.containsKey(JACKSON) && !codegenModel.isEnum) {
+            codegenModel.imports.add("JsonTypeName");
+        }
         if (allDefinitions != null && codegenModel.parentSchema != null && codegenModel.hasEnums) {
             final Schema parentModel = allDefinitions.get(codegenModel.parentSchema);
             final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent, parentModel);
@@ -1370,10 +1373,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
-        if (model.getIsClassnameSanitized() && additionalProperties.containsKey(JACKSON)) {
-            model.imports.add("JsonTypeName");
-        }
-
         if (serializeBigDecimalAsString) {
             if ("decimal".equals(property.baseType) || "bigdecimal".equalsIgnoreCase(property.baseType)) {
                 // we serialize BigDecimal as `string` to avoid precision loss

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -24,8 +24,10 @@ import static org.openapitools.codegen.TestUtils.assertFileNotContains;
 import static org.openapitools.codegen.languages.SpringCodegen.INTERFACE_ONLY;
 import static org.openapitools.codegen.languages.SpringCodegen.REQUEST_MAPPING_OPTION;
 import static org.openapitools.codegen.languages.SpringCodegen.RESPONSE_WRAPPER;
+import static org.openapitools.codegen.languages.SpringCodegen.RETURN_SUCCESS_CODE;
 import static org.openapitools.codegen.languages.SpringCodegen.SPRING_BOOT;
 import static org.openapitools.codegen.languages.SpringCodegen.USE_SPRING_BOOT3;
+import static org.openapitools.codegen.languages.features.DocumentationProviderFeatures.ANNOTATION_LIBRARY;
 import static org.openapitools.codegen.languages.features.DocumentationProviderFeatures.DOCUMENTATION_PROVIDER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -48,6 +50,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.java.assertions.JavaFileAssert;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.ClientOptInput;
@@ -1439,6 +1442,24 @@ public class SpringCodegenTest {
                 .assertMethod("getWithMapOfObjects").hasReturnType("ResponseEntity<Map<String, TestResponse>>")
                 .toFileAssert()
                 .assertMethod("getWithMapOfStrings").hasReturnType("ResponseEntity<Map<String, String>>");
+    }
+
+    @Test
+    public void testResponseWithArray_issue12524() throws Exception {
+        GlobalSettings.setProperty("skipFormModel", "true");
+
+        try {
+            Map<String, Object> additionalProperties = new HashMap<>();
+            additionalProperties.put(DOCUMENTATION_PROVIDER, "none");
+            additionalProperties.put(ANNOTATION_LIBRARY, "none");
+            additionalProperties.put(RETURN_SUCCESS_CODE, "true");
+            Map<String, File> files = generateFromContract("src/test/resources/bugs/issue_12524.json", SPRING_BOOT, additionalProperties);
+
+            JavaFileAssert.assertThat(files.get("API01ListOfStuff.java"))
+                .hasImports("com.fasterxml.jackson.annotation.JsonTypeName");
+        } finally {
+            GlobalSettings.reset();
+        }
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/bugs/issue_12524.json
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_12524.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "title": "Sample APIs",
+    "version": "08960d48-2613-4133-92f3-4ade4f1107f8"
+  },
+  "openapi": "3.0.1",
+  "x-group-parameters": true,
+  "components": {
+    "schemas": {
+      "API01_AbstractStuff": {
+        "discriminator": {
+          "mapping": {
+            "FIRST": "#/components/schemas/API01_FirstStuff",
+            "SECOND": "#/components/schemas/API01_SecondStuff"
+          },
+          "propertyName": "type"
+        },
+        "type": "object",
+        "properties": {
+          "date_created": {
+            "description": "Creation date",
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "API01_FirstStuff": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/API01_AbstractStuff"
+          },
+          {
+            "properties": {
+              "end_time": {
+                "description": "Ending date",
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "First stuff",
+        "type": "object"
+      },
+      "API01_SecondStuff": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/API01_AbstractStuff"
+          },
+          {
+            "properties": {
+              "emission_date": {
+                "description": "Emission date",
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Second stuff",
+        "type": "object"
+      },
+      "API01_ListOfStuff": {
+        "description": "List of stuff",
+        "items": {
+          "$ref": "#/components/schemas/API01_AbstractStuff"
+        },
+        "type": "array",
+        "properties": {
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/stuff": {
+      "get": {
+        "description": "",
+        "operationId": "API01",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/API01_ListOfStuff",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Do stuff",
+        "parameters": [
+          {
+            "description": "Some parameter",
+            "in": "query",
+            "name": "param1",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "servers": []
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Conditional based implementation of https://github.com/OpenAPITools/openapi-generator/pull/12524

The main issue here is that generated model `public class API01ListOfStuff extends ArrayList<API01AbstractStuff>` doesn't have any properties that's why `AbstractJavaCodegen#postProcessModelProperty` doesn't invoked for this model. Since import of `JsonTypeName` is only model dependent  and not model's property dependent, I've moved that import to `fromModel` method

**Note:** seems like there are few more imports which are only model dependent but are present in postProcessModelProperty. I'll clean-up them separately 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<html><body>
<!--StartFragment-->

Java | @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala  (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)  @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
-- | --
Java Spring | @cachescrubber (2022/02) @welshm (2022/02) @MelleD  (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02)  @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09)

<!--EndFragment-->
</body>
</html>