### PR TITLE
Set proxy in ruby faraday client if configured

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -133,7 +133,7 @@
     end
 
     def build_connection
-      Faraday.new(url: config.base_url, ssl: ssl_options) do |conn|
+      Faraday.new(url: config.base_url, ssl: ssl_options, proxy: config.proxy) do |conn|
         basic_auth(conn)
         config.configure_middleware(conn)
         yield(conn) if block_given?

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
@@ -83,6 +83,43 @@ describe {{moduleName}}::ApiClient do
   end
 
 {{/isFaraday}}
+
+{{#isFaraday}}
+  describe 'proxy in #build_connection' do
+    let(:config) { {{moduleName}}::Configuration.new }
+    let(:api_client) { {{moduleName}}::ApiClient.new(config) }
+    let(:proxy_uri) { URI('http://example.org:8080') }
+
+    it 'defaults to nil' do
+      expect({{moduleName}}::Configuration.default.proxy).to be_nil
+      expect(config.proxy).to be_nil
+
+      connection = api_client.build_connection
+      expect(connection.proxy_for_request('/test')).to be_nil
+    end
+
+    it 'can be customized with a string' do
+      config.proxy = proxy_uri.to_s
+
+      connection = api_client.build_connection
+      configured_proxy = connection.proxy_for_request('/test)
+
+      expect(configured_proxy).not_to be_nil
+      expect(configured_proxy.uri.to_s).to eq proxy_uri.to_s
+    end
+
+    it 'can be customized with a hash' do
+      config.proxy = { uri: proxy_uri }
+
+      connection = api_client.build_connection
+      configured_proxy = connection.proxy_for_request('/test)
+
+      expect(configured_proxy).not_to be_nil
+      expect(configured_proxy.uri).to eq proxy_uri
+    end
+  end
+{{/isFaraday}}
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = {{moduleName}}::ApiClient.new

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
@@ -102,7 +102,7 @@ describe {{moduleName}}::ApiClient do
       config.proxy = proxy_uri.to_s
 
       connection = api_client.build_connection
-      configured_proxy = connection.proxy_for_request('/test)
+      configured_proxy = connection.proxy_for_request('/test')
 
       expect(configured_proxy).not_to be_nil
       expect(configured_proxy.uri.to_s).to eq proxy_uri.to_s
@@ -112,7 +112,7 @@ describe {{moduleName}}::ApiClient do
       config.proxy = { uri: proxy_uri }
 
       connection = api_client.build_connection
-      configured_proxy = connection.proxy_for_request('/test)
+      configured_proxy = connection.proxy_for_request('/test')
 
       expect(configured_proxy).not_to be_nil
       expect(configured_proxy.uri).to eq proxy_uri

--- a/samples/client/petstore/ruby-autoload/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby-autoload/spec/api_client_spec.rb
@@ -89,6 +89,8 @@ describe Petstore::ApiClient do
     end
   end
 
+
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = Petstore::ApiClient.new

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -178,7 +178,7 @@ module Petstore
     end
 
     def build_connection
-      Faraday.new(url: config.base_url, ssl: ssl_options) do |conn|
+      Faraday.new(url: config.base_url, ssl: ssl_options, proxy: config.proxy) do |conn|
         basic_auth(conn)
         config.configure_middleware(conn)
         yield(conn) if block_given?

--- a/samples/client/petstore/ruby-faraday/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby-faraday/spec/api_client_spec.rb
@@ -51,6 +51,41 @@ describe Petstore::ApiClient do
     end
   end
 
+
+  describe 'proxy in #build_connection' do
+    let(:config) { Petstore::Configuration.new }
+    let(:api_client) { Petstore::ApiClient.new(config) }
+    let(:proxy_uri) { URI('http://example.org:8080') }
+
+    it 'defaults to nil' do
+      expect(Petstore::Configuration.default.proxy).to be_nil
+      expect(config.proxy).to be_nil
+
+      connection = api_client.build_connection
+      expect(connection.proxy_for_request('/test')).to be_nil
+    end
+
+    it 'can be customized with a string' do
+      config.proxy = proxy_uri.to_s
+
+      connection = api_client.build_connection
+      configured_proxy = connection.proxy_for_request('/test')
+
+      expect(configured_proxy).not_to be_nil
+      expect(configured_proxy.uri.to_s).to eq proxy_uri.to_s
+    end
+
+    it 'can be customized with a hash' do
+      config.proxy = { uri: proxy_uri }
+
+      connection = api_client.build_connection
+      configured_proxy = connection.proxy_for_request('/test')
+
+      expect(configured_proxy).not_to be_nil
+      expect(configured_proxy.uri).to eq proxy_uri
+    end
+  end
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = Petstore::ApiClient.new

--- a/samples/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby/spec/api_client_spec.rb
@@ -89,6 +89,8 @@ describe Petstore::ApiClient do
     end
   end
 
+
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = Petstore::ApiClient.new

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/spec/api_client_spec.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/spec/api_client_spec.rb
@@ -89,6 +89,8 @@ describe XAuthIDAlias::ApiClient do
     end
   end
 
+
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = XAuthIDAlias::ApiClient.new

--- a/samples/openapi3/client/features/dynamic-servers/ruby/spec/api_client_spec.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/spec/api_client_spec.rb
@@ -89,6 +89,8 @@ describe DynamicServers::ApiClient do
     end
   end
 
+
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = DynamicServers::ApiClient.new

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/spec/api_client_spec.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/spec/api_client_spec.rb
@@ -89,6 +89,8 @@ describe Petstore::ApiClient do
     end
   end
 
+
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = Petstore::ApiClient.new


### PR DESCRIPTION
This PR relates to the bug reported in #14596 and configures the proxy for the Ruby Faraday client if a proxy is configured. It also adds a spec to ensure the proxy is set properly.

@cliffano @zlx @autopp 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
