### PR TITLE
Provide non-duplicated list of all operations over all apis for supporting files

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/model/ApiInfoMap.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/model/ApiInfoMap.java
@@ -14,4 +14,12 @@ public class ApiInfoMap extends HashMap<String, Object> {
         return (List<OperationsMap>) get("apis");
     }
 
+    public void setUniqueOperations(OperationsMap uniqueOperations) {
+        put("uniqueOperations", uniqueOperations);
+    }
+
+    @SuppressWarnings("unchecked")
+    public OperationsMap getUniqueOperations() {
+        return (OperationsMap) get("uniqueOperations");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/multi-tags.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/multi-tags.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Test API
+  description: Multi Tags Test
+  version: 1.0.0
+servers:
+  - url: 'http://api.company.xyz/v2'
+paths:
+  /both:
+    get:
+      tags:
+        - tag1
+        - tag2
+      operationId: both
+      responses:
+        '200':
+          description: Ok
+  /tag1:
+    get:
+      tags:
+        - tag1
+      operationId: tag1
+      responses:
+        '200':
+          description: Ok
+  /tag2:
+    get:
+      tags:
+        - tag2
+      operationId: tag2
+      responses:
+        '200':
+          description: Ok
+  /none:
+    get:
+      operationId: none
+      responses:
+        '200':
+          description: Ok


### PR DESCRIPTION
Allow supporting file templates to access a list of all unique operations over all apis within `apiInfo`.

Within a template:

```
{{apiInfo}}
{{uniqueOperations}}
{{operations}}
... do stuff with unique operations
{{/operations}}
{{/uniqueOperations}}
{{/apiInfo}}
```

fix #11843

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
