### PR TITLE
fix(sec): upgrade certifi to 

### DIFF
--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==0.5.0
 aniso8601==7.0.0
 async-exit-stack==1.0.1
 async-generator==1.10
-certifi==2022.12.7
+certifi==2022.12.07
 chardet==4.0.0
 click==7.1.2
 dnspython==2.1.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS