### PR TITLE
[docs][maven-plugin] Add section on type and import mappings with samples

### DIFF
--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -138,6 +138,35 @@ Notice that some of these environment variable options may overwrite or conflict
 
 The difference here is that you may define `generateModels` and `modelsToGenerate` as properties, while `globalProperties` may only be configured as a configuration node.
 
+### Type and import mappings
+
+To override the mappings between OpenAPI spec types and the types used in the generated code, set `typeMappings`.
+
+```xml
+<configuration>
+    <typeMappings>
+        <!-- convert Double to BigDecimal -->
+        <typeMapping>Double=java.math.BigDecimal</typeMapping>
+    </typeMappings>
+</configuration>
+```
+
+For types that are not already included in the generator configuration, you may need to add a corresponding `importMapping` too.
+
+```xml
+<configuration>
+    <!-- convert file/binary to JAX-RS StreamingOutput -->
+    <typeMappings>
+        <typeMapping>binary=StreamingOutput</typeMapping>
+        <typeMapping>file=StreamingOutput</typeMapping>
+    </typeMappings>
+    <importMappings>
+        <importMapping>StreamingOutput=javax.ws.rs.core.StreamingOutput</importMapping>
+    </importMappings>
+</configuration>
+```
+
+
 ### Custom Generator
 
 Specifying a custom generator is a bit different. It doesn't support the classpath:/ syntax, but it does support the fully qualified name of the package. You can also specify your custom templates, which also get pulled in. Notice the dependency on a project, in the plugin scope. That would be your generator/template jar.


### PR DESCRIPTION
Add samples to the documentation of the maven plugin to better show that type mappings are an easy way to customize the generator output.

After [asking on StackOverflow](https://stackoverflow.com/q/74940796), I first implemented a custom generator. It seemed too much effort for such a small change, but I was happy that it worked. I opened #14527 to add a configuration option to the jaxrs-spec generator to make this easier for others. Only then I found out about the much simpler configuration option (thank you to @borsch)


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples ...
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608


