### PR TITLE
[elixir] Fixes issue with setting Header parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
@@ -101,7 +101,12 @@ defmodule {{moduleName}}.RequestBuilder do
   end
 
   def add_param(request, :headers, key, value) do
-    Tesla.put_header(request, key, value)
+    headers =
+      request
+      |> Map.get(:headers, [])
+      |> List.keystore(key, 0, {key, value})
+
+    Map.put(request, :headers, headers)
   end
 
   def add_param(request, :file, name, path) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
@@ -103,7 +103,12 @@ defmodule OpenapiPetstore.RequestBuilder do
   end
 
   def add_param(request, :headers, key, value) do
-    Tesla.put_header(request, key, value)
+    headers =
+      request
+      |> Map.get(:headers, [])
+      |> List.keystore(key, 0, {key, value})
+
+    Map.put(request, :headers, headers)
   end
 
   def add_param(request, :file, name, path) do


### PR DESCRIPTION
Currently, whenever someone passes a header parameter to the request, the request will fail since the `Tesla.put_header/3` will be called with the wrong parameter.

```
     The following arguments were given to Tesla.put_header/3:
     
         # 1
         %{method: :get, url: "/jobs"}
     
         # 2
         :index
     
         # 3
         123
     
     Attempted function clauses (showing 1 out of 1):
     
         def put_header(%Tesla.Env{} = env, key, value) when is_binary(key) and is_binary(value)
```


This PR will fixes this issue by removing the `Tesla.put_header/3` call and replacing it with a simple `get value from list an pass it to the map` logic.

I noticed this bug during the review of https://github.com/OpenAPITools/openapi-generator/pull/14071#discussion_r1033703313

@halostatue or @wing328, Would you mind giving me a review on this one?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
