### PR TITLE
Fix C# NetCore constructors generation with snake case

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -124,12 +124,12 @@
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
         {{#readWriteVars}}
-        /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}.</param>
+        /// <param name="{{name}}">{{description}}{{^description}}{{name}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}.</param>
         {{/readWriteVars}}
     {{#hasOnlyReadOnly}}
         [JsonConstructorAttribute]
     {{/hasOnlyReadOnly}}
-        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}{{/isEnum}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#defaultValue}}{{^isDateTime}}{{{defaultValue}}}{{/isDateTime}}{{#isDateTime}}default({{{datatypeWithEnum}}}){{/isDateTime}}{{/defaultValue}}{{^defaultValue}}default({{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}{{/isEnum}}){{/defaultValue}}{{^-last}}, {{/-last}}{{/readWriteVars}}){{#parent}} : base({{#parentVars}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{^-last}}, {{/-last}}{{/parentVars}}){{/parent}}
+        public {{classname}}( {{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}{{/isEnum}} {{name}} = {{#defaultValue}}{{^isDateTime}}{{{defaultValue}}}{{/isDateTime}}{{#isDateTime}}default({{{datatypeWithEnum}}}){{/isDateTime}}{{/defaultValue}}{{^defaultValue}}default({{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}}{{/isEnum}}){{/defaultValue}}{{^-last}}, {{/-last}}{{/readWriteVars}}){{#parent}} : base({{#parentVars}}{{name}}{{^-last}}, {{/-last}}{{/parentVars}}){{/parent}}
         {
             {{#vars}}
             {{^isInherited}}
@@ -137,28 +137,28 @@
             {{#required}}
             {{^conditionalSerialization}}
             {{^vendorExtensions.x-csharp-value-type}}
-            // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
-            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
+            // to ensure "{{name}}" is required (not null)
+            if ({{name}} == null)
             {
-                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+                throw new ArgumentNullException("{{name}} is a required property for {{classname}} and cannot be null");
             }
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this.{{name}} = {{name}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{#vendorExtensions.x-csharp-value-type}}
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this.{{name}} = {{name}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{/conditionalSerialization}}
             {{#conditionalSerialization}}
             {{^vendorExtensions.x-csharp-value-type}}
-            // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
-            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
+            // to ensure "{{name}}" is required (not null)
+            if ({{name}} == null)
             {
-                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+                throw new ArgumentNullException("{{name}} is a required property for {{classname}} and cannot be null");
             }
-            this._{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this._{{name}} = {{name}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{#vendorExtensions.x-csharp-value-type}}
-            this._{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this._{{name}} = {{name}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{/conditionalSerialization}}
             {{/required}}
@@ -172,20 +172,20 @@
             {{#defaultValue}}
             {{^conditionalSerialization}}
             {{^vendorExtensions.x-csharp-value-type}}
-            // use default value if no "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" provided
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? {{{defaultValue}}};
+            // use default value if no "{{name}}" provided
+            this.{{name}} = {{name}} ?? {{{defaultValue}}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{#vendorExtensions.x-csharp-value-type}}
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this.{{name}} = {{name}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{/conditionalSerialization}}
             {{/defaultValue}}
             {{^defaultValue}}
             {{^conditionalSerialization}}
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this.{{name}} = {{name}};
             {{/conditionalSerialization}}
             {{#conditionalSerialization}}
-            this._{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            this._{{name}} = {{name}};
             if (this.{{name}} != null)
             {
                 this._flag{{name}} = true;

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartArrayRequest.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartArrayRequest.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipartArrayRequest" /> class.
         /// </summary>
-        /// <param name="files">Many files.</param>
-        public MultipartArrayRequest(List<System.IO.Stream> files = default(List<System.IO.Stream>))
+        /// <param name="Files">Many files.</param>
+        public MultipartArrayRequest( List<System.IO.Stream> Files = default(List<System.IO.Stream>))
         {
-            this.Files = files;
+            this.Files = Files;
         }
 
         /// <summary>

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartMixedRequest.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartMixedRequest.cs
@@ -46,21 +46,21 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipartMixedRequest" /> class.
         /// </summary>
-        /// <param name="status">status (required).</param>
-        /// <param name="marker">marker.</param>
-        /// <param name="file">a file (required).</param>
-        /// <param name="statusArray">statusArray.</param>
-        public MultipartMixedRequest(MultipartMixedStatus status = default(MultipartMixedStatus), MultipartMixedRequestMarker marker = default(MultipartMixedRequestMarker), System.IO.Stream file = default(System.IO.Stream), List<MultipartMixedStatus> statusArray = default(List<MultipartMixedStatus>))
+        /// <param name="Status">Status (required).</param>
+        /// <param name="Marker">Marker.</param>
+        /// <param name="File">a file (required).</param>
+        /// <param name="StatusArray">StatusArray.</param>
+        public MultipartMixedRequest( MultipartMixedStatus Status = default(MultipartMixedStatus), MultipartMixedRequestMarker Marker = default(MultipartMixedRequestMarker), System.IO.Stream File = default(System.IO.Stream), List<MultipartMixedStatus> StatusArray = default(List<MultipartMixedStatus>))
         {
-            this.Status = status;
-            // to ensure "file" is required (not null)
-            if (file == null)
+            this.Status = Status;
+            // to ensure "File" is required (not null)
+            if (File == null)
             {
-                throw new ArgumentNullException("file is a required property for MultipartMixedRequest and cannot be null");
+                throw new ArgumentNullException("File is a required property for MultipartMixedRequest and cannot be null");
             }
-            this.File = file;
-            this.Marker = marker;
-            this.StatusArray = statusArray;
+            this.File = File;
+            this.Marker = Marker;
+            this.StatusArray = StatusArray;
         }
 
         /// <summary>

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartMixedRequestMarker.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartMixedRequestMarker.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipartMixedRequestMarker" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public MultipartMixedRequestMarker(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public MultipartMixedRequestMarker( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
         }
 
         /// <summary>

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartSingleRequest.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Model/MultipartSingleRequest.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipartSingleRequest" /> class.
         /// </summary>
-        /// <param name="file">One file.</param>
-        public MultipartSingleRequest(System.IO.Stream file = default(System.IO.Stream))
+        /// <param name="File">One file.</param>
+        public MultipartSingleRequest( System.IO.Stream File = default(System.IO.Stream))
         {
-            this.File = file;
+            this.File = File;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this._ActivityOutputs = activityOutputs;
+            this._ActivityOutputs = ActivityOutputs;
             if (this.ActivityOutputs != null)
             {
                 this._flagActivityOutputs = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this._Prop1 = prop1;
+            this._Prop1 = Prop1;
             if (this.Prop1 != null)
             {
                 this._flagProp1 = true;
             }
-            this._Prop2 = prop2;
+            this._Prop2 = Prop2;
             if (this.Prop2 != null)
             {
                 this._flagProp2 = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -35,52 +35,52 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this._MapProperty = mapProperty;
+            this._MapProperty = MapProperty;
             if (this.MapProperty != null)
             {
                 this._flagMapProperty = true;
             }
-            this._MapOfMapProperty = mapOfMapProperty;
+            this._MapOfMapProperty = MapOfMapProperty;
             if (this.MapOfMapProperty != null)
             {
                 this._flagMapOfMapProperty = true;
             }
-            this._Anytype1 = anytype1;
+            this._Anytype1 = Anytype1;
             if (this.Anytype1 != null)
             {
                 this._flagAnytype1 = true;
             }
-            this._MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
+            this._MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
             if (this.MapWithUndeclaredPropertiesAnytype1 != null)
             {
                 this._flagMapWithUndeclaredPropertiesAnytype1 = true;
             }
-            this._MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
+            this._MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
             if (this.MapWithUndeclaredPropertiesAnytype2 != null)
             {
                 this._flagMapWithUndeclaredPropertiesAnytype2 = true;
             }
-            this._MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
+            this._MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
             if (this.MapWithUndeclaredPropertiesAnytype3 != null)
             {
                 this._flagMapWithUndeclaredPropertiesAnytype3 = true;
             }
-            this._EmptyMap = emptyMap;
+            this._EmptyMap = EmptyMap;
             if (this.EmptyMap != null)
             {
                 this._flagEmptyMap = true;
             }
-            this._MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this._MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
             if (this.MapWithUndeclaredPropertiesString != null)
             {
                 this._flagMapWithUndeclaredPropertiesString = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Animal.cs
@@ -47,16 +47,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this._ClassName = className;
+            this._ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,22 +35,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this._Code = code;
+            this._Code = Code;
             if (this.Code != null)
             {
                 this._flagCode = true;
             }
-            this._Type = type;
+            this._Type = Type;
             if (this.Type != null)
             {
                 this._flagType = true;
             }
-            this._Message = message;
+            this._Message = Message;
             if (this.Message != null)
             {
                 this._flagMessage = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this._Cultivar = cultivar;
+            this._Cultivar = Cultivar;
             if (this.Cultivar != null)
             {
                 this._flagCultivar = true;
             }
-            this._Origin = origin;
+            this._Origin = Origin;
             if (this.Origin != null)
             {
                 this._flagOrigin = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this._Cultivar = cultivar;
-            this._Mealy = mealy;
+            this._Cultivar = Cultivar;
+            this._Mealy = Mealy;
             if (this.Mealy != null)
             {
                 this._flagMealy = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this._ArrayArrayNumber = arrayArrayNumber;
+            this._ArrayArrayNumber = ArrayArrayNumber;
             if (this.ArrayArrayNumber != null)
             {
                 this._flagArrayArrayNumber = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this._ArrayNumber = arrayNumber;
+            this._ArrayNumber = ArrayNumber;
             if (this.ArrayNumber != null)
             {
                 this._flagArrayNumber = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -35,22 +35,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this._ArrayOfString = arrayOfString;
+            this._ArrayOfString = ArrayOfString;
             if (this.ArrayOfString != null)
             {
                 this._flagArrayOfString = true;
             }
-            this._ArrayArrayOfInteger = arrayArrayOfInteger;
+            this._ArrayArrayOfInteger = ArrayArrayOfInteger;
             if (this.ArrayArrayOfInteger != null)
             {
                 this._flagArrayArrayOfInteger = true;
             }
-            this._ArrayArrayOfModel = arrayArrayOfModel;
+            this._ArrayArrayOfModel = ArrayArrayOfModel;
             if (this.ArrayArrayOfModel != null)
             {
                 this._flagArrayArrayOfModel = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this._LengthCm = lengthCm;
+            this._LengthCm = LengthCm;
             if (this.LengthCm != null)
             {
                 this._flagLengthCm = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this._LengthCm = lengthCm;
-            this._Sweet = sweet;
+            this._LengthCm = LengthCm;
+            this._Sweet = Sweet;
             if (this.Sweet != null)
             {
                 this._flagSweet = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this._ClassName = className;
+            this._ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -35,40 +35,40 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this._SmallCamel = smallCamel;
+            this._SmallCamel = SmallCamel;
             if (this.SmallCamel != null)
             {
                 this._flagSmallCamel = true;
             }
-            this._CapitalCamel = capitalCamel;
+            this._CapitalCamel = CapitalCamel;
             if (this.CapitalCamel != null)
             {
                 this._flagCapitalCamel = true;
             }
-            this._SmallSnake = smallSnake;
+            this._SmallSnake = SmallSnake;
             if (this.SmallSnake != null)
             {
                 this._flagSmallSnake = true;
             }
-            this._CapitalSnake = capitalSnake;
+            this._CapitalSnake = CapitalSnake;
             if (this.CapitalSnake != null)
             {
                 this._flagCapitalSnake = true;
             }
-            this._SCAETHFlowPoints = sCAETHFlowPoints;
+            this._SCAETHFlowPoints = SCAETHFlowPoints;
             if (this.SCAETHFlowPoints != null)
             {
                 this._flagSCAETHFlowPoints = true;
             }
-            this._ATT_NAME = aTTNAME;
+            this._ATT_NAME = ATT_NAME;
             if (this.ATT_NAME != null)
             {
                 this._flagATT_NAME = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this._Declawed = declawed;
+            this._Declawed = Declawed;
             if (this.Declawed != null)
             {
                 this._flagDeclawed = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this._Declawed = declawed;
+            this._Declawed = Declawed;
             if (this.Declawed != null)
             {
                 this._flagDeclawed = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Category.cs
@@ -43,17 +43,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this._Name = name;
-            this._Id = id;
+            this._Name = Name;
+            this._Id = Id;
             if (this.Id != null)
             {
                 this._flagId = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -77,11 +77,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this._Name = name;
+            this._Name = Name;
             if (this.Name != null)
             {
                 this._flagName = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -75,11 +75,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this._Name = name;
+            this._Name = Name;
             if (this.Name != null)
             {
                 this._flagName = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this._Class = _class;
+            this._Class = Class;
             if (this.Class != null)
             {
                 this._flagClass = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this._ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this._ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this._QuadrilateralType = quadrilateralType;
+            this._QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this._ClassName = className;
+            this._ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this._Name = name;
+            this._Name = Name;
             if (this.Name != null)
             {
                 this._flagName = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Dog.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this._Breed = breed;
+            this._Breed = Breed;
             if (this.Breed != null)
             {
                 this._flagBreed = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this._Breed = breed;
+            this._Breed = Breed;
             if (this.Breed != null)
             {
                 this._flagBreed = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Drawing.cs
@@ -35,28 +35,28 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this._MainShape = mainShape;
+            this._MainShape = MainShape;
             if (this.MainShape != null)
             {
                 this._flagMainShape = true;
             }
-            this._ShapeOrNull = shapeOrNull;
+            this._ShapeOrNull = ShapeOrNull;
             if (this.ShapeOrNull != null)
             {
                 this._flagShapeOrNull = true;
             }
-            this._NullableShape = nullableShape;
+            this._NullableShape = NullableShape;
             if (this.NullableShape != null)
             {
                 this._flagNullableShape = true;
             }
-            this._Shapes = shapes;
+            this._Shapes = Shapes;
             if (this.Shapes != null)
             {
                 this._flagShapes = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -101,16 +101,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this._JustSymbol = justSymbol;
+            this._JustSymbol = JustSymbol;
             if (this.JustSymbol != null)
             {
                 this._flagJustSymbol = true;
             }
-            this._ArrayEnum = arrayEnum;
+            this._ArrayEnum = ArrayEnum;
             if (this.ArrayEnum != null)
             {
                 this._flagArrayEnum = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -383,54 +383,54 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this._EnumStringRequired = enumStringRequired;
-            this._EnumString = enumString;
+            this._EnumStringRequired = EnumStringRequired;
+            this._EnumString = EnumString;
             if (this.EnumString != null)
             {
                 this._flagEnumString = true;
             }
-            this._EnumInteger = enumInteger;
+            this._EnumInteger = EnumInteger;
             if (this.EnumInteger != null)
             {
                 this._flagEnumInteger = true;
             }
-            this._EnumIntegerOnly = enumIntegerOnly;
+            this._EnumIntegerOnly = EnumIntegerOnly;
             if (this.EnumIntegerOnly != null)
             {
                 this._flagEnumIntegerOnly = true;
             }
-            this._EnumNumber = enumNumber;
+            this._EnumNumber = EnumNumber;
             if (this.EnumNumber != null)
             {
                 this._flagEnumNumber = true;
             }
-            this._OuterEnum = outerEnum;
+            this._OuterEnum = OuterEnum;
             if (this.OuterEnum != null)
             {
                 this._flagOuterEnum = true;
             }
-            this._OuterEnumInteger = outerEnumInteger;
+            this._OuterEnumInteger = OuterEnumInteger;
             if (this.OuterEnumInteger != null)
             {
                 this._flagOuterEnumInteger = true;
             }
-            this._OuterEnumDefaultValue = outerEnumDefaultValue;
+            this._OuterEnumDefaultValue = OuterEnumDefaultValue;
             if (this.OuterEnumDefaultValue != null)
             {
                 this._flagOuterEnumDefaultValue = true;
             }
-            this._OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this._OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
             if (this.OuterEnumIntegerDefaultValue != null)
             {
                 this._flagOuterEnumIntegerDefaultValue = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this._ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this._ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this._TriangleType = triangleType;
+            this._TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/File.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this._SourceURI = sourceURI;
+            this._SourceURI = SourceURI;
             if (this.SourceURI != null)
             {
                 this._flagSourceURI = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this._File = file;
+            this._File = File;
             if (this.File != null)
             {
                 this._flagFile = true;
             }
-            this._Files = files;
+            this._Files = Files;
             if (this.Files != null)
             {
                 this._flagFiles = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,8 +35,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this._String = _string;
+            this._String = String;
             if (this.String != null)
             {
                 this._flagString = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -43,94 +43,94 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), System.IO.Stream Binary = default(System.IO.Stream), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this._Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this._Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this._Byte = _byte;
-            this._Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this._Byte = Byte;
+            this._Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this._Password = password;
-            this._Integer = integer;
+            this._Password = Password;
+            this._Integer = Integer;
             if (this.Integer != null)
             {
                 this._flagInteger = true;
             }
-            this._Int32 = int32;
+            this._Int32 = Int32;
             if (this.Int32 != null)
             {
                 this._flagInt32 = true;
             }
-            this._Int64 = int64;
+            this._Int64 = Int64;
             if (this.Int64 != null)
             {
                 this._flagInt64 = true;
             }
-            this._Float = _float;
+            this._Float = Float;
             if (this.Float != null)
             {
                 this._flagFloat = true;
             }
-            this._Double = _double;
+            this._Double = Double;
             if (this.Double != null)
             {
                 this._flagDouble = true;
             }
-            this._Decimal = _decimal;
+            this._Decimal = Decimal;
             if (this.Decimal != null)
             {
                 this._flagDecimal = true;
             }
-            this._String = _string;
+            this._String = String;
             if (this.String != null)
             {
                 this._flagString = true;
             }
-            this._Binary = binary;
+            this._Binary = Binary;
             if (this.Binary != null)
             {
                 this._flagBinary = true;
             }
-            this._DateTime = dateTime;
+            this._DateTime = DateTime;
             if (this.DateTime != null)
             {
                 this._flagDateTime = true;
             }
-            this._Uuid = uuid;
+            this._Uuid = Uuid;
             if (this.Uuid != null)
             {
                 this._flagUuid = true;
             }
-            this._PatternWithDigits = patternWithDigits;
+            this._PatternWithDigits = PatternWithDigits;
             if (this.PatternWithDigits != null)
             {
                 this._flagPatternWithDigits = true;
             }
-            this._PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this._PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
             if (this.PatternWithDigitsAndDelimiter != null)
             {
                 this._flagPatternWithDigitsAndDelimiter = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -47,15 +47,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this._PetType = petType;
+            this._PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this._NullableMessage = nullableMessage;
+            this._NullableMessage = NullableMessage;
             if (this.NullableMessage != null)
             {
                 this._flagNullableMessage = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this._ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this._ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this._TriangleType = triangleType;
+            this._TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/List.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this.__123List = _123list;
+            this.__123List = _123List;
             if (this._123List != null)
             {
                 this._flag_123List = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MapTest.cs
@@ -55,28 +55,28 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this._MapMapOfString = mapMapOfString;
+            this._MapMapOfString = MapMapOfString;
             if (this.MapMapOfString != null)
             {
                 this._flagMapMapOfString = true;
             }
-            this._MapOfEnumString = mapOfEnumString;
+            this._MapOfEnumString = MapOfEnumString;
             if (this.MapOfEnumString != null)
             {
                 this._flagMapOfEnumString = true;
             }
-            this._DirectMap = directMap;
+            this._DirectMap = DirectMap;
             if (this.DirectMap != null)
             {
                 this._flagDirectMap = true;
             }
-            this._IndirectMap = indirectMap;
+            this._IndirectMap = IndirectMap;
             if (this.IndirectMap != null)
             {
                 this._flagIndirectMap = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -35,22 +35,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this._Uuid = uuid;
+            this._Uuid = Uuid;
             if (this.Uuid != null)
             {
                 this._flagUuid = true;
             }
-            this._DateTime = dateTime;
+            this._DateTime = DateTime;
             if (this.DateTime != null)
             {
                 this._flagDateTime = true;
             }
-            this._Map = map;
+            this._Map = Map;
             if (this.Map != null)
             {
                 this._flagMap = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this._Name = name;
+            this._Name = Name;
             if (this.Name != null)
             {
                 this._flagName = true;
             }
-            this._Class = _class;
+            this._Class = Class;
             if (this.Class != null)
             {
                 this._flagClass = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this.__Client = _client;
+            this.__Client = _Client;
             if (this._Client != null)
             {
                 this._flag_Client = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Name.cs
@@ -43,12 +43,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this.__Name = name;
-            this._Property = property;
+            this.__Name = _Name;
+            this._Property = Property;
             if (this.Property != null)
             {
                 this._flagProperty = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -35,76 +35,76 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this._IntegerProp = integerProp;
+            this._IntegerProp = IntegerProp;
             if (this.IntegerProp != null)
             {
                 this._flagIntegerProp = true;
             }
-            this._NumberProp = numberProp;
+            this._NumberProp = NumberProp;
             if (this.NumberProp != null)
             {
                 this._flagNumberProp = true;
             }
-            this._BooleanProp = booleanProp;
+            this._BooleanProp = BooleanProp;
             if (this.BooleanProp != null)
             {
                 this._flagBooleanProp = true;
             }
-            this._StringProp = stringProp;
+            this._StringProp = StringProp;
             if (this.StringProp != null)
             {
                 this._flagStringProp = true;
             }
-            this._DateProp = dateProp;
+            this._DateProp = DateProp;
             if (this.DateProp != null)
             {
                 this._flagDateProp = true;
             }
-            this._DatetimeProp = datetimeProp;
+            this._DatetimeProp = DatetimeProp;
             if (this.DatetimeProp != null)
             {
                 this._flagDatetimeProp = true;
             }
-            this._ArrayNullableProp = arrayNullableProp;
+            this._ArrayNullableProp = ArrayNullableProp;
             if (this.ArrayNullableProp != null)
             {
                 this._flagArrayNullableProp = true;
             }
-            this._ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
+            this._ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
             if (this.ArrayAndItemsNullableProp != null)
             {
                 this._flagArrayAndItemsNullableProp = true;
             }
-            this._ArrayItemsNullable = arrayItemsNullable;
+            this._ArrayItemsNullable = ArrayItemsNullable;
             if (this.ArrayItemsNullable != null)
             {
                 this._flagArrayItemsNullable = true;
             }
-            this._ObjectNullableProp = objectNullableProp;
+            this._ObjectNullableProp = ObjectNullableProp;
             if (this.ObjectNullableProp != null)
             {
                 this._flagObjectNullableProp = true;
             }
-            this._ObjectAndItemsNullableProp = objectAndItemsNullableProp;
+            this._ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
             if (this.ObjectAndItemsNullableProp != null)
             {
                 this._flagObjectAndItemsNullableProp = true;
             }
-            this._ObjectItemsNullable = objectItemsNullable;
+            this._ObjectItemsNullable = ObjectItemsNullable;
             if (this.ObjectItemsNullable != null)
             {
                 this._flagObjectItemsNullable = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this._Uuid = uuid;
+            this._Uuid = Uuid;
             if (this.Uuid != null)
             {
                 this._flagUuid = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this._JustNumber = justNumber;
+            this._JustNumber = JustNumber;
             if (this.JustNumber != null)
             {
                 this._flagJustNumber = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -35,28 +35,28 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this._Uuid = uuid;
+            this._Uuid = Uuid;
             if (this.Uuid != null)
             {
                 this._flagUuid = true;
             }
-            this._Id = id;
+            this._Id = Id;
             if (this.Id != null)
             {
                 this._flagId = true;
             }
-            this._DeprecatedRef = deprecatedRef;
+            this._DeprecatedRef = DeprecatedRef;
             if (this.DeprecatedRef != null)
             {
                 this._flagDeprecatedRef = true;
             }
-            this._Bars = bars;
+            this._Bars = Bars;
             if (this.Bars != null)
             {
                 this._flagBars = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Order.cs
@@ -89,35 +89,35 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this._Id = id;
+            this._Id = Id;
             if (this.Id != null)
             {
                 this._flagId = true;
             }
-            this._PetId = petId;
+            this._PetId = PetId;
             if (this.PetId != null)
             {
                 this._flagPetId = true;
             }
-            this._Quantity = quantity;
+            this._Quantity = Quantity;
             if (this.Quantity != null)
             {
                 this._flagQuantity = true;
             }
-            this._ShipDate = shipDate;
+            this._ShipDate = ShipDate;
             if (this.ShipDate != null)
             {
                 this._flagShipDate = true;
             }
-            this._Status = status;
+            this._Status = Status;
             if (this.Status != null)
             {
                 this._flagStatus = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -35,22 +35,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this._MyNumber = myNumber;
+            this._MyNumber = MyNumber;
             if (this.MyNumber != null)
             {
                 this._flagMyNumber = true;
             }
-            this._MyString = myString;
+            this._MyString = MyString;
             if (this.MyString != null)
             {
                 this._flagMyString = true;
             }
-            this._MyBoolean = myBoolean;
+            this._MyBoolean = MyBoolean;
             if (this.MyBoolean != null)
             {
                 this._flagMyBoolean = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Pet.cs
@@ -97,42 +97,42 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this._Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this._Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this._PhotoUrls = photoUrls;
-            this._Id = id;
+            this._PhotoUrls = PhotoUrls;
+            this._Id = Id;
             if (this.Id != null)
             {
                 this._flagId = true;
             }
-            this._Category = category;
+            this._Category = Category;
             if (this.Category != null)
             {
                 this._flagCategory = true;
             }
-            this._Tags = tags;
+            this._Tags = Tags;
             if (this.Tags != null)
             {
                 this._flagTags = true;
             }
-            this._Status = status;
+            this._Status = Status;
             if (this.Status != null)
             {
                 this._flagStatus = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this._QuadrilateralType = quadrilateralType;
+            this._QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this._Baz = baz;
+            this._Baz = Baz;
             if (this.Baz != null)
             {
                 this._flagBaz = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Return.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this.__Return = _return;
+            this.__Return = _Return;
             if (this._Return != null)
             {
                 this._flag_Return = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this._ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this._ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this._TriangleType = triangleType;
+            this._TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this._ShapeType = shapeType;
+            this._ShapeType = ShapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this._ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this._ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this._QuadrilateralType = quadrilateralType;
+            this._QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this._SpecialPropertyName = specialPropertyName;
+            this._SpecialPropertyName = SpecialPropertyName;
             if (this.SpecialPropertyName != null)
             {
                 this._flagSpecialPropertyName = true;
             }
-            this.__SpecialModelName = specialModelName;
+            this.__SpecialModelName = _SpecialModelName;
             if (this._SpecialModelName != null)
             {
                 this._flag_SpecialModelName = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this._Id = id;
+            this._Id = Id;
             if (this.Id != null)
             {
                 this._flagId = true;
             }
-            this._Name = name;
+            this._Name = Name;
             if (this.Name != null)
             {
                 this._flagName = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this._TriangleType = triangleType;
+            this._TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/User.cs
@@ -35,76 +35,76 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this._Id = id;
+            this._Id = Id;
             if (this.Id != null)
             {
                 this._flagId = true;
             }
-            this._Username = username;
+            this._Username = Username;
             if (this.Username != null)
             {
                 this._flagUsername = true;
             }
-            this._FirstName = firstName;
+            this._FirstName = FirstName;
             if (this.FirstName != null)
             {
                 this._flagFirstName = true;
             }
-            this._LastName = lastName;
+            this._LastName = LastName;
             if (this.LastName != null)
             {
                 this._flagLastName = true;
             }
-            this._Email = email;
+            this._Email = Email;
             if (this.Email != null)
             {
                 this._flagEmail = true;
             }
-            this._Password = password;
+            this._Password = Password;
             if (this.Password != null)
             {
                 this._flagPassword = true;
             }
-            this._Phone = phone;
+            this._Phone = Phone;
             if (this.Phone != null)
             {
                 this._flagPhone = true;
             }
-            this._UserStatus = userStatus;
+            this._UserStatus = UserStatus;
             if (this.UserStatus != null)
             {
                 this._flagUserStatus = true;
             }
-            this._ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
+            this._ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
             if (this.ObjectWithNoDeclaredProps != null)
             {
                 this._flagObjectWithNoDeclaredProps = true;
             }
-            this._ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
+            this._ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
             if (this.ObjectWithNoDeclaredPropsNullable != null)
             {
                 this._flagObjectWithNoDeclaredPropsNullable = true;
             }
-            this._AnyTypeProp = anyTypeProp;
+            this._AnyTypeProp = AnyTypeProp;
             if (this.AnyTypeProp != null)
             {
                 this._flagAnyTypeProp = true;
             }
-            this._AnyTypePropNullable = anyTypePropNullable;
+            this._AnyTypePropNullable = AnyTypePropNullable;
             if (this.AnyTypePropNullable != null)
             {
                 this._flagAnyTypePropNullable = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Whale.cs
@@ -43,23 +43,23 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this._ClassName = className;
-            this._HasBaleen = hasBaleen;
+            this._ClassName = ClassName;
+            this._HasBaleen = HasBaleen;
             if (this.HasBaleen != null)
             {
                 this._flagHasBaleen = true;
             }
-            this._HasTeeth = hasTeeth;
+            this._HasTeeth = HasTeeth;
             if (this.HasTeeth != null)
             {
                 this._flagHasTeeth = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Zebra.cs
@@ -95,17 +95,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this._ClassName = className;
-            this._Type = type;
+            this._ClassName = ClassName;
+            this._Type = Type;
             if (this.Type != null)
             {
                 this._flagType = true;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Activity.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this.ActivityOutputs = activityOutputs;
+            this.ActivityOutputs = ActivityOutputs;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -36,12 +36,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this.Prop1 = prop1;
-            this.Prop2 = prop2;
+            this.Prop1 = Prop1;
+            this.Prop2 = Prop2;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -36,24 +36,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this.MapProperty = mapProperty;
-            this.MapOfMapProperty = mapOfMapProperty;
-            this.Anytype1 = anytype1;
-            this.MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
-            this.MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
-            this.MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
-            this.EmptyMap = emptyMap;
-            this.MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this.MapProperty = MapProperty;
+            this.MapOfMapProperty = MapOfMapProperty;
+            this.Anytype1 = Anytype1;
+            this.MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
+            this.MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
+            this.MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
+            this.EmptyMap = EmptyMap;
+            this.MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Animal.cs
@@ -48,18 +48,18 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this.ClassName = className;
-            // use default value if no "color" provided
-            this.Color = color ?? "red";
+            this.ClassName = ClassName;
+            // use default value if no "Color" provided
+            this.Color = Color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -36,14 +36,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Apple.cs
@@ -36,12 +36,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this.Cultivar = cultivar;
-            this.Origin = origin;
+            this.Cultivar = Cultivar;
+            this.Origin = Origin;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -41,17 +41,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this.Cultivar = cultivar;
-            this.Mealy = mealy;
+            this.Cultivar = Cultivar;
+            this.Mealy = Mealy;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this.ArrayArrayNumber = arrayArrayNumber;
+            this.ArrayArrayNumber = ArrayArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this.ArrayNumber = arrayNumber;
+            this.ArrayNumber = ArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -36,14 +36,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this.ArrayOfString = arrayOfString;
-            this.ArrayArrayOfInteger = arrayArrayOfInteger;
-            this.ArrayArrayOfModel = arrayArrayOfModel;
+            this.ArrayOfString = ArrayOfString;
+            this.ArrayArrayOfInteger = ArrayArrayOfInteger;
+            this.ArrayArrayOfModel = ArrayArrayOfModel;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this.LengthCm = lengthCm;
+            this.LengthCm = LengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -41,12 +41,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this.LengthCm = lengthCm;
-            this.Sweet = sweet;
+            this.LengthCm = LengthCm;
+            this.Sweet = Sweet;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -44,15 +44,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -36,20 +36,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this.SmallCamel = smallCamel;
-            this.CapitalCamel = capitalCamel;
-            this.SmallSnake = smallSnake;
-            this.CapitalSnake = capitalSnake;
-            this.SCAETHFlowPoints = sCAETHFlowPoints;
-            this.ATT_NAME = aTTNAME;
+            this.SmallCamel = SmallCamel;
+            this.CapitalCamel = CapitalCamel;
+            this.SmallSnake = SmallSnake;
+            this.CapitalSnake = CapitalSnake;
+            this.SCAETHFlowPoints = SCAETHFlowPoints;
+            this.ATT_NAME = ATT_NAME;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
@@ -46,12 +46,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Category.cs
@@ -44,17 +44,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this.Name = name;
-            this.Id = id;
+            this.Name = Name;
+            this.Id = Id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -58,12 +58,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -56,12 +56,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this.Class = _class;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -44,22 +44,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -44,15 +44,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Dog.cs
@@ -46,12 +46,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Drawing.cs
@@ -36,16 +36,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this.MainShape = mainShape;
-            this.ShapeOrNull = shapeOrNull;
-            this.NullableShape = nullableShape;
-            this.Shapes = shapes;
+            this.MainShape = MainShape;
+            this.ShapeOrNull = ShapeOrNull;
+            this.NullableShape = NullableShape;
+            this.Shapes = Shapes;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -82,12 +82,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this.JustSymbol = justSymbol;
-            this.ArrayEnum = arrayEnum;
+            this.JustSymbol = JustSymbol;
+            this.ArrayEnum = ArrayEnum;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -204,26 +204,26 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this.EnumStringRequired = enumStringRequired;
-            this.EnumString = enumString;
-            this.EnumInteger = enumInteger;
-            this.EnumIntegerOnly = enumIntegerOnly;
-            this.EnumNumber = enumNumber;
-            this.OuterEnum = outerEnum;
-            this.OuterEnumInteger = outerEnumInteger;
-            this.OuterEnumDefaultValue = outerEnumDefaultValue;
-            this.OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this.EnumStringRequired = EnumStringRequired;
+            this.EnumString = EnumString;
+            this.EnumInteger = EnumInteger;
+            this.EnumIntegerOnly = EnumIntegerOnly;
+            this.EnumNumber = EnumNumber;
+            this.OuterEnum = OuterEnum;
+            this.OuterEnumInteger = OuterEnumInteger;
+            this.OuterEnumDefaultValue = OuterEnumDefaultValue;
+            this.OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -44,22 +44,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/File.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this.SourceURI = sourceURI;
+            this.SourceURI = SourceURI;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -36,12 +36,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this.File = file;
-            this.Files = files;
+            this.File = File;
+            this.Files = Files;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Foo.cs
@@ -36,11 +36,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
-            // use default value if no "bar" provided
-            this.Bar = bar ?? "bar";
+            // use default value if no "Bar" provided
+            this.Bar = Bar ?? "bar";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this.String = _string;
+            this.String = String;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -44,50 +44,50 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), FileParameter binary = default(FileParameter), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), FileParameter Binary = default(FileParameter), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this.Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this.Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this.Byte = _byte;
-            this.Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this.Byte = Byte;
+            this.Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this.Password = password;
-            this.Integer = integer;
-            this.Int32 = int32;
-            this.Int64 = int64;
-            this.Float = _float;
-            this.Double = _double;
-            this.Decimal = _decimal;
-            this.String = _string;
-            this.Binary = binary;
-            this.DateTime = dateTime;
-            this.Uuid = uuid;
-            this.PatternWithDigits = patternWithDigits;
-            this.PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this.Password = Password;
+            this.Integer = Integer;
+            this.Int32 = Int32;
+            this.Int64 = Int64;
+            this.Float = Float;
+            this.Double = Double;
+            this.Decimal = Decimal;
+            this.String = String;
+            this.Binary = Binary;
+            this.DateTime = DateTime;
+            this.Uuid = Uuid;
+            this.PatternWithDigits = PatternWithDigits;
+            this.PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -48,15 +48,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this.PetType = petType;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this.NullableMessage = nullableMessage;
+            this.NullableMessage = NullableMessage;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -41,22 +41,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/List.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this._123List = _123list;
+            this._123List = _123List;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -56,16 +56,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this.MapMapOfString = mapMapOfString;
-            this.MapOfEnumString = mapOfEnumString;
-            this.DirectMap = directMap;
-            this.IndirectMap = indirectMap;
+            this.MapMapOfString = MapMapOfString;
+            this.MapOfEnumString = MapOfEnumString;
+            this.DirectMap = DirectMap;
+            this.IndirectMap = IndirectMap;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -36,14 +36,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this.Uuid = uuid;
-            this.DateTime = dateTime;
-            this.Map = map;
+            this.Uuid = Uuid;
+            this.DateTime = DateTime;
+            this.Map = Map;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -36,12 +36,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this.Name = name;
-            this.Class = _class;
+            this.Name = Name;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this._Client = _client;
+            this._Client = _Client;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Name.cs
@@ -44,12 +44,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this._Name = name;
-            this.Property = property;
+            this._Name = _Name;
+            this.Property = Property;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -36,32 +36,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this.IntegerProp = integerProp;
-            this.NumberProp = numberProp;
-            this.BooleanProp = booleanProp;
-            this.StringProp = stringProp;
-            this.DateProp = dateProp;
-            this.DatetimeProp = datetimeProp;
-            this.ArrayNullableProp = arrayNullableProp;
-            this.ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
-            this.ArrayItemsNullable = arrayItemsNullable;
-            this.ObjectNullableProp = objectNullableProp;
-            this.ObjectAndItemsNullableProp = objectAndItemsNullableProp;
-            this.ObjectItemsNullable = objectItemsNullable;
+            this.IntegerProp = IntegerProp;
+            this.NumberProp = NumberProp;
+            this.BooleanProp = BooleanProp;
+            this.StringProp = StringProp;
+            this.DateProp = DateProp;
+            this.DatetimeProp = DatetimeProp;
+            this.ArrayNullableProp = ArrayNullableProp;
+            this.ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
+            this.ArrayItemsNullable = ArrayItemsNullable;
+            this.ObjectNullableProp = ObjectNullableProp;
+            this.ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
+            this.ObjectItemsNullable = ObjectItemsNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this.Uuid = uuid;
+            this.Uuid = Uuid;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,10 +39,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this.JustNumber = justNumber;
+            this.JustNumber = JustNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -36,16 +36,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this.Uuid = uuid;
-            this.Id = id;
-            this.DeprecatedRef = deprecatedRef;
-            this.Bars = bars;
+            this.Uuid = Uuid;
+            this.Id = Id;
+            this.DeprecatedRef = DeprecatedRef;
+            this.Bars = Bars;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
@@ -70,20 +70,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -36,14 +36,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this.MyNumber = myNumber;
-            this.MyString = myString;
-            this.MyBoolean = myBoolean;
+            this.MyNumber = MyNumber;
+            this.MyString = MyString;
+            this.MyBoolean = MyBoolean;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -47,8 +47,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
@@ -78,30 +78,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -44,15 +44,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this.Baz = baz;
+            this.Baz = Baz;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Return.cs
@@ -36,10 +36,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this._Return = _return;
+            this._Return = _Return;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -44,22 +44,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -44,15 +44,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this.ShapeType = shapeType;
+            this.ShapeType = ShapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -44,22 +44,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -36,12 +36,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this.SpecialPropertyName = specialPropertyName;
-            this._SpecialModelName = specialModelName;
+            this.SpecialPropertyName = SpecialPropertyName;
+            this._SpecialModelName = _SpecialModelName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Tag.cs
@@ -36,12 +36,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -44,15 +44,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/User.cs
@@ -36,32 +36,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
-            this.ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
-            this.ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
-            this.AnyTypeProp = anyTypeProp;
-            this.AnyTypePropNullable = anyTypePropNullable;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
+            this.ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
+            this.ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
+            this.AnyTypeProp = AnyTypeProp;
+            this.AnyTypePropNullable = AnyTypePropNullable;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
@@ -44,19 +44,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this.ClassName = className;
-            this.HasBaleen = hasBaleen;
-            this.HasTeeth = hasTeeth;
+            this.ClassName = ClassName;
+            this.HasBaleen = HasBaleen;
+            this.HasTeeth = HasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -76,17 +76,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this.ClassName = className;
-            this.Type = type;
+            this.ClassName = ClassName;
+            this.Type = Type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this.ActivityOutputs = activityOutputs;
+            this.ActivityOutputs = ActivityOutputs;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this.Prop1 = prop1;
-            this.Prop2 = prop2;
+            this.Prop1 = Prop1;
+            this.Prop2 = Prop2;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -35,24 +35,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this.MapProperty = mapProperty;
-            this.MapOfMapProperty = mapOfMapProperty;
-            this.Anytype1 = anytype1;
-            this.MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
-            this.MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
-            this.MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
-            this.EmptyMap = emptyMap;
-            this.MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this.MapProperty = MapProperty;
+            this.MapOfMapProperty = MapOfMapProperty;
+            this.Anytype1 = Anytype1;
+            this.MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
+            this.MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
+            this.MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
+            this.EmptyMap = EmptyMap;
+            this.MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Animal.cs
@@ -47,18 +47,18 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this.ClassName = className;
-            // use default value if no "color" provided
-            this.Color = color ?? "red";
+            this.ClassName = ClassName;
+            // use default value if no "Color" provided
+            this.Color = Color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this.Cultivar = cultivar;
-            this.Origin = origin;
+            this.Cultivar = Cultivar;
+            this.Origin = Origin;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this.Cultivar = cultivar;
-            this.Mealy = mealy;
+            this.Cultivar = Cultivar;
+            this.Mealy = Mealy;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this.ArrayArrayNumber = arrayArrayNumber;
+            this.ArrayArrayNumber = ArrayArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this.ArrayNumber = arrayNumber;
+            this.ArrayNumber = ArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this.ArrayOfString = arrayOfString;
-            this.ArrayArrayOfInteger = arrayArrayOfInteger;
-            this.ArrayArrayOfModel = arrayArrayOfModel;
+            this.ArrayOfString = ArrayOfString;
+            this.ArrayArrayOfInteger = ArrayArrayOfInteger;
+            this.ArrayArrayOfModel = ArrayArrayOfModel;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this.LengthCm = lengthCm;
+            this.LengthCm = LengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this.LengthCm = lengthCm;
-            this.Sweet = sweet;
+            this.LengthCm = LengthCm;
+            this.Sweet = Sweet;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -35,20 +35,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this.SmallCamel = smallCamel;
-            this.CapitalCamel = capitalCamel;
-            this.SmallSnake = smallSnake;
-            this.CapitalSnake = capitalSnake;
-            this.SCAETHFlowPoints = sCAETHFlowPoints;
-            this.ATT_NAME = aTTNAME;
+            this.SmallCamel = SmallCamel;
+            this.CapitalCamel = CapitalCamel;
+            this.SmallSnake = SmallSnake;
+            this.CapitalSnake = CapitalSnake;
+            this.SCAETHFlowPoints = SCAETHFlowPoints;
+            this.ATT_NAME = ATT_NAME;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Category.cs
@@ -43,17 +43,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this.Name = name;
-            this.Id = id;
+            this.Name = Name;
+            this.Id = Id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -57,12 +57,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this.Class = _class;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Dog.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Drawing.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this.MainShape = mainShape;
-            this.ShapeOrNull = shapeOrNull;
-            this.NullableShape = nullableShape;
-            this.Shapes = shapes;
+            this.MainShape = MainShape;
+            this.ShapeOrNull = ShapeOrNull;
+            this.NullableShape = NullableShape;
+            this.Shapes = Shapes;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this.JustSymbol = justSymbol;
-            this.ArrayEnum = arrayEnum;
+            this.JustSymbol = JustSymbol;
+            this.ArrayEnum = ArrayEnum;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -203,26 +203,26 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this.EnumStringRequired = enumStringRequired;
-            this.EnumString = enumString;
-            this.EnumInteger = enumInteger;
-            this.EnumIntegerOnly = enumIntegerOnly;
-            this.EnumNumber = enumNumber;
-            this.OuterEnum = outerEnum;
-            this.OuterEnumInteger = outerEnumInteger;
-            this.OuterEnumDefaultValue = outerEnumDefaultValue;
-            this.OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this.EnumStringRequired = EnumStringRequired;
+            this.EnumString = EnumString;
+            this.EnumInteger = EnumInteger;
+            this.EnumIntegerOnly = EnumIntegerOnly;
+            this.EnumNumber = EnumNumber;
+            this.OuterEnum = OuterEnum;
+            this.OuterEnumInteger = OuterEnumInteger;
+            this.OuterEnumDefaultValue = OuterEnumDefaultValue;
+            this.OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/File.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this.SourceURI = sourceURI;
+            this.SourceURI = SourceURI;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this.File = file;
-            this.Files = files;
+            this.File = File;
+            this.Files = Files;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,11 +35,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
-            // use default value if no "bar" provided
-            this.Bar = bar ?? "bar";
+            // use default value if no "Bar" provided
+            this.Bar = Bar ?? "bar";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this.String = _string;
+            this.String = String;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -43,50 +43,50 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), System.IO.Stream Binary = default(System.IO.Stream), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this.Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this.Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this.Byte = _byte;
-            this.Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this.Byte = Byte;
+            this.Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this.Password = password;
-            this.Integer = integer;
-            this.Int32 = int32;
-            this.Int64 = int64;
-            this.Float = _float;
-            this.Double = _double;
-            this.Decimal = _decimal;
-            this.String = _string;
-            this.Binary = binary;
-            this.DateTime = dateTime;
-            this.Uuid = uuid;
-            this.PatternWithDigits = patternWithDigits;
-            this.PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this.Password = Password;
+            this.Integer = Integer;
+            this.Int32 = Int32;
+            this.Int64 = Int64;
+            this.Float = Float;
+            this.Double = Double;
+            this.Decimal = Decimal;
+            this.String = String;
+            this.Binary = Binary;
+            this.DateTime = DateTime;
+            this.Uuid = Uuid;
+            this.PatternWithDigits = PatternWithDigits;
+            this.PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -47,15 +47,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this.PetType = petType;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this.NullableMessage = nullableMessage;
+            this.NullableMessage = NullableMessage;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/List.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this._123List = _123list;
+            this._123List = _123List;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
@@ -55,16 +55,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this.MapMapOfString = mapMapOfString;
-            this.MapOfEnumString = mapOfEnumString;
-            this.DirectMap = directMap;
-            this.IndirectMap = indirectMap;
+            this.MapMapOfString = MapMapOfString;
+            this.MapOfEnumString = MapOfEnumString;
+            this.DirectMap = DirectMap;
+            this.IndirectMap = IndirectMap;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this.Uuid = uuid;
-            this.DateTime = dateTime;
-            this.Map = map;
+            this.Uuid = Uuid;
+            this.DateTime = DateTime;
+            this.Map = Map;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this.Name = name;
-            this.Class = _class;
+            this.Name = Name;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this._Client = _client;
+            this._Client = _Client;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
@@ -43,12 +43,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this._Name = name;
-            this.Property = property;
+            this._Name = _Name;
+            this.Property = Property;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this.IntegerProp = integerProp;
-            this.NumberProp = numberProp;
-            this.BooleanProp = booleanProp;
-            this.StringProp = stringProp;
-            this.DateProp = dateProp;
-            this.DatetimeProp = datetimeProp;
-            this.ArrayNullableProp = arrayNullableProp;
-            this.ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
-            this.ArrayItemsNullable = arrayItemsNullable;
-            this.ObjectNullableProp = objectNullableProp;
-            this.ObjectAndItemsNullableProp = objectAndItemsNullableProp;
-            this.ObjectItemsNullable = objectItemsNullable;
+            this.IntegerProp = IntegerProp;
+            this.NumberProp = NumberProp;
+            this.BooleanProp = BooleanProp;
+            this.StringProp = StringProp;
+            this.DateProp = DateProp;
+            this.DatetimeProp = DatetimeProp;
+            this.ArrayNullableProp = ArrayNullableProp;
+            this.ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
+            this.ArrayItemsNullable = ArrayItemsNullable;
+            this.ObjectNullableProp = ObjectNullableProp;
+            this.ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
+            this.ObjectItemsNullable = ObjectItemsNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this.Uuid = uuid;
+            this.Uuid = Uuid;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this.JustNumber = justNumber;
+            this.JustNumber = JustNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this.Uuid = uuid;
-            this.Id = id;
-            this.DeprecatedRef = deprecatedRef;
-            this.Bars = bars;
+            this.Uuid = Uuid;
+            this.Id = Id;
+            this.DeprecatedRef = DeprecatedRef;
+            this.Bars = Bars;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
@@ -69,20 +69,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this.MyNumber = myNumber;
-            this.MyString = myString;
-            this.MyBoolean = myBoolean;
+            this.MyNumber = MyNumber;
+            this.MyString = MyString;
+            this.MyBoolean = MyBoolean;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
@@ -77,30 +77,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this.Baz = baz;
+            this.Baz = Baz;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Return.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this._Return = _return;
+            this._Return = _Return;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this.ShapeType = shapeType;
+            this.ShapeType = ShapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this.SpecialPropertyName = specialPropertyName;
-            this._SpecialModelName = specialModelName;
+            this.SpecialPropertyName = SpecialPropertyName;
+            this._SpecialModelName = _SpecialModelName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/User.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
-            this.ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
-            this.ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
-            this.AnyTypeProp = anyTypeProp;
-            this.AnyTypePropNullable = anyTypePropNullable;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
+            this.ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
+            this.ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
+            this.AnyTypeProp = AnyTypeProp;
+            this.AnyTypePropNullable = AnyTypePropNullable;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
@@ -43,19 +43,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this.ClassName = className;
-            this.HasBaleen = hasBaleen;
-            this.HasTeeth = hasTeeth;
+            this.ClassName = ClassName;
+            this.HasBaleen = HasBaleen;
+            this.HasTeeth = HasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
@@ -75,17 +75,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this.ClassName = className;
-            this.Type = type;
+            this.ClassName = ClassName;
+            this.Type = Type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this.ActivityOutputs = activityOutputs;
+            this.ActivityOutputs = ActivityOutputs;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this.Prop1 = prop1;
-            this.Prop2 = prop2;
+            this.Prop1 = Prop1;
+            this.Prop2 = Prop2;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -35,24 +35,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this.MapProperty = mapProperty;
-            this.MapOfMapProperty = mapOfMapProperty;
-            this.Anytype1 = anytype1;
-            this.MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
-            this.MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
-            this.MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
-            this.EmptyMap = emptyMap;
-            this.MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this.MapProperty = MapProperty;
+            this.MapOfMapProperty = MapOfMapProperty;
+            this.Anytype1 = Anytype1;
+            this.MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
+            this.MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
+            this.MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
+            this.EmptyMap = EmptyMap;
+            this.MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Animal.cs
@@ -47,18 +47,18 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this.ClassName = className;
-            // use default value if no "color" provided
-            this.Color = color ?? "red";
+            this.ClassName = ClassName;
+            // use default value if no "Color" provided
+            this.Color = Color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this.Cultivar = cultivar;
-            this.Origin = origin;
+            this.Cultivar = Cultivar;
+            this.Origin = Origin;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this.Cultivar = cultivar;
-            this.Mealy = mealy;
+            this.Cultivar = Cultivar;
+            this.Mealy = Mealy;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this.ArrayArrayNumber = arrayArrayNumber;
+            this.ArrayArrayNumber = ArrayArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this.ArrayNumber = arrayNumber;
+            this.ArrayNumber = ArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this.ArrayOfString = arrayOfString;
-            this.ArrayArrayOfInteger = arrayArrayOfInteger;
-            this.ArrayArrayOfModel = arrayArrayOfModel;
+            this.ArrayOfString = ArrayOfString;
+            this.ArrayArrayOfInteger = ArrayArrayOfInteger;
+            this.ArrayArrayOfModel = ArrayArrayOfModel;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this.LengthCm = lengthCm;
+            this.LengthCm = LengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this.LengthCm = lengthCm;
-            this.Sweet = sweet;
+            this.LengthCm = LengthCm;
+            this.Sweet = Sweet;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -35,20 +35,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this.SmallCamel = smallCamel;
-            this.CapitalCamel = capitalCamel;
-            this.SmallSnake = smallSnake;
-            this.CapitalSnake = capitalSnake;
-            this.SCAETHFlowPoints = sCAETHFlowPoints;
-            this.ATT_NAME = aTTNAME;
+            this.SmallCamel = SmallCamel;
+            this.CapitalCamel = CapitalCamel;
+            this.SmallSnake = SmallSnake;
+            this.CapitalSnake = CapitalSnake;
+            this.SCAETHFlowPoints = SCAETHFlowPoints;
+            this.ATT_NAME = ATT_NAME;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Cat.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Category.cs
@@ -43,17 +43,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this.Name = name;
-            this.Id = id;
+            this.Name = Name;
+            this.Id = Id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -57,12 +57,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this.Class = _class;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Dog.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Drawing.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this.MainShape = mainShape;
-            this.ShapeOrNull = shapeOrNull;
-            this.NullableShape = nullableShape;
-            this.Shapes = shapes;
+            this.MainShape = MainShape;
+            this.ShapeOrNull = ShapeOrNull;
+            this.NullableShape = NullableShape;
+            this.Shapes = Shapes;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this.JustSymbol = justSymbol;
-            this.ArrayEnum = arrayEnum;
+            this.JustSymbol = JustSymbol;
+            this.ArrayEnum = ArrayEnum;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -203,26 +203,26 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this.EnumStringRequired = enumStringRequired;
-            this.EnumString = enumString;
-            this.EnumInteger = enumInteger;
-            this.EnumIntegerOnly = enumIntegerOnly;
-            this.EnumNumber = enumNumber;
-            this.OuterEnum = outerEnum;
-            this.OuterEnumInteger = outerEnumInteger;
-            this.OuterEnumDefaultValue = outerEnumDefaultValue;
-            this.OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this.EnumStringRequired = EnumStringRequired;
+            this.EnumString = EnumString;
+            this.EnumInteger = EnumInteger;
+            this.EnumIntegerOnly = EnumIntegerOnly;
+            this.EnumNumber = EnumNumber;
+            this.OuterEnum = OuterEnum;
+            this.OuterEnumInteger = OuterEnumInteger;
+            this.OuterEnumDefaultValue = OuterEnumDefaultValue;
+            this.OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/File.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this.SourceURI = sourceURI;
+            this.SourceURI = SourceURI;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this.File = file;
-            this.Files = files;
+            this.File = File;
+            this.Files = Files;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,11 +35,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
-            // use default value if no "bar" provided
-            this.Bar = bar ?? "bar";
+            // use default value if no "Bar" provided
+            this.Bar = Bar ?? "bar";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this.String = _string;
+            this.String = String;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -43,50 +43,50 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), System.IO.Stream Binary = default(System.IO.Stream), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this.Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this.Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this.Byte = _byte;
-            this.Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this.Byte = Byte;
+            this.Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this.Password = password;
-            this.Integer = integer;
-            this.Int32 = int32;
-            this.Int64 = int64;
-            this.Float = _float;
-            this.Double = _double;
-            this.Decimal = _decimal;
-            this.String = _string;
-            this.Binary = binary;
-            this.DateTime = dateTime;
-            this.Uuid = uuid;
-            this.PatternWithDigits = patternWithDigits;
-            this.PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this.Password = Password;
+            this.Integer = Integer;
+            this.Int32 = Int32;
+            this.Int64 = Int64;
+            this.Float = Float;
+            this.Double = Double;
+            this.Decimal = Decimal;
+            this.String = String;
+            this.Binary = Binary;
+            this.DateTime = DateTime;
+            this.Uuid = Uuid;
+            this.PatternWithDigits = PatternWithDigits;
+            this.PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -47,15 +47,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this.PetType = petType;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this.NullableMessage = nullableMessage;
+            this.NullableMessage = NullableMessage;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/List.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this._123List = _123list;
+            this._123List = _123List;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MapTest.cs
@@ -55,16 +55,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this.MapMapOfString = mapMapOfString;
-            this.MapOfEnumString = mapOfEnumString;
-            this.DirectMap = directMap;
-            this.IndirectMap = indirectMap;
+            this.MapMapOfString = MapMapOfString;
+            this.MapOfEnumString = MapOfEnumString;
+            this.DirectMap = DirectMap;
+            this.IndirectMap = IndirectMap;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this.Uuid = uuid;
-            this.DateTime = dateTime;
-            this.Map = map;
+            this.Uuid = Uuid;
+            this.DateTime = DateTime;
+            this.Map = Map;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this.Name = name;
-            this.Class = _class;
+            this.Name = Name;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this._Client = _client;
+            this._Client = _Client;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Name.cs
@@ -43,12 +43,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this._Name = name;
-            this.Property = property;
+            this._Name = _Name;
+            this.Property = Property;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this.IntegerProp = integerProp;
-            this.NumberProp = numberProp;
-            this.BooleanProp = booleanProp;
-            this.StringProp = stringProp;
-            this.DateProp = dateProp;
-            this.DatetimeProp = datetimeProp;
-            this.ArrayNullableProp = arrayNullableProp;
-            this.ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
-            this.ArrayItemsNullable = arrayItemsNullable;
-            this.ObjectNullableProp = objectNullableProp;
-            this.ObjectAndItemsNullableProp = objectAndItemsNullableProp;
-            this.ObjectItemsNullable = objectItemsNullable;
+            this.IntegerProp = IntegerProp;
+            this.NumberProp = NumberProp;
+            this.BooleanProp = BooleanProp;
+            this.StringProp = StringProp;
+            this.DateProp = DateProp;
+            this.DatetimeProp = DatetimeProp;
+            this.ArrayNullableProp = ArrayNullableProp;
+            this.ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
+            this.ArrayItemsNullable = ArrayItemsNullable;
+            this.ObjectNullableProp = ObjectNullableProp;
+            this.ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
+            this.ObjectItemsNullable = ObjectItemsNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this.Uuid = uuid;
+            this.Uuid = Uuid;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this.JustNumber = justNumber;
+            this.JustNumber = JustNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this.Uuid = uuid;
-            this.Id = id;
-            this.DeprecatedRef = deprecatedRef;
-            this.Bars = bars;
+            this.Uuid = Uuid;
+            this.Id = Id;
+            this.DeprecatedRef = DeprecatedRef;
+            this.Bars = Bars;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Order.cs
@@ -69,20 +69,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this.MyNumber = myNumber;
-            this.MyString = myString;
-            this.MyBoolean = myBoolean;
+            this.MyNumber = MyNumber;
+            this.MyString = MyString;
+            this.MyBoolean = MyBoolean;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Pet.cs
@@ -77,30 +77,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this.Baz = baz;
+            this.Baz = Baz;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Return.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this._Return = _return;
+            this._Return = _Return;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this.ShapeType = shapeType;
+            this.ShapeType = ShapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this.SpecialPropertyName = specialPropertyName;
-            this._SpecialModelName = specialModelName;
+            this.SpecialPropertyName = SpecialPropertyName;
+            this._SpecialModelName = _SpecialModelName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/User.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
-            this.ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
-            this.ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
-            this.AnyTypeProp = anyTypeProp;
-            this.AnyTypePropNullable = anyTypePropNullable;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
+            this.ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
+            this.ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
+            this.AnyTypeProp = AnyTypeProp;
+            this.AnyTypePropNullable = AnyTypePropNullable;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Whale.cs
@@ -43,19 +43,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this.ClassName = className;
-            this.HasBaleen = hasBaleen;
-            this.HasTeeth = hasTeeth;
+            this.ClassName = ClassName;
+            this.HasBaleen = HasBaleen;
+            this.HasTeeth = HasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Zebra.cs
@@ -75,17 +75,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this.ClassName = className;
-            this.Type = type;
+            this.ClassName = ClassName;
+            this.Type = Type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this.ActivityOutputs = activityOutputs;
+            this.ActivityOutputs = ActivityOutputs;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this.Prop1 = prop1;
-            this.Prop2 = prop2;
+            this.Prop1 = Prop1;
+            this.Prop2 = Prop2;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -35,24 +35,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this.MapProperty = mapProperty;
-            this.MapOfMapProperty = mapOfMapProperty;
-            this.Anytype1 = anytype1;
-            this.MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
-            this.MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
-            this.MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
-            this.EmptyMap = emptyMap;
-            this.MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this.MapProperty = MapProperty;
+            this.MapOfMapProperty = MapOfMapProperty;
+            this.Anytype1 = Anytype1;
+            this.MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
+            this.MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
+            this.MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
+            this.EmptyMap = EmptyMap;
+            this.MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -47,18 +47,18 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this.ClassName = className;
-            // use default value if no "color" provided
-            this.Color = color ?? "red";
+            this.ClassName = ClassName;
+            // use default value if no "Color" provided
+            this.Color = Color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this.Cultivar = cultivar;
-            this.Origin = origin;
+            this.Cultivar = Cultivar;
+            this.Origin = Origin;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this.Cultivar = cultivar;
-            this.Mealy = mealy;
+            this.Cultivar = Cultivar;
+            this.Mealy = Mealy;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this.ArrayArrayNumber = arrayArrayNumber;
+            this.ArrayArrayNumber = ArrayArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this.ArrayNumber = arrayNumber;
+            this.ArrayNumber = ArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this.ArrayOfString = arrayOfString;
-            this.ArrayArrayOfInteger = arrayArrayOfInteger;
-            this.ArrayArrayOfModel = arrayArrayOfModel;
+            this.ArrayOfString = ArrayOfString;
+            this.ArrayArrayOfInteger = ArrayArrayOfInteger;
+            this.ArrayArrayOfModel = ArrayArrayOfModel;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this.LengthCm = lengthCm;
+            this.LengthCm = LengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this.LengthCm = lengthCm;
-            this.Sweet = sweet;
+            this.LengthCm = LengthCm;
+            this.Sweet = Sweet;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -35,20 +35,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this.SmallCamel = smallCamel;
-            this.CapitalCamel = capitalCamel;
-            this.SmallSnake = smallSnake;
-            this.CapitalSnake = capitalSnake;
-            this.SCAETHFlowPoints = sCAETHFlowPoints;
-            this.ATT_NAME = aTTNAME;
+            this.SmallCamel = SmallCamel;
+            this.CapitalCamel = CapitalCamel;
+            this.SmallSnake = SmallSnake;
+            this.CapitalSnake = CapitalSnake;
+            this.SCAETHFlowPoints = SCAETHFlowPoints;
+            this.ATT_NAME = ATT_NAME;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Category.cs
@@ -43,17 +43,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this.Name = name;
-            this.Id = id;
+            this.Name = Name;
+            this.Id = Id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -57,12 +57,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this.Class = _class;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Dog.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this.MainShape = mainShape;
-            this.ShapeOrNull = shapeOrNull;
-            this.NullableShape = nullableShape;
-            this.Shapes = shapes;
+            this.MainShape = MainShape;
+            this.ShapeOrNull = ShapeOrNull;
+            this.NullableShape = NullableShape;
+            this.Shapes = Shapes;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this.JustSymbol = justSymbol;
-            this.ArrayEnum = arrayEnum;
+            this.JustSymbol = JustSymbol;
+            this.ArrayEnum = ArrayEnum;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -203,26 +203,26 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this.EnumStringRequired = enumStringRequired;
-            this.EnumString = enumString;
-            this.EnumInteger = enumInteger;
-            this.EnumIntegerOnly = enumIntegerOnly;
-            this.EnumNumber = enumNumber;
-            this.OuterEnum = outerEnum;
-            this.OuterEnumInteger = outerEnumInteger;
-            this.OuterEnumDefaultValue = outerEnumDefaultValue;
-            this.OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this.EnumStringRequired = EnumStringRequired;
+            this.EnumString = EnumString;
+            this.EnumInteger = EnumInteger;
+            this.EnumIntegerOnly = EnumIntegerOnly;
+            this.EnumNumber = EnumNumber;
+            this.OuterEnum = OuterEnum;
+            this.OuterEnumInteger = OuterEnumInteger;
+            this.OuterEnumDefaultValue = OuterEnumDefaultValue;
+            this.OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/File.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this.SourceURI = sourceURI;
+            this.SourceURI = SourceURI;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this.File = file;
-            this.Files = files;
+            this.File = File;
+            this.Files = Files;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,11 +35,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
-            // use default value if no "bar" provided
-            this.Bar = bar ?? "bar";
+            // use default value if no "Bar" provided
+            this.Bar = Bar ?? "bar";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this.String = _string;
+            this.String = String;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -43,50 +43,50 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), System.IO.Stream Binary = default(System.IO.Stream), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this.Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this.Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this.Byte = _byte;
-            this.Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this.Byte = Byte;
+            this.Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this.Password = password;
-            this.Integer = integer;
-            this.Int32 = int32;
-            this.Int64 = int64;
-            this.Float = _float;
-            this.Double = _double;
-            this.Decimal = _decimal;
-            this.String = _string;
-            this.Binary = binary;
-            this.DateTime = dateTime;
-            this.Uuid = uuid;
-            this.PatternWithDigits = patternWithDigits;
-            this.PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this.Password = Password;
+            this.Integer = Integer;
+            this.Int32 = Int32;
+            this.Int64 = Int64;
+            this.Float = Float;
+            this.Double = Double;
+            this.Decimal = Decimal;
+            this.String = String;
+            this.Binary = Binary;
+            this.DateTime = DateTime;
+            this.Uuid = Uuid;
+            this.PatternWithDigits = PatternWithDigits;
+            this.PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -47,15 +47,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this.PetType = petType;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this.NullableMessage = nullableMessage;
+            this.NullableMessage = NullableMessage;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/List.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this._123List = _123list;
+            this._123List = _123List;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -55,16 +55,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this.MapMapOfString = mapMapOfString;
-            this.MapOfEnumString = mapOfEnumString;
-            this.DirectMap = directMap;
-            this.IndirectMap = indirectMap;
+            this.MapMapOfString = MapMapOfString;
+            this.MapOfEnumString = MapOfEnumString;
+            this.DirectMap = DirectMap;
+            this.IndirectMap = IndirectMap;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this.Uuid = uuid;
-            this.DateTime = dateTime;
-            this.Map = map;
+            this.Uuid = Uuid;
+            this.DateTime = DateTime;
+            this.Map = Map;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this.Name = name;
-            this.Class = _class;
+            this.Name = Name;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this._Client = _client;
+            this._Client = _Client;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Name.cs
@@ -43,12 +43,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this._Name = name;
-            this.Property = property;
+            this._Name = _Name;
+            this.Property = Property;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this.IntegerProp = integerProp;
-            this.NumberProp = numberProp;
-            this.BooleanProp = booleanProp;
-            this.StringProp = stringProp;
-            this.DateProp = dateProp;
-            this.DatetimeProp = datetimeProp;
-            this.ArrayNullableProp = arrayNullableProp;
-            this.ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
-            this.ArrayItemsNullable = arrayItemsNullable;
-            this.ObjectNullableProp = objectNullableProp;
-            this.ObjectAndItemsNullableProp = objectAndItemsNullableProp;
-            this.ObjectItemsNullable = objectItemsNullable;
+            this.IntegerProp = IntegerProp;
+            this.NumberProp = NumberProp;
+            this.BooleanProp = BooleanProp;
+            this.StringProp = StringProp;
+            this.DateProp = DateProp;
+            this.DatetimeProp = DatetimeProp;
+            this.ArrayNullableProp = ArrayNullableProp;
+            this.ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
+            this.ArrayItemsNullable = ArrayItemsNullable;
+            this.ObjectNullableProp = ObjectNullableProp;
+            this.ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
+            this.ObjectItemsNullable = ObjectItemsNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this.Uuid = uuid;
+            this.Uuid = Uuid;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this.JustNumber = justNumber;
+            this.JustNumber = JustNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this.Uuid = uuid;
-            this.Id = id;
-            this.DeprecatedRef = deprecatedRef;
-            this.Bars = bars;
+            this.Uuid = Uuid;
+            this.Id = Id;
+            this.DeprecatedRef = DeprecatedRef;
+            this.Bars = Bars;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
@@ -69,20 +69,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this.MyNumber = myNumber;
-            this.MyString = myString;
-            this.MyBoolean = myBoolean;
+            this.MyNumber = MyNumber;
+            this.MyString = MyString;
+            this.MyBoolean = MyBoolean;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -77,30 +77,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this.Baz = baz;
+            this.Baz = Baz;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Return.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this._Return = _return;
+            this._Return = _Return;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this.ShapeType = shapeType;
+            this.ShapeType = ShapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this.SpecialPropertyName = specialPropertyName;
-            this._SpecialModelName = specialModelName;
+            this.SpecialPropertyName = SpecialPropertyName;
+            this._SpecialModelName = _SpecialModelName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/User.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
-            this.ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
-            this.ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
-            this.AnyTypeProp = anyTypeProp;
-            this.AnyTypePropNullable = anyTypePropNullable;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
+            this.ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
+            this.ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
+            this.AnyTypeProp = AnyTypeProp;
+            this.AnyTypePropNullable = AnyTypePropNullable;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -43,19 +43,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this.ClassName = className;
-            this.HasBaleen = hasBaleen;
-            this.HasTeeth = hasTeeth;
+            this.ClassName = ClassName;
+            this.HasBaleen = HasBaleen;
+            this.HasTeeth = HasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -75,17 +75,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this.ClassName = className;
-            this.Type = type;
+            this.ClassName = ClassName;
+            this.Type = Type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this.ActivityOutputs = activityOutputs;
+            this.ActivityOutputs = ActivityOutputs;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this.Prop1 = prop1;
-            this.Prop2 = prop2;
+            this.Prop1 = Prop1;
+            this.Prop2 = Prop2;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -35,24 +35,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this.MapProperty = mapProperty;
-            this.MapOfMapProperty = mapOfMapProperty;
-            this.Anytype1 = anytype1;
-            this.MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
-            this.MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
-            this.MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
-            this.EmptyMap = emptyMap;
-            this.MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this.MapProperty = MapProperty;
+            this.MapOfMapProperty = MapOfMapProperty;
+            this.Anytype1 = Anytype1;
+            this.MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
+            this.MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
+            this.MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
+            this.EmptyMap = EmptyMap;
+            this.MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -47,18 +47,18 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this.ClassName = className;
-            // use default value if no "color" provided
-            this.Color = color ?? "red";
+            this.ClassName = ClassName;
+            // use default value if no "Color" provided
+            this.Color = Color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this.Cultivar = cultivar;
-            this.Origin = origin;
+            this.Cultivar = Cultivar;
+            this.Origin = Origin;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this.Cultivar = cultivar;
-            this.Mealy = mealy;
+            this.Cultivar = Cultivar;
+            this.Mealy = Mealy;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this.ArrayArrayNumber = arrayArrayNumber;
+            this.ArrayArrayNumber = ArrayArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this.ArrayNumber = arrayNumber;
+            this.ArrayNumber = ArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this.ArrayOfString = arrayOfString;
-            this.ArrayArrayOfInteger = arrayArrayOfInteger;
-            this.ArrayArrayOfModel = arrayArrayOfModel;
+            this.ArrayOfString = ArrayOfString;
+            this.ArrayArrayOfInteger = ArrayArrayOfInteger;
+            this.ArrayArrayOfModel = ArrayArrayOfModel;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this.LengthCm = lengthCm;
+            this.LengthCm = LengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this.LengthCm = lengthCm;
-            this.Sweet = sweet;
+            this.LengthCm = LengthCm;
+            this.Sweet = Sweet;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -35,20 +35,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this.SmallCamel = smallCamel;
-            this.CapitalCamel = capitalCamel;
-            this.SmallSnake = smallSnake;
-            this.CapitalSnake = capitalSnake;
-            this.SCAETHFlowPoints = sCAETHFlowPoints;
-            this.ATT_NAME = aTTNAME;
+            this.SmallCamel = SmallCamel;
+            this.CapitalCamel = CapitalCamel;
+            this.SmallSnake = SmallSnake;
+            this.CapitalSnake = CapitalSnake;
+            this.SCAETHFlowPoints = SCAETHFlowPoints;
+            this.ATT_NAME = ATT_NAME;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -43,17 +43,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this.Name = name;
-            this.Id = id;
+            this.Name = Name;
+            this.Id = Id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -57,12 +57,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this.Class = _class;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Dog.cs
@@ -45,12 +45,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this.Breed = breed;
+            this.Breed = Breed;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Drawing.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this.MainShape = mainShape;
-            this.ShapeOrNull = shapeOrNull;
-            this.NullableShape = nullableShape;
-            this.Shapes = shapes;
+            this.MainShape = MainShape;
+            this.ShapeOrNull = ShapeOrNull;
+            this.NullableShape = NullableShape;
+            this.Shapes = Shapes;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this.JustSymbol = justSymbol;
-            this.ArrayEnum = arrayEnum;
+            this.JustSymbol = JustSymbol;
+            this.ArrayEnum = ArrayEnum;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -203,26 +203,26 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this.EnumStringRequired = enumStringRequired;
-            this.EnumString = enumString;
-            this.EnumInteger = enumInteger;
-            this.EnumIntegerOnly = enumIntegerOnly;
-            this.EnumNumber = enumNumber;
-            this.OuterEnum = outerEnum;
-            this.OuterEnumInteger = outerEnumInteger;
-            this.OuterEnumDefaultValue = outerEnumDefaultValue;
-            this.OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this.EnumStringRequired = EnumStringRequired;
+            this.EnumString = EnumString;
+            this.EnumInteger = EnumInteger;
+            this.EnumIntegerOnly = EnumIntegerOnly;
+            this.EnumNumber = EnumNumber;
+            this.OuterEnum = OuterEnum;
+            this.OuterEnumInteger = OuterEnumInteger;
+            this.OuterEnumDefaultValue = OuterEnumDefaultValue;
+            this.OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/File.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this.SourceURI = sourceURI;
+            this.SourceURI = SourceURI;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this.File = file;
-            this.Files = files;
+            this.File = File;
+            this.Files = Files;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,11 +35,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
-            // use default value if no "bar" provided
-            this.Bar = bar ?? "bar";
+            // use default value if no "Bar" provided
+            this.Bar = Bar ?? "bar";
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this.String = _string;
+            this.String = String;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -43,50 +43,50 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), System.IO.Stream Binary = default(System.IO.Stream), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this.Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this.Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this.Byte = _byte;
-            this.Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this.Byte = Byte;
+            this.Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this.Password = password;
-            this.Integer = integer;
-            this.Int32 = int32;
-            this.Int64 = int64;
-            this.Float = _float;
-            this.Double = _double;
-            this.Decimal = _decimal;
-            this.String = _string;
-            this.Binary = binary;
-            this.DateTime = dateTime;
-            this.Uuid = uuid;
-            this.PatternWithDigits = patternWithDigits;
-            this.PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this.Password = Password;
+            this.Integer = Integer;
+            this.Int32 = Int32;
+            this.Int64 = Int64;
+            this.Float = Float;
+            this.Double = Double;
+            this.Decimal = Decimal;
+            this.String = String;
+            this.Binary = Binary;
+            this.DateTime = DateTime;
+            this.Uuid = Uuid;
+            this.PatternWithDigits = PatternWithDigits;
+            this.PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -47,15 +47,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this.PetType = petType;
+            this.PetType = PetType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this.NullableMessage = nullableMessage;
+            this.NullableMessage = NullableMessage;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/List.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this._123List = _123list;
+            this._123List = _123List;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -55,16 +55,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this.MapMapOfString = mapMapOfString;
-            this.MapOfEnumString = mapOfEnumString;
-            this.DirectMap = directMap;
-            this.IndirectMap = indirectMap;
+            this.MapMapOfString = MapMapOfString;
+            this.MapOfEnumString = MapOfEnumString;
+            this.DirectMap = DirectMap;
+            this.IndirectMap = IndirectMap;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this.Uuid = uuid;
-            this.DateTime = dateTime;
-            this.Map = map;
+            this.Uuid = Uuid;
+            this.DateTime = DateTime;
+            this.Map = Map;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this.Name = name;
-            this.Class = _class;
+            this.Name = Name;
+            this.Class = Class;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this._Client = _client;
+            this._Client = _Client;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
@@ -43,12 +43,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this._Name = name;
-            this.Property = property;
+            this._Name = _Name;
+            this.Property = Property;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this.IntegerProp = integerProp;
-            this.NumberProp = numberProp;
-            this.BooleanProp = booleanProp;
-            this.StringProp = stringProp;
-            this.DateProp = dateProp;
-            this.DatetimeProp = datetimeProp;
-            this.ArrayNullableProp = arrayNullableProp;
-            this.ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
-            this.ArrayItemsNullable = arrayItemsNullable;
-            this.ObjectNullableProp = objectNullableProp;
-            this.ObjectAndItemsNullableProp = objectAndItemsNullableProp;
-            this.ObjectItemsNullable = objectItemsNullable;
+            this.IntegerProp = IntegerProp;
+            this.NumberProp = NumberProp;
+            this.BooleanProp = BooleanProp;
+            this.StringProp = StringProp;
+            this.DateProp = DateProp;
+            this.DatetimeProp = DatetimeProp;
+            this.ArrayNullableProp = ArrayNullableProp;
+            this.ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
+            this.ArrayItemsNullable = ArrayItemsNullable;
+            this.ObjectNullableProp = ObjectNullableProp;
+            this.ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
+            this.ObjectItemsNullable = ObjectItemsNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this.Uuid = uuid;
+            this.Uuid = Uuid;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this.JustNumber = justNumber;
+            this.JustNumber = JustNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this.Uuid = uuid;
-            this.Id = id;
-            this.DeprecatedRef = deprecatedRef;
-            this.Bars = bars;
+            this.Uuid = Uuid;
+            this.Id = Id;
+            this.DeprecatedRef = DeprecatedRef;
+            this.Bars = Bars;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -69,20 +69,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this.MyNumber = myNumber;
-            this.MyString = myString;
-            this.MyBoolean = myBoolean;
+            this.MyNumber = MyNumber;
+            this.MyString = MyString;
+            this.MyBoolean = MyBoolean;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -77,30 +77,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this.Baz = baz;
+            this.Baz = Baz;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Return.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this._Return = _return;
+            this._Return = _Return;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this.ShapeType = shapeType;
+            this.ShapeType = ShapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -43,22 +43,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this.SpecialPropertyName = specialPropertyName;
-            this._SpecialModelName = specialModelName;
+            this.SpecialPropertyName = SpecialPropertyName;
+            this._SpecialModelName = _SpecialModelName;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -43,15 +43,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
-            this.ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
-            this.ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
-            this.AnyTypeProp = anyTypeProp;
-            this.AnyTypePropNullable = anyTypePropNullable;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
+            this.ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
+            this.ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
+            this.AnyTypeProp = AnyTypeProp;
+            this.AnyTypePropNullable = AnyTypePropNullable;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
@@ -43,19 +43,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this.ClassName = className;
-            this.HasBaleen = hasBaleen;
-            this.HasTeeth = hasTeeth;
+            this.ClassName = ClassName;
+            this.HasBaleen = HasBaleen;
+            this.HasTeeth = HasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -75,17 +75,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this.ClassName = className;
-            this.Type = type;
+            this.ClassName = ClassName;
+            this.Type = Type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
-        /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        /// <param name="ActivityOutputs">ActivityOutputs.</param>
+        public Activity( Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
         {
-            this.ActivityOutputs = activityOutputs;
+            this.ActivityOutputs = ActivityOutputs;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
         /// </summary>
-        /// <param name="prop1">prop1.</param>
-        /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        /// <param name="Prop1">Prop1.</param>
+        /// <param name="Prop2">Prop2.</param>
+        public ActivityOutputElementRepresentation( string Prop1 = default(string), Object Prop2 = default(Object))
         {
-            this.Prop1 = prop1;
-            this.Prop2 = prop2;
+            this.Prop1 = Prop1;
+            this.Prop2 = Prop2;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -35,24 +35,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="mapProperty">mapProperty.</param>
-        /// <param name="mapOfMapProperty">mapOfMapProperty.</param>
-        /// <param name="anytype1">anytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype1">mapWithUndeclaredPropertiesAnytype1.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype2">mapWithUndeclaredPropertiesAnytype2.</param>
-        /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
-        /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
-        /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        /// <param name="MapProperty">MapProperty.</param>
+        /// <param name="MapOfMapProperty">MapOfMapProperty.</param>
+        /// <param name="Anytype1">Anytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype1">MapWithUndeclaredPropertiesAnytype1.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype2">MapWithUndeclaredPropertiesAnytype2.</param>
+        /// <param name="MapWithUndeclaredPropertiesAnytype3">MapWithUndeclaredPropertiesAnytype3.</param>
+        /// <param name="EmptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
+        /// <param name="MapWithUndeclaredPropertiesString">MapWithUndeclaredPropertiesString.</param>
+        public AdditionalPropertiesClass( Dictionary<string, string> MapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> MapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object Anytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype1 = default(Object), Object MapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object EmptyMap = default(Object), Dictionary<string, string> MapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
         {
-            this.MapProperty = mapProperty;
-            this.MapOfMapProperty = mapOfMapProperty;
-            this.Anytype1 = anytype1;
-            this.MapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
-            this.MapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
-            this.MapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
-            this.EmptyMap = emptyMap;
-            this.MapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
+            this.MapProperty = MapProperty;
+            this.MapOfMapProperty = MapOfMapProperty;
+            this.Anytype1 = Anytype1;
+            this.MapWithUndeclaredPropertiesAnytype1 = MapWithUndeclaredPropertiesAnytype1;
+            this.MapWithUndeclaredPropertiesAnytype2 = MapWithUndeclaredPropertiesAnytype2;
+            this.MapWithUndeclaredPropertiesAnytype3 = MapWithUndeclaredPropertiesAnytype3;
+            this.EmptyMap = EmptyMap;
+            this.MapWithUndeclaredPropertiesString = MapWithUndeclaredPropertiesString;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
@@ -44,18 +44,18 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = "red")
+        /// <param name="ClassName">ClassName (required).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Animal( string ClassName = default(string), string Color = "red")
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Animal and cannot be null");
             }
-            this.ClassName = className;
-            // use default value if no "color" provided
-            this.Color = color ?? "red";
+            this.ClassName = ClassName;
+            // use default value if no "Color" provided
+            this.Color = Color ?? "red";
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar.</param>
-        /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="Cultivar">Cultivar.</param>
+        /// <param name="Origin">Origin.</param>
+        public Apple( string Cultivar = default(string), string Origin = default(string))
         {
-            this.Cultivar = cultivar;
-            this.Origin = origin;
+            this.Cultivar = Cultivar;
+            this.Origin = Origin;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
         /// </summary>
-        /// <param name="cultivar">cultivar (required).</param>
-        /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        /// <param name="Cultivar">Cultivar (required).</param>
+        /// <param name="Mealy">Mealy.</param>
+        public AppleReq( string Cultivar = default(string), bool Mealy = default(bool))
         {
-            // to ensure "cultivar" is required (not null)
-            if (cultivar == null)
+            // to ensure "Cultivar" is required (not null)
+            if (Cultivar == null)
             {
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+                throw new ArgumentNullException("Cultivar is a required property for AppleReq and cannot be null");
             }
-            this.Cultivar = cultivar;
-            this.Mealy = mealy;
+            this.Cultivar = Cultivar;
+            this.Mealy = Mealy;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        /// <param name="ArrayArrayNumber">ArrayArrayNumber.</param>
+        public ArrayOfArrayOfNumberOnly( List<List<decimal>> ArrayArrayNumber = default(List<List<decimal>>))
         {
-            this.ArrayArrayNumber = arrayArrayNumber;
+            this.ArrayArrayNumber = ArrayArrayNumber;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
-        /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        /// <param name="ArrayNumber">ArrayNumber.</param>
+        public ArrayOfNumberOnly( List<decimal> ArrayNumber = default(List<decimal>))
         {
-            this.ArrayNumber = arrayNumber;
+            this.ArrayNumber = ArrayNumber;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
         /// </summary>
-        /// <param name="arrayOfString">arrayOfString.</param>
-        /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
-        /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        /// <param name="ArrayOfString">ArrayOfString.</param>
+        /// <param name="ArrayArrayOfInteger">ArrayArrayOfInteger.</param>
+        /// <param name="ArrayArrayOfModel">ArrayArrayOfModel.</param>
+        public ArrayTest( List<string> ArrayOfString = default(List<string>), List<List<long>> ArrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> ArrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
-            this.ArrayOfString = arrayOfString;
-            this.ArrayArrayOfInteger = arrayArrayOfInteger;
-            this.ArrayArrayOfModel = arrayArrayOfModel;
+            this.ArrayOfString = ArrayOfString;
+            this.ArrayArrayOfInteger = ArrayArrayOfInteger;
+            this.ArrayArrayOfModel = ArrayArrayOfModel;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        /// <param name="LengthCm">LengthCm.</param>
+        public Banana( decimal LengthCm = default(decimal))
         {
-            this.LengthCm = lengthCm;
+            this.LengthCm = LengthCm;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
         /// </summary>
-        /// <param name="lengthCm">lengthCm (required).</param>
-        /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        /// <param name="LengthCm">LengthCm (required).</param>
+        /// <param name="Sweet">Sweet.</param>
+        public BananaReq( decimal LengthCm = default(decimal), bool Sweet = default(bool))
         {
-            this.LengthCm = lengthCm;
-            this.Sweet = sweet;
+            this.LengthCm = LengthCm;
+            this.Sweet = Sweet;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -40,15 +40,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public BasquePig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public BasquePig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for BasquePig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -35,20 +35,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
         /// </summary>
-        /// <param name="smallCamel">smallCamel.</param>
-        /// <param name="capitalCamel">capitalCamel.</param>
-        /// <param name="smallSnake">smallSnake.</param>
-        /// <param name="capitalSnake">capitalSnake.</param>
-        /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
-        /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        /// <param name="SmallCamel">SmallCamel.</param>
+        /// <param name="CapitalCamel">CapitalCamel.</param>
+        /// <param name="SmallSnake">SmallSnake.</param>
+        /// <param name="CapitalSnake">CapitalSnake.</param>
+        /// <param name="SCAETHFlowPoints">SCAETHFlowPoints.</param>
+        /// <param name="ATT_NAME">Name of the pet .</param>
+        public Capitalization( string SmallCamel = default(string), string CapitalCamel = default(string), string SmallSnake = default(string), string CapitalSnake = default(string), string SCAETHFlowPoints = default(string), string ATT_NAME = default(string))
         {
-            this.SmallCamel = smallCamel;
-            this.CapitalCamel = capitalCamel;
-            this.SmallSnake = smallSnake;
-            this.CapitalSnake = capitalSnake;
-            this.SCAETHFlowPoints = sCAETHFlowPoints;
-            this.ATT_NAME = aTTNAME;
+            this.SmallCamel = SmallCamel;
+            this.CapitalCamel = CapitalCamel;
+            this.SmallSnake = SmallSnake;
+            this.CapitalSnake = CapitalSnake;
+            this.SCAETHFlowPoints = SCAETHFlowPoints;
+            this.ATT_NAME = ATT_NAME;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
@@ -42,12 +42,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = "Cat", string color = "red") : base(className, color)
+        /// <param name="Declawed">Declawed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Cat&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Cat( bool Declawed = default(bool), string ClassName = "Cat", string Color = "red") : base(ClassName, Color)
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CatAllOf" /> class.
         /// </summary>
-        /// <param name="declawed">declawed.</param>
-        public CatAllOf(bool declawed = default(bool))
+        /// <param name="Declawed">Declawed.</param>
+        public CatAllOf( bool Declawed = default(bool))
         {
-            this.Declawed = declawed;
+            this.Declawed = Declawed;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
@@ -40,17 +40,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = "default-name")
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name (required) (default to &quot;default-name&quot;).</param>
+        public Category( long Id = default(long), string Name = "default-name")
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Category and cannot be null");
             }
-            this.Name = name;
-            this.Id = id;
+            this.Name = Name;
+            this.Id = Id;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -57,12 +57,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat) : base()
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCatAllOf" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
-        public ChildCatAllOf(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat)
+        /// <param name="Name">Name.</param>
+        /// <param name="PetType">PetType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCatAllOf( string Name = default(string), PetTypeEnum? PetType = PetTypeEnum.ChildCat)
         {
-            this.Name = name;
-            this.PetType = petType;
+            this.Name = Name;
+            this.PetType = PetType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
-        /// <param name="_class">_class.</param>
-        public ClassModel(string _class = default(string))
+        /// <param name="Class">Class.</param>
+        public ClassModel( string Class = default(string))
         {
-            this.Class = _class;
+            this.Class = Class;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public ComplexQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -40,15 +40,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
         /// </summary>
-        /// <param name="className">className (required).</param>
-        public DanishPig(string className = default(string))
+        /// <param name="ClassName">ClassName (required).</param>
+        public DanishPig( string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for DanishPig and cannot be null");
             }
-            this.ClassName = className;
+            this.ClassName = ClassName;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        /// <param name="Name">Name.</param>
+        public DeprecatedObject( string Name = default(string))
         {
-            this.Name = name;
+            this.Name = Name;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Dog.cs
@@ -42,12 +42,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
-        /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = "Dog", string color = "red") : base(className, color)
+        /// <param name="Breed">Breed.</param>
+        /// <param name="ClassName">ClassName (required) (default to &quot;Dog&quot;).</param>
+        /// <param name="Color">Color (default to &quot;red&quot;).</param>
+        public Dog( string Breed = default(string), string ClassName = "Dog", string Color = "red") : base(ClassName, Color)
         {
-            this.Breed = breed;
+            this.Breed = Breed;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="DogAllOf" /> class.
         /// </summary>
-        /// <param name="breed">breed.</param>
-        public DogAllOf(string breed = default(string))
+        /// <param name="Breed">Breed.</param>
+        public DogAllOf( string Breed = default(string))
         {
-            this.Breed = breed;
+            this.Breed = Breed;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
-        /// <param name="mainShape">mainShape.</param>
-        /// <param name="shapeOrNull">shapeOrNull.</param>
-        /// <param name="nullableShape">nullableShape.</param>
-        /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>)) : base()
+        /// <param name="MainShape">MainShape.</param>
+        /// <param name="ShapeOrNull">ShapeOrNull.</param>
+        /// <param name="NullableShape">NullableShape.</param>
+        /// <param name="Shapes">Shapes.</param>
+        public Drawing( Shape MainShape = default(Shape), ShapeOrNull ShapeOrNull = default(ShapeOrNull), NullableShape NullableShape = default(NullableShape), List<Shape> Shapes = default(List<Shape>)) : base()
         {
-            this.MainShape = mainShape;
-            this.ShapeOrNull = shapeOrNull;
-            this.NullableShape = nullableShape;
-            this.Shapes = shapes;
+            this.MainShape = MainShape;
+            this.ShapeOrNull = ShapeOrNull;
+            this.NullableShape = NullableShape;
+            this.Shapes = Shapes;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
         /// </summary>
-        /// <param name="justSymbol">justSymbol.</param>
-        /// <param name="arrayEnum">arrayEnum.</param>
-        public EnumArrays(JustSymbolEnum? justSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> arrayEnum = default(List<ArrayEnumEnum>))
+        /// <param name="JustSymbol">JustSymbol.</param>
+        /// <param name="ArrayEnum">ArrayEnum.</param>
+        public EnumArrays( JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>))
         {
-            this.JustSymbol = justSymbol;
-            this.ArrayEnum = arrayEnum;
+            this.JustSymbol = JustSymbol;
+            this.ArrayEnum = ArrayEnum;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -200,26 +200,26 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
         /// </summary>
-        /// <param name="enumString">enumString.</param>
-        /// <param name="enumStringRequired">enumStringRequired (required).</param>
-        /// <param name="enumInteger">enumInteger.</param>
-        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
-        /// <param name="enumNumber">enumNumber.</param>
-        /// <param name="outerEnum">outerEnum.</param>
-        /// <param name="outerEnumInteger">outerEnumInteger.</param>
-        /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
-        /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        /// <param name="EnumString">EnumString.</param>
+        /// <param name="EnumStringRequired">EnumStringRequired (required).</param>
+        /// <param name="EnumInteger">EnumInteger.</param>
+        /// <param name="EnumIntegerOnly">EnumIntegerOnly.</param>
+        /// <param name="EnumNumber">EnumNumber.</param>
+        /// <param name="OuterEnum">OuterEnum.</param>
+        /// <param name="OuterEnumInteger">OuterEnumInteger.</param>
+        /// <param name="OuterEnumDefaultValue">OuterEnumDefaultValue.</param>
+        /// <param name="OuterEnumIntegerDefaultValue">OuterEnumIntegerDefaultValue.</param>
+        public EnumTest( EnumStringEnum? EnumString = default(EnumStringEnum?), EnumStringRequiredEnum EnumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? EnumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? EnumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? EnumNumber = default(EnumNumberEnum?), OuterEnum? OuterEnum = default(OuterEnum?), OuterEnumInteger? OuterEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? OuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? OuterEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
-            this.EnumStringRequired = enumStringRequired;
-            this.EnumString = enumString;
-            this.EnumInteger = enumInteger;
-            this.EnumIntegerOnly = enumIntegerOnly;
-            this.EnumNumber = enumNumber;
-            this.OuterEnum = outerEnum;
-            this.OuterEnumInteger = outerEnumInteger;
-            this.OuterEnumDefaultValue = outerEnumDefaultValue;
-            this.OuterEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
+            this.EnumStringRequired = EnumStringRequired;
+            this.EnumString = EnumString;
+            this.EnumInteger = EnumInteger;
+            this.EnumIntegerOnly = EnumIntegerOnly;
+            this.EnumNumber = EnumNumber;
+            this.OuterEnum = OuterEnum;
+            this.OuterEnumInteger = OuterEnumInteger;
+            this.OuterEnumDefaultValue = OuterEnumDefaultValue;
+            this.OuterEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public EquilateralTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for EquilateralTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/File.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
-        /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        /// <param name="SourceURI">Test capitalization.</param>
+        public File( string SourceURI = default(string))
         {
-            this.SourceURI = sourceURI;
+            this.SourceURI = SourceURI;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
         /// </summary>
-        /// <param name="file">file.</param>
-        /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        /// <param name="File">File.</param>
+        /// <param name="Files">Files.</param>
+        public FileSchemaTestClass( File File = default(File), List<File> Files = default(List<File>))
         {
-            this.File = file;
-            this.Files = files;
+            this.File = File;
+            this.Files = Files;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,11 +35,11 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
-        /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = "bar")
+        /// <param name="Bar">Bar (default to &quot;bar&quot;).</param>
+        public Foo( string Bar = "bar")
         {
-            // use default value if no "bar" provided
-            this.Bar = bar ?? "bar";
+            // use default value if no "Bar" provided
+            this.Bar = Bar ?? "bar";
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
-        /// <param name="_string">_string.</param>
-        public FooGetDefaultResponse(Foo _string = default(Foo))
+        /// <param name="String">String.</param>
+        public FooGetDefaultResponse( Foo String = default(Foo))
         {
-            this.String = _string;
+            this.String = String;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -40,50 +40,50 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
         /// </summary>
-        /// <param name="integer">integer.</param>
-        /// <param name="int32">int32.</param>
-        /// <param name="int64">int64.</param>
-        /// <param name="number">number (required).</param>
-        /// <param name="_float">_float.</param>
-        /// <param name="_double">_double.</param>
-        /// <param name="_decimal">_decimal.</param>
-        /// <param name="_string">_string.</param>
-        /// <param name="_byte">_byte (required).</param>
-        /// <param name="binary">binary.</param>
-        /// <param name="date">date (required).</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="password">password (required).</param>
-        /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
-        /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), decimal _decimal = default(decimal), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string))
+        /// <param name="Integer">Integer.</param>
+        /// <param name="Int32">Int32.</param>
+        /// <param name="Int64">Int64.</param>
+        /// <param name="Number">Number (required).</param>
+        /// <param name="Float">Float.</param>
+        /// <param name="Double">Double.</param>
+        /// <param name="Decimal">Decimal.</param>
+        /// <param name="String">String.</param>
+        /// <param name="Byte">Byte (required).</param>
+        /// <param name="Binary">Binary.</param>
+        /// <param name="Date">Date (required).</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Password">Password (required).</param>
+        /// <param name="PatternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
+        /// <param name="PatternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
+        public FormatTest( int Integer = default(int), int Int32 = default(int), long Int64 = default(long), decimal Number = default(decimal), float Float = default(float), double Double = default(double), decimal Decimal = default(decimal), string String = default(string), byte[] Byte = default(byte[]), System.IO.Stream Binary = default(System.IO.Stream), DateTime Date = default(DateTime), DateTime DateTime = default(DateTime), Guid Uuid = default(Guid), string Password = default(string), string PatternWithDigits = default(string), string PatternWithDigitsAndDelimiter = default(string))
         {
-            this.Number = number;
-            // to ensure "_byte" is required (not null)
-            if (_byte == null)
+            this.Number = Number;
+            // to ensure "Byte" is required (not null)
+            if (Byte == null)
             {
-                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Byte is a required property for FormatTest and cannot be null");
             }
-            this.Byte = _byte;
-            this.Date = date;
-            // to ensure "password" is required (not null)
-            if (password == null)
+            this.Byte = Byte;
+            this.Date = Date;
+            // to ensure "Password" is required (not null)
+            if (Password == null)
             {
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+                throw new ArgumentNullException("Password is a required property for FormatTest and cannot be null");
             }
-            this.Password = password;
-            this.Integer = integer;
-            this.Int32 = int32;
-            this.Int64 = int64;
-            this.Float = _float;
-            this.Double = _double;
-            this.Decimal = _decimal;
-            this.String = _string;
-            this.Binary = binary;
-            this.DateTime = dateTime;
-            this.Uuid = uuid;
-            this.PatternWithDigits = patternWithDigits;
-            this.PatternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
+            this.Password = Password;
+            this.Integer = Integer;
+            this.Int32 = Int32;
+            this.Int64 = Int64;
+            this.Float = Float;
+            this.Double = Double;
+            this.Decimal = Decimal;
+            this.String = String;
+            this.Binary = Binary;
+            this.DateTime = DateTime;
+            this.Uuid = Uuid;
+            this.PatternWithDigits = PatternWithDigits;
+            this.PatternWithDigitsAndDelimiter = PatternWithDigitsAndDelimiter;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -44,15 +44,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
         /// </summary>
-        /// <param name="petType">petType (required).</param>
-        public GrandparentAnimal(string petType = default(string))
+        /// <param name="PetType">PetType (required).</param>
+        public GrandparentAnimal( string PetType = default(string))
         {
-            // to ensure "petType" is required (not null)
-            if (petType == null)
+            // to ensure "PetType" is required (not null)
+            if (PetType == null)
             {
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+                throw new ArgumentNullException("PetType is a required property for GrandparentAnimal and cannot be null");
             }
-            this.PetType = petType;
+            this.PetType = PetType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HasOnlyReadOnly" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public HasOnlyReadOnly()
+        public HasOnlyReadOnly( )
         {
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
-        /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        /// <param name="NullableMessage">NullableMessage.</param>
+        public HealthCheckResult( string NullableMessage = default(string))
         {
-            this.NullableMessage = nullableMessage;
+            this.NullableMessage = NullableMessage;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public IsoscelesTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for IsoscelesTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/List.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
-        /// <param name="_123list">_123list.</param>
-        public List(string _123list = default(string))
+        /// <param name="_123List">_123List.</param>
+        public List( string _123List = default(string))
         {
-            this._123List = _123list;
+            this._123List = _123List;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -55,16 +55,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
         /// </summary>
-        /// <param name="mapMapOfString">mapMapOfString.</param>
-        /// <param name="mapOfEnumString">mapOfEnumString.</param>
-        /// <param name="directMap">directMap.</param>
-        /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        /// <param name="MapMapOfString">MapMapOfString.</param>
+        /// <param name="MapOfEnumString">MapOfEnumString.</param>
+        /// <param name="DirectMap">DirectMap.</param>
+        /// <param name="IndirectMap">IndirectMap.</param>
+        public MapTest( Dictionary<string, Dictionary<string, string>> MapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> MapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> DirectMap = default(Dictionary<string, bool>), Dictionary<string, bool> IndirectMap = default(Dictionary<string, bool>))
         {
-            this.MapMapOfString = mapMapOfString;
-            this.MapOfEnumString = mapOfEnumString;
-            this.DirectMap = directMap;
-            this.IndirectMap = indirectMap;
+            this.MapMapOfString = MapMapOfString;
+            this.MapOfEnumString = MapOfEnumString;
+            this.DirectMap = DirectMap;
+            this.IndirectMap = IndirectMap;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="dateTime">dateTime.</param>
-        /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="DateTime">DateTime.</param>
+        /// <param name="Map">Map.</param>
+        public MixedPropertiesAndAdditionalPropertiesClass( Guid Uuid = default(Guid), DateTime DateTime = default(DateTime), Dictionary<string, Animal> Map = default(Dictionary<string, Animal>))
         {
-            this.Uuid = uuid;
-            this.DateTime = dateTime;
-            this.Map = map;
+            this.Uuid = Uuid;
+            this.DateTime = DateTime;
+            this.Map = Map;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
         /// </summary>
-        /// <param name="name">name.</param>
-        /// <param name="_class">_class.</param>
-        public Model200Response(int name = default(int), string _class = default(string))
+        /// <param name="Name">Name.</param>
+        /// <param name="Class">Class.</param>
+        public Model200Response( int Name = default(int), string Class = default(string))
         {
-            this.Name = name;
-            this.Class = _class;
+            this.Name = Name;
+            this.Class = Class;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
-        /// <param name="_client">_client.</param>
-        public ModelClient(string _client = default(string))
+        /// <param name="_Client">_Client.</param>
+        public ModelClient( string _Client = default(string))
         {
-            this._Client = _client;
+            this._Client = _Client;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
@@ -40,12 +40,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="name">name (required).</param>
-        /// <param name="property">property.</param>
-        public Name(int name = default(int), string property = default(string))
+        /// <param name="Name">Name (required).</param>
+        /// <param name="Property">Property.</param>
+        public Name( int Name = default(int), string Property = default(string))
         {
-            this._Name = name;
-            this.Property = property;
+            this._Name = _Name;
+            this.Property = Property;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
         /// </summary>
-        /// <param name="integerProp">integerProp.</param>
-        /// <param name="numberProp">numberProp.</param>
-        /// <param name="booleanProp">booleanProp.</param>
-        /// <param name="stringProp">stringProp.</param>
-        /// <param name="dateProp">dateProp.</param>
-        /// <param name="datetimeProp">datetimeProp.</param>
-        /// <param name="arrayNullableProp">arrayNullableProp.</param>
-        /// <param name="arrayAndItemsNullableProp">arrayAndItemsNullableProp.</param>
-        /// <param name="arrayItemsNullable">arrayItemsNullable.</param>
-        /// <param name="objectNullableProp">objectNullableProp.</param>
-        /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
-        /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>)) : base()
+        /// <param name="IntegerProp">IntegerProp.</param>
+        /// <param name="NumberProp">NumberProp.</param>
+        /// <param name="BooleanProp">BooleanProp.</param>
+        /// <param name="StringProp">StringProp.</param>
+        /// <param name="DateProp">DateProp.</param>
+        /// <param name="DatetimeProp">DatetimeProp.</param>
+        /// <param name="ArrayNullableProp">ArrayNullableProp.</param>
+        /// <param name="ArrayAndItemsNullableProp">ArrayAndItemsNullableProp.</param>
+        /// <param name="ArrayItemsNullable">ArrayItemsNullable.</param>
+        /// <param name="ObjectNullableProp">ObjectNullableProp.</param>
+        /// <param name="ObjectAndItemsNullableProp">ObjectAndItemsNullableProp.</param>
+        /// <param name="ObjectItemsNullable">ObjectItemsNullable.</param>
+        public NullableClass( int? IntegerProp = default(int?), decimal? NumberProp = default(decimal?), bool? BooleanProp = default(bool?), string StringProp = default(string), DateTime? DateProp = default(DateTime?), DateTime? DatetimeProp = default(DateTime?), List<Object> ArrayNullableProp = default(List<Object>), List<Object> ArrayAndItemsNullableProp = default(List<Object>), List<Object> ArrayItemsNullable = default(List<Object>), Dictionary<string, Object> ObjectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> ObjectItemsNullable = default(Dictionary<string, Object>)) : base()
         {
-            this.IntegerProp = integerProp;
-            this.NumberProp = numberProp;
-            this.BooleanProp = booleanProp;
-            this.StringProp = stringProp;
-            this.DateProp = dateProp;
-            this.DatetimeProp = datetimeProp;
-            this.ArrayNullableProp = arrayNullableProp;
-            this.ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
-            this.ArrayItemsNullable = arrayItemsNullable;
-            this.ObjectNullableProp = objectNullableProp;
-            this.ObjectAndItemsNullableProp = objectAndItemsNullableProp;
-            this.ObjectItemsNullable = objectItemsNullable;
+            this.IntegerProp = IntegerProp;
+            this.NumberProp = NumberProp;
+            this.BooleanProp = BooleanProp;
+            this.StringProp = StringProp;
+            this.DateProp = DateProp;
+            this.DatetimeProp = DatetimeProp;
+            this.ArrayNullableProp = ArrayNullableProp;
+            this.ArrayAndItemsNullableProp = ArrayAndItemsNullableProp;
+            this.ArrayItemsNullable = ArrayItemsNullable;
+            this.ObjectNullableProp = ObjectNullableProp;
+            this.ObjectAndItemsNullableProp = ObjectAndItemsNullableProp;
+            this.ObjectItemsNullable = ObjectItemsNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        public NullableGuidClass(Guid? uuid = default(Guid?))
+        /// <param name="Uuid">Uuid.</param>
+        public NullableGuidClass( Guid? Uuid = default(Guid?))
         {
-            this.Uuid = uuid;
+            this.Uuid = Uuid;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
-        /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        /// <param name="JustNumber">JustNumber.</param>
+        public NumberOnly( decimal JustNumber = default(decimal))
         {
-            this.JustNumber = justNumber;
+            this.JustNumber = JustNumber;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -35,16 +35,16 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
         /// </summary>
-        /// <param name="uuid">uuid.</param>
-        /// <param name="id">id.</param>
-        /// <param name="deprecatedRef">deprecatedRef.</param>
-        /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        /// <param name="Uuid">Uuid.</param>
+        /// <param name="Id">Id.</param>
+        /// <param name="DeprecatedRef">DeprecatedRef.</param>
+        /// <param name="Bars">Bars.</param>
+        public ObjectWithDeprecatedFields( string Uuid = default(string), decimal Id = default(decimal), DeprecatedObject DeprecatedRef = default(DeprecatedObject), List<string> Bars = default(List<string>))
         {
-            this.Uuid = uuid;
-            this.Id = id;
-            this.DeprecatedRef = deprecatedRef;
-            this.Bars = bars;
+            this.Uuid = Uuid;
+            this.Id = Id;
+            this.DeprecatedRef = DeprecatedRef;
+            this.Bars = Bars;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
@@ -69,20 +69,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
         /// </summary>
-        /// <param name="myNumber">myNumber.</param>
-        /// <param name="myString">myString.</param>
-        /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        /// <param name="MyNumber">MyNumber.</param>
+        /// <param name="MyString">MyString.</param>
+        /// <param name="MyBoolean">MyBoolean.</param>
+        public OuterComposite( decimal MyNumber = default(decimal), string MyString = default(string), bool MyBoolean = default(bool))
         {
-            this.MyNumber = myNumber;
-            this.MyString = myString;
-            this.MyBoolean = myBoolean;
+            this.MyNumber = MyNumber;
+            this.MyString = MyString;
+            this.MyBoolean = MyBoolean;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
         /// </summary>
-        /// <param name="petType">petType (required) (default to &quot;ParentPet&quot;).</param>
-        public ParentPet(string petType = "ParentPet") : base(petType)
+        /// <param name="PetType">PetType (required) (default to &quot;ParentPet&quot;).</param>
+        public ParentPet( string PetType = "ParentPet") : base(PetType)
         {
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
@@ -74,30 +74,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -40,15 +40,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
         /// </summary>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public QuadrilateralInterface(string quadrilateralType = default(string))
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public QuadrilateralInterface( string QuadrilateralType = default(string))
         {
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for QuadrilateralInterface and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
-        /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        /// <param name="Baz">Baz.</param>
+        public ReadOnlyFirst( string Baz = default(string))
         {
-            this.Baz = baz;
+            this.Baz = Baz;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Return.cs
@@ -35,10 +35,10 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
-        /// <param name="_return">_return.</param>
-        public Return(int _return = default(int))
+        /// <param name="Return">Return.</param>
+        public Return( int Return = default(int))
         {
-            this._Return = _return;
+            this._Return = _Return;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="triangleType">triangleType (required).</param>
-        public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public ScaleneTriangle( string ShapeType = default(string), string TriangleType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for ScaleneTriangle and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -40,15 +40,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        public ShapeInterface(string shapeType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        public ShapeInterface( string ShapeType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for ShapeInterface and cannot be null");
             }
-            this.ShapeType = shapeType;
+            this.ShapeType = ShapeType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -40,22 +40,22 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
         /// </summary>
-        /// <param name="shapeType">shapeType (required).</param>
-        /// <param name="quadrilateralType">quadrilateralType (required).</param>
-        public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
+        /// <param name="ShapeType">ShapeType (required).</param>
+        /// <param name="QuadrilateralType">QuadrilateralType (required).</param>
+        public SimpleQuadrilateral( string ShapeType = default(string), string QuadrilateralType = default(string))
         {
-            // to ensure "shapeType" is required (not null)
-            if (shapeType == null)
+            // to ensure "ShapeType" is required (not null)
+            if (ShapeType == null)
             {
-                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("ShapeType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.ShapeType = shapeType;
-            // to ensure "quadrilateralType" is required (not null)
-            if (quadrilateralType == null)
+            this.ShapeType = ShapeType;
+            // to ensure "QuadrilateralType" is required (not null)
+            if (QuadrilateralType == null)
             {
-                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+                throw new ArgumentNullException("QuadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
             }
-            this.QuadrilateralType = quadrilateralType;
+            this.QuadrilateralType = QuadrilateralType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
-        /// <param name="specialPropertyName">specialPropertyName.</param>
-        /// <param name="specialModelName">specialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string specialModelName = default(string))
+        /// <param name="SpecialPropertyName">SpecialPropertyName.</param>
+        /// <param name="SpecialModelName">SpecialModelName.</param>
+        public SpecialModelName( long SpecialPropertyName = default(long), string SpecialModelName = default(string))
         {
-            this.SpecialPropertyName = specialPropertyName;
-            this._SpecialModelName = specialModelName;
+            this.SpecialPropertyName = SpecialPropertyName;
+            this._SpecialModelName = _SpecialModelName;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -40,15 +40,15 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
         /// </summary>
-        /// <param name="triangleType">triangleType (required).</param>
-        public TriangleInterface(string triangleType = default(string))
+        /// <param name="TriangleType">TriangleType (required).</param>
+        public TriangleInterface( string TriangleType = default(string))
         {
-            // to ensure "triangleType" is required (not null)
-            if (triangleType == null)
+            // to ensure "TriangleType" is required (not null)
+            if (TriangleType == null)
             {
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+                throw new ArgumentNullException("TriangleType is a required property for TriangleInterface and cannot be null");
             }
-            this.TriangleType = triangleType;
+            this.TriangleType = TriangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/User.cs
@@ -35,32 +35,32 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        /// <param name="objectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
-        /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
-        /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
-        /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        /// <param name="ObjectWithNoDeclaredProps">test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value..</param>
+        /// <param name="ObjectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
+        /// <param name="AnyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
+        /// <param name="AnyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int), Object ObjectWithNoDeclaredProps = default(Object), Object ObjectWithNoDeclaredPropsNullable = default(Object), Object AnyTypeProp = default(Object), Object AnyTypePropNullable = default(Object))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
-            this.ObjectWithNoDeclaredProps = objectWithNoDeclaredProps;
-            this.ObjectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
-            this.AnyTypeProp = anyTypeProp;
-            this.AnyTypePropNullable = anyTypePropNullable;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
+            this.ObjectWithNoDeclaredProps = ObjectWithNoDeclaredProps;
+            this.ObjectWithNoDeclaredPropsNullable = ObjectWithNoDeclaredPropsNullable;
+            this.AnyTypeProp = AnyTypeProp;
+            this.AnyTypePropNullable = AnyTypePropNullable;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
@@ -40,19 +40,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
         /// </summary>
-        /// <param name="hasBaleen">hasBaleen.</param>
-        /// <param name="hasTeeth">hasTeeth.</param>
-        /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        /// <param name="HasBaleen">HasBaleen.</param>
+        /// <param name="HasTeeth">HasTeeth.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Whale( bool HasBaleen = default(bool), bool HasTeeth = default(bool), string ClassName = default(string))
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Whale and cannot be null");
             }
-            this.ClassName = className;
-            this.HasBaleen = hasBaleen;
-            this.HasTeeth = hasTeeth;
+            this.ClassName = ClassName;
+            this.HasBaleen = HasBaleen;
+            this.HasTeeth = HasTeeth;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -75,17 +75,17 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
         /// </summary>
-        /// <param name="type">type.</param>
-        /// <param name="className">className (required).</param>
-        public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
+        /// <param name="Type">Type.</param>
+        /// <param name="ClassName">ClassName (required).</param>
+        public Zebra( TypeEnum? Type = default(TypeEnum?), string ClassName = default(string)) : base()
         {
-            // to ensure "className" is required (not null)
-            if (className == null)
+            // to ensure "ClassName" is required (not null)
+            if (ClassName == null)
             {
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+                throw new ArgumentNullException("ClassName is a required property for Zebra and cannot be null");
             }
-            this.ClassName = className;
-            this.Type = type;
+            this.ClassName = ClassName;
+            this.Type = Type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -35,14 +35,14 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
-        /// <param name="code">code.</param>
-        /// <param name="type">type.</param>
-        /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        /// <param name="Code">Code.</param>
+        /// <param name="Type">Type.</param>
+        /// <param name="Message">Message.</param>
+        public ApiResponse( int Code = default(int), string Type = default(string), string Message = default(string))
         {
-            this.Code = code;
-            this.Type = type;
-            this.Message = message;
+            this.Code = Code;
+            this.Type = Type;
+            this.Message = Message;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Category.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Category(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Category( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Order.cs
@@ -69,20 +69,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="petId">petId.</param>
-        /// <param name="quantity">quantity.</param>
-        /// <param name="shipDate">shipDate.</param>
-        /// <param name="status">Order Status.</param>
-        /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        /// <param name="Id">Id.</param>
+        /// <param name="PetId">PetId.</param>
+        /// <param name="Quantity">Quantity.</param>
+        /// <param name="ShipDate">ShipDate.</param>
+        /// <param name="Status">Order Status.</param>
+        /// <param name="Complete">Complete (default to false).</param>
+        public Order( long Id = default(long), long PetId = default(long), int Quantity = default(int), DateTime ShipDate = default(DateTime), StatusEnum? Status = default(StatusEnum?), bool Complete = false)
         {
-            this.Id = id;
-            this.PetId = petId;
-            this.Quantity = quantity;
-            this.ShipDate = shipDate;
-            this.Status = status;
-            this.Complete = complete;
+            this.Id = Id;
+            this.PetId = PetId;
+            this.Quantity = Quantity;
+            this.ShipDate = ShipDate;
+            this.Status = Status;
+            this.Complete = Complete;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Pet.cs
@@ -75,30 +75,30 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="category">category.</param>
-        /// <param name="name">name (required).</param>
-        /// <param name="photoUrls">photoUrls (required).</param>
-        /// <param name="tags">tags.</param>
-        /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        /// <param name="Id">Id.</param>
+        /// <param name="Category">Category.</param>
+        /// <param name="Name">Name (required).</param>
+        /// <param name="PhotoUrls">PhotoUrls (required).</param>
+        /// <param name="Tags">Tags.</param>
+        /// <param name="Status">pet status in the store.</param>
+        public Pet( long Id = default(long), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
+            // to ensure "Name" is required (not null)
+            if (Name == null)
             {
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("Name is a required property for Pet and cannot be null");
             }
-            this.Name = name;
-            // to ensure "photoUrls" is required (not null)
-            if (photoUrls == null)
+            this.Name = Name;
+            // to ensure "PhotoUrls" is required (not null)
+            if (PhotoUrls == null)
             {
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+                throw new ArgumentNullException("PhotoUrls is a required property for Pet and cannot be null");
             }
-            this.PhotoUrls = photoUrls;
-            this.Id = id;
-            this.Category = category;
-            this.Tags = tags;
-            this.Status = status;
+            this.PhotoUrls = PhotoUrls;
+            this.Id = Id;
+            this.Category = Category;
+            this.Tags = Tags;
+            this.Status = Status;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        /// <param name="Id">Id.</param>
+        /// <param name="Name">Name.</param>
+        public Tag( long Id = default(long), string Name = default(string))
         {
-            this.Id = id;
-            this.Name = name;
+            this.Id = Id;
+            this.Name = Name;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/User.cs
@@ -35,24 +35,24 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
-        /// <param name="id">id.</param>
-        /// <param name="username">username.</param>
-        /// <param name="firstName">firstName.</param>
-        /// <param name="lastName">lastName.</param>
-        /// <param name="email">email.</param>
-        /// <param name="password">password.</param>
-        /// <param name="phone">phone.</param>
-        /// <param name="userStatus">User Status.</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int))
+        /// <param name="Id">Id.</param>
+        /// <param name="Username">Username.</param>
+        /// <param name="FirstName">FirstName.</param>
+        /// <param name="LastName">LastName.</param>
+        /// <param name="Email">Email.</param>
+        /// <param name="Password">Password.</param>
+        /// <param name="Phone">Phone.</param>
+        /// <param name="UserStatus">User Status.</param>
+        public User( long Id = default(long), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int UserStatus = default(int))
         {
-            this.Id = id;
-            this.Username = username;
-            this.FirstName = firstName;
-            this.LastName = lastName;
-            this.Email = email;
-            this.Password = password;
-            this.Phone = phone;
-            this.UserStatus = userStatus;
+            this.Id = Id;
+            this.Username = Username;
+            this.FirstName = FirstName;
+            this.LastName = LastName;
+            this.Email = Email;
+            this.Password = Password;
+            this.Phone = Phone;
+            this.UserStatus = UserStatus;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

resolve #14571 

This PR resolves the issue by removing camelCase transformation in models constructor for csharp-netcore.

Using this OpenApi specificatin file 


```json
{
    "openapi": "3.0.1",
    "info": {
        "title": "My Web API",
        "description": "My Web API",
        "version": "1.22.2"
    },
    "tags": [],
    "paths": {},
    "components": {
        "schemas": {
            "MyTokenType": {
                "type": "string",
                "description": "Token type",
                "enum": [
                    "JWT",
                    "OIDC_ACCESS_TOKEN"
                ],
                "x-enum-descriptions": [
                    "JWT",
                    "OIDC_ACCESS_TOKEN"
                ]
            },
            "MyTokenRequest": {
                "type": "object",
                "description": "My token request",
                "properties": {
                    "$_type": {
                        "type": "string",
                        "default": "MyTokenRequest",
                        "enum": [
                            "MyTokenRequest"
                        ]
                    },
                    "token": {
                        "type": "string"
                    },
                    "type": {
                        "$ref": "#/components/schemas/MyTokenType"
                    }
                }
            }
        }
    }
}
```

And using this config file

```json
{
    "packageName" : "com.myApi",
    "nullableReferenceTypes" : true,
    "targetFramework" : "net6.0",
    "modelPropertyNaming" : "snake_case"
}
```

And using this command

`npx openapi-generator-cli generate -i swagger_simple_anonymised.json -g csharp-netcore -o out_dotnet -c openApiGeneratorConfig.json`

Without the fix, the resulted constructor was
```c#
 public MyTokenRequest(TypeEnum? type = TypeEnum.MyTokenRequest, string token = default(string), MyTokenType? type = default(MyTokenType?))
        {
            this._type = type;
            this.token = token;
            this.type = type;
        }
```

With the fix, the resulted constructor is now
```c#
public MyTokenRequest(TypeEnum? _type = TypeEnum.MyTokenRequest, string token = default(string), MyTokenType? type = default(MyTokenType?))
        {
            this._type = _type;
            this.token = token;
            this.type = type;
        }
```

See issue [#14571](https://github.com/OpenAPITools/openapi-generator/issues/14571) to know more

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] (Not needed here) In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean @shibayan @Blackclaws @lucamazzanti 