### PR TITLE
Support CommaSeparatedTuples including commas

### DIFF
--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/utils/OptionUtilsTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/utils/OptionUtilsTest.java
@@ -52,6 +52,10 @@ public class OptionUtilsTest {
         doTupleListTest("a=1,=,c=3", asList(Pair.of("a", "1"), Pair.of("c", "3")));
         doTupleListTest("", emptyPairList());
         doTupleListTest(null, emptyPairList());
+        doTupleListTest("a=1,b=2,c=\"3,4,5\"",
+                asList(Pair.of("a", "1"), Pair.of("b", "2"),
+                        Pair.of("c", "\"3,4,5\"")));
+
     }
 
     private static void doTupleListTest(String input, List<Pair<String, String>> expectedResults) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OptionUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OptionUtils.java
@@ -51,7 +51,9 @@ public class OptionUtils {
         List<String> results = new ArrayList<String>();
 
         if(input != null && !input.isEmpty()) {
-            for (String value : input.split(",")) {
+            String[] tokens = input.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
+//            for (String value : input.split(",")) {
+            for (String value : tokens) {
                 if(isNotEmpty(value))
                 results.add(value);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OptionUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OptionUtils.java
@@ -52,7 +52,6 @@ public class OptionUtils {
 
         if(input != null && !input.isEmpty()) {
             String[] tokens = input.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
-//            for (String value : input.split(",")) {
             for (String value : tokens) {
                 if(isNotEmpty(value))
                 results.add(value);


### PR DESCRIPTION

This PR improves the management of CommaSeparatedTuples to be able to support strings that include commas:
```
a,b,c,"1,2,3" -> [a][b][c][1,2,3]
```
When the value (ie "1,2,3") is quoted the commas are ignored and the (sub)list is considered a single value

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
