### PR TITLE
Update PR template to contain all scripts to run

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,16 @@
   ./mvnw clean package 
   ./bin/generate-samples.sh
   ./bin/utils/export_docs_generators.sh
-  ./bin/utils/export_generators_readme.sh
   ``` 
   Commit all changed files. 
   This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
   These must match the expectations made by your contribution. 
   You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
   For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
+- [ ] In case you are adding a new generator, run the following additional script : 
+  ```
+  ./bin/utils/ensure-up-to-date.sh
+  ``` 
+  Commit all changed files.
 - [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
 - [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
   ./mvnw clean package 
   ./bin/generate-samples.sh
   ./bin/utils/export_docs_generators.sh
+  ./bin/utils/export_generators_readme.sh
   ``` 
   Commit all changed files. 
   This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 


### PR DESCRIPTION
The current list of items to be run in the PR template is incomplete. Looking at the `Docs up-to-date` workflow, an additional bin script is run which was making the PR fail in my case. I added it to the template

https://github.com/OpenAPITools/openapi-generator/actions/runs/3975110788/workflow

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
