### PR TITLE
[elixir] Properly map AnyType

### DIFF
--- a/docs/generators/elixir.md
+++ b/docs/generators/elixir.md
@@ -45,6 +45,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## LANGUAGE PRIMITIVES
 
 <ul class="column-ul">
+<li>AnyType</li>
 <li>Atom</li>
 <li>Boolean</li>
 <li>DateTime</li>
@@ -56,6 +57,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>PID</li>
 <li>String</li>
 <li>Tuple</li>
+<li>any()</li>
 <li>map()</li>
 </ul>
 
@@ -103,7 +105,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |Uuid|✗|
 |Array|✓|OAS2,OAS3
 |Null|✗|OAS3
-|AnyType|✗|OAS2,OAS3
+|AnyType|✓|OAS2,OAS3
 |Object|✓|OAS2,OAS3
 |Maps|✓|ToolingExtension
 |CollectionFormat|✓|OAS2

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -88,6 +88,9 @@ public class ElixirClientCodegen extends DefaultCodegen {
                 .includeClientModificationFeatures(
                         ClientModificationFeature.BasePath
                 )
+                .includeDataTypeFeatures(
+                        DataTypeFeature.AnyType
+                )
         );
 
         // set the output folder here
@@ -192,7 +195,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "Tuple",
                         "PID",
                         "DateTime",
-                        "map()" // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec datetype to evaluate the primitive
+                        "map()", // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec datetype to evaluate the primitive
+                        "any()"
                 )
         );
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -188,6 +188,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "List",
                         "Atom",
                         "Map",
+                        "AnyType",
                         "Tuple",
                         "PID",
                         "DateTime",
@@ -575,6 +576,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
             return "String.t";
         } else if (ModelUtils.isStringSchema(p)) {
             return "String.t";
+        } else if (p.getType() == null) {
+            return "any()";
         }
         return super.getTypeDeclaration(p);
     }
@@ -664,6 +667,10 @@ public class ElixirClientCodegen extends DefaultCodegen {
                 return "false";
             } else if (isArray && languageSpecificPrimitives().contains(baseType)) {
                 return "[]";
+            }
+
+            if (this.baseType.equals("AnyType")){
+                return "%{}";
             }
             StringBuilder sb = new StringBuilder();
             if (isArray) {
@@ -785,8 +792,13 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         returnEntry.append(moduleName);
                         returnEntry.append(".Model.");
                     }
-                    returnEntry.append(exResponse.baseType);
-                    returnEntry.append(".t");
+
+                    if (exResponse.baseType.equals("AnyType")) {
+                        returnEntry.append("any()");
+                    }else {
+                        returnEntry.append(exResponse.baseType);
+                        returnEntry.append(".t");
+                    }
                 } else {
                     if (exResponse.containerType.equals("array") ||
                             exResponse.containerType.equals("set")) {
@@ -795,8 +807,13 @@ public class ElixirClientCodegen extends DefaultCodegen {
                             returnEntry.append(moduleName);
                             returnEntry.append(".Model.");
                         }
-                        returnEntry.append(exResponse.baseType);
-                        returnEntry.append(".t)");
+
+                        if (exResponse.baseType.equals("AnyType")) {
+                            returnEntry.append("any())");
+                        }else {
+                            returnEntry.append(exResponse.baseType);
+                            returnEntry.append(".t)");
+                        }
                     } else if (exResponse.containerType.equals("map")) {
                         returnEntry.append("map()");
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -672,10 +672,6 @@ public class ElixirClientCodegen extends DefaultCodegen {
             } else if (isArray && languageSpecificPrimitives().contains(baseType)) {
                 return "[]";
             }
-
-            if (this.baseType.equals("AnyType")){
-                return "%{}";
-            }
             StringBuilder sb = new StringBuilder();
             if (isArray) {
                 sb.append("[");

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/all_of_with_single_ref.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/all_of_with_single_ref.ex
@@ -19,10 +19,8 @@ defmodule OpenapiPetstore.Model.AllOfWithSingleRef do
 end
 
 defimpl Poison.Decoder, for: OpenapiPetstore.Model.AllOfWithSingleRef do
-  import OpenapiPetstore.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
-    |> deserialize(:SingleRefType, :struct, OpenapiPetstore.Model.SingleRefType, options)
   end
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/all_of_with_single_ref.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/all_of_with_single_ref.ex
@@ -14,7 +14,7 @@ defmodule OpenapiPetstore.Model.AllOfWithSingleRef do
 
   @type t :: %__MODULE__{
     :username => String.t | nil,
-    :SingleRefType => SingleRefType | nil
+    :SingleRefType => any() | nil
   }
 end
 


### PR DESCRIPTION
Fixes #14070

This PR will handle `AnyType` as primitives to prevent the generator from generating specific classes, since in elixir structs cannot have any extra undefined files. This will also result in `AnyType` parameters not be serialized in any other way than Poison interprets it.

Since the Pet Store doesn't have some good examples to see the results of this change, here's a Dummy Spec:
```yaml
openapi: 3.0.3
info:
  title: Dummy Spec
  version: 1.0.11
servers:
  - url: https://dummy.example.com/api
paths:
  /quotas:
    get:
      operationId: GetQuotas
      responses:
        "200":
          $ref: '#/components/responses/GetQuotasResponse'
      tags:
      - Enterprise
  /dummy:
    get:
      operationId: GetQuotas
      responses:
        "200":
          $ref: '#/components/responses/GetJobScaleStatusResponse'
      tags:
      - Enterprise
components:
  schemas:
    ConsulGateway:
      properties:
        Mesh: {}
      type: object
  responses:
    GetJobScaleStatusResponse:
      description: ""
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/ConsulGateway'
    GetQuotasResponse:
      content:
        application/json:
          schema:
            items: {}
            type: array
      description: ""
```

The Spec contains two interesting parts. First, there is the `ConsulGateway` with the `Mesh` properties, with no further definition. 
Secondly, there is the `GetQuotasResponse` with an array of `AnyType` objects.

```diff
--- a/lib/nomad_client/api/enterprise.ex
+++ b/lib/nomad_client/api/enterprise.ex
@@ -21,7 +21,7 @@ defmodule NomadClient.Api.Enterprise do
   - `{:ok, [%AnyType{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec get_quotas(Tesla.Env.client, keyword()) :: {:ok, list(NomadClient.Model.AnyType.t)} | {:error, Tesla.Env.t}
+  @spec get_quotas(Tesla.Env.client, keyword()) :: {:ok, list(any())} | {:error, Tesla.Env.t}
   def get_quotas(connection, _opts \\ []) do
     request =
       %{}
@@ -32,7 +32,7 @@ defmodule NomadClient.Api.Enterprise do
     connection
     |> Connection.request(request)
     |> evaluate_response([
-      {200, [%NomadClient.Model.AnyType{}]}
+      {200, []}
     ])
   end
```

As you can see in the upper diff. The generator won't interpret the undefined list as  `%NomadClient.Model.AnyType{}` anymore, but uses `[]` instead.

```diff
--- a/lib/nomad_client/model/consul_gateway.ex
+++ b/lib/nomad_client/model/consul_gateway.ex
@@ -12,15 +12,13 @@ defmodule NomadClient.Model.ConsulGateway do
   ]
 
   @type t :: %__MODULE__{
-    :Mesh => AnyType | nil
+    :Mesh => any() | nil
   }
 end
 
 defimpl Poison.Decoder, for: NomadClient.Model.ConsulGateway do
-  import NomadClient.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
-    |> deserialize(:Mesh, :struct, NomadClient.Model.AnyType, options)
   end
 end
```

In the upper diff, you can see that `Mesh` will not be decoded to the not existing `NomadClient.Model.AnyType` anymore. `Mesh` will not be serialized to a struct and will be left as is from Poison

@halostatue or @wing328 I would be honored if you could review my changes.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
