### PR TITLE
[python-nextgen] fix issue on API example doc autogeneration

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/api_doc_example.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/api_doc_example.mustache
@@ -7,12 +7,7 @@ from {{{packageName}}}.rest import ApiException
 from pprint import pprint
 {{> python_doc_auth_partial}}
 # Enter a context with an instance of the API client
-{{#hasAuthMethods}}
 {{#asyncio}}async {{/asyncio}}with {{{packageName}}}.ApiClient(configuration) as api_client:
-{{/hasAuthMethods}}
-{{^hasAuthMethods}}
-{{#asyncio}}async {{/asyncio}}with {{{packageName}}}.ApiClient() as api_client:
-{{/hasAuthMethods}}
     # Create an instance of the API class
     api_instance = {{{packageName}}}.{{{classname}}}(api_client)
     {{#allParams}}

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/AnotherFakeApi.md
@@ -31,7 +31,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.AnotherFakeApi(api_client)
     client = petstore_api.Client() # Client | client model

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/DefaultApi.md
@@ -29,7 +29,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.DefaultApi(api_client)
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FakeApi.md
@@ -44,7 +44,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
 
@@ -232,7 +232,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = True # bool | Input boolean as post body (optional)
@@ -295,7 +295,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     outer_composite = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
@@ -358,7 +358,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = 3.4 # float | Input number as post body (optional)
@@ -421,7 +421,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = 'body_example' # str | Input string as post body (optional)
@@ -484,7 +484,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     outer_object_with_enum_property = petstore_api.OuterObjectWithEnumProperty() # OuterObjectWithEnumProperty | Input enum (int) as post body
@@ -547,7 +547,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = 'body_example' # str | image to upload
@@ -608,7 +608,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     file_schema_test_class = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
@@ -667,7 +667,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     query = 'query_example' # str | 
@@ -730,7 +730,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     client = petstore_api.Client() # Client | client model
@@ -976,7 +976,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     request_body = {'key': 'request_body_example'} # Dict[str, str] | request body
@@ -1038,7 +1038,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     param = 'param_example' # str | field1
@@ -1102,7 +1102,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     pipe = ['pipe_example'] # List[str] | 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/StoreApi.md
@@ -34,7 +34,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.StoreApi(api_client)
     order_id = 'order_id_example' # str | ID of the order that needs to be deleted
@@ -168,7 +168,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.StoreApi(api_client)
     order_id = 56 # int | ID of pet that needs to be fetched
@@ -234,7 +234,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.StoreApi(api_client)
     order = petstore_api.Order() # Order | order placed for purchasing the pet

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/UserApi.md
@@ -38,7 +38,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     user = petstore_api.User() # User | Created user object
@@ -100,7 +100,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     user = [petstore_api.User()] # List[User] | List of user object
@@ -162,7 +162,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     user = [petstore_api.User()] # List[User] | List of user object
@@ -224,7 +224,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | The name that needs to be deleted
@@ -287,7 +287,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
@@ -353,7 +353,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | The user name for login
@@ -420,7 +420,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
 
@@ -478,7 +478,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-async with petstore_api.ApiClient() as api_client:
+async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | name that need to be deleted

--- a/samples/openapi3/client/petstore/python-nextgen/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/AnotherFakeApi.md
@@ -31,7 +31,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.AnotherFakeApi(api_client)
     client = petstore_api.Client() # Client | client model

--- a/samples/openapi3/client/petstore/python-nextgen/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/DefaultApi.md
@@ -29,7 +29,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.DefaultApi(api_client)
 

--- a/samples/openapi3/client/petstore/python-nextgen/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/FakeApi.md
@@ -44,7 +44,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
 
@@ -232,7 +232,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = True # bool | Input boolean as post body (optional)
@@ -295,7 +295,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     outer_composite = petstore_api.OuterComposite() # OuterComposite | Input composite as post body (optional)
@@ -358,7 +358,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = 3.4 # float | Input number as post body (optional)
@@ -421,7 +421,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = 'body_example' # str | Input string as post body (optional)
@@ -484,7 +484,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     outer_object_with_enum_property = petstore_api.OuterObjectWithEnumProperty() # OuterObjectWithEnumProperty | Input enum (int) as post body
@@ -547,7 +547,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     body = 'body_example' # str | image to upload
@@ -608,7 +608,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     file_schema_test_class = petstore_api.FileSchemaTestClass() # FileSchemaTestClass | 
@@ -667,7 +667,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     query = 'query_example' # str | 
@@ -730,7 +730,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     client = petstore_api.Client() # Client | client model
@@ -976,7 +976,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     request_body = {'key': 'request_body_example'} # Dict[str, str] | request body
@@ -1038,7 +1038,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     param = 'param_example' # str | field1
@@ -1102,7 +1102,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
     pipe = ['pipe_example'] # List[str] | 

--- a/samples/openapi3/client/petstore/python-nextgen/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/StoreApi.md
@@ -34,7 +34,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.StoreApi(api_client)
     order_id = 'order_id_example' # str | ID of the order that needs to be deleted
@@ -168,7 +168,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.StoreApi(api_client)
     order_id = 56 # int | ID of pet that needs to be fetched
@@ -234,7 +234,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.StoreApi(api_client)
     order = petstore_api.Order() # Order | order placed for purchasing the pet

--- a/samples/openapi3/client/petstore/python-nextgen/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/UserApi.md
@@ -38,7 +38,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     user = petstore_api.User() # User | Created user object
@@ -100,7 +100,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     user = [petstore_api.User()] # List[User] | List of user object
@@ -162,7 +162,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     user = [petstore_api.User()] # List[User] | List of user object
@@ -224,7 +224,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | The name that needs to be deleted
@@ -287,7 +287,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | The name that needs to be fetched. Use user1 for testing.
@@ -353,7 +353,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | The user name for login
@@ -420,7 +420,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
 
@@ -478,7 +478,7 @@ configuration = petstore_api.Configuration(
 
 
 # Enter a context with an instance of the API client
-with petstore_api.ApiClient() as api_client:
+with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.UserApi(api_client)
     username = 'username_example' # str | name that need to be deleted


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes the issue #14538
as described in the above issue, this PR makes auto generated API example doc runnable in success even when OpenAPI spec has no auth methods.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@spacether @wing328 