### PR TITLE
[csharp-netcore] Fixes issue with enum discriminators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -429,6 +429,10 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         return discriminator == null ? null : discriminator.getPropertyName();
     }
 
+    public String getDiscriminatorBaseName() {
+        return discriminator == null ? null : discriminator.getPropertyBaseName();
+    }
+
     public ExternalDocumentation getExternalDocumentation() {
         return externalDocumentation;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -600,6 +600,10 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         for (String openAPIName : models.keySet()) {
             CodegenModel model = ModelUtils.getModelByName(openAPIName, models);
             if (model != null) {
+                Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
+                final Schema parentModel = allDefinitions.get(toModelName(model.parent));
+                final CodegenModel parentCodegenModel = parentModel != null ? super.fromModel(model.parent, parentModel) : null;
+
                 for (CodegenProperty var : model.allVars) {
                     if (enumRefs.containsKey(var.dataType)) {
                         // Handle any enum properties referred to by $ref.
@@ -611,6 +615,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
                         // We do these after updateCodegenPropertyEnum to avoid generalities that don't mesh with C#.
                         var.isPrimitiveType = true;
+
+                        updateCodegenPropertyEnumDefaultValue(var, parentCodegenModel);
                     }
                 }
                 for (CodegenProperty var : model.vars) {
@@ -624,6 +630,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
                         // We do these after updateCodegenPropertyEnum to avoid generalities that don't mesh with C#.
                         var.isPrimitiveType = true;
+
+                        updateCodegenPropertyEnumDefaultValue(var, parentCodegenModel);
                     }
                 }
                 for (CodegenProperty var : model.readWriteVars) {
@@ -637,6 +645,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
                         // We do these after updateCodegenPropertyEnum to avoid generalities that don't mesh with C#.
                         var.isPrimitiveType = true;
+
+                        updateCodegenPropertyEnumDefaultValue(var, parentCodegenModel);
                     }
                 }
                 for (CodegenProperty var : model.readOnlyVars) {
@@ -650,6 +660,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
                         // We do these after updateCodegenPropertyEnum to avoid generalities that don't mesh with C#.
                         var.isPrimitiveType = true;
+
+                        updateCodegenPropertyEnumDefaultValue(var, parentCodegenModel);
                     }
                 }
 
@@ -705,6 +717,30 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 } */
             } else {
                 LOGGER.warn("Expected to retrieve model %s by name, but no model was found. Check your -Dmodels inclusions.", openAPIName);
+            }
+        }
+    }
+
+    private void updateCodegenPropertyEnumDefaultValue(CodegenProperty var, CodegenModel parentCodegenModel) {
+        if (var.defaultValue != null && parentCodegenModel != null) {
+            String rawDefaultValue = var.defaultValue.replace("\"", "");
+
+            if (parentCodegenModel.discriminator != null) {
+                for (Map.Entry<String, String> mapping : parentCodegenModel.discriminator.getMapping().entrySet()) {
+                    String candidate;
+                    if (mapping.getValue().indexOf('/') >= 0) {
+                        candidate = ModelUtils.getSimpleRef(mapping.getValue());
+                        if (ModelUtils.getSchema(openAPI, candidate) == null) {
+                            LOGGER.error("Failed to lookup the schema '{}' when processing the discriminator mapping of oneOf/anyOf. Please check to ensure it's defined properly.", candidate);
+                        }
+                    } else {
+                        candidate = mapping.getValue();
+                    }
+
+                    if (rawDefaultValue.equals(candidate)) {
+                        var.defaultValue = var.datatypeWithEnum + "." + mapping.getKey();
+                    }
+                }
             }
         }
     }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -9,7 +9,7 @@
     {{/vendorExtensions.x-com-visible}}
     [DataContract(Name = "{{{name}}}")]
     {{#discriminator}}
-    [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorName}}}")]
+    [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorBaseName}}}")] // {{{discriminatorName}}}
     {{#mappedModels}}
     [JsonSubtypes.KnownSubType(typeof({{{modelName}}}), "{{^vendorExtensions.x-discriminator-value}}{{{mappingName}}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{.}}}{{/vendorExtensions.x-discriminator-value}}")]
     {{/mappedModels}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ModelTest.java
@@ -55,6 +55,7 @@ public class Swift5ModelTest {
         Assert.assertEquals(cm.description, "a sample model");
         Assert.assertEquals(cm.vars.size(), 7);
         Assert.assertEquals(cm.getDiscriminatorName(),"test");
+        Assert.assertEquals(cm.getDiscriminatorBaseName(),"test");
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Animal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Org.OpenAPITools.Test</AssemblyName>
     <RootNamespace>Org.OpenAPITools.Test</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Animal.cs
@@ -32,7 +32,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
@@ -32,7 +32,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -32,7 +32,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Dog.cs
@@ -32,7 +32,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -32,7 +32,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -32,7 +32,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Animal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Animal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract(Name = "Animal")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     public partial class Animal : IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Cat
     /// </summary>
     [DataContract(Name = "Cat")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ChildCat
     /// </summary>
     [DataContract(Name = "ChildCat")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Dog.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// Dog
     /// </summary>
     [DataContract(Name = "Dog")]
-    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
+    [JsonConverter(typeof(JsonSubtypes), "className")] // ClassName
     public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// GrandparentAnimal
     /// </summary>
     [DataContract(Name = "GrandparentAnimal")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     [JsonSubtypes.KnownSubType(typeof(ParentPet), "ParentPet")]
     public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -31,7 +31,7 @@ namespace Org.OpenAPITools.Model
     /// ParentPet
     /// </summary>
     [DataContract(Name = "ParentPet")]
-    [JsonConverter(typeof(JsonSubtypes), "PetType")]
+    [JsonConverter(typeof(JsonSubtypes), "pet_type")] // PetType
     [JsonSubtypes.KnownSubType(typeof(ChildCat), "ChildCat")]
     public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {


### PR DESCRIPTION
This PR fixes two issues with csharp code generator:
1. When `enum` type is used as discriminator autogenerated constructors for derived types default to string representation of discriminator type name rather concrete enum value.
2. Polymorphic Json.NET serialization configures `JsonSubtypes` converter with CLR property name discriminator value rather JSON property name.

### Sample Schema

```yaml
    MyDiscriminatorType:
      type: string
      enum:
        - Abc
        - Def
    MyBaseType:
      type: object
      required:
        - some_discriminator
      properties:
        some_discriminator:
          $ref: '#/components/schemas/MyDiscriminatorType'
      discriminator:
        propertyName: some_discriminator
        mapping:
          # NOTE: These need to match MyDiscriminatorType options above
          Abc: '#/components/schemas/MyAbc'
          Def: '#/components/schemas/MyDef'
    MyAbc:
      allOf:
        - $ref: '#/components/schemas/MyBaseType'
        - type: object
          required:
            - my_abc_prop
          properties:
            my_abc_prop:
              type: string
    MyDef:
      allOf:
        - $ref: '#/components/schemas/MyBaseType'
        - type: object
          required:
            - my_def_prop
          properties:
            my_def_prop:
              type: boolean
```

Generated Types (simplified)

```sharp
// all good
public enum MyDiscriminatorType
{
  Abc = 1,
  Def = 2,
}

[JsonConverter(typeof(JsonSubtypes), "SomeDiscriminator")] // some_discriminator expected
[JsonSubtypes.KnownSubType(typeof(MyAbc), "Abc")]
[JsonSubtypes.KnownSubType(typeof(MyDef), "Def")]
[JsonSubtypes.KnownSubType(typeof(MyAbc), "MyAbc")]
[JsonSubtypes.KnownSubType(typeof(MyDef), "MyDef")]
public partial class MyBaseType : IEquatable<MyBaseType>
{
    // all good
    public MyBaseType(MyDiscriminatorType someDiscriminator = default(MyDiscriminatorType))
    {
        // ...
    }
}

[DataContract(Name = "MyAbc")]
[JsonConverter(typeof(JsonSubtypes), "SomeDiscriminator")] // some_discriminator expected
[JsonSubtypes.KnownSubType(typeof(MyAbc), "Abc")]
[JsonSubtypes.KnownSubType(typeof(MyDef), "Def")]
public partial class MyAbc : MyBaseType, IEquatable<MyAbc>
{
    // compile-time error, MyDiscriminatorType someDiscriminator = MyDiscriminatorType.Abc expected
    public MyAbc(string myAbcProp = default(string), MyDiscriminatorType someDiscriminator = "Abc") : base(someDiscriminator)
    {
        // ...
    }
}
```

@mandrean  @frankyjuang  @shibayan  @Blackclaws @lucamazzanti