### PR TITLE
fix(sec): upgrade websockets to 10.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -33,4 +33,4 @@ urllib3==1.26.5
 uvicorn==0.13.4
 uvloop==0.14.0
 watchgod==0.7
-websockets==8.1
+websockets==10.0

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -33,4 +33,4 @@ urllib3==1.26.5
 uvicorn==0.13.4
 uvloop==0.14.0
 watchgod==0.7
-websockets==8.1
+websockets==10.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in websockets 8.1
- [CVE-2021-33880](https://www.oscs1024.com/hd/CVE-2021-33880)


### What did I do？
Upgrade websockets from 8.1 to 10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS