### PR TITLE
[java] Fix template logic related to supportUrlQuery

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -68,6 +68,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     public static final String USE_ABSTRACTION_FOR_FILES = "useAbstractionForFiles";
     public static final String DYNAMIC_OPERATIONS = "dynamicOperations";
     public static final String SUPPORT_STREAMING = "supportStreaming";
+    public static final String SUPPORT_URL_QUERY = "supportUrlQuery";
     public static final String GRADLE_PROPERTIES = "gradleProperties";
     public static final String ERROR_OBJECT_TYPE = "errorObjectType";
 
@@ -428,10 +429,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         }
 
         // add URL query deepObject support to native, apache-httpclient by default
-        if (!additionalProperties.containsKey("supportUrlQuery") && (isLibrary(NATIVE) || isLibrary(APACHE))) {
-            additionalProperties.put("supportUrlQuery", true);
+        if (!additionalProperties.containsKey(SUPPORT_URL_QUERY) && (isLibrary(NATIVE) || isLibrary(APACHE))) {
+            additionalProperties.put(SUPPORT_URL_QUERY, true);
         } else {
-            additionalProperties.put("supportUrlQuery", Boolean.parseBoolean(additionalProperties.get(SUPPORT_STREAMING).toString()));
+            additionalProperties.put(SUPPORT_URL_QUERY, Boolean.parseBoolean(additionalProperties.get(SUPPORT_URL_QUERY).toString()));
         }
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/oneof_model.mustache
@@ -294,7 +294,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         if (getActualInstance() != null) {
           int i = 0;
           for ({{items.dataType}} _item : ({{{dataType}}})getActualInstance()) {
-            if ((({{{dataType}}})getActualInstance()).get(i) != null) {
+            if (_item != null) {
               joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
                   "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
             }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -413,7 +413,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     if ({{getter}}() != null) {
       int i = 0;
       for ({{items.dataType}} _item : {{getter}}()) {
-        if ({{getter}}().get(i) != null) {
+        if (_item != null) {
           joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
               "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
         }

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -411,7 +411,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     if ({{getter}}() != null) {
       int i = 0;
       for ({{items.dataType}} _item : {{getter}}()) {
-        if ({{getter}}().get(i) != null) {
+        if (_item != null) {
           joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
               "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
         }


### PR DESCRIPTION
Generated models for arrays marked with `uniqueItems: true` (which end up as a `Set<>` in java) won't compile because the templates are in some places using `.get(i)` on the sets.

Also, when the `supportUrlQuery` property is present in the  `additionalProperties` map the resulting value will be read using the constant `SUPPORT_STREAMING` instead of the key 'supportUrlQuery'.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [-] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package <--- Get errors when I run this on a clean `master`...
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)