### PR TITLE
[R] Fix escaping in templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
@@ -60,7 +60,7 @@
 
       {{#composedSchemas.anyOf}}
       {{^isNull}}
-      {{{dataType}}}_result <- tryCatch({
+      `{{{dataType}}}_result` <- tryCatch({
           {{#isPrimitiveType}}
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "{{{dataType}}}") {
@@ -68,18 +68,18 @@
           }
           {{/isPrimitiveType}}
           {{^isPrimitiveType}}
-          {{{dataType}}}$public_methods$validateJSON(input)
-          {{{dataType}}}_instance <- {{{dataType}}}$new()
+          `{{{dataType}}}`$public_methods$validateJSON(input)
+          `{{{dataType}}}_instance` <- `{{{dataType}}}`$new()
           {{/isPrimitiveType}}
-          self$actual_instance <- {{{dataType}}}_instance$fromJSON(input)
+          self$actual_instance <- `{{{dataType}}}_instance`$fromJSON(input)
           self$actual_type <- "{{{dataType}}}"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null({{{dataType}}}_result["error"])) {
-        error_messages <- append(error_messages, {{{dataType}}}_result["message"])
+      if (!is.null(`{{{dataType}}}_result`["error"])) {
+        error_messages <- append(error_messages, `{{{dataType}}}_result`["message"])
       }
 
       {{/isNull}}

--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -289,9 +289,9 @@
         self$`{{name}}` <- this_object$`{{baseName}}`
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        {{#lambda.lowercase}}{{{name}}}{{/lambda.lowercase}}_object <- {{dataType}}$new()
-        {{#lambda.lowercase}}{{{name}}}{{/lambda.lowercase}}_object$fromJSON(jsonlite::toJSON(this_object${{baseName}}, auto_unbox = TRUE, digits = NA))
-        self$`{{name}}` <- {{#lambda.lowercase}}{{{name}}}{{/lambda.lowercase}}_object
+        `{{#lambda.lowercase}}{{{name}}}{{/lambda.lowercase}}_object` <- {{dataType}}$new()
+        `{{#lambda.lowercase}}{{{name}}}{{/lambda.lowercase}}_object`$fromJSON(jsonlite::toJSON(this_object$`{{baseName}}`, auto_unbox = TRUE, digits = NA))
+        self$`{{name}}` <- `{{#lambda.lowercase}}{{{name}}}{{/lambda.lowercase}}_object`
         {{/isPrimitiveType}}
         {{/isContainer}}
       }
@@ -421,7 +421,7 @@
       self$`{{name}}` <- this_object$`{{name}}`
       {{/isPrimitiveType}}
       {{^isPrimitiveType}}
-      self$`{{name}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON(this_object${{name}}, auto_unbox = TRUE, digits = NA))
+      self$`{{name}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON(this_object$`{{name}}`, auto_unbox = TRUE, digits = NA))
       {{/isPrimitiveType}}
       {{/isContainer}}
       {{/vars}}

--- a/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
@@ -99,7 +99,7 @@
       {{/useOneOfDiscriminatorLookup}}
       {{#composedSchemas.oneOf}}
       {{^isNull}}
-      {{{dataType}}}_result <- tryCatch({
+      `{{{dataType}}}_result` <- tryCatch({
           {{#isPrimitiveType}}
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "{{{dataType}}}") {
@@ -107,9 +107,9 @@
           }
           {{/isPrimitiveType}}
           {{^isPrimitiveType}}
-          {{{dataType}}}$public_methods$validateJSON(input)
-          {{{dataType}}}_instance <- {{{dataType}}}$new()
-          instance <- {{{dataType}}}_instance$fromJSON(input)
+          `{{{dataType}}}`$public_methods$validateJSON(input)
+          `{{{dataType}}}_instance` <- `{{{dataType}}}`$new()
+          instance <- `{{{dataType}}}_instance`$fromJSON(input)
           {{/isPrimitiveType}}
           instance_type <- "{{{dataType}}}"
           matched_schemas <- append(matched_schemas, "{{{dataType}}}")
@@ -118,8 +118,8 @@
         error = function(err) err
       )
 
-      if (!is.null({{{dataType}}}_result["error"])) {
-        error_messages <- append(error_messages, {{{dataType}}}_result["message"])
+      if (!is.null(`{{{dataType}}}_result`["error"])) {
+        error_messages <- append(error_messages, `{{{dataType}}}_result`["message"])
       }
 
       {{/isNull}}

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
@@ -61,32 +61,32 @@ AnyOfPig <- R6::R6Class(
     fromJSON = function(input) {
       error_messages <- list()
 
-      BasquePig_result <- tryCatch({
-          BasquePig$public_methods$validateJSON(input)
-          BasquePig_instance <- BasquePig$new()
-          self$actual_instance <- BasquePig_instance$fromJSON(input)
+      `BasquePig_result` <- tryCatch({
+          `BasquePig`$public_methods$validateJSON(input)
+          `BasquePig_instance` <- `BasquePig`$new()
+          self$actual_instance <- `BasquePig_instance`$fromJSON(input)
           self$actual_type <- "BasquePig"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null(BasquePig_result["error"])) {
-        error_messages <- append(error_messages, BasquePig_result["message"])
+      if (!is.null(`BasquePig_result`["error"])) {
+        error_messages <- append(error_messages, `BasquePig_result`["message"])
       }
 
-      DanishPig_result <- tryCatch({
-          DanishPig$public_methods$validateJSON(input)
-          DanishPig_instance <- DanishPig$new()
-          self$actual_instance <- DanishPig_instance$fromJSON(input)
+      `DanishPig_result` <- tryCatch({
+          `DanishPig`$public_methods$validateJSON(input)
+          `DanishPig_instance` <- `DanishPig`$new()
+          self$actual_instance <- `DanishPig_instance`$fromJSON(input)
           self$actual_type <- "DanishPig"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null(DanishPig_result["error"])) {
-        error_messages <- append(error_messages, DanishPig_result["message"])
+      if (!is.null(`DanishPig_result`["error"])) {
+        error_messages <- append(error_messages, `DanishPig_result`["message"])
       }
 
       # no match

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
@@ -64,7 +64,7 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      integer_result <- tryCatch({
+      `integer_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "integer") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "integer", typeof(instance)))
@@ -76,11 +76,11 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(integer_result["error"])) {
-        error_messages <- append(error_messages, integer_result["message"])
+      if (!is.null(`integer_result`["error"])) {
+        error_messages <- append(error_messages, `integer_result`["message"])
       }
 
-      character_result <- tryCatch({
+      `character_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "character") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "character", typeof(instance)))
@@ -92,8 +92,8 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(character_result["error"])) {
-        error_messages <- append(error_messages, character_result["message"])
+      if (!is.null(`character_result`["error"])) {
+        error_messages <- append(error_messages, `character_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2-wrapper/R/mammal.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/mammal.R
@@ -90,10 +90,10 @@ Mammal <- R6::R6Class(
         error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for Mammal. Error message: %s. JSON input: %s", oneof_lookup_result["message"], input))
       }
 
-      Whale_result <- tryCatch({
-          Whale$public_methods$validateJSON(input)
-          Whale_instance <- Whale$new()
-          instance <- Whale_instance$fromJSON(input)
+      `Whale_result` <- tryCatch({
+          `Whale`$public_methods$validateJSON(input)
+          `Whale_instance` <- `Whale`$new()
+          instance <- `Whale_instance`$fromJSON(input)
           instance_type <- "Whale"
           matched_schemas <- append(matched_schemas, "Whale")
           matched <- matched + 1
@@ -101,14 +101,14 @@ Mammal <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(Whale_result["error"])) {
-        error_messages <- append(error_messages, Whale_result["message"])
+      if (!is.null(`Whale_result`["error"])) {
+        error_messages <- append(error_messages, `Whale_result`["message"])
       }
 
-      Zebra_result <- tryCatch({
-          Zebra$public_methods$validateJSON(input)
-          Zebra_instance <- Zebra$new()
-          instance <- Zebra_instance$fromJSON(input)
+      `Zebra_result` <- tryCatch({
+          `Zebra`$public_methods$validateJSON(input)
+          `Zebra_instance` <- `Zebra`$new()
+          instance <- `Zebra_instance`$fromJSON(input)
           instance_type <- "Zebra"
           matched_schemas <- append(matched_schemas, "Zebra")
           matched <- matched + 1
@@ -116,8 +116,8 @@ Mammal <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(Zebra_result["error"])) {
-        error_messages <- append(error_messages, Zebra_result["message"])
+      if (!is.null(`Zebra_result`["error"])) {
+        error_messages <- append(error_messages, `Zebra_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
@@ -85,9 +85,9 @@ NestedOneOf <- R6::R6Class(
         self$`size` <- this_object$`size`
       }
       if (!is.null(this_object$`nested_pig`)) {
-        nested_pig_object <- Pig$new()
-        nested_pig_object$fromJSON(jsonlite::toJSON(this_object$nested_pig, auto_unbox = TRUE, digits = NA))
-        self$`nested_pig` <- nested_pig_object
+        `nested_pig_object` <- Pig$new()
+        `nested_pig_object`$fromJSON(jsonlite::toJSON(this_object$`nested_pig`, auto_unbox = TRUE, digits = NA))
+        self$`nested_pig` <- `nested_pig_object`
       }
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
@@ -143,7 +143,7 @@ NestedOneOf <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`size` <- this_object$`size`
-      self$`nested_pig` <- Pig$new()$fromJSON(jsonlite::toJSON(this_object$nested_pig, auto_unbox = TRUE, digits = NA))
+      self$`nested_pig` <- Pig$new()$fromJSON(jsonlite::toJSON(this_object$`nested_pig`, auto_unbox = TRUE, digits = NA))
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
         if (!(key %in% self$`_field_list`)) { # json key not in list of fields

--- a/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
@@ -64,7 +64,7 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      integer_result <- tryCatch({
+      `integer_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "integer") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "integer", typeof(instance)))
@@ -76,11 +76,11 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(integer_result["error"])) {
-        error_messages <- append(error_messages, integer_result["message"])
+      if (!is.null(`integer_result`["error"])) {
+        error_messages <- append(error_messages, `integer_result`["message"])
       }
 
-      character_result <- tryCatch({
+      `character_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "character") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "character", typeof(instance)))
@@ -92,8 +92,8 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(character_result["error"])) {
-        error_messages <- append(error_messages, character_result["message"])
+      if (!is.null(`character_result`["error"])) {
+        error_messages <- append(error_messages, `character_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2-wrapper/R/pet.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet.R
@@ -138,9 +138,9 @@ Pet <- R6::R6Class(
         self$`id` <- this_object$`id`
       }
       if (!is.null(this_object$`category`)) {
-        category_object <- Category$new()
-        category_object$fromJSON(jsonlite::toJSON(this_object$category, auto_unbox = TRUE, digits = NA))
-        self$`category` <- category_object
+        `category_object` <- Category$new()
+        `category_object`$fromJSON(jsonlite::toJSON(this_object$`category`, auto_unbox = TRUE, digits = NA))
+        self$`category` <- `category_object`
       }
       if (!is.null(this_object$`name`)) {
         self$`name` <- this_object$`name`
@@ -243,7 +243,7 @@ Pet <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`id` <- this_object$`id`
-      self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(this_object$category, auto_unbox = TRUE, digits = NA))
+      self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(this_object$`category`, auto_unbox = TRUE, digits = NA))
       self$`name` <- this_object$`name`
       self$`photoUrls` <- ApiClient$new()$deserializeObj(this_object$`photoUrls`, "array[character]", loadNamespace("petstore"))
       self$`tags` <- ApiClient$new()$deserializeObj(this_object$`tags`, "array[Tag]", loadNamespace("petstore"))

--- a/samples/client/petstore/R-httr2-wrapper/R/pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pig.R
@@ -90,10 +90,10 @@ Pig <- R6::R6Class(
         error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for Pig. Error message: %s. JSON input: %s", oneof_lookup_result["message"], input))
       }
 
-      BasquePig_result <- tryCatch({
-          BasquePig$public_methods$validateJSON(input)
-          BasquePig_instance <- BasquePig$new()
-          instance <- BasquePig_instance$fromJSON(input)
+      `BasquePig_result` <- tryCatch({
+          `BasquePig`$public_methods$validateJSON(input)
+          `BasquePig_instance` <- `BasquePig`$new()
+          instance <- `BasquePig_instance`$fromJSON(input)
           instance_type <- "BasquePig"
           matched_schemas <- append(matched_schemas, "BasquePig")
           matched <- matched + 1
@@ -101,14 +101,14 @@ Pig <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(BasquePig_result["error"])) {
-        error_messages <- append(error_messages, BasquePig_result["message"])
+      if (!is.null(`BasquePig_result`["error"])) {
+        error_messages <- append(error_messages, `BasquePig_result`["message"])
       }
 
-      DanishPig_result <- tryCatch({
-          DanishPig$public_methods$validateJSON(input)
-          DanishPig_instance <- DanishPig$new()
-          instance <- DanishPig_instance$fromJSON(input)
+      `DanishPig_result` <- tryCatch({
+          `DanishPig`$public_methods$validateJSON(input)
+          `DanishPig_instance` <- `DanishPig`$new()
+          instance <- `DanishPig_instance`$fromJSON(input)
           instance_type <- "DanishPig"
           matched_schemas <- append(matched_schemas, "DanishPig")
           matched <- matched + 1
@@ -116,8 +116,8 @@ Pig <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(DanishPig_result["error"])) {
-        error_messages <- append(error_messages, DanishPig_result["message"])
+      if (!is.null(`DanishPig_result`["error"])) {
+        error_messages <- append(error_messages, `DanishPig_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
@@ -79,9 +79,9 @@ UpdatePetRequest <- R6::R6Class(
     fromJSON = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       if (!is.null(this_object$`jsonData`)) {
-        jsondata_object <- Pet$new()
-        jsondata_object$fromJSON(jsonlite::toJSON(this_object$jsonData, auto_unbox = TRUE, digits = NA))
-        self$`jsonData` <- jsondata_object
+        `jsondata_object` <- Pet$new()
+        `jsondata_object`$fromJSON(jsonlite::toJSON(this_object$`jsonData`, auto_unbox = TRUE, digits = NA))
+        self$`jsonData` <- `jsondata_object`
       }
       if (!is.null(this_object$`binaryDataN2Information`)) {
         self$`binaryDataN2Information` <- this_object$`binaryDataN2Information`
@@ -139,7 +139,7 @@ UpdatePetRequest <- R6::R6Class(
     #' @export
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
-      self$`jsonData` <- Pet$new()$fromJSON(jsonlite::toJSON(this_object$jsonData, auto_unbox = TRUE, digits = NA))
+      self$`jsonData` <- Pet$new()$fromJSON(jsonlite::toJSON(this_object$`jsonData`, auto_unbox = TRUE, digits = NA))
       self$`binaryDataN2Information` <- this_object$`binaryDataN2Information`
       # process additional properties/fields in the payload
       for (key in names(this_object)) {

--- a/samples/client/petstore/R-httr2/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2/R/any_of_pig.R
@@ -61,32 +61,32 @@ AnyOfPig <- R6::R6Class(
     fromJSON = function(input) {
       error_messages <- list()
 
-      BasquePig_result <- tryCatch({
-          BasquePig$public_methods$validateJSON(input)
-          BasquePig_instance <- BasquePig$new()
-          self$actual_instance <- BasquePig_instance$fromJSON(input)
+      `BasquePig_result` <- tryCatch({
+          `BasquePig`$public_methods$validateJSON(input)
+          `BasquePig_instance` <- `BasquePig`$new()
+          self$actual_instance <- `BasquePig_instance`$fromJSON(input)
           self$actual_type <- "BasquePig"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null(BasquePig_result["error"])) {
-        error_messages <- append(error_messages, BasquePig_result["message"])
+      if (!is.null(`BasquePig_result`["error"])) {
+        error_messages <- append(error_messages, `BasquePig_result`["message"])
       }
 
-      DanishPig_result <- tryCatch({
-          DanishPig$public_methods$validateJSON(input)
-          DanishPig_instance <- DanishPig$new()
-          self$actual_instance <- DanishPig_instance$fromJSON(input)
+      `DanishPig_result` <- tryCatch({
+          `DanishPig`$public_methods$validateJSON(input)
+          `DanishPig_instance` <- `DanishPig`$new()
+          self$actual_instance <- `DanishPig_instance`$fromJSON(input)
           self$actual_type <- "DanishPig"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null(DanishPig_result["error"])) {
-        error_messages <- append(error_messages, DanishPig_result["message"])
+      if (!is.null(`DanishPig_result`["error"])) {
+        error_messages <- append(error_messages, `DanishPig_result`["message"])
       }
 
       # no match

--- a/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
@@ -64,7 +64,7 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      integer_result <- tryCatch({
+      `integer_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "integer") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "integer", typeof(instance)))
@@ -76,11 +76,11 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(integer_result["error"])) {
-        error_messages <- append(error_messages, integer_result["message"])
+      if (!is.null(`integer_result`["error"])) {
+        error_messages <- append(error_messages, `integer_result`["message"])
       }
 
-      character_result <- tryCatch({
+      `character_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "character") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "character", typeof(instance)))
@@ -92,8 +92,8 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(character_result["error"])) {
-        error_messages <- append(error_messages, character_result["message"])
+      if (!is.null(`character_result`["error"])) {
+        error_messages <- append(error_messages, `character_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2/R/mammal.R
+++ b/samples/client/petstore/R-httr2/R/mammal.R
@@ -64,10 +64,10 @@ Mammal <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      Whale_result <- tryCatch({
-          Whale$public_methods$validateJSON(input)
-          Whale_instance <- Whale$new()
-          instance <- Whale_instance$fromJSON(input)
+      `Whale_result` <- tryCatch({
+          `Whale`$public_methods$validateJSON(input)
+          `Whale_instance` <- `Whale`$new()
+          instance <- `Whale_instance`$fromJSON(input)
           instance_type <- "Whale"
           matched_schemas <- append(matched_schemas, "Whale")
           matched <- matched + 1
@@ -75,14 +75,14 @@ Mammal <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(Whale_result["error"])) {
-        error_messages <- append(error_messages, Whale_result["message"])
+      if (!is.null(`Whale_result`["error"])) {
+        error_messages <- append(error_messages, `Whale_result`["message"])
       }
 
-      Zebra_result <- tryCatch({
-          Zebra$public_methods$validateJSON(input)
-          Zebra_instance <- Zebra$new()
-          instance <- Zebra_instance$fromJSON(input)
+      `Zebra_result` <- tryCatch({
+          `Zebra`$public_methods$validateJSON(input)
+          `Zebra_instance` <- `Zebra`$new()
+          instance <- `Zebra_instance`$fromJSON(input)
           instance_type <- "Zebra"
           matched_schemas <- append(matched_schemas, "Zebra")
           matched <- matched + 1
@@ -90,8 +90,8 @@ Mammal <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(Zebra_result["error"])) {
-        error_messages <- append(error_messages, Zebra_result["message"])
+      if (!is.null(`Zebra_result`["error"])) {
+        error_messages <- append(error_messages, `Zebra_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2/R/nested_one_of.R
@@ -71,9 +71,9 @@ NestedOneOf <- R6::R6Class(
         self$`size` <- this_object$`size`
       }
       if (!is.null(this_object$`nested_pig`)) {
-        nested_pig_object <- Pig$new()
-        nested_pig_object$fromJSON(jsonlite::toJSON(this_object$nested_pig, auto_unbox = TRUE, digits = NA))
-        self$`nested_pig` <- nested_pig_object
+        `nested_pig_object` <- Pig$new()
+        `nested_pig_object`$fromJSON(jsonlite::toJSON(this_object$`nested_pig`, auto_unbox = TRUE, digits = NA))
+        self$`nested_pig` <- `nested_pig_object`
       }
       self
     },
@@ -117,7 +117,7 @@ NestedOneOf <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`size` <- this_object$`size`
-      self$`nested_pig` <- Pig$new()$fromJSON(jsonlite::toJSON(this_object$nested_pig, auto_unbox = TRUE, digits = NA))
+      self$`nested_pig` <- Pig$new()$fromJSON(jsonlite::toJSON(this_object$`nested_pig`, auto_unbox = TRUE, digits = NA))
       self
     },
     #' Validate JSON input with respect to NestedOneOf

--- a/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
@@ -64,7 +64,7 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      integer_result <- tryCatch({
+      `integer_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "integer") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "integer", typeof(instance)))
@@ -76,11 +76,11 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(integer_result["error"])) {
-        error_messages <- append(error_messages, integer_result["message"])
+      if (!is.null(`integer_result`["error"])) {
+        error_messages <- append(error_messages, `integer_result`["message"])
       }
 
-      character_result <- tryCatch({
+      `character_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "character") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "character", typeof(instance)))
@@ -92,8 +92,8 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(character_result["error"])) {
-        error_messages <- append(error_messages, character_result["message"])
+      if (!is.null(`character_result`["error"])) {
+        error_messages <- append(error_messages, `character_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2/R/pet.R
+++ b/samples/client/petstore/R-httr2/R/pet.R
@@ -124,9 +124,9 @@ Pet <- R6::R6Class(
         self$`id` <- this_object$`id`
       }
       if (!is.null(this_object$`category`)) {
-        category_object <- Category$new()
-        category_object$fromJSON(jsonlite::toJSON(this_object$category, auto_unbox = TRUE, digits = NA))
-        self$`category` <- category_object
+        `category_object` <- Category$new()
+        `category_object`$fromJSON(jsonlite::toJSON(this_object$`category`, auto_unbox = TRUE, digits = NA))
+        self$`category` <- `category_object`
       }
       if (!is.null(this_object$`name`)) {
         self$`name` <- this_object$`name`
@@ -217,7 +217,7 @@ Pet <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`id` <- this_object$`id`
-      self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(this_object$category, auto_unbox = TRUE, digits = NA))
+      self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(this_object$`category`, auto_unbox = TRUE, digits = NA))
       self$`name` <- this_object$`name`
       self$`photoUrls` <- ApiClient$new()$deserializeObj(this_object$`photoUrls`, "array[character]", loadNamespace("petstore"))
       self$`tags` <- ApiClient$new()$deserializeObj(this_object$`tags`, "array[Tag]", loadNamespace("petstore"))

--- a/samples/client/petstore/R-httr2/R/pig.R
+++ b/samples/client/petstore/R-httr2/R/pig.R
@@ -64,10 +64,10 @@ Pig <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      BasquePig_result <- tryCatch({
-          BasquePig$public_methods$validateJSON(input)
-          BasquePig_instance <- BasquePig$new()
-          instance <- BasquePig_instance$fromJSON(input)
+      `BasquePig_result` <- tryCatch({
+          `BasquePig`$public_methods$validateJSON(input)
+          `BasquePig_instance` <- `BasquePig`$new()
+          instance <- `BasquePig_instance`$fromJSON(input)
           instance_type <- "BasquePig"
           matched_schemas <- append(matched_schemas, "BasquePig")
           matched <- matched + 1
@@ -75,14 +75,14 @@ Pig <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(BasquePig_result["error"])) {
-        error_messages <- append(error_messages, BasquePig_result["message"])
+      if (!is.null(`BasquePig_result`["error"])) {
+        error_messages <- append(error_messages, `BasquePig_result`["message"])
       }
 
-      DanishPig_result <- tryCatch({
-          DanishPig$public_methods$validateJSON(input)
-          DanishPig_instance <- DanishPig$new()
-          instance <- DanishPig_instance$fromJSON(input)
+      `DanishPig_result` <- tryCatch({
+          `DanishPig`$public_methods$validateJSON(input)
+          `DanishPig_instance` <- `DanishPig`$new()
+          instance <- `DanishPig_instance`$fromJSON(input)
           instance_type <- "DanishPig"
           matched_schemas <- append(matched_schemas, "DanishPig")
           matched <- matched + 1
@@ -90,8 +90,8 @@ Pig <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(DanishPig_result["error"])) {
-        error_messages <- append(error_messages, DanishPig_result["message"])
+      if (!is.null(`DanishPig_result`["error"])) {
+        error_messages <- append(error_messages, `DanishPig_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R-httr2/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2/R/update_pet_request.R
@@ -65,9 +65,9 @@ UpdatePetRequest <- R6::R6Class(
     fromJSON = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       if (!is.null(this_object$`jsonData`)) {
-        jsondata_object <- Pet$new()
-        jsondata_object$fromJSON(jsonlite::toJSON(this_object$jsonData, auto_unbox = TRUE, digits = NA))
-        self$`jsonData` <- jsondata_object
+        `jsondata_object` <- Pet$new()
+        `jsondata_object`$fromJSON(jsonlite::toJSON(this_object$`jsonData`, auto_unbox = TRUE, digits = NA))
+        self$`jsonData` <- `jsondata_object`
       }
       if (!is.null(this_object$`binaryDataN2Information`)) {
         self$`binaryDataN2Information` <- this_object$`binaryDataN2Information`
@@ -113,7 +113,7 @@ UpdatePetRequest <- R6::R6Class(
     #' @export
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
-      self$`jsonData` <- Pet$new()$fromJSON(jsonlite::toJSON(this_object$jsonData, auto_unbox = TRUE, digits = NA))
+      self$`jsonData` <- Pet$new()$fromJSON(jsonlite::toJSON(this_object$`jsonData`, auto_unbox = TRUE, digits = NA))
       self$`binaryDataN2Information` <- this_object$`binaryDataN2Information`
       self
     },

--- a/samples/client/petstore/R/R/any_of_pig.R
+++ b/samples/client/petstore/R/R/any_of_pig.R
@@ -61,32 +61,32 @@ AnyOfPig <- R6::R6Class(
     fromJSON = function(input) {
       error_messages <- list()
 
-      BasquePig_result <- tryCatch({
-          BasquePig$public_methods$validateJSON(input)
-          BasquePig_instance <- BasquePig$new()
-          self$actual_instance <- BasquePig_instance$fromJSON(input)
+      `BasquePig_result` <- tryCatch({
+          `BasquePig`$public_methods$validateJSON(input)
+          `BasquePig_instance` <- `BasquePig`$new()
+          self$actual_instance <- `BasquePig_instance`$fromJSON(input)
           self$actual_type <- "BasquePig"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null(BasquePig_result["error"])) {
-        error_messages <- append(error_messages, BasquePig_result["message"])
+      if (!is.null(`BasquePig_result`["error"])) {
+        error_messages <- append(error_messages, `BasquePig_result`["message"])
       }
 
-      DanishPig_result <- tryCatch({
-          DanishPig$public_methods$validateJSON(input)
-          DanishPig_instance <- DanishPig$new()
-          self$actual_instance <- DanishPig_instance$fromJSON(input)
+      `DanishPig_result` <- tryCatch({
+          `DanishPig`$public_methods$validateJSON(input)
+          `DanishPig_instance` <- `DanishPig`$new()
+          self$actual_instance <- `DanishPig_instance`$fromJSON(input)
           self$actual_type <- "DanishPig"
           return(self)
         },
         error = function(err) err
       )
 
-      if (!is.null(DanishPig_result["error"])) {
-        error_messages <- append(error_messages, DanishPig_result["message"])
+      if (!is.null(`DanishPig_result`["error"])) {
+        error_messages <- append(error_messages, `DanishPig_result`["message"])
       }
 
       # no match

--- a/samples/client/petstore/R/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/any_of_primitive_type_test.R
@@ -64,7 +64,7 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      integer_result <- tryCatch({
+      `integer_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "integer") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "integer", typeof(instance)))
@@ -76,11 +76,11 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(integer_result["error"])) {
-        error_messages <- append(error_messages, integer_result["message"])
+      if (!is.null(`integer_result`["error"])) {
+        error_messages <- append(error_messages, `integer_result`["message"])
       }
 
-      character_result <- tryCatch({
+      `character_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "character") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "character", typeof(instance)))
@@ -92,8 +92,8 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(character_result["error"])) {
-        error_messages <- append(error_messages, character_result["message"])
+      if (!is.null(`character_result`["error"])) {
+        error_messages <- append(error_messages, `character_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R/R/mammal.R
+++ b/samples/client/petstore/R/R/mammal.R
@@ -64,10 +64,10 @@ Mammal <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      Whale_result <- tryCatch({
-          Whale$public_methods$validateJSON(input)
-          Whale_instance <- Whale$new()
-          instance <- Whale_instance$fromJSON(input)
+      `Whale_result` <- tryCatch({
+          `Whale`$public_methods$validateJSON(input)
+          `Whale_instance` <- `Whale`$new()
+          instance <- `Whale_instance`$fromJSON(input)
           instance_type <- "Whale"
           matched_schemas <- append(matched_schemas, "Whale")
           matched <- matched + 1
@@ -75,14 +75,14 @@ Mammal <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(Whale_result["error"])) {
-        error_messages <- append(error_messages, Whale_result["message"])
+      if (!is.null(`Whale_result`["error"])) {
+        error_messages <- append(error_messages, `Whale_result`["message"])
       }
 
-      Zebra_result <- tryCatch({
-          Zebra$public_methods$validateJSON(input)
-          Zebra_instance <- Zebra$new()
-          instance <- Zebra_instance$fromJSON(input)
+      `Zebra_result` <- tryCatch({
+          `Zebra`$public_methods$validateJSON(input)
+          `Zebra_instance` <- `Zebra`$new()
+          instance <- `Zebra_instance`$fromJSON(input)
           instance_type <- "Zebra"
           matched_schemas <- append(matched_schemas, "Zebra")
           matched <- matched + 1
@@ -90,8 +90,8 @@ Mammal <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(Zebra_result["error"])) {
-        error_messages <- append(error_messages, Zebra_result["message"])
+      if (!is.null(`Zebra_result`["error"])) {
+        error_messages <- append(error_messages, `Zebra_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R/R/nested_one_of.R
+++ b/samples/client/petstore/R/R/nested_one_of.R
@@ -85,9 +85,9 @@ NestedOneOf <- R6::R6Class(
         self$`size` <- this_object$`size`
       }
       if (!is.null(this_object$`nested_pig`)) {
-        nested_pig_object <- Pig$new()
-        nested_pig_object$fromJSON(jsonlite::toJSON(this_object$nested_pig, auto_unbox = TRUE, digits = NA))
-        self$`nested_pig` <- nested_pig_object
+        `nested_pig_object` <- Pig$new()
+        `nested_pig_object`$fromJSON(jsonlite::toJSON(this_object$`nested_pig`, auto_unbox = TRUE, digits = NA))
+        self$`nested_pig` <- `nested_pig_object`
       }
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
@@ -143,7 +143,7 @@ NestedOneOf <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`size` <- this_object$`size`
-      self$`nested_pig` <- Pig$new()$fromJSON(jsonlite::toJSON(this_object$nested_pig, auto_unbox = TRUE, digits = NA))
+      self$`nested_pig` <- Pig$new()$fromJSON(jsonlite::toJSON(this_object$`nested_pig`, auto_unbox = TRUE, digits = NA))
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
         if (!(key %in% self$`_field_list`)) { # json key not in list of fields

--- a/samples/client/petstore/R/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/one_of_primitive_type_test.R
@@ -64,7 +64,7 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      integer_result <- tryCatch({
+      `integer_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "integer") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "integer", typeof(instance)))
@@ -76,11 +76,11 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(integer_result["error"])) {
-        error_messages <- append(error_messages, integer_result["message"])
+      if (!is.null(`integer_result`["error"])) {
+        error_messages <- append(error_messages, `integer_result`["message"])
       }
 
-      character_result <- tryCatch({
+      `character_result` <- tryCatch({
           instance <- jsonlite::fromJSON(input, simplifyVector = FALSE)
           if (typeof(instance) != "character") {
             stop(sprintf("Data type doesn't match. Expected: %s. Actual: %s.", "character", typeof(instance)))
@@ -92,8 +92,8 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(character_result["error"])) {
-        error_messages <- append(error_messages, character_result["message"])
+      if (!is.null(`character_result`["error"])) {
+        error_messages <- append(error_messages, `character_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R/R/pet.R
+++ b/samples/client/petstore/R/R/pet.R
@@ -138,9 +138,9 @@ Pet <- R6::R6Class(
         self$`id` <- this_object$`id`
       }
       if (!is.null(this_object$`category`)) {
-        category_object <- Category$new()
-        category_object$fromJSON(jsonlite::toJSON(this_object$category, auto_unbox = TRUE, digits = NA))
-        self$`category` <- category_object
+        `category_object` <- Category$new()
+        `category_object`$fromJSON(jsonlite::toJSON(this_object$`category`, auto_unbox = TRUE, digits = NA))
+        self$`category` <- `category_object`
       }
       if (!is.null(this_object$`name`)) {
         self$`name` <- this_object$`name`
@@ -243,7 +243,7 @@ Pet <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`id` <- this_object$`id`
-      self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(this_object$category, auto_unbox = TRUE, digits = NA))
+      self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(this_object$`category`, auto_unbox = TRUE, digits = NA))
       self$`name` <- this_object$`name`
       self$`photoUrls` <- ApiClient$new()$deserializeObj(this_object$`photoUrls`, "array[character]", loadNamespace("petstore"))
       self$`tags` <- ApiClient$new()$deserializeObj(this_object$`tags`, "array[Tag]", loadNamespace("petstore"))

--- a/samples/client/petstore/R/R/pig.R
+++ b/samples/client/petstore/R/R/pig.R
@@ -64,10 +64,10 @@ Pig <- R6::R6Class(
       error_messages <- list()
       instance <- NULL
 
-      BasquePig_result <- tryCatch({
-          BasquePig$public_methods$validateJSON(input)
-          BasquePig_instance <- BasquePig$new()
-          instance <- BasquePig_instance$fromJSON(input)
+      `BasquePig_result` <- tryCatch({
+          `BasquePig`$public_methods$validateJSON(input)
+          `BasquePig_instance` <- `BasquePig`$new()
+          instance <- `BasquePig_instance`$fromJSON(input)
           instance_type <- "BasquePig"
           matched_schemas <- append(matched_schemas, "BasquePig")
           matched <- matched + 1
@@ -75,14 +75,14 @@ Pig <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(BasquePig_result["error"])) {
-        error_messages <- append(error_messages, BasquePig_result["message"])
+      if (!is.null(`BasquePig_result`["error"])) {
+        error_messages <- append(error_messages, `BasquePig_result`["message"])
       }
 
-      DanishPig_result <- tryCatch({
-          DanishPig$public_methods$validateJSON(input)
-          DanishPig_instance <- DanishPig$new()
-          instance <- DanishPig_instance$fromJSON(input)
+      `DanishPig_result` <- tryCatch({
+          `DanishPig`$public_methods$validateJSON(input)
+          `DanishPig_instance` <- `DanishPig`$new()
+          instance <- `DanishPig_instance`$fromJSON(input)
           instance_type <- "DanishPig"
           matched_schemas <- append(matched_schemas, "DanishPig")
           matched <- matched + 1
@@ -90,8 +90,8 @@ Pig <- R6::R6Class(
         error = function(err) err
       )
 
-      if (!is.null(DanishPig_result["error"])) {
-        error_messages <- append(error_messages, DanishPig_result["message"])
+      if (!is.null(`DanishPig_result`["error"])) {
+        error_messages <- append(error_messages, `DanishPig_result`["message"])
       }
 
       if (matched == 1) {

--- a/samples/client/petstore/R/R/update_pet_request.R
+++ b/samples/client/petstore/R/R/update_pet_request.R
@@ -79,9 +79,9 @@ UpdatePetRequest <- R6::R6Class(
     fromJSON = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       if (!is.null(this_object$`jsonData`)) {
-        jsondata_object <- Pet$new()
-        jsondata_object$fromJSON(jsonlite::toJSON(this_object$jsonData, auto_unbox = TRUE, digits = NA))
-        self$`jsonData` <- jsondata_object
+        `jsondata_object` <- Pet$new()
+        `jsondata_object`$fromJSON(jsonlite::toJSON(this_object$`jsonData`, auto_unbox = TRUE, digits = NA))
+        self$`jsonData` <- `jsondata_object`
       }
       if (!is.null(this_object$`binaryDataN2Information`)) {
         self$`binaryDataN2Information` <- this_object$`binaryDataN2Information`
@@ -139,7 +139,7 @@ UpdatePetRequest <- R6::R6Class(
     #' @export
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
-      self$`jsonData` <- Pet$new()$fromJSON(jsonlite::toJSON(this_object$jsonData, auto_unbox = TRUE, digits = NA))
+      self$`jsonData` <- Pet$new()$fromJSON(jsonlite::toJSON(this_object$`jsonData`, auto_unbox = TRUE, digits = NA))
       self$`binaryDataN2Information` <- this_object$`binaryDataN2Information`
       # process additional properties/fields in the payload
       for (key in names(this_object)) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
[This spec](https://github.com/OpenAPITools/openapi-generator/files/10546957/openapi.zip) generates failing code (error during `R CMD check`) because some fields have an underscore prefix.
This PR adds some backticks where necessary.

@Ramanth  @saigiridhar21 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
