### PR TITLE
[Go] Export isNil function in utils.go

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -125,7 +125,7 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 // Deprecated
 {{/deprecated}}
 func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
-	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || isNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 {{^isFreeFormObject}}
 		return nil, false
 	{{/isFreeFormObject}}
@@ -171,7 +171,7 @@ func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 // Deprecated
 {{/deprecated}}
 func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
-	if o == nil{{^isNullable}} || isNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || isNil(o.{{name}}.Get()){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}.Get()){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 		var ret {{vendorExtensions.x-go-base-type}}
 		return ret
 	}
@@ -197,7 +197,7 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 // Deprecated
 {{/deprecated}}
 func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
-	if o == nil{{^isNullable}} || isNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || isNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 	{{^isFreeFormObject}}
 		return nil, false
 	{{/isFreeFormObject}}
@@ -220,7 +220,7 @@ func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/is
 
 // Has{{name}} returns a boolean if a field has been set.
 func (o *{{classname}}) Has{{name}}() bool {
-	if o != nil && {{^isNullable}}!isNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}isNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	if o != nil && {{^isNullable}}!IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 		return true
 	}
 
@@ -316,7 +316,7 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	toSerialize["{{baseName}}"] = o.{{name}}
 	{{/required}}
 	{{^required}}
-	if !isNil(o.{{name}}) {
+	if !IsNil(o.{{name}}) {
 		toSerialize["{{baseName}}"] = o.{{name}}
 	}
 	{{/required}}

--- a/modules/openapi-generator/src/main/resources/go/utils.mustache
+++ b/modules/openapi-generator/src/main/resources/go/utils.mustache
@@ -319,8 +319,8 @@ func (v *NullableTime) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-// isNil checks if an input is nil
-func isNil(i interface{}) bool {
+// IsNil checks if an input is nil
+func IsNil(i interface{}) bool {
 	if i == nil {
 		return true
 	}

--- a/samples/client/petstore/go/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go/go-petstore/model_200_response.go
@@ -42,7 +42,7 @@ func NewModel200ResponseWithDefaults() *Model200Response {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *Model200Response) GetName() int32 {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret int32
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *Model200Response) GetName() int32 {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetNameOk() (*int32, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -60,7 +60,7 @@ func (o *Model200Response) GetNameOk() (*int32, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *Model200Response) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -74,7 +74,7 @@ func (o *Model200Response) SetName(v int32) {
 
 // GetClass returns the Class field value if set, zero value otherwise.
 func (o *Model200Response) GetClass() string {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		var ret string
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *Model200Response) GetClass() string {
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetClassOk() (*string, bool) {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		return nil, false
 	}
 	return o.Class, true
@@ -92,7 +92,7 @@ func (o *Model200Response) GetClassOk() (*string, bool) {
 
 // HasClass returns a boolean if a field has been set.
 func (o *Model200Response) HasClass() bool {
-	if o != nil && !isNil(o.Class) {
+	if o != nil && !IsNil(o.Class) {
 		return true
 	}
 
@@ -114,10 +114,10 @@ func (o Model200Response) MarshalJSON() ([]byte, error) {
 
 func (o Model200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
-	if !isNil(o.Class) {
+	if !IsNil(o.Class) {
 		toSerialize["class"] = o.Class
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesAnyTypeWithDefaults() *AdditionalPropertiesAnyType {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesAnyType) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesAnyType) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesAnyType) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesAnyType) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesAnyType) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesAnyType) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesArrayWithDefaults() *AdditionalPropertiesArray {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesArray) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesArray) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesArray) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesArray) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesArray) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesArray) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesArray) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesBooleanWithDefaults() *AdditionalPropertiesBoolean {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesBoolean) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesBoolean) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesBoolean) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesBoolean) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesBoolean) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesBoolean) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesBoolean) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_class.go
@@ -51,7 +51,7 @@ func NewAdditionalPropertiesClassWithDefaults() *AdditionalPropertiesClass {
 
 // GetMapString returns the MapString field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapString() map[string]string {
-	if o == nil || isNil(o.MapString) {
+	if o == nil || IsNil(o.MapString) {
 		var ret map[string]string
 		return ret
 	}
@@ -61,7 +61,7 @@ func (o *AdditionalPropertiesClass) GetMapString() map[string]string {
 // GetMapStringOk returns a tuple with the MapString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapStringOk() (*map[string]string, bool) {
-	if o == nil || isNil(o.MapString) {
+	if o == nil || IsNil(o.MapString) {
 		return nil, false
 	}
 	return o.MapString, true
@@ -69,7 +69,7 @@ func (o *AdditionalPropertiesClass) GetMapStringOk() (*map[string]string, bool) 
 
 // HasMapString returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapString() bool {
-	if o != nil && !isNil(o.MapString) {
+	if o != nil && !IsNil(o.MapString) {
 		return true
 	}
 
@@ -83,7 +83,7 @@ func (o *AdditionalPropertiesClass) SetMapString(v map[string]string) {
 
 // GetMapNumber returns the MapNumber field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapNumber() map[string]float32 {
-	if o == nil || isNil(o.MapNumber) {
+	if o == nil || IsNil(o.MapNumber) {
 		var ret map[string]float32
 		return ret
 	}
@@ -93,7 +93,7 @@ func (o *AdditionalPropertiesClass) GetMapNumber() map[string]float32 {
 // GetMapNumberOk returns a tuple with the MapNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapNumberOk() (*map[string]float32, bool) {
-	if o == nil || isNil(o.MapNumber) {
+	if o == nil || IsNil(o.MapNumber) {
 		return nil, false
 	}
 	return o.MapNumber, true
@@ -101,7 +101,7 @@ func (o *AdditionalPropertiesClass) GetMapNumberOk() (*map[string]float32, bool)
 
 // HasMapNumber returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapNumber() bool {
-	if o != nil && !isNil(o.MapNumber) {
+	if o != nil && !IsNil(o.MapNumber) {
 		return true
 	}
 
@@ -115,7 +115,7 @@ func (o *AdditionalPropertiesClass) SetMapNumber(v map[string]float32) {
 
 // GetMapInteger returns the MapInteger field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapInteger() map[string]int32 {
-	if o == nil || isNil(o.MapInteger) {
+	if o == nil || IsNil(o.MapInteger) {
 		var ret map[string]int32
 		return ret
 	}
@@ -125,7 +125,7 @@ func (o *AdditionalPropertiesClass) GetMapInteger() map[string]int32 {
 // GetMapIntegerOk returns a tuple with the MapInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapIntegerOk() (*map[string]int32, bool) {
-	if o == nil || isNil(o.MapInteger) {
+	if o == nil || IsNil(o.MapInteger) {
 		return nil, false
 	}
 	return o.MapInteger, true
@@ -133,7 +133,7 @@ func (o *AdditionalPropertiesClass) GetMapIntegerOk() (*map[string]int32, bool) 
 
 // HasMapInteger returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapInteger() bool {
-	if o != nil && !isNil(o.MapInteger) {
+	if o != nil && !IsNil(o.MapInteger) {
 		return true
 	}
 
@@ -147,7 +147,7 @@ func (o *AdditionalPropertiesClass) SetMapInteger(v map[string]int32) {
 
 // GetMapBoolean returns the MapBoolean field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapBoolean() map[string]bool {
-	if o == nil || isNil(o.MapBoolean) {
+	if o == nil || IsNil(o.MapBoolean) {
 		var ret map[string]bool
 		return ret
 	}
@@ -157,7 +157,7 @@ func (o *AdditionalPropertiesClass) GetMapBoolean() map[string]bool {
 // GetMapBooleanOk returns a tuple with the MapBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapBooleanOk() (*map[string]bool, bool) {
-	if o == nil || isNil(o.MapBoolean) {
+	if o == nil || IsNil(o.MapBoolean) {
 		return nil, false
 	}
 	return o.MapBoolean, true
@@ -165,7 +165,7 @@ func (o *AdditionalPropertiesClass) GetMapBooleanOk() (*map[string]bool, bool) {
 
 // HasMapBoolean returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapBoolean() bool {
-	if o != nil && !isNil(o.MapBoolean) {
+	if o != nil && !IsNil(o.MapBoolean) {
 		return true
 	}
 
@@ -179,7 +179,7 @@ func (o *AdditionalPropertiesClass) SetMapBoolean(v map[string]bool) {
 
 // GetMapArrayInteger returns the MapArrayInteger field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapArrayInteger() map[string][]int32 {
-	if o == nil || isNil(o.MapArrayInteger) {
+	if o == nil || IsNil(o.MapArrayInteger) {
 		var ret map[string][]int32
 		return ret
 	}
@@ -189,7 +189,7 @@ func (o *AdditionalPropertiesClass) GetMapArrayInteger() map[string][]int32 {
 // GetMapArrayIntegerOk returns a tuple with the MapArrayInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (*map[string][]int32, bool) {
-	if o == nil || isNil(o.MapArrayInteger) {
+	if o == nil || IsNil(o.MapArrayInteger) {
 		return nil, false
 	}
 	return o.MapArrayInteger, true
@@ -197,7 +197,7 @@ func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (*map[string][]int32,
 
 // HasMapArrayInteger returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapArrayInteger() bool {
-	if o != nil && !isNil(o.MapArrayInteger) {
+	if o != nil && !IsNil(o.MapArrayInteger) {
 		return true
 	}
 
@@ -211,7 +211,7 @@ func (o *AdditionalPropertiesClass) SetMapArrayInteger(v map[string][]int32) {
 
 // GetMapArrayAnytype returns the MapArrayAnytype field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapArrayAnytype() map[string][]map[string]interface{} {
-	if o == nil || isNil(o.MapArrayAnytype) {
+	if o == nil || IsNil(o.MapArrayAnytype) {
 		var ret map[string][]map[string]interface{}
 		return ret
 	}
@@ -221,7 +221,7 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytype() map[string][]map[string
 // GetMapArrayAnytypeOk returns a tuple with the MapArrayAnytype field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (*map[string][]map[string]interface{}, bool) {
-	if o == nil || isNil(o.MapArrayAnytype) {
+	if o == nil || IsNil(o.MapArrayAnytype) {
 		return nil, false
 	}
 	return o.MapArrayAnytype, true
@@ -229,7 +229,7 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (*map[string][]map[st
 
 // HasMapArrayAnytype returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapArrayAnytype() bool {
-	if o != nil && !isNil(o.MapArrayAnytype) {
+	if o != nil && !IsNil(o.MapArrayAnytype) {
 		return true
 	}
 
@@ -243,7 +243,7 @@ func (o *AdditionalPropertiesClass) SetMapArrayAnytype(v map[string][]map[string
 
 // GetMapMapString returns the MapMapString field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapMapString() map[string]map[string]string {
-	if o == nil || isNil(o.MapMapString) {
+	if o == nil || IsNil(o.MapMapString) {
 		var ret map[string]map[string]string
 		return ret
 	}
@@ -253,7 +253,7 @@ func (o *AdditionalPropertiesClass) GetMapMapString() map[string]map[string]stri
 // GetMapMapStringOk returns a tuple with the MapMapString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapMapStringOk() (*map[string]map[string]string, bool) {
-	if o == nil || isNil(o.MapMapString) {
+	if o == nil || IsNil(o.MapMapString) {
 		return nil, false
 	}
 	return o.MapMapString, true
@@ -261,7 +261,7 @@ func (o *AdditionalPropertiesClass) GetMapMapStringOk() (*map[string]map[string]
 
 // HasMapMapString returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapMapString() bool {
-	if o != nil && !isNil(o.MapMapString) {
+	if o != nil && !IsNil(o.MapMapString) {
 		return true
 	}
 
@@ -275,7 +275,7 @@ func (o *AdditionalPropertiesClass) SetMapMapString(v map[string]map[string]stri
 
 // GetMapMapAnytype returns the MapMapAnytype field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapMapAnytype() map[string]map[string]map[string]interface{} {
-	if o == nil || isNil(o.MapMapAnytype) {
+	if o == nil || IsNil(o.MapMapAnytype) {
 		var ret map[string]map[string]map[string]interface{}
 		return ret
 	}
@@ -285,7 +285,7 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytype() map[string]map[string]map
 // GetMapMapAnytypeOk returns a tuple with the MapMapAnytype field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (*map[string]map[string]map[string]interface{}, bool) {
-	if o == nil || isNil(o.MapMapAnytype) {
+	if o == nil || IsNil(o.MapMapAnytype) {
 		return nil, false
 	}
 	return o.MapMapAnytype, true
@@ -293,7 +293,7 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (*map[string]map[string
 
 // HasMapMapAnytype returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapMapAnytype() bool {
-	if o != nil && !isNil(o.MapMapAnytype) {
+	if o != nil && !IsNil(o.MapMapAnytype) {
 		return true
 	}
 
@@ -307,7 +307,7 @@ func (o *AdditionalPropertiesClass) SetMapMapAnytype(v map[string]map[string]map
 
 // GetAnytype1 returns the Anytype1 field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetAnytype1() map[string]interface{} {
-	if o == nil || isNil(o.Anytype1) {
+	if o == nil || IsNil(o.Anytype1) {
 		var ret map[string]interface{}
 		return ret
 	}
@@ -317,7 +317,7 @@ func (o *AdditionalPropertiesClass) GetAnytype1() map[string]interface{} {
 // GetAnytype1Ok returns a tuple with the Anytype1 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, bool) {
-	if o == nil || isNil(o.Anytype1) {
+	if o == nil || IsNil(o.Anytype1) {
 		return map[string]interface{}{}, false
 	}
 	return o.Anytype1, true
@@ -325,7 +325,7 @@ func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, boo
 
 // HasAnytype1 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype1() bool {
-	if o != nil && !isNil(o.Anytype1) {
+	if o != nil && !IsNil(o.Anytype1) {
 		return true
 	}
 
@@ -339,7 +339,7 @@ func (o *AdditionalPropertiesClass) SetAnytype1(v map[string]interface{}) {
 
 // GetAnytype2 returns the Anytype2 field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetAnytype2() map[string]interface{} {
-	if o == nil || isNil(o.Anytype2) {
+	if o == nil || IsNil(o.Anytype2) {
 		var ret map[string]interface{}
 		return ret
 	}
@@ -349,7 +349,7 @@ func (o *AdditionalPropertiesClass) GetAnytype2() map[string]interface{} {
 // GetAnytype2Ok returns a tuple with the Anytype2 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, bool) {
-	if o == nil || isNil(o.Anytype2) {
+	if o == nil || IsNil(o.Anytype2) {
 		return map[string]interface{}{}, false
 	}
 	return o.Anytype2, true
@@ -357,7 +357,7 @@ func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, boo
 
 // HasAnytype2 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype2() bool {
-	if o != nil && !isNil(o.Anytype2) {
+	if o != nil && !IsNil(o.Anytype2) {
 		return true
 	}
 
@@ -371,7 +371,7 @@ func (o *AdditionalPropertiesClass) SetAnytype2(v map[string]interface{}) {
 
 // GetAnytype3 returns the Anytype3 field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetAnytype3() map[string]interface{} {
-	if o == nil || isNil(o.Anytype3) {
+	if o == nil || IsNil(o.Anytype3) {
 		var ret map[string]interface{}
 		return ret
 	}
@@ -381,7 +381,7 @@ func (o *AdditionalPropertiesClass) GetAnytype3() map[string]interface{} {
 // GetAnytype3Ok returns a tuple with the Anytype3 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, bool) {
-	if o == nil || isNil(o.Anytype3) {
+	if o == nil || IsNil(o.Anytype3) {
 		return map[string]interface{}{}, false
 	}
 	return o.Anytype3, true
@@ -389,7 +389,7 @@ func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, boo
 
 // HasAnytype3 returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasAnytype3() bool {
-	if o != nil && !isNil(o.Anytype3) {
+	if o != nil && !IsNil(o.Anytype3) {
 		return true
 	}
 
@@ -411,37 +411,37 @@ func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesClass) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.MapString) {
+	if !IsNil(o.MapString) {
 		toSerialize["map_string"] = o.MapString
 	}
-	if !isNil(o.MapNumber) {
+	if !IsNil(o.MapNumber) {
 		toSerialize["map_number"] = o.MapNumber
 	}
-	if !isNil(o.MapInteger) {
+	if !IsNil(o.MapInteger) {
 		toSerialize["map_integer"] = o.MapInteger
 	}
-	if !isNil(o.MapBoolean) {
+	if !IsNil(o.MapBoolean) {
 		toSerialize["map_boolean"] = o.MapBoolean
 	}
-	if !isNil(o.MapArrayInteger) {
+	if !IsNil(o.MapArrayInteger) {
 		toSerialize["map_array_integer"] = o.MapArrayInteger
 	}
-	if !isNil(o.MapArrayAnytype) {
+	if !IsNil(o.MapArrayAnytype) {
 		toSerialize["map_array_anytype"] = o.MapArrayAnytype
 	}
-	if !isNil(o.MapMapString) {
+	if !IsNil(o.MapMapString) {
 		toSerialize["map_map_string"] = o.MapMapString
 	}
-	if !isNil(o.MapMapAnytype) {
+	if !IsNil(o.MapMapAnytype) {
 		toSerialize["map_map_anytype"] = o.MapMapAnytype
 	}
-	if !isNil(o.Anytype1) {
+	if !IsNil(o.Anytype1) {
 		toSerialize["anytype_1"] = o.Anytype1
 	}
-	if !isNil(o.Anytype2) {
+	if !IsNil(o.Anytype2) {
 		toSerialize["anytype_2"] = o.Anytype2
 	}
-	if !isNil(o.Anytype3) {
+	if !IsNil(o.Anytype3) {
 		toSerialize["anytype_3"] = o.Anytype3
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesIntegerWithDefaults() *AdditionalPropertiesInteger {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesInteger) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesInteger) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesInteger) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesInteger) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesInteger) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesInteger) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesInteger) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesNumberWithDefaults() *AdditionalPropertiesNumber {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesNumber) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesNumber) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesNumber) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesNumber) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesNumber) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesNumber) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesNumber) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesObjectWithDefaults() *AdditionalPropertiesObject {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesObject) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesObject) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesObject) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesObject) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesObject) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesObject) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesObject) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
@@ -41,7 +41,7 @@ func NewAdditionalPropertiesStringWithDefaults() *AdditionalPropertiesString {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *AdditionalPropertiesString) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *AdditionalPropertiesString) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesString) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesString) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *AdditionalPropertiesString) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o AdditionalPropertiesString) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesString) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -71,7 +71,7 @@ func (o *Animal) SetClassName(v string) {
 
 // GetColor returns the Color field value if set, zero value otherwise.
 func (o *Animal) GetColor() string {
-	if o == nil || isNil(o.Color) {
+	if o == nil || IsNil(o.Color) {
 		var ret string
 		return ret
 	}
@@ -81,7 +81,7 @@ func (o *Animal) GetColor() string {
 // GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Animal) GetColorOk() (*string, bool) {
-	if o == nil || isNil(o.Color) {
+	if o == nil || IsNil(o.Color) {
 		return nil, false
 	}
 	return o.Color, true
@@ -89,7 +89,7 @@ func (o *Animal) GetColorOk() (*string, bool) {
 
 // HasColor returns a boolean if a field has been set.
 func (o *Animal) HasColor() bool {
-	if o != nil && !isNil(o.Color) {
+	if o != nil && !IsNil(o.Color) {
 		return true
 	}
 
@@ -112,7 +112,7 @@ func (o Animal) MarshalJSON() ([]byte, error) {
 func (o Animal) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["className"] = o.ClassName
-	if !isNil(o.Color) {
+	if !IsNil(o.Color) {
 		toSerialize["color"] = o.Color
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go/go-petstore/model_api_response.go
@@ -43,7 +43,7 @@ func NewApiResponseWithDefaults() *ApiResponse {
 
 // GetCode returns the Code field value if set, zero value otherwise.
 func (o *ApiResponse) GetCode() int32 {
-	if o == nil || isNil(o.Code) {
+	if o == nil || IsNil(o.Code) {
 		var ret int32
 		return ret
 	}
@@ -53,7 +53,7 @@ func (o *ApiResponse) GetCode() int32 {
 // GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetCodeOk() (*int32, bool) {
-	if o == nil || isNil(o.Code) {
+	if o == nil || IsNil(o.Code) {
 		return nil, false
 	}
 	return o.Code, true
@@ -61,7 +61,7 @@ func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 
 // HasCode returns a boolean if a field has been set.
 func (o *ApiResponse) HasCode() bool {
-	if o != nil && !isNil(o.Code) {
+	if o != nil && !IsNil(o.Code) {
 		return true
 	}
 
@@ -75,7 +75,7 @@ func (o *ApiResponse) SetCode(v int32) {
 
 // GetType returns the Type field value if set, zero value otherwise.
 func (o *ApiResponse) GetType() string {
-	if o == nil || isNil(o.Type) {
+	if o == nil || IsNil(o.Type) {
 		var ret string
 		return ret
 	}
@@ -85,7 +85,7 @@ func (o *ApiResponse) GetType() string {
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetTypeOk() (*string, bool) {
-	if o == nil || isNil(o.Type) {
+	if o == nil || IsNil(o.Type) {
 		return nil, false
 	}
 	return o.Type, true
@@ -93,7 +93,7 @@ func (o *ApiResponse) GetTypeOk() (*string, bool) {
 
 // HasType returns a boolean if a field has been set.
 func (o *ApiResponse) HasType() bool {
-	if o != nil && !isNil(o.Type) {
+	if o != nil && !IsNil(o.Type) {
 		return true
 	}
 
@@ -107,7 +107,7 @@ func (o *ApiResponse) SetType(v string) {
 
 // GetMessage returns the Message field value if set, zero value otherwise.
 func (o *ApiResponse) GetMessage() string {
-	if o == nil || isNil(o.Message) {
+	if o == nil || IsNil(o.Message) {
 		var ret string
 		return ret
 	}
@@ -117,7 +117,7 @@ func (o *ApiResponse) GetMessage() string {
 // GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetMessageOk() (*string, bool) {
-	if o == nil || isNil(o.Message) {
+	if o == nil || IsNil(o.Message) {
 		return nil, false
 	}
 	return o.Message, true
@@ -125,7 +125,7 @@ func (o *ApiResponse) GetMessageOk() (*string, bool) {
 
 // HasMessage returns a boolean if a field has been set.
 func (o *ApiResponse) HasMessage() bool {
-	if o != nil && !isNil(o.Message) {
+	if o != nil && !IsNil(o.Message) {
 		return true
 	}
 
@@ -147,13 +147,13 @@ func (o ApiResponse) MarshalJSON() ([]byte, error) {
 
 func (o ApiResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Code) {
+	if !IsNil(o.Code) {
 		toSerialize["code"] = o.Code
 	}
-	if !isNil(o.Type) {
+	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
-	if !isNil(o.Message) {
+	if !IsNil(o.Message) {
 		toSerialize["message"] = o.Message
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
@@ -41,7 +41,7 @@ func NewArrayOfArrayOfNumberOnlyWithDefaults() *ArrayOfArrayOfNumberOnly {
 
 // GetArrayArrayNumber returns the ArrayArrayNumber field value if set, zero value otherwise.
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
-	if o == nil || isNil(o.ArrayArrayNumber) {
+	if o == nil || IsNil(o.ArrayArrayNumber) {
 		var ret [][]float32
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 // GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
-	if o == nil || isNil(o.ArrayArrayNumber) {
+	if o == nil || IsNil(o.ArrayArrayNumber) {
 		return nil, false
 	}
 	return o.ArrayArrayNumber, true
@@ -59,7 +59,7 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 
 // HasArrayArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool {
-	if o != nil && !isNil(o.ArrayArrayNumber) {
+	if o != nil && !IsNil(o.ArrayArrayNumber) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 
 func (o ArrayOfArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.ArrayArrayNumber) {
+	if !IsNil(o.ArrayArrayNumber) {
 		toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go/go-petstore/model_array_of_number_only.go
@@ -41,7 +41,7 @@ func NewArrayOfNumberOnlyWithDefaults() *ArrayOfNumberOnly {
 
 // GetArrayNumber returns the ArrayNumber field value if set, zero value otherwise.
 func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
-	if o == nil || isNil(o.ArrayNumber) {
+	if o == nil || IsNil(o.ArrayNumber) {
 		var ret []float32
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 // GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
-	if o == nil || isNil(o.ArrayNumber) {
+	if o == nil || IsNil(o.ArrayNumber) {
 		return nil, false
 	}
 	return o.ArrayNumber, true
@@ -59,7 +59,7 @@ func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 
 // HasArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfNumberOnly) HasArrayNumber() bool {
-	if o != nil && !isNil(o.ArrayNumber) {
+	if o != nil && !IsNil(o.ArrayNumber) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 
 func (o ArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.ArrayNumber) {
+	if !IsNil(o.ArrayNumber) {
 		toSerialize["ArrayNumber"] = o.ArrayNumber
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_array_test_.go
@@ -43,7 +43,7 @@ func NewArrayTestWithDefaults() *ArrayTest {
 
 // GetArrayOfString returns the ArrayOfString field value if set, zero value otherwise.
 func (o *ArrayTest) GetArrayOfString() []string {
-	if o == nil || isNil(o.ArrayOfString) {
+	if o == nil || IsNil(o.ArrayOfString) {
 		var ret []string
 		return ret
 	}
@@ -53,7 +53,7 @@ func (o *ArrayTest) GetArrayOfString() []string {
 // GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
-	if o == nil || isNil(o.ArrayOfString) {
+	if o == nil || IsNil(o.ArrayOfString) {
 		return nil, false
 	}
 	return o.ArrayOfString, true
@@ -61,7 +61,7 @@ func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 
 // HasArrayOfString returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayOfString() bool {
-	if o != nil && !isNil(o.ArrayOfString) {
+	if o != nil && !IsNil(o.ArrayOfString) {
 		return true
 	}
 
@@ -75,7 +75,7 @@ func (o *ArrayTest) SetArrayOfString(v []string) {
 
 // GetArrayArrayOfInteger returns the ArrayArrayOfInteger field value if set, zero value otherwise.
 func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
-	if o == nil || isNil(o.ArrayArrayOfInteger) {
+	if o == nil || IsNil(o.ArrayArrayOfInteger) {
 		var ret [][]int64
 		return ret
 	}
@@ -85,7 +85,7 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 // GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
-	if o == nil || isNil(o.ArrayArrayOfInteger) {
+	if o == nil || IsNil(o.ArrayArrayOfInteger) {
 		return nil, false
 	}
 	return o.ArrayArrayOfInteger, true
@@ -93,7 +93,7 @@ func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfInteger() bool {
-	if o != nil && !isNil(o.ArrayArrayOfInteger) {
+	if o != nil && !IsNil(o.ArrayArrayOfInteger) {
 		return true
 	}
 
@@ -107,7 +107,7 @@ func (o *ArrayTest) SetArrayArrayOfInteger(v [][]int64) {
 
 // GetArrayArrayOfModel returns the ArrayArrayOfModel field value if set, zero value otherwise.
 func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
-	if o == nil || isNil(o.ArrayArrayOfModel) {
+	if o == nil || IsNil(o.ArrayArrayOfModel) {
 		var ret [][]ReadOnlyFirst
 		return ret
 	}
@@ -117,7 +117,7 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 // GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
-	if o == nil || isNil(o.ArrayArrayOfModel) {
+	if o == nil || IsNil(o.ArrayArrayOfModel) {
 		return nil, false
 	}
 	return o.ArrayArrayOfModel, true
@@ -125,7 +125,7 @@ func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfModel() bool {
-	if o != nil && !isNil(o.ArrayArrayOfModel) {
+	if o != nil && !IsNil(o.ArrayArrayOfModel) {
 		return true
 	}
 
@@ -147,13 +147,13 @@ func (o ArrayTest) MarshalJSON() ([]byte, error) {
 
 func (o ArrayTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.ArrayOfString) {
+	if !IsNil(o.ArrayOfString) {
 		toSerialize["array_of_string"] = o.ArrayOfString
 	}
-	if !isNil(o.ArrayArrayOfInteger) {
+	if !IsNil(o.ArrayArrayOfInteger) {
 		toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
 	}
-	if !isNil(o.ArrayArrayOfModel) {
+	if !IsNil(o.ArrayArrayOfModel) {
 		toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -45,7 +45,7 @@ func NewBigCatWithDefaults() *BigCat {
 
 // GetKind returns the Kind field value if set, zero value otherwise.
 func (o *BigCat) GetKind() string {
-	if o == nil || isNil(o.Kind) {
+	if o == nil || IsNil(o.Kind) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *BigCat) GetKind() string {
 // GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *BigCat) GetKindOk() (*string, bool) {
-	if o == nil || isNil(o.Kind) {
+	if o == nil || IsNil(o.Kind) {
 		return nil, false
 	}
 	return o.Kind, true
@@ -63,7 +63,7 @@ func (o *BigCat) GetKindOk() (*string, bool) {
 
 // HasKind returns a boolean if a field has been set.
 func (o *BigCat) HasKind() bool {
-	if o != nil && !isNil(o.Kind) {
+	if o != nil && !IsNil(o.Kind) {
 		return true
 	}
 
@@ -93,7 +93,7 @@ func (o BigCat) ToMap() (map[string]interface{}, error) {
 	if errCat != nil {
 		return map[string]interface{}{}, errCat
 	}
-	if !isNil(o.Kind) {
+	if !IsNil(o.Kind) {
 		toSerialize["kind"] = o.Kind
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat_all_of.go
@@ -41,7 +41,7 @@ func NewBigCatAllOfWithDefaults() *BigCatAllOf {
 
 // GetKind returns the Kind field value if set, zero value otherwise.
 func (o *BigCatAllOf) GetKind() string {
-	if o == nil || isNil(o.Kind) {
+	if o == nil || IsNil(o.Kind) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *BigCatAllOf) GetKind() string {
 // GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *BigCatAllOf) GetKindOk() (*string, bool) {
-	if o == nil || isNil(o.Kind) {
+	if o == nil || IsNil(o.Kind) {
 		return nil, false
 	}
 	return o.Kind, true
@@ -59,7 +59,7 @@ func (o *BigCatAllOf) GetKindOk() (*string, bool) {
 
 // HasKind returns a boolean if a field has been set.
 func (o *BigCatAllOf) HasKind() bool {
-	if o != nil && !isNil(o.Kind) {
+	if o != nil && !IsNil(o.Kind) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o BigCatAllOf) MarshalJSON() ([]byte, error) {
 
 func (o BigCatAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Kind) {
+	if !IsNil(o.Kind) {
 		toSerialize["kind"] = o.Kind
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go/go-petstore/model_capitalization.go
@@ -47,7 +47,7 @@ func NewCapitalizationWithDefaults() *Capitalization {
 
 // GetSmallCamel returns the SmallCamel field value if set, zero value otherwise.
 func (o *Capitalization) GetSmallCamel() string {
-	if o == nil || isNil(o.SmallCamel) {
+	if o == nil || IsNil(o.SmallCamel) {
 		var ret string
 		return ret
 	}
@@ -57,7 +57,7 @@ func (o *Capitalization) GetSmallCamel() string {
 // GetSmallCamelOk returns a tuple with the SmallCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
-	if o == nil || isNil(o.SmallCamel) {
+	if o == nil || IsNil(o.SmallCamel) {
 		return nil, false
 	}
 	return o.SmallCamel, true
@@ -65,7 +65,7 @@ func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 
 // HasSmallCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallCamel() bool {
-	if o != nil && !isNil(o.SmallCamel) {
+	if o != nil && !IsNil(o.SmallCamel) {
 		return true
 	}
 
@@ -79,7 +79,7 @@ func (o *Capitalization) SetSmallCamel(v string) {
 
 // GetCapitalCamel returns the CapitalCamel field value if set, zero value otherwise.
 func (o *Capitalization) GetCapitalCamel() string {
-	if o == nil || isNil(o.CapitalCamel) {
+	if o == nil || IsNil(o.CapitalCamel) {
 		var ret string
 		return ret
 	}
@@ -89,7 +89,7 @@ func (o *Capitalization) GetCapitalCamel() string {
 // GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
-	if o == nil || isNil(o.CapitalCamel) {
+	if o == nil || IsNil(o.CapitalCamel) {
 		return nil, false
 	}
 	return o.CapitalCamel, true
@@ -97,7 +97,7 @@ func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 
 // HasCapitalCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalCamel() bool {
-	if o != nil && !isNil(o.CapitalCamel) {
+	if o != nil && !IsNil(o.CapitalCamel) {
 		return true
 	}
 
@@ -111,7 +111,7 @@ func (o *Capitalization) SetCapitalCamel(v string) {
 
 // GetSmallSnake returns the SmallSnake field value if set, zero value otherwise.
 func (o *Capitalization) GetSmallSnake() string {
-	if o == nil || isNil(o.SmallSnake) {
+	if o == nil || IsNil(o.SmallSnake) {
 		var ret string
 		return ret
 	}
@@ -121,7 +121,7 @@ func (o *Capitalization) GetSmallSnake() string {
 // GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
-	if o == nil || isNil(o.SmallSnake) {
+	if o == nil || IsNil(o.SmallSnake) {
 		return nil, false
 	}
 	return o.SmallSnake, true
@@ -129,7 +129,7 @@ func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 
 // HasSmallSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallSnake() bool {
-	if o != nil && !isNil(o.SmallSnake) {
+	if o != nil && !IsNil(o.SmallSnake) {
 		return true
 	}
 
@@ -143,7 +143,7 @@ func (o *Capitalization) SetSmallSnake(v string) {
 
 // GetCapitalSnake returns the CapitalSnake field value if set, zero value otherwise.
 func (o *Capitalization) GetCapitalSnake() string {
-	if o == nil || isNil(o.CapitalSnake) {
+	if o == nil || IsNil(o.CapitalSnake) {
 		var ret string
 		return ret
 	}
@@ -153,7 +153,7 @@ func (o *Capitalization) GetCapitalSnake() string {
 // GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
-	if o == nil || isNil(o.CapitalSnake) {
+	if o == nil || IsNil(o.CapitalSnake) {
 		return nil, false
 	}
 	return o.CapitalSnake, true
@@ -161,7 +161,7 @@ func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 
 // HasCapitalSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalSnake() bool {
-	if o != nil && !isNil(o.CapitalSnake) {
+	if o != nil && !IsNil(o.CapitalSnake) {
 		return true
 	}
 
@@ -175,7 +175,7 @@ func (o *Capitalization) SetCapitalSnake(v string) {
 
 // GetSCAETHFlowPoints returns the SCAETHFlowPoints field value if set, zero value otherwise.
 func (o *Capitalization) GetSCAETHFlowPoints() string {
-	if o == nil || isNil(o.SCAETHFlowPoints) {
+	if o == nil || IsNil(o.SCAETHFlowPoints) {
 		var ret string
 		return ret
 	}
@@ -185,7 +185,7 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 // GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
-	if o == nil || isNil(o.SCAETHFlowPoints) {
+	if o == nil || IsNil(o.SCAETHFlowPoints) {
 		return nil, false
 	}
 	return o.SCAETHFlowPoints, true
@@ -193,7 +193,7 @@ func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
 func (o *Capitalization) HasSCAETHFlowPoints() bool {
-	if o != nil && !isNil(o.SCAETHFlowPoints) {
+	if o != nil && !IsNil(o.SCAETHFlowPoints) {
 		return true
 	}
 
@@ -207,7 +207,7 @@ func (o *Capitalization) SetSCAETHFlowPoints(v string) {
 
 // GetATT_NAME returns the ATT_NAME field value if set, zero value otherwise.
 func (o *Capitalization) GetATT_NAME() string {
-	if o == nil || isNil(o.ATT_NAME) {
+	if o == nil || IsNil(o.ATT_NAME) {
 		var ret string
 		return ret
 	}
@@ -217,7 +217,7 @@ func (o *Capitalization) GetATT_NAME() string {
 // GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
-	if o == nil || isNil(o.ATT_NAME) {
+	if o == nil || IsNil(o.ATT_NAME) {
 		return nil, false
 	}
 	return o.ATT_NAME, true
@@ -225,7 +225,7 @@ func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 
 // HasATT_NAME returns a boolean if a field has been set.
 func (o *Capitalization) HasATT_NAME() bool {
-	if o != nil && !isNil(o.ATT_NAME) {
+	if o != nil && !IsNil(o.ATT_NAME) {
 		return true
 	}
 
@@ -247,22 +247,22 @@ func (o Capitalization) MarshalJSON() ([]byte, error) {
 
 func (o Capitalization) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.SmallCamel) {
+	if !IsNil(o.SmallCamel) {
 		toSerialize["smallCamel"] = o.SmallCamel
 	}
-	if !isNil(o.CapitalCamel) {
+	if !IsNil(o.CapitalCamel) {
 		toSerialize["CapitalCamel"] = o.CapitalCamel
 	}
-	if !isNil(o.SmallSnake) {
+	if !IsNil(o.SmallSnake) {
 		toSerialize["small_Snake"] = o.SmallSnake
 	}
-	if !isNil(o.CapitalSnake) {
+	if !IsNil(o.CapitalSnake) {
 		toSerialize["Capital_Snake"] = o.CapitalSnake
 	}
-	if !isNil(o.SCAETHFlowPoints) {
+	if !IsNil(o.SCAETHFlowPoints) {
 		toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
 	}
-	if !isNil(o.ATT_NAME) {
+	if !IsNil(o.ATT_NAME) {
 		toSerialize["ATT_NAME"] = o.ATT_NAME
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -45,7 +45,7 @@ func NewCatWithDefaults() *Cat {
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
 func (o *Cat) GetDeclawed() bool {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		var ret bool
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *Cat) GetDeclawed() bool {
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Cat) GetDeclawedOk() (*bool, bool) {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		return nil, false
 	}
 	return o.Declawed, true
@@ -63,7 +63,7 @@ func (o *Cat) GetDeclawedOk() (*bool, bool) {
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *Cat) HasDeclawed() bool {
-	if o != nil && !isNil(o.Declawed) {
+	if o != nil && !IsNil(o.Declawed) {
 		return true
 	}
 
@@ -93,7 +93,7 @@ func (o Cat) ToMap() (map[string]interface{}, error) {
 	if errAnimal != nil {
 		return map[string]interface{}{}, errAnimal
 	}
-	if !isNil(o.Declawed) {
+	if !IsNil(o.Declawed) {
 		toSerialize["declawed"] = o.Declawed
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go/go-petstore/model_cat_all_of.go
@@ -41,7 +41,7 @@ func NewCatAllOfWithDefaults() *CatAllOf {
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
 func (o *CatAllOf) GetDeclawed() bool {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		var ret bool
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *CatAllOf) GetDeclawed() bool {
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		return nil, false
 	}
 	return o.Declawed, true
@@ -59,7 +59,7 @@ func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *CatAllOf) HasDeclawed() bool {
-	if o != nil && !isNil(o.Declawed) {
+	if o != nil && !IsNil(o.Declawed) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o CatAllOf) MarshalJSON() ([]byte, error) {
 
 func (o CatAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Declawed) {
+	if !IsNil(o.Declawed) {
 		toSerialize["declawed"] = o.Declawed
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_category.go
+++ b/samples/client/petstore/go/go-petstore/model_category.go
@@ -45,7 +45,7 @@ func NewCategoryWithDefaults() *Category {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Category) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *Category) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Category) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -63,7 +63,7 @@ func (o *Category) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Category) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -109,7 +109,7 @@ func (o Category) MarshalJSON() ([]byte, error) {
 
 func (o Category) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
 	toSerialize["name"] = o.Name

--- a/samples/client/petstore/go/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go/go-petstore/model_class_model.go
@@ -41,7 +41,7 @@ func NewClassModelWithDefaults() *ClassModel {
 
 // GetClass returns the Class field value if set, zero value otherwise.
 func (o *ClassModel) GetClass() string {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *ClassModel) GetClass() string {
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ClassModel) GetClassOk() (*string, bool) {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		return nil, false
 	}
 	return o.Class, true
@@ -59,7 +59,7 @@ func (o *ClassModel) GetClassOk() (*string, bool) {
 
 // HasClass returns a boolean if a field has been set.
 func (o *ClassModel) HasClass() bool {
-	if o != nil && !isNil(o.Class) {
+	if o != nil && !IsNil(o.Class) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o ClassModel) MarshalJSON() ([]byte, error) {
 
 func (o ClassModel) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Class) {
+	if !IsNil(o.Class) {
 		toSerialize["_class"] = o.Class
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_client.go
+++ b/samples/client/petstore/go/go-petstore/model_client.go
@@ -41,7 +41,7 @@ func NewClientWithDefaults() *Client {
 
 // GetClient returns the Client field value if set, zero value otherwise.
 func (o *Client) GetClient() string {
-	if o == nil || isNil(o.Client) {
+	if o == nil || IsNil(o.Client) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *Client) GetClient() string {
 // GetClientOk returns a tuple with the Client field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Client) GetClientOk() (*string, bool) {
-	if o == nil || isNil(o.Client) {
+	if o == nil || IsNil(o.Client) {
 		return nil, false
 	}
 	return o.Client, true
@@ -59,7 +59,7 @@ func (o *Client) GetClientOk() (*string, bool) {
 
 // HasClient returns a boolean if a field has been set.
 func (o *Client) HasClient() bool {
-	if o != nil && !isNil(o.Client) {
+	if o != nil && !IsNil(o.Client) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o Client) MarshalJSON() ([]byte, error) {
 
 func (o Client) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Client) {
+	if !IsNil(o.Client) {
 		toSerialize["client"] = o.Client
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -45,7 +45,7 @@ func NewDogWithDefaults() *Dog {
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
 func (o *Dog) GetBreed() string {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *Dog) GetBreed() string {
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Dog) GetBreedOk() (*string, bool) {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		return nil, false
 	}
 	return o.Breed, true
@@ -63,7 +63,7 @@ func (o *Dog) GetBreedOk() (*string, bool) {
 
 // HasBreed returns a boolean if a field has been set.
 func (o *Dog) HasBreed() bool {
-	if o != nil && !isNil(o.Breed) {
+	if o != nil && !IsNil(o.Breed) {
 		return true
 	}
 
@@ -93,7 +93,7 @@ func (o Dog) ToMap() (map[string]interface{}, error) {
 	if errAnimal != nil {
 		return map[string]interface{}{}, errAnimal
 	}
-	if !isNil(o.Breed) {
+	if !IsNil(o.Breed) {
 		toSerialize["breed"] = o.Breed
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go/go-petstore/model_dog_all_of.go
@@ -41,7 +41,7 @@ func NewDogAllOfWithDefaults() *DogAllOf {
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
 func (o *DogAllOf) GetBreed() string {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *DogAllOf) GetBreed() string {
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *DogAllOf) GetBreedOk() (*string, bool) {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		return nil, false
 	}
 	return o.Breed, true
@@ -59,7 +59,7 @@ func (o *DogAllOf) GetBreedOk() (*string, bool) {
 
 // HasBreed returns a boolean if a field has been set.
 func (o *DogAllOf) HasBreed() bool {
-	if o != nil && !isNil(o.Breed) {
+	if o != nil && !IsNil(o.Breed) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o DogAllOf) MarshalJSON() ([]byte, error) {
 
 func (o DogAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Breed) {
+	if !IsNil(o.Breed) {
 		toSerialize["breed"] = o.Breed
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -42,7 +42,7 @@ func NewEnumArraysWithDefaults() *EnumArrays {
 
 // GetJustSymbol returns the JustSymbol field value if set, zero value otherwise.
 func (o *EnumArrays) GetJustSymbol() string {
-	if o == nil || isNil(o.JustSymbol) {
+	if o == nil || IsNil(o.JustSymbol) {
 		var ret string
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *EnumArrays) GetJustSymbol() string {
 // GetJustSymbolOk returns a tuple with the JustSymbol field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
-	if o == nil || isNil(o.JustSymbol) {
+	if o == nil || IsNil(o.JustSymbol) {
 		return nil, false
 	}
 	return o.JustSymbol, true
@@ -60,7 +60,7 @@ func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 
 // HasJustSymbol returns a boolean if a field has been set.
 func (o *EnumArrays) HasJustSymbol() bool {
-	if o != nil && !isNil(o.JustSymbol) {
+	if o != nil && !IsNil(o.JustSymbol) {
 		return true
 	}
 
@@ -74,7 +74,7 @@ func (o *EnumArrays) SetJustSymbol(v string) {
 
 // GetArrayEnum returns the ArrayEnum field value if set, zero value otherwise.
 func (o *EnumArrays) GetArrayEnum() []string {
-	if o == nil || isNil(o.ArrayEnum) {
+	if o == nil || IsNil(o.ArrayEnum) {
 		var ret []string
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *EnumArrays) GetArrayEnum() []string {
 // GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
-	if o == nil || isNil(o.ArrayEnum) {
+	if o == nil || IsNil(o.ArrayEnum) {
 		return nil, false
 	}
 	return o.ArrayEnum, true
@@ -92,7 +92,7 @@ func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 
 // HasArrayEnum returns a boolean if a field has been set.
 func (o *EnumArrays) HasArrayEnum() bool {
-	if o != nil && !isNil(o.ArrayEnum) {
+	if o != nil && !IsNil(o.ArrayEnum) {
 		return true
 	}
 
@@ -114,10 +114,10 @@ func (o EnumArrays) MarshalJSON() ([]byte, error) {
 
 func (o EnumArrays) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.JustSymbol) {
+	if !IsNil(o.JustSymbol) {
 		toSerialize["just_symbol"] = o.JustSymbol
 	}
-	if !isNil(o.ArrayEnum) {
+	if !IsNil(o.ArrayEnum) {
 		toSerialize["array_enum"] = o.ArrayEnum
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -46,7 +46,7 @@ func NewEnumTestWithDefaults() *EnumTest {
 
 // GetEnumString returns the EnumString field value if set, zero value otherwise.
 func (o *EnumTest) GetEnumString() string {
-	if o == nil || isNil(o.EnumString) {
+	if o == nil || IsNil(o.EnumString) {
 		var ret string
 		return ret
 	}
@@ -56,7 +56,7 @@ func (o *EnumTest) GetEnumString() string {
 // GetEnumStringOk returns a tuple with the EnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumStringOk() (*string, bool) {
-	if o == nil || isNil(o.EnumString) {
+	if o == nil || IsNil(o.EnumString) {
 		return nil, false
 	}
 	return o.EnumString, true
@@ -64,7 +64,7 @@ func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 
 // HasEnumString returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumString() bool {
-	if o != nil && !isNil(o.EnumString) {
+	if o != nil && !IsNil(o.EnumString) {
 		return true
 	}
 
@@ -102,7 +102,7 @@ func (o *EnumTest) SetEnumStringRequired(v string) {
 
 // GetEnumInteger returns the EnumInteger field value if set, zero value otherwise.
 func (o *EnumTest) GetEnumInteger() int32 {
-	if o == nil || isNil(o.EnumInteger) {
+	if o == nil || IsNil(o.EnumInteger) {
 		var ret int32
 		return ret
 	}
@@ -112,7 +112,7 @@ func (o *EnumTest) GetEnumInteger() int32 {
 // GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.EnumInteger) {
+	if o == nil || IsNil(o.EnumInteger) {
 		return nil, false
 	}
 	return o.EnumInteger, true
@@ -120,7 +120,7 @@ func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 
 // HasEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumInteger() bool {
-	if o != nil && !isNil(o.EnumInteger) {
+	if o != nil && !IsNil(o.EnumInteger) {
 		return true
 	}
 
@@ -134,7 +134,7 @@ func (o *EnumTest) SetEnumInteger(v int32) {
 
 // GetEnumNumber returns the EnumNumber field value if set, zero value otherwise.
 func (o *EnumTest) GetEnumNumber() float64 {
-	if o == nil || isNil(o.EnumNumber) {
+	if o == nil || IsNil(o.EnumNumber) {
 		var ret float64
 		return ret
 	}
@@ -144,7 +144,7 @@ func (o *EnumTest) GetEnumNumber() float64 {
 // GetEnumNumberOk returns a tuple with the EnumNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
-	if o == nil || isNil(o.EnumNumber) {
+	if o == nil || IsNil(o.EnumNumber) {
 		return nil, false
 	}
 	return o.EnumNumber, true
@@ -152,7 +152,7 @@ func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 
 // HasEnumNumber returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumNumber() bool {
-	if o != nil && !isNil(o.EnumNumber) {
+	if o != nil && !IsNil(o.EnumNumber) {
 		return true
 	}
 
@@ -166,7 +166,7 @@ func (o *EnumTest) SetEnumNumber(v float64) {
 
 // GetOuterEnum returns the OuterEnum field value if set, zero value otherwise.
 func (o *EnumTest) GetOuterEnum() OuterEnum {
-	if o == nil || isNil(o.OuterEnum) {
+	if o == nil || IsNil(o.OuterEnum) {
 		var ret OuterEnum
 		return ret
 	}
@@ -176,7 +176,7 @@ func (o *EnumTest) GetOuterEnum() OuterEnum {
 // GetOuterEnumOk returns a tuple with the OuterEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
-	if o == nil || isNil(o.OuterEnum) {
+	if o == nil || IsNil(o.OuterEnum) {
 		return nil, false
 	}
 	return o.OuterEnum, true
@@ -184,7 +184,7 @@ func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
 
 // HasOuterEnum returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnum() bool {
-	if o != nil && !isNil(o.OuterEnum) {
+	if o != nil && !IsNil(o.OuterEnum) {
 		return true
 	}
 
@@ -206,17 +206,17 @@ func (o EnumTest) MarshalJSON() ([]byte, error) {
 
 func (o EnumTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.EnumString) {
+	if !IsNil(o.EnumString) {
 		toSerialize["enum_string"] = o.EnumString
 	}
 	toSerialize["enum_string_required"] = o.EnumStringRequired
-	if !isNil(o.EnumInteger) {
+	if !IsNil(o.EnumInteger) {
 		toSerialize["enum_integer"] = o.EnumInteger
 	}
-	if !isNil(o.EnumNumber) {
+	if !IsNil(o.EnumNumber) {
 		toSerialize["enum_number"] = o.EnumNumber
 	}
-	if !isNil(o.OuterEnum) {
+	if !IsNil(o.OuterEnum) {
 		toSerialize["outerEnum"] = o.OuterEnum
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_file.go
+++ b/samples/client/petstore/go/go-petstore/model_file.go
@@ -42,7 +42,7 @@ func NewFileWithDefaults() *File {
 
 // GetSourceURI returns the SourceURI field value if set, zero value otherwise.
 func (o *File) GetSourceURI() string {
-	if o == nil || isNil(o.SourceURI) {
+	if o == nil || IsNil(o.SourceURI) {
 		var ret string
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *File) GetSourceURI() string {
 // GetSourceURIOk returns a tuple with the SourceURI field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *File) GetSourceURIOk() (*string, bool) {
-	if o == nil || isNil(o.SourceURI) {
+	if o == nil || IsNil(o.SourceURI) {
 		return nil, false
 	}
 	return o.SourceURI, true
@@ -60,7 +60,7 @@ func (o *File) GetSourceURIOk() (*string, bool) {
 
 // HasSourceURI returns a boolean if a field has been set.
 func (o *File) HasSourceURI() bool {
-	if o != nil && !isNil(o.SourceURI) {
+	if o != nil && !IsNil(o.SourceURI) {
 		return true
 	}
 
@@ -82,7 +82,7 @@ func (o File) MarshalJSON() ([]byte, error) {
 
 func (o File) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.SourceURI) {
+	if !IsNil(o.SourceURI) {
 		toSerialize["sourceURI"] = o.SourceURI
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go/go-petstore/model_file_schema_test_class.go
@@ -42,7 +42,7 @@ func NewFileSchemaTestClassWithDefaults() *FileSchemaTestClass {
 
 // GetFile returns the File field value if set, zero value otherwise.
 func (o *FileSchemaTestClass) GetFile() File {
-	if o == nil || isNil(o.File) {
+	if o == nil || IsNil(o.File) {
 		var ret File
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *FileSchemaTestClass) GetFile() File {
 // GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
-	if o == nil || isNil(o.File) {
+	if o == nil || IsNil(o.File) {
 		return nil, false
 	}
 	return o.File, true
@@ -60,7 +60,7 @@ func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 
 // HasFile returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFile() bool {
-	if o != nil && !isNil(o.File) {
+	if o != nil && !IsNil(o.File) {
 		return true
 	}
 
@@ -74,7 +74,7 @@ func (o *FileSchemaTestClass) SetFile(v File) {
 
 // GetFiles returns the Files field value if set, zero value otherwise.
 func (o *FileSchemaTestClass) GetFiles() []File {
-	if o == nil || isNil(o.Files) {
+	if o == nil || IsNil(o.Files) {
 		var ret []File
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 // GetFilesOk returns a tuple with the Files field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
-	if o == nil || isNil(o.Files) {
+	if o == nil || IsNil(o.Files) {
 		return nil, false
 	}
 	return o.Files, true
@@ -92,7 +92,7 @@ func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 
 // HasFiles returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFiles() bool {
-	if o != nil && !isNil(o.Files) {
+	if o != nil && !IsNil(o.Files) {
 		return true
 	}
 
@@ -114,10 +114,10 @@ func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
 
 func (o FileSchemaTestClass) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.File) {
+	if !IsNil(o.File) {
 		toSerialize["file"] = o.File
 	}
-	if !isNil(o.Files) {
+	if !IsNil(o.Files) {
 		toSerialize["files"] = o.Files
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -60,7 +60,7 @@ func NewFormatTestWithDefaults() *FormatTest {
 
 // GetInteger returns the Integer field value if set, zero value otherwise.
 func (o *FormatTest) GetInteger() int32 {
-	if o == nil || isNil(o.Integer) {
+	if o == nil || IsNil(o.Integer) {
 		var ret int32
 		return ret
 	}
@@ -70,7 +70,7 @@ func (o *FormatTest) GetInteger() int32 {
 // GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.Integer) {
+	if o == nil || IsNil(o.Integer) {
 		return nil, false
 	}
 	return o.Integer, true
@@ -78,7 +78,7 @@ func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 
 // HasInteger returns a boolean if a field has been set.
 func (o *FormatTest) HasInteger() bool {
-	if o != nil && !isNil(o.Integer) {
+	if o != nil && !IsNil(o.Integer) {
 		return true
 	}
 
@@ -92,7 +92,7 @@ func (o *FormatTest) SetInteger(v int32) {
 
 // GetInt32 returns the Int32 field value if set, zero value otherwise.
 func (o *FormatTest) GetInt32() int32 {
-	if o == nil || isNil(o.Int32) {
+	if o == nil || IsNil(o.Int32) {
 		var ret int32
 		return ret
 	}
@@ -102,7 +102,7 @@ func (o *FormatTest) GetInt32() int32 {
 // GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt32Ok() (*int32, bool) {
-	if o == nil || isNil(o.Int32) {
+	if o == nil || IsNil(o.Int32) {
 		return nil, false
 	}
 	return o.Int32, true
@@ -110,7 +110,7 @@ func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt32() bool {
-	if o != nil && !isNil(o.Int32) {
+	if o != nil && !IsNil(o.Int32) {
 		return true
 	}
 
@@ -124,7 +124,7 @@ func (o *FormatTest) SetInt32(v int32) {
 
 // GetInt64 returns the Int64 field value if set, zero value otherwise.
 func (o *FormatTest) GetInt64() int64 {
-	if o == nil || isNil(o.Int64) {
+	if o == nil || IsNil(o.Int64) {
 		var ret int64
 		return ret
 	}
@@ -134,7 +134,7 @@ func (o *FormatTest) GetInt64() int64 {
 // GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt64Ok() (*int64, bool) {
-	if o == nil || isNil(o.Int64) {
+	if o == nil || IsNil(o.Int64) {
 		return nil, false
 	}
 	return o.Int64, true
@@ -142,7 +142,7 @@ func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt64() bool {
-	if o != nil && !isNil(o.Int64) {
+	if o != nil && !IsNil(o.Int64) {
 		return true
 	}
 
@@ -180,7 +180,7 @@ func (o *FormatTest) SetNumber(v float32) {
 
 // GetFloat returns the Float field value if set, zero value otherwise.
 func (o *FormatTest) GetFloat() float32 {
-	if o == nil || isNil(o.Float) {
+	if o == nil || IsNil(o.Float) {
 		var ret float32
 		return ret
 	}
@@ -190,7 +190,7 @@ func (o *FormatTest) GetFloat() float32 {
 // GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetFloatOk() (*float32, bool) {
-	if o == nil || isNil(o.Float) {
+	if o == nil || IsNil(o.Float) {
 		return nil, false
 	}
 	return o.Float, true
@@ -198,7 +198,7 @@ func (o *FormatTest) GetFloatOk() (*float32, bool) {
 
 // HasFloat returns a boolean if a field has been set.
 func (o *FormatTest) HasFloat() bool {
-	if o != nil && !isNil(o.Float) {
+	if o != nil && !IsNil(o.Float) {
 		return true
 	}
 
@@ -212,7 +212,7 @@ func (o *FormatTest) SetFloat(v float32) {
 
 // GetDouble returns the Double field value if set, zero value otherwise.
 func (o *FormatTest) GetDouble() float64 {
-	if o == nil || isNil(o.Double) {
+	if o == nil || IsNil(o.Double) {
 		var ret float64
 		return ret
 	}
@@ -222,7 +222,7 @@ func (o *FormatTest) GetDouble() float64 {
 // GetDoubleOk returns a tuple with the Double field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDoubleOk() (*float64, bool) {
-	if o == nil || isNil(o.Double) {
+	if o == nil || IsNil(o.Double) {
 		return nil, false
 	}
 	return o.Double, true
@@ -230,7 +230,7 @@ func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 
 // HasDouble returns a boolean if a field has been set.
 func (o *FormatTest) HasDouble() bool {
-	if o != nil && !isNil(o.Double) {
+	if o != nil && !IsNil(o.Double) {
 		return true
 	}
 
@@ -244,7 +244,7 @@ func (o *FormatTest) SetDouble(v float64) {
 
 // GetString returns the String field value if set, zero value otherwise.
 func (o *FormatTest) GetString() string {
-	if o == nil || isNil(o.String) {
+	if o == nil || IsNil(o.String) {
 		var ret string
 		return ret
 	}
@@ -254,7 +254,7 @@ func (o *FormatTest) GetString() string {
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetStringOk() (*string, bool) {
-	if o == nil || isNil(o.String) {
+	if o == nil || IsNil(o.String) {
 		return nil, false
 	}
 	return o.String, true
@@ -262,7 +262,7 @@ func (o *FormatTest) GetStringOk() (*string, bool) {
 
 // HasString returns a boolean if a field has been set.
 func (o *FormatTest) HasString() bool {
-	if o != nil && !isNil(o.String) {
+	if o != nil && !IsNil(o.String) {
 		return true
 	}
 
@@ -300,7 +300,7 @@ func (o *FormatTest) SetByte(v string) {
 
 // GetBinary returns the Binary field value if set, zero value otherwise.
 func (o *FormatTest) GetBinary() *os.File {
-	if o == nil || isNil(o.Binary) {
+	if o == nil || IsNil(o.Binary) {
 		var ret *os.File
 		return ret
 	}
@@ -310,7 +310,7 @@ func (o *FormatTest) GetBinary() *os.File {
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
-	if o == nil || isNil(o.Binary) {
+	if o == nil || IsNil(o.Binary) {
 		return nil, false
 	}
 	return o.Binary, true
@@ -318,7 +318,7 @@ func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 
 // HasBinary returns a boolean if a field has been set.
 func (o *FormatTest) HasBinary() bool {
-	if o != nil && !isNil(o.Binary) {
+	if o != nil && !IsNil(o.Binary) {
 		return true
 	}
 
@@ -356,7 +356,7 @@ func (o *FormatTest) SetDate(v string) {
 
 // GetDateTime returns the DateTime field value if set, zero value otherwise.
 func (o *FormatTest) GetDateTime() time.Time {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		var ret time.Time
 		return ret
 	}
@@ -366,7 +366,7 @@ func (o *FormatTest) GetDateTime() time.Time {
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		return nil, false
 	}
 	return o.DateTime, true
@@ -374,7 +374,7 @@ func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *FormatTest) HasDateTime() bool {
-	if o != nil && !isNil(o.DateTime) {
+	if o != nil && !IsNil(o.DateTime) {
 		return true
 	}
 
@@ -388,7 +388,7 @@ func (o *FormatTest) SetDateTime(v time.Time) {
 
 // GetUuid returns the Uuid field value if set, zero value otherwise.
 func (o *FormatTest) GetUuid() string {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		var ret string
 		return ret
 	}
@@ -398,7 +398,7 @@ func (o *FormatTest) GetUuid() string {
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetUuidOk() (*string, bool) {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		return nil, false
 	}
 	return o.Uuid, true
@@ -406,7 +406,7 @@ func (o *FormatTest) GetUuidOk() (*string, bool) {
 
 // HasUuid returns a boolean if a field has been set.
 func (o *FormatTest) HasUuid() bool {
-	if o != nil && !isNil(o.Uuid) {
+	if o != nil && !IsNil(o.Uuid) {
 		return true
 	}
 
@@ -444,7 +444,7 @@ func (o *FormatTest) SetPassword(v string) {
 
 // GetBigDecimal returns the BigDecimal field value if set, zero value otherwise.
 func (o *FormatTest) GetBigDecimal() float64 {
-	if o == nil || isNil(o.BigDecimal) {
+	if o == nil || IsNil(o.BigDecimal) {
 		var ret float64
 		return ret
 	}
@@ -454,7 +454,7 @@ func (o *FormatTest) GetBigDecimal() float64 {
 // GetBigDecimalOk returns a tuple with the BigDecimal field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetBigDecimalOk() (*float64, bool) {
-	if o == nil || isNil(o.BigDecimal) {
+	if o == nil || IsNil(o.BigDecimal) {
 		return nil, false
 	}
 	return o.BigDecimal, true
@@ -462,7 +462,7 @@ func (o *FormatTest) GetBigDecimalOk() (*float64, bool) {
 
 // HasBigDecimal returns a boolean if a field has been set.
 func (o *FormatTest) HasBigDecimal() bool {
-	if o != nil && !isNil(o.BigDecimal) {
+	if o != nil && !IsNil(o.BigDecimal) {
 		return true
 	}
 
@@ -484,38 +484,38 @@ func (o FormatTest) MarshalJSON() ([]byte, error) {
 
 func (o FormatTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Integer) {
+	if !IsNil(o.Integer) {
 		toSerialize["integer"] = o.Integer
 	}
-	if !isNil(o.Int32) {
+	if !IsNil(o.Int32) {
 		toSerialize["int32"] = o.Int32
 	}
-	if !isNil(o.Int64) {
+	if !IsNil(o.Int64) {
 		toSerialize["int64"] = o.Int64
 	}
 	toSerialize["number"] = o.Number
-	if !isNil(o.Float) {
+	if !IsNil(o.Float) {
 		toSerialize["float"] = o.Float
 	}
-	if !isNil(o.Double) {
+	if !IsNil(o.Double) {
 		toSerialize["double"] = o.Double
 	}
-	if !isNil(o.String) {
+	if !IsNil(o.String) {
 		toSerialize["string"] = o.String
 	}
 	toSerialize["byte"] = o.Byte
-	if !isNil(o.Binary) {
+	if !IsNil(o.Binary) {
 		toSerialize["binary"] = o.Binary
 	}
 	toSerialize["date"] = o.Date
-	if !isNil(o.DateTime) {
+	if !IsNil(o.DateTime) {
 		toSerialize["dateTime"] = o.DateTime
 	}
-	if !isNil(o.Uuid) {
+	if !IsNil(o.Uuid) {
 		toSerialize["uuid"] = o.Uuid
 	}
 	toSerialize["password"] = o.Password
-	if !isNil(o.BigDecimal) {
+	if !IsNil(o.BigDecimal) {
 		toSerialize["BigDecimal"] = o.BigDecimal
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -42,7 +42,7 @@ func NewHasOnlyReadOnlyWithDefaults() *HasOnlyReadOnly {
 
 // GetBar returns the Bar field value if set, zero value otherwise.
 func (o *HasOnlyReadOnly) GetBar() string {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		var ret string
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *HasOnlyReadOnly) GetBar() string {
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		return nil, false
 	}
 	return o.Bar, true
@@ -60,7 +60,7 @@ func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 
 // HasBar returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasBar() bool {
-	if o != nil && !isNil(o.Bar) {
+	if o != nil && !IsNil(o.Bar) {
 		return true
 	}
 
@@ -74,7 +74,7 @@ func (o *HasOnlyReadOnly) SetBar(v string) {
 
 // GetFoo returns the Foo field value if set, zero value otherwise.
 func (o *HasOnlyReadOnly) GetFoo() string {
-	if o == nil || isNil(o.Foo) {
+	if o == nil || IsNil(o.Foo) {
 		var ret string
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 // GetFooOk returns a tuple with the Foo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
-	if o == nil || isNil(o.Foo) {
+	if o == nil || IsNil(o.Foo) {
 		return nil, false
 	}
 	return o.Foo, true
@@ -92,7 +92,7 @@ func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 
 // HasFoo returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasFoo() bool {
-	if o != nil && !isNil(o.Foo) {
+	if o != nil && !IsNil(o.Foo) {
 		return true
 	}
 

--- a/samples/client/petstore/go/go-petstore/model_list.go
+++ b/samples/client/petstore/go/go-petstore/model_list.go
@@ -41,7 +41,7 @@ func NewListWithDefaults() *List {
 
 // GetVar123List returns the Var123List field value if set, zero value otherwise.
 func (o *List) GetVar123List() string {
-	if o == nil || isNil(o.Var123List) {
+	if o == nil || IsNil(o.Var123List) {
 		var ret string
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *List) GetVar123List() string {
 // GetVar123ListOk returns a tuple with the Var123List field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *List) GetVar123ListOk() (*string, bool) {
-	if o == nil || isNil(o.Var123List) {
+	if o == nil || IsNil(o.Var123List) {
 		return nil, false
 	}
 	return o.Var123List, true
@@ -59,7 +59,7 @@ func (o *List) GetVar123ListOk() (*string, bool) {
 
 // HasVar123List returns a boolean if a field has been set.
 func (o *List) HasVar123List() bool {
-	if o != nil && !isNil(o.Var123List) {
+	if o != nil && !IsNil(o.Var123List) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o List) MarshalJSON() ([]byte, error) {
 
 func (o List) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Var123List) {
+	if !IsNil(o.Var123List) {
 		toSerialize["123-list"] = o.Var123List
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_map_test_.go
@@ -44,7 +44,7 @@ func NewMapTestWithDefaults() *MapTest {
 
 // GetMapMapOfString returns the MapMapOfString field value if set, zero value otherwise.
 func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
-	if o == nil || isNil(o.MapMapOfString) {
+	if o == nil || IsNil(o.MapMapOfString) {
 		var ret map[string]map[string]string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 // GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
-	if o == nil || isNil(o.MapMapOfString) {
+	if o == nil || IsNil(o.MapMapOfString) {
 		return nil, false
 	}
 	return o.MapMapOfString, true
@@ -62,7 +62,7 @@ func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 
 // HasMapMapOfString returns a boolean if a field has been set.
 func (o *MapTest) HasMapMapOfString() bool {
-	if o != nil && !isNil(o.MapMapOfString) {
+	if o != nil && !IsNil(o.MapMapOfString) {
 		return true
 	}
 
@@ -76,7 +76,7 @@ func (o *MapTest) SetMapMapOfString(v map[string]map[string]string) {
 
 // GetMapOfEnumString returns the MapOfEnumString field value if set, zero value otherwise.
 func (o *MapTest) GetMapOfEnumString() map[string]string {
-	if o == nil || isNil(o.MapOfEnumString) {
+	if o == nil || IsNil(o.MapOfEnumString) {
 		var ret map[string]string
 		return ret
 	}
@@ -86,7 +86,7 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 // GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
-	if o == nil || isNil(o.MapOfEnumString) {
+	if o == nil || IsNil(o.MapOfEnumString) {
 		return nil, false
 	}
 	return o.MapOfEnumString, true
@@ -94,7 +94,7 @@ func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 
 // HasMapOfEnumString returns a boolean if a field has been set.
 func (o *MapTest) HasMapOfEnumString() bool {
-	if o != nil && !isNil(o.MapOfEnumString) {
+	if o != nil && !IsNil(o.MapOfEnumString) {
 		return true
 	}
 
@@ -108,7 +108,7 @@ func (o *MapTest) SetMapOfEnumString(v map[string]string) {
 
 // GetDirectMap returns the DirectMap field value if set, zero value otherwise.
 func (o *MapTest) GetDirectMap() map[string]bool {
-	if o == nil || isNil(o.DirectMap) {
+	if o == nil || IsNil(o.DirectMap) {
 		var ret map[string]bool
 		return ret
 	}
@@ -118,7 +118,7 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 // GetDirectMapOk returns a tuple with the DirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
-	if o == nil || isNil(o.DirectMap) {
+	if o == nil || IsNil(o.DirectMap) {
 		return nil, false
 	}
 	return o.DirectMap, true
@@ -126,7 +126,7 @@ func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 
 // HasDirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasDirectMap() bool {
-	if o != nil && !isNil(o.DirectMap) {
+	if o != nil && !IsNil(o.DirectMap) {
 		return true
 	}
 
@@ -140,7 +140,7 @@ func (o *MapTest) SetDirectMap(v map[string]bool) {
 
 // GetIndirectMap returns the IndirectMap field value if set, zero value otherwise.
 func (o *MapTest) GetIndirectMap() map[string]bool {
-	if o == nil || isNil(o.IndirectMap) {
+	if o == nil || IsNil(o.IndirectMap) {
 		var ret map[string]bool
 		return ret
 	}
@@ -150,7 +150,7 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 // GetIndirectMapOk returns a tuple with the IndirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
-	if o == nil || isNil(o.IndirectMap) {
+	if o == nil || IsNil(o.IndirectMap) {
 		return nil, false
 	}
 	return o.IndirectMap, true
@@ -158,7 +158,7 @@ func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 
 // HasIndirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasIndirectMap() bool {
-	if o != nil && !isNil(o.IndirectMap) {
+	if o != nil && !IsNil(o.IndirectMap) {
 		return true
 	}
 
@@ -180,16 +180,16 @@ func (o MapTest) MarshalJSON() ([]byte, error) {
 
 func (o MapTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.MapMapOfString) {
+	if !IsNil(o.MapMapOfString) {
 		toSerialize["map_map_of_string"] = o.MapMapOfString
 	}
-	if !isNil(o.MapOfEnumString) {
+	if !IsNil(o.MapOfEnumString) {
 		toSerialize["map_of_enum_string"] = o.MapOfEnumString
 	}
-	if !isNil(o.DirectMap) {
+	if !IsNil(o.DirectMap) {
 		toSerialize["direct_map"] = o.DirectMap
 	}
-	if !isNil(o.IndirectMap) {
+	if !IsNil(o.IndirectMap) {
 		toSerialize["indirect_map"] = o.IndirectMap
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -44,7 +44,7 @@ func NewMixedPropertiesAndAdditionalPropertiesClassWithDefaults() *MixedProperti
 
 // GetUuid returns the Uuid field value if set, zero value otherwise.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		return nil, false
 	}
 	return o.Uuid, true
@@ -62,7 +62,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool
 
 // HasUuid returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool {
-	if o != nil && !isNil(o.Uuid) {
+	if o != nil && !IsNil(o.Uuid) {
 		return true
 	}
 
@@ -76,7 +76,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetUuid(v string) {
 
 // GetDateTime returns the DateTime field value if set, zero value otherwise.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		var ret time.Time
 		return ret
 	}
@@ -86,7 +86,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		return nil, false
 	}
 	return o.DateTime, true
@@ -94,7 +94,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Tim
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool {
-	if o != nil && !isNil(o.DateTime) {
+	if o != nil && !IsNil(o.DateTime) {
 		return true
 	}
 
@@ -108,7 +108,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetDateTime(v time.Time) {
 
 // GetMap returns the Map field value if set, zero value otherwise.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal {
-	if o == nil || isNil(o.Map) {
+	if o == nil || IsNil(o.Map) {
 		var ret map[string]Animal
 		return ret
 	}
@@ -118,7 +118,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 // GetMapOk returns a tuple with the Map field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
-	if o == nil || isNil(o.Map) {
+	if o == nil || IsNil(o.Map) {
 		return nil, false
 	}
 	return o.Map, true
@@ -126,7 +126,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]An
 
 // HasMap returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool {
-	if o != nil && !isNil(o.Map) {
+	if o != nil && !IsNil(o.Map) {
 		return true
 	}
 
@@ -148,13 +148,13 @@ func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, erro
 
 func (o MixedPropertiesAndAdditionalPropertiesClass) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Uuid) {
+	if !IsNil(o.Uuid) {
 		toSerialize["uuid"] = o.Uuid
 	}
-	if !isNil(o.DateTime) {
+	if !IsNil(o.DateTime) {
 		toSerialize["dateTime"] = o.DateTime
 	}
-	if !isNil(o.Map) {
+	if !IsNil(o.Map) {
 		toSerialize["map"] = o.Map
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -69,7 +69,7 @@ func (o *Name) SetName(v int32) {
 
 // GetSnakeCase returns the SnakeCase field value if set, zero value otherwise.
 func (o *Name) GetSnakeCase() int32 {
-	if o == nil || isNil(o.SnakeCase) {
+	if o == nil || IsNil(o.SnakeCase) {
 		var ret int32
 		return ret
 	}
@@ -79,7 +79,7 @@ func (o *Name) GetSnakeCase() int32 {
 // GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Name) GetSnakeCaseOk() (*int32, bool) {
-	if o == nil || isNil(o.SnakeCase) {
+	if o == nil || IsNil(o.SnakeCase) {
 		return nil, false
 	}
 	return o.SnakeCase, true
@@ -87,7 +87,7 @@ func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 
 // HasSnakeCase returns a boolean if a field has been set.
 func (o *Name) HasSnakeCase() bool {
-	if o != nil && !isNil(o.SnakeCase) {
+	if o != nil && !IsNil(o.SnakeCase) {
 		return true
 	}
 
@@ -101,7 +101,7 @@ func (o *Name) SetSnakeCase(v int32) {
 
 // GetProperty returns the Property field value if set, zero value otherwise.
 func (o *Name) GetProperty() string {
-	if o == nil || isNil(o.Property) {
+	if o == nil || IsNil(o.Property) {
 		var ret string
 		return ret
 	}
@@ -111,7 +111,7 @@ func (o *Name) GetProperty() string {
 // GetPropertyOk returns a tuple with the Property field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Name) GetPropertyOk() (*string, bool) {
-	if o == nil || isNil(o.Property) {
+	if o == nil || IsNil(o.Property) {
 		return nil, false
 	}
 	return o.Property, true
@@ -119,7 +119,7 @@ func (o *Name) GetPropertyOk() (*string, bool) {
 
 // HasProperty returns a boolean if a field has been set.
 func (o *Name) HasProperty() bool {
-	if o != nil && !isNil(o.Property) {
+	if o != nil && !IsNil(o.Property) {
 		return true
 	}
 
@@ -133,7 +133,7 @@ func (o *Name) SetProperty(v string) {
 
 // GetVar123Number returns the Var123Number field value if set, zero value otherwise.
 func (o *Name) GetVar123Number() int32 {
-	if o == nil || isNil(o.Var123Number) {
+	if o == nil || IsNil(o.Var123Number) {
 		var ret int32
 		return ret
 	}
@@ -143,7 +143,7 @@ func (o *Name) GetVar123Number() int32 {
 // GetVar123NumberOk returns a tuple with the Var123Number field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Name) GetVar123NumberOk() (*int32, bool) {
-	if o == nil || isNil(o.Var123Number) {
+	if o == nil || IsNil(o.Var123Number) {
 		return nil, false
 	}
 	return o.Var123Number, true
@@ -151,7 +151,7 @@ func (o *Name) GetVar123NumberOk() (*int32, bool) {
 
 // HasVar123Number returns a boolean if a field has been set.
 func (o *Name) HasVar123Number() bool {
-	if o != nil && !isNil(o.Var123Number) {
+	if o != nil && !IsNil(o.Var123Number) {
 		return true
 	}
 
@@ -175,7 +175,7 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	// skip: snake_case is readOnly
-	if !isNil(o.Property) {
+	if !IsNil(o.Property) {
 		toSerialize["property"] = o.Property
 	}
 	// skip: 123Number is readOnly

--- a/samples/client/petstore/go/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go/go-petstore/model_number_only.go
@@ -41,7 +41,7 @@ func NewNumberOnlyWithDefaults() *NumberOnly {
 
 // GetJustNumber returns the JustNumber field value if set, zero value otherwise.
 func (o *NumberOnly) GetJustNumber() float32 {
-	if o == nil || isNil(o.JustNumber) {
+	if o == nil || IsNil(o.JustNumber) {
 		var ret float32
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *NumberOnly) GetJustNumber() float32 {
 // GetJustNumberOk returns a tuple with the JustNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.JustNumber) {
+	if o == nil || IsNil(o.JustNumber) {
 		return nil, false
 	}
 	return o.JustNumber, true
@@ -59,7 +59,7 @@ func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 
 // HasJustNumber returns a boolean if a field has been set.
 func (o *NumberOnly) HasJustNumber() bool {
-	if o != nil && !isNil(o.JustNumber) {
+	if o != nil && !IsNil(o.JustNumber) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o NumberOnly) MarshalJSON() ([]byte, error) {
 
 func (o NumberOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.JustNumber) {
+	if !IsNil(o.JustNumber) {
 		toSerialize["JustNumber"] = o.JustNumber
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_order.go
+++ b/samples/client/petstore/go/go-petstore/model_order.go
@@ -52,7 +52,7 @@ func NewOrderWithDefaults() *Order {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Order) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -62,7 +62,7 @@ func (o *Order) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -70,7 +70,7 @@ func (o *Order) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Order) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o *Order) SetId(v int64) {
 
 // GetPetId returns the PetId field value if set, zero value otherwise.
 func (o *Order) GetPetId() int64 {
-	if o == nil || isNil(o.PetId) {
+	if o == nil || IsNil(o.PetId) {
 		var ret int64
 		return ret
 	}
@@ -94,7 +94,7 @@ func (o *Order) GetPetId() int64 {
 // GetPetIdOk returns a tuple with the PetId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetPetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.PetId) {
+	if o == nil || IsNil(o.PetId) {
 		return nil, false
 	}
 	return o.PetId, true
@@ -102,7 +102,7 @@ func (o *Order) GetPetIdOk() (*int64, bool) {
 
 // HasPetId returns a boolean if a field has been set.
 func (o *Order) HasPetId() bool {
-	if o != nil && !isNil(o.PetId) {
+	if o != nil && !IsNil(o.PetId) {
 		return true
 	}
 
@@ -116,7 +116,7 @@ func (o *Order) SetPetId(v int64) {
 
 // GetQuantity returns the Quantity field value if set, zero value otherwise.
 func (o *Order) GetQuantity() int32 {
-	if o == nil || isNil(o.Quantity) {
+	if o == nil || IsNil(o.Quantity) {
 		var ret int32
 		return ret
 	}
@@ -126,7 +126,7 @@ func (o *Order) GetQuantity() int32 {
 // GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetQuantityOk() (*int32, bool) {
-	if o == nil || isNil(o.Quantity) {
+	if o == nil || IsNil(o.Quantity) {
 		return nil, false
 	}
 	return o.Quantity, true
@@ -134,7 +134,7 @@ func (o *Order) GetQuantityOk() (*int32, bool) {
 
 // HasQuantity returns a boolean if a field has been set.
 func (o *Order) HasQuantity() bool {
-	if o != nil && !isNil(o.Quantity) {
+	if o != nil && !IsNil(o.Quantity) {
 		return true
 	}
 
@@ -148,7 +148,7 @@ func (o *Order) SetQuantity(v int32) {
 
 // GetShipDate returns the ShipDate field value if set, zero value otherwise.
 func (o *Order) GetShipDate() time.Time {
-	if o == nil || isNil(o.ShipDate) {
+	if o == nil || IsNil(o.ShipDate) {
 		var ret time.Time
 		return ret
 	}
@@ -158,7 +158,7 @@ func (o *Order) GetShipDate() time.Time {
 // GetShipDateOk returns a tuple with the ShipDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetShipDateOk() (*time.Time, bool) {
-	if o == nil || isNil(o.ShipDate) {
+	if o == nil || IsNil(o.ShipDate) {
 		return nil, false
 	}
 	return o.ShipDate, true
@@ -166,7 +166,7 @@ func (o *Order) GetShipDateOk() (*time.Time, bool) {
 
 // HasShipDate returns a boolean if a field has been set.
 func (o *Order) HasShipDate() bool {
-	if o != nil && !isNil(o.ShipDate) {
+	if o != nil && !IsNil(o.ShipDate) {
 		return true
 	}
 
@@ -180,7 +180,7 @@ func (o *Order) SetShipDate(v time.Time) {
 
 // GetStatus returns the Status field value if set, zero value otherwise.
 func (o *Order) GetStatus() string {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		var ret string
 		return ret
 	}
@@ -190,7 +190,7 @@ func (o *Order) GetStatus() string {
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetStatusOk() (*string, bool) {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		return nil, false
 	}
 	return o.Status, true
@@ -198,7 +198,7 @@ func (o *Order) GetStatusOk() (*string, bool) {
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Order) HasStatus() bool {
-	if o != nil && !isNil(o.Status) {
+	if o != nil && !IsNil(o.Status) {
 		return true
 	}
 
@@ -212,7 +212,7 @@ func (o *Order) SetStatus(v string) {
 
 // GetComplete returns the Complete field value if set, zero value otherwise.
 func (o *Order) GetComplete() bool {
-	if o == nil || isNil(o.Complete) {
+	if o == nil || IsNil(o.Complete) {
 		var ret bool
 		return ret
 	}
@@ -222,7 +222,7 @@ func (o *Order) GetComplete() bool {
 // GetCompleteOk returns a tuple with the Complete field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetCompleteOk() (*bool, bool) {
-	if o == nil || isNil(o.Complete) {
+	if o == nil || IsNil(o.Complete) {
 		return nil, false
 	}
 	return o.Complete, true
@@ -230,7 +230,7 @@ func (o *Order) GetCompleteOk() (*bool, bool) {
 
 // HasComplete returns a boolean if a field has been set.
 func (o *Order) HasComplete() bool {
-	if o != nil && !isNil(o.Complete) {
+	if o != nil && !IsNil(o.Complete) {
 		return true
 	}
 
@@ -252,22 +252,22 @@ func (o Order) MarshalJSON() ([]byte, error) {
 
 func (o Order) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.PetId) {
+	if !IsNil(o.PetId) {
 		toSerialize["petId"] = o.PetId
 	}
-	if !isNil(o.Quantity) {
+	if !IsNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
-	if !isNil(o.ShipDate) {
+	if !IsNil(o.ShipDate) {
 		toSerialize["shipDate"] = o.ShipDate
 	}
-	if !isNil(o.Status) {
+	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
-	if !isNil(o.Complete) {
+	if !IsNil(o.Complete) {
 		toSerialize["complete"] = o.Complete
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go/go-petstore/model_outer_composite.go
@@ -43,7 +43,7 @@ func NewOuterCompositeWithDefaults() *OuterComposite {
 
 // GetMyNumber returns the MyNumber field value if set, zero value otherwise.
 func (o *OuterComposite) GetMyNumber() float32 {
-	if o == nil || isNil(o.MyNumber) {
+	if o == nil || IsNil(o.MyNumber) {
 		var ret float32
 		return ret
 	}
@@ -53,7 +53,7 @@ func (o *OuterComposite) GetMyNumber() float32 {
 // GetMyNumberOk returns a tuple with the MyNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.MyNumber) {
+	if o == nil || IsNil(o.MyNumber) {
 		return nil, false
 	}
 	return o.MyNumber, true
@@ -61,7 +61,7 @@ func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 
 // HasMyNumber returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyNumber() bool {
-	if o != nil && !isNil(o.MyNumber) {
+	if o != nil && !IsNil(o.MyNumber) {
 		return true
 	}
 
@@ -75,7 +75,7 @@ func (o *OuterComposite) SetMyNumber(v float32) {
 
 // GetMyString returns the MyString field value if set, zero value otherwise.
 func (o *OuterComposite) GetMyString() string {
-	if o == nil || isNil(o.MyString) {
+	if o == nil || IsNil(o.MyString) {
 		var ret string
 		return ret
 	}
@@ -85,7 +85,7 @@ func (o *OuterComposite) GetMyString() string {
 // GetMyStringOk returns a tuple with the MyString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyStringOk() (*string, bool) {
-	if o == nil || isNil(o.MyString) {
+	if o == nil || IsNil(o.MyString) {
 		return nil, false
 	}
 	return o.MyString, true
@@ -93,7 +93,7 @@ func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 
 // HasMyString returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyString() bool {
-	if o != nil && !isNil(o.MyString) {
+	if o != nil && !IsNil(o.MyString) {
 		return true
 	}
 
@@ -107,7 +107,7 @@ func (o *OuterComposite) SetMyString(v string) {
 
 // GetMyBoolean returns the MyBoolean field value if set, zero value otherwise.
 func (o *OuterComposite) GetMyBoolean() bool {
-	if o == nil || isNil(o.MyBoolean) {
+	if o == nil || IsNil(o.MyBoolean) {
 		var ret bool
 		return ret
 	}
@@ -117,7 +117,7 @@ func (o *OuterComposite) GetMyBoolean() bool {
 // GetMyBooleanOk returns a tuple with the MyBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.MyBoolean) {
+	if o == nil || IsNil(o.MyBoolean) {
 		return nil, false
 	}
 	return o.MyBoolean, true
@@ -125,7 +125,7 @@ func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 
 // HasMyBoolean returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyBoolean() bool {
-	if o != nil && !isNil(o.MyBoolean) {
+	if o != nil && !IsNil(o.MyBoolean) {
 		return true
 	}
 
@@ -147,13 +147,13 @@ func (o OuterComposite) MarshalJSON() ([]byte, error) {
 
 func (o OuterComposite) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.MyNumber) {
+	if !IsNil(o.MyNumber) {
 		toSerialize["my_number"] = o.MyNumber
 	}
-	if !isNil(o.MyString) {
+	if !IsNil(o.MyString) {
 		toSerialize["my_string"] = o.MyString
 	}
-	if !isNil(o.MyBoolean) {
+	if !IsNil(o.MyBoolean) {
 		toSerialize["my_boolean"] = o.MyBoolean
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -49,7 +49,7 @@ func NewPetWithDefaults() *Pet {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Pet) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -59,7 +59,7 @@ func (o *Pet) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -67,7 +67,7 @@ func (o *Pet) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Pet) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o *Pet) SetId(v int64) {
 
 // GetCategory returns the Category field value if set, zero value otherwise.
 func (o *Pet) GetCategory() Category {
-	if o == nil || isNil(o.Category) {
+	if o == nil || IsNil(o.Category) {
 		var ret Category
 		return ret
 	}
@@ -91,7 +91,7 @@ func (o *Pet) GetCategory() Category {
 // GetCategoryOk returns a tuple with the Category field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetCategoryOk() (*Category, bool) {
-	if o == nil || isNil(o.Category) {
+	if o == nil || IsNil(o.Category) {
 		return nil, false
 	}
 	return o.Category, true
@@ -99,7 +99,7 @@ func (o *Pet) GetCategoryOk() (*Category, bool) {
 
 // HasCategory returns a boolean if a field has been set.
 func (o *Pet) HasCategory() bool {
-	if o != nil && !isNil(o.Category) {
+	if o != nil && !IsNil(o.Category) {
 		return true
 	}
 
@@ -161,7 +161,7 @@ func (o *Pet) SetPhotoUrls(v []string) {
 
 // GetTags returns the Tags field value if set, zero value otherwise.
 func (o *Pet) GetTags() []Tag {
-	if o == nil || isNil(o.Tags) {
+	if o == nil || IsNil(o.Tags) {
 		var ret []Tag
 		return ret
 	}
@@ -171,7 +171,7 @@ func (o *Pet) GetTags() []Tag {
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetTagsOk() ([]Tag, bool) {
-	if o == nil || isNil(o.Tags) {
+	if o == nil || IsNil(o.Tags) {
 		return nil, false
 	}
 	return o.Tags, true
@@ -179,7 +179,7 @@ func (o *Pet) GetTagsOk() ([]Tag, bool) {
 
 // HasTags returns a boolean if a field has been set.
 func (o *Pet) HasTags() bool {
-	if o != nil && !isNil(o.Tags) {
+	if o != nil && !IsNil(o.Tags) {
 		return true
 	}
 
@@ -193,7 +193,7 @@ func (o *Pet) SetTags(v []Tag) {
 
 // GetStatus returns the Status field value if set, zero value otherwise.
 func (o *Pet) GetStatus() string {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		var ret string
 		return ret
 	}
@@ -203,7 +203,7 @@ func (o *Pet) GetStatus() string {
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetStatusOk() (*string, bool) {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		return nil, false
 	}
 	return o.Status, true
@@ -211,7 +211,7 @@ func (o *Pet) GetStatusOk() (*string, bool) {
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Pet) HasStatus() bool {
-	if o != nil && !isNil(o.Status) {
+	if o != nil && !IsNil(o.Status) {
 		return true
 	}
 
@@ -233,18 +233,18 @@ func (o Pet) MarshalJSON() ([]byte, error) {
 
 func (o Pet) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.Category) {
+	if !IsNil(o.Category) {
 		toSerialize["category"] = o.Category
 	}
 	toSerialize["name"] = o.Name
 	toSerialize["photoUrls"] = o.PhotoUrls
-	if !isNil(o.Tags) {
+	if !IsNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
 	}
-	if !isNil(o.Status) {
+	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go/go-petstore/model_read_only_first.go
@@ -42,7 +42,7 @@ func NewReadOnlyFirstWithDefaults() *ReadOnlyFirst {
 
 // GetBar returns the Bar field value if set, zero value otherwise.
 func (o *ReadOnlyFirst) GetBar() string {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		var ret string
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *ReadOnlyFirst) GetBar() string {
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		return nil, false
 	}
 	return o.Bar, true
@@ -60,7 +60,7 @@ func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 
 // HasBar returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBar() bool {
-	if o != nil && !isNil(o.Bar) {
+	if o != nil && !IsNil(o.Bar) {
 		return true
 	}
 
@@ -74,7 +74,7 @@ func (o *ReadOnlyFirst) SetBar(v string) {
 
 // GetBaz returns the Baz field value if set, zero value otherwise.
 func (o *ReadOnlyFirst) GetBaz() string {
-	if o == nil || isNil(o.Baz) {
+	if o == nil || IsNil(o.Baz) {
 		var ret string
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *ReadOnlyFirst) GetBaz() string {
 // GetBazOk returns a tuple with the Baz field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
-	if o == nil || isNil(o.Baz) {
+	if o == nil || IsNil(o.Baz) {
 		return nil, false
 	}
 	return o.Baz, true
@@ -92,7 +92,7 @@ func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 
 // HasBaz returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBaz() bool {
-	if o != nil && !isNil(o.Baz) {
+	if o != nil && !IsNil(o.Baz) {
 		return true
 	}
 
@@ -115,7 +115,7 @@ func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
 func (o ReadOnlyFirst) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	// skip: bar is readOnly
-	if !isNil(o.Baz) {
+	if !IsNil(o.Baz) {
 		toSerialize["baz"] = o.Baz
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_return.go
+++ b/samples/client/petstore/go/go-petstore/model_return.go
@@ -41,7 +41,7 @@ func NewReturnWithDefaults() *Return {
 
 // GetReturn returns the Return field value if set, zero value otherwise.
 func (o *Return) GetReturn() int32 {
-	if o == nil || isNil(o.Return) {
+	if o == nil || IsNil(o.Return) {
 		var ret int32
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *Return) GetReturn() int32 {
 // GetReturnOk returns a tuple with the Return field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Return) GetReturnOk() (*int32, bool) {
-	if o == nil || isNil(o.Return) {
+	if o == nil || IsNil(o.Return) {
 		return nil, false
 	}
 	return o.Return, true
@@ -59,7 +59,7 @@ func (o *Return) GetReturnOk() (*int32, bool) {
 
 // HasReturn returns a boolean if a field has been set.
 func (o *Return) HasReturn() bool {
-	if o != nil && !isNil(o.Return) {
+	if o != nil && !IsNil(o.Return) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o Return) MarshalJSON() ([]byte, error) {
 
 func (o Return) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Return) {
+	if !IsNil(o.Return) {
 		toSerialize["return"] = o.Return
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_special_model_name.go
@@ -41,7 +41,7 @@ func NewSpecialModelNameWithDefaults() *SpecialModelName {
 
 // GetSpecialPropertyName returns the SpecialPropertyName field value if set, zero value otherwise.
 func (o *SpecialModelName) GetSpecialPropertyName() int64 {
-	if o == nil || isNil(o.SpecialPropertyName) {
+	if o == nil || IsNil(o.SpecialPropertyName) {
 		var ret int64
 		return ret
 	}
@@ -51,7 +51,7 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 // GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
-	if o == nil || isNil(o.SpecialPropertyName) {
+	if o == nil || IsNil(o.SpecialPropertyName) {
 		return nil, false
 	}
 	return o.SpecialPropertyName, true
@@ -59,7 +59,7 @@ func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 
 // HasSpecialPropertyName returns a boolean if a field has been set.
 func (o *SpecialModelName) HasSpecialPropertyName() bool {
-	if o != nil && !isNil(o.SpecialPropertyName) {
+	if o != nil && !IsNil(o.SpecialPropertyName) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o SpecialModelName) MarshalJSON() ([]byte, error) {
 
 func (o SpecialModelName) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.SpecialPropertyName) {
+	if !IsNil(o.SpecialPropertyName) {
 		toSerialize["$special[property.name]"] = o.SpecialPropertyName
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_tag.go
+++ b/samples/client/petstore/go/go-petstore/model_tag.go
@@ -42,7 +42,7 @@ func NewTagWithDefaults() *Tag {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Tag) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -52,7 +52,7 @@ func (o *Tag) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Tag) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -60,7 +60,7 @@ func (o *Tag) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Tag) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -74,7 +74,7 @@ func (o *Tag) SetId(v int64) {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *Tag) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *Tag) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Tag) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -92,7 +92,7 @@ func (o *Tag) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *Tag) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -114,10 +114,10 @@ func (o Tag) MarshalJSON() ([]byte, error) {
 
 func (o Tag) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_user.go
+++ b/samples/client/petstore/go/go-petstore/model_user.go
@@ -49,7 +49,7 @@ func NewUserWithDefaults() *User {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *User) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -59,7 +59,7 @@ func (o *User) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -67,7 +67,7 @@ func (o *User) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *User) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -81,7 +81,7 @@ func (o *User) SetId(v int64) {
 
 // GetUsername returns the Username field value if set, zero value otherwise.
 func (o *User) GetUsername() string {
-	if o == nil || isNil(o.Username) {
+	if o == nil || IsNil(o.Username) {
 		var ret string
 		return ret
 	}
@@ -91,7 +91,7 @@ func (o *User) GetUsername() string {
 // GetUsernameOk returns a tuple with the Username field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetUsernameOk() (*string, bool) {
-	if o == nil || isNil(o.Username) {
+	if o == nil || IsNil(o.Username) {
 		return nil, false
 	}
 	return o.Username, true
@@ -99,7 +99,7 @@ func (o *User) GetUsernameOk() (*string, bool) {
 
 // HasUsername returns a boolean if a field has been set.
 func (o *User) HasUsername() bool {
-	if o != nil && !isNil(o.Username) {
+	if o != nil && !IsNil(o.Username) {
 		return true
 	}
 
@@ -113,7 +113,7 @@ func (o *User) SetUsername(v string) {
 
 // GetFirstName returns the FirstName field value if set, zero value otherwise.
 func (o *User) GetFirstName() string {
-	if o == nil || isNil(o.FirstName) {
+	if o == nil || IsNil(o.FirstName) {
 		var ret string
 		return ret
 	}
@@ -123,7 +123,7 @@ func (o *User) GetFirstName() string {
 // GetFirstNameOk returns a tuple with the FirstName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetFirstNameOk() (*string, bool) {
-	if o == nil || isNil(o.FirstName) {
+	if o == nil || IsNil(o.FirstName) {
 		return nil, false
 	}
 	return o.FirstName, true
@@ -131,7 +131,7 @@ func (o *User) GetFirstNameOk() (*string, bool) {
 
 // HasFirstName returns a boolean if a field has been set.
 func (o *User) HasFirstName() bool {
-	if o != nil && !isNil(o.FirstName) {
+	if o != nil && !IsNil(o.FirstName) {
 		return true
 	}
 
@@ -145,7 +145,7 @@ func (o *User) SetFirstName(v string) {
 
 // GetLastName returns the LastName field value if set, zero value otherwise.
 func (o *User) GetLastName() string {
-	if o == nil || isNil(o.LastName) {
+	if o == nil || IsNil(o.LastName) {
 		var ret string
 		return ret
 	}
@@ -155,7 +155,7 @@ func (o *User) GetLastName() string {
 // GetLastNameOk returns a tuple with the LastName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetLastNameOk() (*string, bool) {
-	if o == nil || isNil(o.LastName) {
+	if o == nil || IsNil(o.LastName) {
 		return nil, false
 	}
 	return o.LastName, true
@@ -163,7 +163,7 @@ func (o *User) GetLastNameOk() (*string, bool) {
 
 // HasLastName returns a boolean if a field has been set.
 func (o *User) HasLastName() bool {
-	if o != nil && !isNil(o.LastName) {
+	if o != nil && !IsNil(o.LastName) {
 		return true
 	}
 
@@ -177,7 +177,7 @@ func (o *User) SetLastName(v string) {
 
 // GetEmail returns the Email field value if set, zero value otherwise.
 func (o *User) GetEmail() string {
-	if o == nil || isNil(o.Email) {
+	if o == nil || IsNil(o.Email) {
 		var ret string
 		return ret
 	}
@@ -187,7 +187,7 @@ func (o *User) GetEmail() string {
 // GetEmailOk returns a tuple with the Email field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetEmailOk() (*string, bool) {
-	if o == nil || isNil(o.Email) {
+	if o == nil || IsNil(o.Email) {
 		return nil, false
 	}
 	return o.Email, true
@@ -195,7 +195,7 @@ func (o *User) GetEmailOk() (*string, bool) {
 
 // HasEmail returns a boolean if a field has been set.
 func (o *User) HasEmail() bool {
-	if o != nil && !isNil(o.Email) {
+	if o != nil && !IsNil(o.Email) {
 		return true
 	}
 
@@ -209,7 +209,7 @@ func (o *User) SetEmail(v string) {
 
 // GetPassword returns the Password field value if set, zero value otherwise.
 func (o *User) GetPassword() string {
-	if o == nil || isNil(o.Password) {
+	if o == nil || IsNil(o.Password) {
 		var ret string
 		return ret
 	}
@@ -219,7 +219,7 @@ func (o *User) GetPassword() string {
 // GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetPasswordOk() (*string, bool) {
-	if o == nil || isNil(o.Password) {
+	if o == nil || IsNil(o.Password) {
 		return nil, false
 	}
 	return o.Password, true
@@ -227,7 +227,7 @@ func (o *User) GetPasswordOk() (*string, bool) {
 
 // HasPassword returns a boolean if a field has been set.
 func (o *User) HasPassword() bool {
-	if o != nil && !isNil(o.Password) {
+	if o != nil && !IsNil(o.Password) {
 		return true
 	}
 
@@ -241,7 +241,7 @@ func (o *User) SetPassword(v string) {
 
 // GetPhone returns the Phone field value if set, zero value otherwise.
 func (o *User) GetPhone() string {
-	if o == nil || isNil(o.Phone) {
+	if o == nil || IsNil(o.Phone) {
 		var ret string
 		return ret
 	}
@@ -251,7 +251,7 @@ func (o *User) GetPhone() string {
 // GetPhoneOk returns a tuple with the Phone field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetPhoneOk() (*string, bool) {
-	if o == nil || isNil(o.Phone) {
+	if o == nil || IsNil(o.Phone) {
 		return nil, false
 	}
 	return o.Phone, true
@@ -259,7 +259,7 @@ func (o *User) GetPhoneOk() (*string, bool) {
 
 // HasPhone returns a boolean if a field has been set.
 func (o *User) HasPhone() bool {
-	if o != nil && !isNil(o.Phone) {
+	if o != nil && !IsNil(o.Phone) {
 		return true
 	}
 
@@ -273,7 +273,7 @@ func (o *User) SetPhone(v string) {
 
 // GetUserStatus returns the UserStatus field value if set, zero value otherwise.
 func (o *User) GetUserStatus() int32 {
-	if o == nil || isNil(o.UserStatus) {
+	if o == nil || IsNil(o.UserStatus) {
 		var ret int32
 		return ret
 	}
@@ -283,7 +283,7 @@ func (o *User) GetUserStatus() int32 {
 // GetUserStatusOk returns a tuple with the UserStatus field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetUserStatusOk() (*int32, bool) {
-	if o == nil || isNil(o.UserStatus) {
+	if o == nil || IsNil(o.UserStatus) {
 		return nil, false
 	}
 	return o.UserStatus, true
@@ -291,7 +291,7 @@ func (o *User) GetUserStatusOk() (*int32, bool) {
 
 // HasUserStatus returns a boolean if a field has been set.
 func (o *User) HasUserStatus() bool {
-	if o != nil && !isNil(o.UserStatus) {
+	if o != nil && !IsNil(o.UserStatus) {
 		return true
 	}
 
@@ -313,28 +313,28 @@ func (o User) MarshalJSON() ([]byte, error) {
 
 func (o User) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.Username) {
+	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
 	}
-	if !isNil(o.FirstName) {
+	if !IsNil(o.FirstName) {
 		toSerialize["firstName"] = o.FirstName
 	}
-	if !isNil(o.LastName) {
+	if !IsNil(o.LastName) {
 		toSerialize["lastName"] = o.LastName
 	}
-	if !isNil(o.Email) {
+	if !IsNil(o.Email) {
 		toSerialize["email"] = o.Email
 	}
-	if !isNil(o.Password) {
+	if !IsNil(o.Password) {
 		toSerialize["password"] = o.Password
 	}
-	if !isNil(o.Phone) {
+	if !IsNil(o.Phone) {
 		toSerialize["phone"] = o.Phone
 	}
-	if !isNil(o.UserStatus) {
+	if !IsNil(o.UserStatus) {
 		toSerialize["userStatus"] = o.UserStatus
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go/go-petstore/model_xml_item.go
@@ -69,7 +69,7 @@ func NewXmlItemWithDefaults() *XmlItem {
 
 // GetAttributeString returns the AttributeString field value if set, zero value otherwise.
 func (o *XmlItem) GetAttributeString() string {
-	if o == nil || isNil(o.AttributeString) {
+	if o == nil || IsNil(o.AttributeString) {
 		var ret string
 		return ret
 	}
@@ -79,7 +79,7 @@ func (o *XmlItem) GetAttributeString() string {
 // GetAttributeStringOk returns a tuple with the AttributeString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeStringOk() (*string, bool) {
-	if o == nil || isNil(o.AttributeString) {
+	if o == nil || IsNil(o.AttributeString) {
 		return nil, false
 	}
 	return o.AttributeString, true
@@ -87,7 +87,7 @@ func (o *XmlItem) GetAttributeStringOk() (*string, bool) {
 
 // HasAttributeString returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeString() bool {
-	if o != nil && !isNil(o.AttributeString) {
+	if o != nil && !IsNil(o.AttributeString) {
 		return true
 	}
 
@@ -101,7 +101,7 @@ func (o *XmlItem) SetAttributeString(v string) {
 
 // GetAttributeNumber returns the AttributeNumber field value if set, zero value otherwise.
 func (o *XmlItem) GetAttributeNumber() float32 {
-	if o == nil || isNil(o.AttributeNumber) {
+	if o == nil || IsNil(o.AttributeNumber) {
 		var ret float32
 		return ret
 	}
@@ -111,7 +111,7 @@ func (o *XmlItem) GetAttributeNumber() float32 {
 // GetAttributeNumberOk returns a tuple with the AttributeNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.AttributeNumber) {
+	if o == nil || IsNil(o.AttributeNumber) {
 		return nil, false
 	}
 	return o.AttributeNumber, true
@@ -119,7 +119,7 @@ func (o *XmlItem) GetAttributeNumberOk() (*float32, bool) {
 
 // HasAttributeNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeNumber() bool {
-	if o != nil && !isNil(o.AttributeNumber) {
+	if o != nil && !IsNil(o.AttributeNumber) {
 		return true
 	}
 
@@ -133,7 +133,7 @@ func (o *XmlItem) SetAttributeNumber(v float32) {
 
 // GetAttributeInteger returns the AttributeInteger field value if set, zero value otherwise.
 func (o *XmlItem) GetAttributeInteger() int32 {
-	if o == nil || isNil(o.AttributeInteger) {
+	if o == nil || IsNil(o.AttributeInteger) {
 		var ret int32
 		return ret
 	}
@@ -143,7 +143,7 @@ func (o *XmlItem) GetAttributeInteger() int32 {
 // GetAttributeIntegerOk returns a tuple with the AttributeInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.AttributeInteger) {
+	if o == nil || IsNil(o.AttributeInteger) {
 		return nil, false
 	}
 	return o.AttributeInteger, true
@@ -151,7 +151,7 @@ func (o *XmlItem) GetAttributeIntegerOk() (*int32, bool) {
 
 // HasAttributeInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeInteger() bool {
-	if o != nil && !isNil(o.AttributeInteger) {
+	if o != nil && !IsNil(o.AttributeInteger) {
 		return true
 	}
 
@@ -165,7 +165,7 @@ func (o *XmlItem) SetAttributeInteger(v int32) {
 
 // GetAttributeBoolean returns the AttributeBoolean field value if set, zero value otherwise.
 func (o *XmlItem) GetAttributeBoolean() bool {
-	if o == nil || isNil(o.AttributeBoolean) {
+	if o == nil || IsNil(o.AttributeBoolean) {
 		var ret bool
 		return ret
 	}
@@ -175,7 +175,7 @@ func (o *XmlItem) GetAttributeBoolean() bool {
 // GetAttributeBooleanOk returns a tuple with the AttributeBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.AttributeBoolean) {
+	if o == nil || IsNil(o.AttributeBoolean) {
 		return nil, false
 	}
 	return o.AttributeBoolean, true
@@ -183,7 +183,7 @@ func (o *XmlItem) GetAttributeBooleanOk() (*bool, bool) {
 
 // HasAttributeBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasAttributeBoolean() bool {
-	if o != nil && !isNil(o.AttributeBoolean) {
+	if o != nil && !IsNil(o.AttributeBoolean) {
 		return true
 	}
 
@@ -197,7 +197,7 @@ func (o *XmlItem) SetAttributeBoolean(v bool) {
 
 // GetWrappedArray returns the WrappedArray field value if set, zero value otherwise.
 func (o *XmlItem) GetWrappedArray() []int32 {
-	if o == nil || isNil(o.WrappedArray) {
+	if o == nil || IsNil(o.WrappedArray) {
 		var ret []int32
 		return ret
 	}
@@ -207,7 +207,7 @@ func (o *XmlItem) GetWrappedArray() []int32 {
 // GetWrappedArrayOk returns a tuple with the WrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.WrappedArray) {
+	if o == nil || IsNil(o.WrappedArray) {
 		return nil, false
 	}
 	return o.WrappedArray, true
@@ -215,7 +215,7 @@ func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool) {
 
 // HasWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasWrappedArray() bool {
-	if o != nil && !isNil(o.WrappedArray) {
+	if o != nil && !IsNil(o.WrappedArray) {
 		return true
 	}
 
@@ -229,7 +229,7 @@ func (o *XmlItem) SetWrappedArray(v []int32) {
 
 // GetNameString returns the NameString field value if set, zero value otherwise.
 func (o *XmlItem) GetNameString() string {
-	if o == nil || isNil(o.NameString) {
+	if o == nil || IsNil(o.NameString) {
 		var ret string
 		return ret
 	}
@@ -239,7 +239,7 @@ func (o *XmlItem) GetNameString() string {
 // GetNameStringOk returns a tuple with the NameString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameStringOk() (*string, bool) {
-	if o == nil || isNil(o.NameString) {
+	if o == nil || IsNil(o.NameString) {
 		return nil, false
 	}
 	return o.NameString, true
@@ -247,7 +247,7 @@ func (o *XmlItem) GetNameStringOk() (*string, bool) {
 
 // HasNameString returns a boolean if a field has been set.
 func (o *XmlItem) HasNameString() bool {
-	if o != nil && !isNil(o.NameString) {
+	if o != nil && !IsNil(o.NameString) {
 		return true
 	}
 
@@ -261,7 +261,7 @@ func (o *XmlItem) SetNameString(v string) {
 
 // GetNameNumber returns the NameNumber field value if set, zero value otherwise.
 func (o *XmlItem) GetNameNumber() float32 {
-	if o == nil || isNil(o.NameNumber) {
+	if o == nil || IsNil(o.NameNumber) {
 		var ret float32
 		return ret
 	}
@@ -271,7 +271,7 @@ func (o *XmlItem) GetNameNumber() float32 {
 // GetNameNumberOk returns a tuple with the NameNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.NameNumber) {
+	if o == nil || IsNil(o.NameNumber) {
 		return nil, false
 	}
 	return o.NameNumber, true
@@ -279,7 +279,7 @@ func (o *XmlItem) GetNameNumberOk() (*float32, bool) {
 
 // HasNameNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasNameNumber() bool {
-	if o != nil && !isNil(o.NameNumber) {
+	if o != nil && !IsNil(o.NameNumber) {
 		return true
 	}
 
@@ -293,7 +293,7 @@ func (o *XmlItem) SetNameNumber(v float32) {
 
 // GetNameInteger returns the NameInteger field value if set, zero value otherwise.
 func (o *XmlItem) GetNameInteger() int32 {
-	if o == nil || isNil(o.NameInteger) {
+	if o == nil || IsNil(o.NameInteger) {
 		var ret int32
 		return ret
 	}
@@ -303,7 +303,7 @@ func (o *XmlItem) GetNameInteger() int32 {
 // GetNameIntegerOk returns a tuple with the NameInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.NameInteger) {
+	if o == nil || IsNil(o.NameInteger) {
 		return nil, false
 	}
 	return o.NameInteger, true
@@ -311,7 +311,7 @@ func (o *XmlItem) GetNameIntegerOk() (*int32, bool) {
 
 // HasNameInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasNameInteger() bool {
-	if o != nil && !isNil(o.NameInteger) {
+	if o != nil && !IsNil(o.NameInteger) {
 		return true
 	}
 
@@ -325,7 +325,7 @@ func (o *XmlItem) SetNameInteger(v int32) {
 
 // GetNameBoolean returns the NameBoolean field value if set, zero value otherwise.
 func (o *XmlItem) GetNameBoolean() bool {
-	if o == nil || isNil(o.NameBoolean) {
+	if o == nil || IsNil(o.NameBoolean) {
 		var ret bool
 		return ret
 	}
@@ -335,7 +335,7 @@ func (o *XmlItem) GetNameBoolean() bool {
 // GetNameBooleanOk returns a tuple with the NameBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.NameBoolean) {
+	if o == nil || IsNil(o.NameBoolean) {
 		return nil, false
 	}
 	return o.NameBoolean, true
@@ -343,7 +343,7 @@ func (o *XmlItem) GetNameBooleanOk() (*bool, bool) {
 
 // HasNameBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasNameBoolean() bool {
-	if o != nil && !isNil(o.NameBoolean) {
+	if o != nil && !IsNil(o.NameBoolean) {
 		return true
 	}
 
@@ -357,7 +357,7 @@ func (o *XmlItem) SetNameBoolean(v bool) {
 
 // GetNameArray returns the NameArray field value if set, zero value otherwise.
 func (o *XmlItem) GetNameArray() []int32 {
-	if o == nil || isNil(o.NameArray) {
+	if o == nil || IsNil(o.NameArray) {
 		var ret []int32
 		return ret
 	}
@@ -367,7 +367,7 @@ func (o *XmlItem) GetNameArray() []int32 {
 // GetNameArrayOk returns a tuple with the NameArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.NameArray) {
+	if o == nil || IsNil(o.NameArray) {
 		return nil, false
 	}
 	return o.NameArray, true
@@ -375,7 +375,7 @@ func (o *XmlItem) GetNameArrayOk() ([]int32, bool) {
 
 // HasNameArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNameArray() bool {
-	if o != nil && !isNil(o.NameArray) {
+	if o != nil && !IsNil(o.NameArray) {
 		return true
 	}
 
@@ -389,7 +389,7 @@ func (o *XmlItem) SetNameArray(v []int32) {
 
 // GetNameWrappedArray returns the NameWrappedArray field value if set, zero value otherwise.
 func (o *XmlItem) GetNameWrappedArray() []int32 {
-	if o == nil || isNil(o.NameWrappedArray) {
+	if o == nil || IsNil(o.NameWrappedArray) {
 		var ret []int32
 		return ret
 	}
@@ -399,7 +399,7 @@ func (o *XmlItem) GetNameWrappedArray() []int32 {
 // GetNameWrappedArrayOk returns a tuple with the NameWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.NameWrappedArray) {
+	if o == nil || IsNil(o.NameWrappedArray) {
 		return nil, false
 	}
 	return o.NameWrappedArray, true
@@ -407,7 +407,7 @@ func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool) {
 
 // HasNameWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNameWrappedArray() bool {
-	if o != nil && !isNil(o.NameWrappedArray) {
+	if o != nil && !IsNil(o.NameWrappedArray) {
 		return true
 	}
 
@@ -421,7 +421,7 @@ func (o *XmlItem) SetNameWrappedArray(v []int32) {
 
 // GetPrefixString returns the PrefixString field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixString() string {
-	if o == nil || isNil(o.PrefixString) {
+	if o == nil || IsNil(o.PrefixString) {
 		var ret string
 		return ret
 	}
@@ -431,7 +431,7 @@ func (o *XmlItem) GetPrefixString() string {
 // GetPrefixStringOk returns a tuple with the PrefixString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixStringOk() (*string, bool) {
-	if o == nil || isNil(o.PrefixString) {
+	if o == nil || IsNil(o.PrefixString) {
 		return nil, false
 	}
 	return o.PrefixString, true
@@ -439,7 +439,7 @@ func (o *XmlItem) GetPrefixStringOk() (*string, bool) {
 
 // HasPrefixString returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixString() bool {
-	if o != nil && !isNil(o.PrefixString) {
+	if o != nil && !IsNil(o.PrefixString) {
 		return true
 	}
 
@@ -453,7 +453,7 @@ func (o *XmlItem) SetPrefixString(v string) {
 
 // GetPrefixNumber returns the PrefixNumber field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNumber() float32 {
-	if o == nil || isNil(o.PrefixNumber) {
+	if o == nil || IsNil(o.PrefixNumber) {
 		var ret float32
 		return ret
 	}
@@ -463,7 +463,7 @@ func (o *XmlItem) GetPrefixNumber() float32 {
 // GetPrefixNumberOk returns a tuple with the PrefixNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.PrefixNumber) {
+	if o == nil || IsNil(o.PrefixNumber) {
 		return nil, false
 	}
 	return o.PrefixNumber, true
@@ -471,7 +471,7 @@ func (o *XmlItem) GetPrefixNumberOk() (*float32, bool) {
 
 // HasPrefixNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNumber() bool {
-	if o != nil && !isNil(o.PrefixNumber) {
+	if o != nil && !IsNil(o.PrefixNumber) {
 		return true
 	}
 
@@ -485,7 +485,7 @@ func (o *XmlItem) SetPrefixNumber(v float32) {
 
 // GetPrefixInteger returns the PrefixInteger field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixInteger() int32 {
-	if o == nil || isNil(o.PrefixInteger) {
+	if o == nil || IsNil(o.PrefixInteger) {
 		var ret int32
 		return ret
 	}
@@ -495,7 +495,7 @@ func (o *XmlItem) GetPrefixInteger() int32 {
 // GetPrefixIntegerOk returns a tuple with the PrefixInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.PrefixInteger) {
+	if o == nil || IsNil(o.PrefixInteger) {
 		return nil, false
 	}
 	return o.PrefixInteger, true
@@ -503,7 +503,7 @@ func (o *XmlItem) GetPrefixIntegerOk() (*int32, bool) {
 
 // HasPrefixInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixInteger() bool {
-	if o != nil && !isNil(o.PrefixInteger) {
+	if o != nil && !IsNil(o.PrefixInteger) {
 		return true
 	}
 
@@ -517,7 +517,7 @@ func (o *XmlItem) SetPrefixInteger(v int32) {
 
 // GetPrefixBoolean returns the PrefixBoolean field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixBoolean() bool {
-	if o == nil || isNil(o.PrefixBoolean) {
+	if o == nil || IsNil(o.PrefixBoolean) {
 		var ret bool
 		return ret
 	}
@@ -527,7 +527,7 @@ func (o *XmlItem) GetPrefixBoolean() bool {
 // GetPrefixBooleanOk returns a tuple with the PrefixBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.PrefixBoolean) {
+	if o == nil || IsNil(o.PrefixBoolean) {
 		return nil, false
 	}
 	return o.PrefixBoolean, true
@@ -535,7 +535,7 @@ func (o *XmlItem) GetPrefixBooleanOk() (*bool, bool) {
 
 // HasPrefixBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixBoolean() bool {
-	if o != nil && !isNil(o.PrefixBoolean) {
+	if o != nil && !IsNil(o.PrefixBoolean) {
 		return true
 	}
 
@@ -549,7 +549,7 @@ func (o *XmlItem) SetPrefixBoolean(v bool) {
 
 // GetPrefixArray returns the PrefixArray field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixArray() []int32 {
-	if o == nil || isNil(o.PrefixArray) {
+	if o == nil || IsNil(o.PrefixArray) {
 		var ret []int32
 		return ret
 	}
@@ -559,7 +559,7 @@ func (o *XmlItem) GetPrefixArray() []int32 {
 // GetPrefixArrayOk returns a tuple with the PrefixArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.PrefixArray) {
+	if o == nil || IsNil(o.PrefixArray) {
 		return nil, false
 	}
 	return o.PrefixArray, true
@@ -567,7 +567,7 @@ func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool) {
 
 // HasPrefixArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixArray() bool {
-	if o != nil && !isNil(o.PrefixArray) {
+	if o != nil && !IsNil(o.PrefixArray) {
 		return true
 	}
 
@@ -581,7 +581,7 @@ func (o *XmlItem) SetPrefixArray(v []int32) {
 
 // GetPrefixWrappedArray returns the PrefixWrappedArray field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixWrappedArray() []int32 {
-	if o == nil || isNil(o.PrefixWrappedArray) {
+	if o == nil || IsNil(o.PrefixWrappedArray) {
 		var ret []int32
 		return ret
 	}
@@ -591,7 +591,7 @@ func (o *XmlItem) GetPrefixWrappedArray() []int32 {
 // GetPrefixWrappedArrayOk returns a tuple with the PrefixWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.PrefixWrappedArray) {
+	if o == nil || IsNil(o.PrefixWrappedArray) {
 		return nil, false
 	}
 	return o.PrefixWrappedArray, true
@@ -599,7 +599,7 @@ func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool) {
 
 // HasPrefixWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixWrappedArray() bool {
-	if o != nil && !isNil(o.PrefixWrappedArray) {
+	if o != nil && !IsNil(o.PrefixWrappedArray) {
 		return true
 	}
 
@@ -613,7 +613,7 @@ func (o *XmlItem) SetPrefixWrappedArray(v []int32) {
 
 // GetNamespaceString returns the NamespaceString field value if set, zero value otherwise.
 func (o *XmlItem) GetNamespaceString() string {
-	if o == nil || isNil(o.NamespaceString) {
+	if o == nil || IsNil(o.NamespaceString) {
 		var ret string
 		return ret
 	}
@@ -623,7 +623,7 @@ func (o *XmlItem) GetNamespaceString() string {
 // GetNamespaceStringOk returns a tuple with the NamespaceString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceStringOk() (*string, bool) {
-	if o == nil || isNil(o.NamespaceString) {
+	if o == nil || IsNil(o.NamespaceString) {
 		return nil, false
 	}
 	return o.NamespaceString, true
@@ -631,7 +631,7 @@ func (o *XmlItem) GetNamespaceStringOk() (*string, bool) {
 
 // HasNamespaceString returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceString() bool {
-	if o != nil && !isNil(o.NamespaceString) {
+	if o != nil && !IsNil(o.NamespaceString) {
 		return true
 	}
 
@@ -645,7 +645,7 @@ func (o *XmlItem) SetNamespaceString(v string) {
 
 // GetNamespaceNumber returns the NamespaceNumber field value if set, zero value otherwise.
 func (o *XmlItem) GetNamespaceNumber() float32 {
-	if o == nil || isNil(o.NamespaceNumber) {
+	if o == nil || IsNil(o.NamespaceNumber) {
 		var ret float32
 		return ret
 	}
@@ -655,7 +655,7 @@ func (o *XmlItem) GetNamespaceNumber() float32 {
 // GetNamespaceNumberOk returns a tuple with the NamespaceNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.NamespaceNumber) {
+	if o == nil || IsNil(o.NamespaceNumber) {
 		return nil, false
 	}
 	return o.NamespaceNumber, true
@@ -663,7 +663,7 @@ func (o *XmlItem) GetNamespaceNumberOk() (*float32, bool) {
 
 // HasNamespaceNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceNumber() bool {
-	if o != nil && !isNil(o.NamespaceNumber) {
+	if o != nil && !IsNil(o.NamespaceNumber) {
 		return true
 	}
 
@@ -677,7 +677,7 @@ func (o *XmlItem) SetNamespaceNumber(v float32) {
 
 // GetNamespaceInteger returns the NamespaceInteger field value if set, zero value otherwise.
 func (o *XmlItem) GetNamespaceInteger() int32 {
-	if o == nil || isNil(o.NamespaceInteger) {
+	if o == nil || IsNil(o.NamespaceInteger) {
 		var ret int32
 		return ret
 	}
@@ -687,7 +687,7 @@ func (o *XmlItem) GetNamespaceInteger() int32 {
 // GetNamespaceIntegerOk returns a tuple with the NamespaceInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.NamespaceInteger) {
+	if o == nil || IsNil(o.NamespaceInteger) {
 		return nil, false
 	}
 	return o.NamespaceInteger, true
@@ -695,7 +695,7 @@ func (o *XmlItem) GetNamespaceIntegerOk() (*int32, bool) {
 
 // HasNamespaceInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceInteger() bool {
-	if o != nil && !isNil(o.NamespaceInteger) {
+	if o != nil && !IsNil(o.NamespaceInteger) {
 		return true
 	}
 
@@ -709,7 +709,7 @@ func (o *XmlItem) SetNamespaceInteger(v int32) {
 
 // GetNamespaceBoolean returns the NamespaceBoolean field value if set, zero value otherwise.
 func (o *XmlItem) GetNamespaceBoolean() bool {
-	if o == nil || isNil(o.NamespaceBoolean) {
+	if o == nil || IsNil(o.NamespaceBoolean) {
 		var ret bool
 		return ret
 	}
@@ -719,7 +719,7 @@ func (o *XmlItem) GetNamespaceBoolean() bool {
 // GetNamespaceBooleanOk returns a tuple with the NamespaceBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.NamespaceBoolean) {
+	if o == nil || IsNil(o.NamespaceBoolean) {
 		return nil, false
 	}
 	return o.NamespaceBoolean, true
@@ -727,7 +727,7 @@ func (o *XmlItem) GetNamespaceBooleanOk() (*bool, bool) {
 
 // HasNamespaceBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceBoolean() bool {
-	if o != nil && !isNil(o.NamespaceBoolean) {
+	if o != nil && !IsNil(o.NamespaceBoolean) {
 		return true
 	}
 
@@ -741,7 +741,7 @@ func (o *XmlItem) SetNamespaceBoolean(v bool) {
 
 // GetNamespaceArray returns the NamespaceArray field value if set, zero value otherwise.
 func (o *XmlItem) GetNamespaceArray() []int32 {
-	if o == nil || isNil(o.NamespaceArray) {
+	if o == nil || IsNil(o.NamespaceArray) {
 		var ret []int32
 		return ret
 	}
@@ -751,7 +751,7 @@ func (o *XmlItem) GetNamespaceArray() []int32 {
 // GetNamespaceArrayOk returns a tuple with the NamespaceArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.NamespaceArray) {
+	if o == nil || IsNil(o.NamespaceArray) {
 		return nil, false
 	}
 	return o.NamespaceArray, true
@@ -759,7 +759,7 @@ func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool) {
 
 // HasNamespaceArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceArray() bool {
-	if o != nil && !isNil(o.NamespaceArray) {
+	if o != nil && !IsNil(o.NamespaceArray) {
 		return true
 	}
 
@@ -773,7 +773,7 @@ func (o *XmlItem) SetNamespaceArray(v []int32) {
 
 // GetNamespaceWrappedArray returns the NamespaceWrappedArray field value if set, zero value otherwise.
 func (o *XmlItem) GetNamespaceWrappedArray() []int32 {
-	if o == nil || isNil(o.NamespaceWrappedArray) {
+	if o == nil || IsNil(o.NamespaceWrappedArray) {
 		var ret []int32
 		return ret
 	}
@@ -783,7 +783,7 @@ func (o *XmlItem) GetNamespaceWrappedArray() []int32 {
 // GetNamespaceWrappedArrayOk returns a tuple with the NamespaceWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.NamespaceWrappedArray) {
+	if o == nil || IsNil(o.NamespaceWrappedArray) {
 		return nil, false
 	}
 	return o.NamespaceWrappedArray, true
@@ -791,7 +791,7 @@ func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool) {
 
 // HasNamespaceWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasNamespaceWrappedArray() bool {
-	if o != nil && !isNil(o.NamespaceWrappedArray) {
+	if o != nil && !IsNil(o.NamespaceWrappedArray) {
 		return true
 	}
 
@@ -805,7 +805,7 @@ func (o *XmlItem) SetNamespaceWrappedArray(v []int32) {
 
 // GetPrefixNsString returns the PrefixNsString field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNsString() string {
-	if o == nil || isNil(o.PrefixNsString) {
+	if o == nil || IsNil(o.PrefixNsString) {
 		var ret string
 		return ret
 	}
@@ -815,7 +815,7 @@ func (o *XmlItem) GetPrefixNsString() string {
 // GetPrefixNsStringOk returns a tuple with the PrefixNsString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsStringOk() (*string, bool) {
-	if o == nil || isNil(o.PrefixNsString) {
+	if o == nil || IsNil(o.PrefixNsString) {
 		return nil, false
 	}
 	return o.PrefixNsString, true
@@ -823,7 +823,7 @@ func (o *XmlItem) GetPrefixNsStringOk() (*string, bool) {
 
 // HasPrefixNsString returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsString() bool {
-	if o != nil && !isNil(o.PrefixNsString) {
+	if o != nil && !IsNil(o.PrefixNsString) {
 		return true
 	}
 
@@ -837,7 +837,7 @@ func (o *XmlItem) SetPrefixNsString(v string) {
 
 // GetPrefixNsNumber returns the PrefixNsNumber field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNsNumber() float32 {
-	if o == nil || isNil(o.PrefixNsNumber) {
+	if o == nil || IsNil(o.PrefixNsNumber) {
 		var ret float32
 		return ret
 	}
@@ -847,7 +847,7 @@ func (o *XmlItem) GetPrefixNsNumber() float32 {
 // GetPrefixNsNumberOk returns a tuple with the PrefixNsNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.PrefixNsNumber) {
+	if o == nil || IsNil(o.PrefixNsNumber) {
 		return nil, false
 	}
 	return o.PrefixNsNumber, true
@@ -855,7 +855,7 @@ func (o *XmlItem) GetPrefixNsNumberOk() (*float32, bool) {
 
 // HasPrefixNsNumber returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsNumber() bool {
-	if o != nil && !isNil(o.PrefixNsNumber) {
+	if o != nil && !IsNil(o.PrefixNsNumber) {
 		return true
 	}
 
@@ -869,7 +869,7 @@ func (o *XmlItem) SetPrefixNsNumber(v float32) {
 
 // GetPrefixNsInteger returns the PrefixNsInteger field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNsInteger() int32 {
-	if o == nil || isNil(o.PrefixNsInteger) {
+	if o == nil || IsNil(o.PrefixNsInteger) {
 		var ret int32
 		return ret
 	}
@@ -879,7 +879,7 @@ func (o *XmlItem) GetPrefixNsInteger() int32 {
 // GetPrefixNsIntegerOk returns a tuple with the PrefixNsInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.PrefixNsInteger) {
+	if o == nil || IsNil(o.PrefixNsInteger) {
 		return nil, false
 	}
 	return o.PrefixNsInteger, true
@@ -887,7 +887,7 @@ func (o *XmlItem) GetPrefixNsIntegerOk() (*int32, bool) {
 
 // HasPrefixNsInteger returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsInteger() bool {
-	if o != nil && !isNil(o.PrefixNsInteger) {
+	if o != nil && !IsNil(o.PrefixNsInteger) {
 		return true
 	}
 
@@ -901,7 +901,7 @@ func (o *XmlItem) SetPrefixNsInteger(v int32) {
 
 // GetPrefixNsBoolean returns the PrefixNsBoolean field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNsBoolean() bool {
-	if o == nil || isNil(o.PrefixNsBoolean) {
+	if o == nil || IsNil(o.PrefixNsBoolean) {
 		var ret bool
 		return ret
 	}
@@ -911,7 +911,7 @@ func (o *XmlItem) GetPrefixNsBoolean() bool {
 // GetPrefixNsBooleanOk returns a tuple with the PrefixNsBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.PrefixNsBoolean) {
+	if o == nil || IsNil(o.PrefixNsBoolean) {
 		return nil, false
 	}
 	return o.PrefixNsBoolean, true
@@ -919,7 +919,7 @@ func (o *XmlItem) GetPrefixNsBooleanOk() (*bool, bool) {
 
 // HasPrefixNsBoolean returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsBoolean() bool {
-	if o != nil && !isNil(o.PrefixNsBoolean) {
+	if o != nil && !IsNil(o.PrefixNsBoolean) {
 		return true
 	}
 
@@ -933,7 +933,7 @@ func (o *XmlItem) SetPrefixNsBoolean(v bool) {
 
 // GetPrefixNsArray returns the PrefixNsArray field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNsArray() []int32 {
-	if o == nil || isNil(o.PrefixNsArray) {
+	if o == nil || IsNil(o.PrefixNsArray) {
 		var ret []int32
 		return ret
 	}
@@ -943,7 +943,7 @@ func (o *XmlItem) GetPrefixNsArray() []int32 {
 // GetPrefixNsArrayOk returns a tuple with the PrefixNsArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.PrefixNsArray) {
+	if o == nil || IsNil(o.PrefixNsArray) {
 		return nil, false
 	}
 	return o.PrefixNsArray, true
@@ -951,7 +951,7 @@ func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool) {
 
 // HasPrefixNsArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsArray() bool {
-	if o != nil && !isNil(o.PrefixNsArray) {
+	if o != nil && !IsNil(o.PrefixNsArray) {
 		return true
 	}
 
@@ -965,7 +965,7 @@ func (o *XmlItem) SetPrefixNsArray(v []int32) {
 
 // GetPrefixNsWrappedArray returns the PrefixNsWrappedArray field value if set, zero value otherwise.
 func (o *XmlItem) GetPrefixNsWrappedArray() []int32 {
-	if o == nil || isNil(o.PrefixNsWrappedArray) {
+	if o == nil || IsNil(o.PrefixNsWrappedArray) {
 		var ret []int32
 		return ret
 	}
@@ -975,7 +975,7 @@ func (o *XmlItem) GetPrefixNsWrappedArray() []int32 {
 // GetPrefixNsWrappedArrayOk returns a tuple with the PrefixNsWrappedArray field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool) {
-	if o == nil || isNil(o.PrefixNsWrappedArray) {
+	if o == nil || IsNil(o.PrefixNsWrappedArray) {
 		return nil, false
 	}
 	return o.PrefixNsWrappedArray, true
@@ -983,7 +983,7 @@ func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool) {
 
 // HasPrefixNsWrappedArray returns a boolean if a field has been set.
 func (o *XmlItem) HasPrefixNsWrappedArray() bool {
-	if o != nil && !isNil(o.PrefixNsWrappedArray) {
+	if o != nil && !IsNil(o.PrefixNsWrappedArray) {
 		return true
 	}
 
@@ -1005,91 +1005,91 @@ func (o XmlItem) MarshalJSON() ([]byte, error) {
 
 func (o XmlItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.AttributeString) {
+	if !IsNil(o.AttributeString) {
 		toSerialize["attribute_string"] = o.AttributeString
 	}
-	if !isNil(o.AttributeNumber) {
+	if !IsNil(o.AttributeNumber) {
 		toSerialize["attribute_number"] = o.AttributeNumber
 	}
-	if !isNil(o.AttributeInteger) {
+	if !IsNil(o.AttributeInteger) {
 		toSerialize["attribute_integer"] = o.AttributeInteger
 	}
-	if !isNil(o.AttributeBoolean) {
+	if !IsNil(o.AttributeBoolean) {
 		toSerialize["attribute_boolean"] = o.AttributeBoolean
 	}
-	if !isNil(o.WrappedArray) {
+	if !IsNil(o.WrappedArray) {
 		toSerialize["wrapped_array"] = o.WrappedArray
 	}
-	if !isNil(o.NameString) {
+	if !IsNil(o.NameString) {
 		toSerialize["name_string"] = o.NameString
 	}
-	if !isNil(o.NameNumber) {
+	if !IsNil(o.NameNumber) {
 		toSerialize["name_number"] = o.NameNumber
 	}
-	if !isNil(o.NameInteger) {
+	if !IsNil(o.NameInteger) {
 		toSerialize["name_integer"] = o.NameInteger
 	}
-	if !isNil(o.NameBoolean) {
+	if !IsNil(o.NameBoolean) {
 		toSerialize["name_boolean"] = o.NameBoolean
 	}
-	if !isNil(o.NameArray) {
+	if !IsNil(o.NameArray) {
 		toSerialize["name_array"] = o.NameArray
 	}
-	if !isNil(o.NameWrappedArray) {
+	if !IsNil(o.NameWrappedArray) {
 		toSerialize["name_wrapped_array"] = o.NameWrappedArray
 	}
-	if !isNil(o.PrefixString) {
+	if !IsNil(o.PrefixString) {
 		toSerialize["prefix_string"] = o.PrefixString
 	}
-	if !isNil(o.PrefixNumber) {
+	if !IsNil(o.PrefixNumber) {
 		toSerialize["prefix_number"] = o.PrefixNumber
 	}
-	if !isNil(o.PrefixInteger) {
+	if !IsNil(o.PrefixInteger) {
 		toSerialize["prefix_integer"] = o.PrefixInteger
 	}
-	if !isNil(o.PrefixBoolean) {
+	if !IsNil(o.PrefixBoolean) {
 		toSerialize["prefix_boolean"] = o.PrefixBoolean
 	}
-	if !isNil(o.PrefixArray) {
+	if !IsNil(o.PrefixArray) {
 		toSerialize["prefix_array"] = o.PrefixArray
 	}
-	if !isNil(o.PrefixWrappedArray) {
+	if !IsNil(o.PrefixWrappedArray) {
 		toSerialize["prefix_wrapped_array"] = o.PrefixWrappedArray
 	}
-	if !isNil(o.NamespaceString) {
+	if !IsNil(o.NamespaceString) {
 		toSerialize["namespace_string"] = o.NamespaceString
 	}
-	if !isNil(o.NamespaceNumber) {
+	if !IsNil(o.NamespaceNumber) {
 		toSerialize["namespace_number"] = o.NamespaceNumber
 	}
-	if !isNil(o.NamespaceInteger) {
+	if !IsNil(o.NamespaceInteger) {
 		toSerialize["namespace_integer"] = o.NamespaceInteger
 	}
-	if !isNil(o.NamespaceBoolean) {
+	if !IsNil(o.NamespaceBoolean) {
 		toSerialize["namespace_boolean"] = o.NamespaceBoolean
 	}
-	if !isNil(o.NamespaceArray) {
+	if !IsNil(o.NamespaceArray) {
 		toSerialize["namespace_array"] = o.NamespaceArray
 	}
-	if !isNil(o.NamespaceWrappedArray) {
+	if !IsNil(o.NamespaceWrappedArray) {
 		toSerialize["namespace_wrapped_array"] = o.NamespaceWrappedArray
 	}
-	if !isNil(o.PrefixNsString) {
+	if !IsNil(o.PrefixNsString) {
 		toSerialize["prefix_ns_string"] = o.PrefixNsString
 	}
-	if !isNil(o.PrefixNsNumber) {
+	if !IsNil(o.PrefixNsNumber) {
 		toSerialize["prefix_ns_number"] = o.PrefixNsNumber
 	}
-	if !isNil(o.PrefixNsInteger) {
+	if !IsNil(o.PrefixNsInteger) {
 		toSerialize["prefix_ns_integer"] = o.PrefixNsInteger
 	}
-	if !isNil(o.PrefixNsBoolean) {
+	if !IsNil(o.PrefixNsBoolean) {
 		toSerialize["prefix_ns_boolean"] = o.PrefixNsBoolean
 	}
-	if !isNil(o.PrefixNsArray) {
+	if !IsNil(o.PrefixNsArray) {
 		toSerialize["prefix_ns_array"] = o.PrefixNsArray
 	}
-	if !isNil(o.PrefixNsWrappedArray) {
+	if !IsNil(o.PrefixNsWrappedArray) {
 		toSerialize["prefix_ns_wrapped_array"] = o.PrefixNsWrappedArray
 	}
 	return toSerialize, nil

--- a/samples/client/petstore/go/go-petstore/utils.go
+++ b/samples/client/petstore/go/go-petstore/utils.go
@@ -328,8 +328,8 @@ func (v *NullableTime) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-// isNil checks if an input is nil
-func isNil(i interface{}) bool {
+// IsNil checks if an input is nil
+func IsNil(i interface{}) bool {
 	if i == nil {
 		return true
 	}

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/utils.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/utils.go
@@ -328,8 +328,8 @@ func (v *NullableTime) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-// isNil checks if an input is nil
-func isNil(i interface{}) bool {
+// IsNil checks if an input is nil
+func IsNil(i interface{}) bool {
 	if i == nil {
 		return true
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
@@ -45,7 +45,7 @@ func NewModel200ResponseWithDefaults() *Model200Response {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *Model200Response) GetName() int32 {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret int32
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *Model200Response) GetName() int32 {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetNameOk() (*int32, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -63,7 +63,7 @@ func (o *Model200Response) GetNameOk() (*int32, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *Model200Response) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *Model200Response) SetName(v int32) {
 
 // GetClass returns the Class field value if set, zero value otherwise.
 func (o *Model200Response) GetClass() string {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		var ret string
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *Model200Response) GetClass() string {
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetClassOk() (*string, bool) {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		return nil, false
 	}
 	return o.Class, true
@@ -95,7 +95,7 @@ func (o *Model200Response) GetClassOk() (*string, bool) {
 
 // HasClass returns a boolean if a field has been set.
 func (o *Model200Response) HasClass() bool {
-	if o != nil && !isNil(o.Class) {
+	if o != nil && !IsNil(o.Class) {
 		return true
 	}
 
@@ -117,10 +117,10 @@ func (o Model200Response) MarshalJSON() ([]byte, error) {
 
 func (o Model200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
-	if !isNil(o.Class) {
+	if !IsNil(o.Class) {
 		toSerialize["class"] = o.Class
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
@@ -44,7 +44,7 @@ func NewFooGetDefaultResponseWithDefaults() *FooGetDefaultResponse {
 
 // GetString returns the String field value if set, zero value otherwise.
 func (o *FooGetDefaultResponse) GetString() Foo {
-	if o == nil || isNil(o.String) {
+	if o == nil || IsNil(o.String) {
 		var ret Foo
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *FooGetDefaultResponse) GetString() Foo {
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FooGetDefaultResponse) GetStringOk() (*Foo, bool) {
-	if o == nil || isNil(o.String) {
+	if o == nil || IsNil(o.String) {
 		return nil, false
 	}
 	return o.String, true
@@ -62,7 +62,7 @@ func (o *FooGetDefaultResponse) GetStringOk() (*Foo, bool) {
 
 // HasString returns a boolean if a field has been set.
 func (o *FooGetDefaultResponse) HasString() bool {
-	if o != nil && !isNil(o.String) {
+	if o != nil && !IsNil(o.String) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o FooGetDefaultResponse) MarshalJSON() ([]byte, error) {
 
 func (o FooGetDefaultResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.String) {
+	if !IsNil(o.String) {
 		toSerialize["string"] = o.String
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
@@ -44,7 +44,7 @@ func NewSpecialModelNameWithDefaults() *SpecialModelName {
 
 // GetSpecialPropertyName returns the SpecialPropertyName field value if set, zero value otherwise.
 func (o *SpecialModelName) GetSpecialPropertyName() int64 {
-	if o == nil || isNil(o.SpecialPropertyName) {
+	if o == nil || IsNil(o.SpecialPropertyName) {
 		var ret int64
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 // GetSpecialPropertyNameOk returns a tuple with the SpecialPropertyName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
-	if o == nil || isNil(o.SpecialPropertyName) {
+	if o == nil || IsNil(o.SpecialPropertyName) {
 		return nil, false
 	}
 	return o.SpecialPropertyName, true
@@ -62,7 +62,7 @@ func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 
 // HasSpecialPropertyName returns a boolean if a field has been set.
 func (o *SpecialModelName) HasSpecialPropertyName() bool {
-	if o != nil && !isNil(o.SpecialPropertyName) {
+	if o != nil && !IsNil(o.SpecialPropertyName) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o SpecialModelName) MarshalJSON() ([]byte, error) {
 
 func (o SpecialModelName) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.SpecialPropertyName) {
+	if !IsNil(o.SpecialPropertyName) {
 		toSerialize["$special[property.name]"] = o.SpecialPropertyName
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
@@ -45,7 +45,7 @@ func NewAdditionalPropertiesClassWithDefaults() *AdditionalPropertiesClass {
 
 // GetMapProperty returns the MapProperty field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapProperty() map[string]string {
-	if o == nil || isNil(o.MapProperty) {
+	if o == nil || IsNil(o.MapProperty) {
 		var ret map[string]string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *AdditionalPropertiesClass) GetMapProperty() map[string]string {
 // GetMapPropertyOk returns a tuple with the MapProperty field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapPropertyOk() (*map[string]string, bool) {
-	if o == nil || isNil(o.MapProperty) {
+	if o == nil || IsNil(o.MapProperty) {
 		return nil, false
 	}
 	return o.MapProperty, true
@@ -63,7 +63,7 @@ func (o *AdditionalPropertiesClass) GetMapPropertyOk() (*map[string]string, bool
 
 // HasMapProperty returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapProperty() bool {
-	if o != nil && !isNil(o.MapProperty) {
+	if o != nil && !IsNil(o.MapProperty) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *AdditionalPropertiesClass) SetMapProperty(v map[string]string) {
 
 // GetMapOfMapProperty returns the MapOfMapProperty field value if set, zero value otherwise.
 func (o *AdditionalPropertiesClass) GetMapOfMapProperty() map[string]map[string]string {
-	if o == nil || isNil(o.MapOfMapProperty) {
+	if o == nil || IsNil(o.MapOfMapProperty) {
 		var ret map[string]map[string]string
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *AdditionalPropertiesClass) GetMapOfMapProperty() map[string]map[string]
 // GetMapOfMapPropertyOk returns a tuple with the MapOfMapProperty field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (*map[string]map[string]string, bool) {
-	if o == nil || isNil(o.MapOfMapProperty) {
+	if o == nil || IsNil(o.MapOfMapProperty) {
 		return nil, false
 	}
 	return o.MapOfMapProperty, true
@@ -95,7 +95,7 @@ func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (*map[string]map[str
 
 // HasMapOfMapProperty returns a boolean if a field has been set.
 func (o *AdditionalPropertiesClass) HasMapOfMapProperty() bool {
-	if o != nil && !isNil(o.MapOfMapProperty) {
+	if o != nil && !IsNil(o.MapOfMapProperty) {
 		return true
 	}
 
@@ -117,10 +117,10 @@ func (o AdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
 
 func (o AdditionalPropertiesClass) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.MapProperty) {
+	if !IsNil(o.MapProperty) {
 		toSerialize["map_property"] = o.MapProperty
 	}
-	if !isNil(o.MapOfMapProperty) {
+	if !IsNil(o.MapOfMapProperty) {
 		toSerialize["map_of_map_property"] = o.MapOfMapProperty
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types.go
@@ -45,7 +45,7 @@ func NewAllOfPrimitiveTypesWithDefaults() *AllOfPrimitiveTypes {
 
 // GetTest returns the Test field value if set, zero value otherwise.
 func (o *AllOfPrimitiveTypes) GetTest() time.Time {
-	if o == nil || isNil(o.Test) {
+	if o == nil || IsNil(o.Test) {
 		var ret time.Time
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *AllOfPrimitiveTypes) GetTest() time.Time {
 // GetTestOk returns a tuple with the Test field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AllOfPrimitiveTypes) GetTestOk() (*time.Time, bool) {
-	if o == nil || isNil(o.Test) {
+	if o == nil || IsNil(o.Test) {
 		return nil, false
 	}
 	return o.Test, true
@@ -63,7 +63,7 @@ func (o *AllOfPrimitiveTypes) GetTestOk() (*time.Time, bool) {
 
 // HasTest returns a boolean if a field has been set.
 func (o *AllOfPrimitiveTypes) HasTest() bool {
-	if o != nil && !isNil(o.Test) {
+	if o != nil && !IsNil(o.Test) {
 		return true
 	}
 
@@ -85,7 +85,7 @@ func (o AllOfPrimitiveTypes) MarshalJSON() ([]byte, error) {
 
 func (o AllOfPrimitiveTypes) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Test) {
+	if !IsNil(o.Test) {
 		toSerialize["test"] = o.Test
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types_all_of.go
@@ -45,7 +45,7 @@ func NewAllOfPrimitiveTypesAllOfWithDefaults() *AllOfPrimitiveTypesAllOf {
 
 // GetTest returns the Test field value if set, zero value otherwise.
 func (o *AllOfPrimitiveTypesAllOf) GetTest() time.Time {
-	if o == nil || isNil(o.Test) {
+	if o == nil || IsNil(o.Test) {
 		var ret time.Time
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *AllOfPrimitiveTypesAllOf) GetTest() time.Time {
 // GetTestOk returns a tuple with the Test field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AllOfPrimitiveTypesAllOf) GetTestOk() (*time.Time, bool) {
-	if o == nil || isNil(o.Test) {
+	if o == nil || IsNil(o.Test) {
 		return nil, false
 	}
 	return o.Test, true
@@ -63,7 +63,7 @@ func (o *AllOfPrimitiveTypesAllOf) GetTestOk() (*time.Time, bool) {
 
 // HasTest returns a boolean if a field has been set.
 func (o *AllOfPrimitiveTypesAllOf) HasTest() bool {
-	if o != nil && !isNil(o.Test) {
+	if o != nil && !IsNil(o.Test) {
 		return true
 	}
 
@@ -85,7 +85,7 @@ func (o AllOfPrimitiveTypesAllOf) MarshalJSON() ([]byte, error) {
 
 func (o AllOfPrimitiveTypesAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Test) {
+	if !IsNil(o.Test) {
 		toSerialize["test"] = o.Test
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -74,7 +74,7 @@ func (o *Animal) SetClassName(v string) {
 
 // GetColor returns the Color field value if set, zero value otherwise.
 func (o *Animal) GetColor() string {
-	if o == nil || isNil(o.Color) {
+	if o == nil || IsNil(o.Color) {
 		var ret string
 		return ret
 	}
@@ -84,7 +84,7 @@ func (o *Animal) GetColor() string {
 // GetColorOk returns a tuple with the Color field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Animal) GetColorOk() (*string, bool) {
-	if o == nil || isNil(o.Color) {
+	if o == nil || IsNil(o.Color) {
 		return nil, false
 	}
 	return o.Color, true
@@ -92,7 +92,7 @@ func (o *Animal) GetColorOk() (*string, bool) {
 
 // HasColor returns a boolean if a field has been set.
 func (o *Animal) HasColor() bool {
-	if o != nil && !isNil(o.Color) {
+	if o != nil && !IsNil(o.Color) {
 		return true
 	}
 
@@ -115,7 +115,7 @@ func (o Animal) MarshalJSON() ([]byte, error) {
 func (o Animal) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["className"] = o.ClassName
-	if !isNil(o.Color) {
+	if !IsNil(o.Color) {
 		toSerialize["color"] = o.Color
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
@@ -46,7 +46,7 @@ func NewApiResponseWithDefaults() *ApiResponse {
 
 // GetCode returns the Code field value if set, zero value otherwise.
 func (o *ApiResponse) GetCode() int32 {
-	if o == nil || isNil(o.Code) {
+	if o == nil || IsNil(o.Code) {
 		var ret int32
 		return ret
 	}
@@ -56,7 +56,7 @@ func (o *ApiResponse) GetCode() int32 {
 // GetCodeOk returns a tuple with the Code field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetCodeOk() (*int32, bool) {
-	if o == nil || isNil(o.Code) {
+	if o == nil || IsNil(o.Code) {
 		return nil, false
 	}
 	return o.Code, true
@@ -64,7 +64,7 @@ func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 
 // HasCode returns a boolean if a field has been set.
 func (o *ApiResponse) HasCode() bool {
-	if o != nil && !isNil(o.Code) {
+	if o != nil && !IsNil(o.Code) {
 		return true
 	}
 
@@ -78,7 +78,7 @@ func (o *ApiResponse) SetCode(v int32) {
 
 // GetType returns the Type field value if set, zero value otherwise.
 func (o *ApiResponse) GetType() string {
-	if o == nil || isNil(o.Type) {
+	if o == nil || IsNil(o.Type) {
 		var ret string
 		return ret
 	}
@@ -88,7 +88,7 @@ func (o *ApiResponse) GetType() string {
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetTypeOk() (*string, bool) {
-	if o == nil || isNil(o.Type) {
+	if o == nil || IsNil(o.Type) {
 		return nil, false
 	}
 	return o.Type, true
@@ -96,7 +96,7 @@ func (o *ApiResponse) GetTypeOk() (*string, bool) {
 
 // HasType returns a boolean if a field has been set.
 func (o *ApiResponse) HasType() bool {
-	if o != nil && !isNil(o.Type) {
+	if o != nil && !IsNil(o.Type) {
 		return true
 	}
 
@@ -110,7 +110,7 @@ func (o *ApiResponse) SetType(v string) {
 
 // GetMessage returns the Message field value if set, zero value otherwise.
 func (o *ApiResponse) GetMessage() string {
-	if o == nil || isNil(o.Message) {
+	if o == nil || IsNil(o.Message) {
 		var ret string
 		return ret
 	}
@@ -120,7 +120,7 @@ func (o *ApiResponse) GetMessage() string {
 // GetMessageOk returns a tuple with the Message field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetMessageOk() (*string, bool) {
-	if o == nil || isNil(o.Message) {
+	if o == nil || IsNil(o.Message) {
 		return nil, false
 	}
 	return o.Message, true
@@ -128,7 +128,7 @@ func (o *ApiResponse) GetMessageOk() (*string, bool) {
 
 // HasMessage returns a boolean if a field has been set.
 func (o *ApiResponse) HasMessage() bool {
-	if o != nil && !isNil(o.Message) {
+	if o != nil && !IsNil(o.Message) {
 		return true
 	}
 
@@ -150,13 +150,13 @@ func (o ApiResponse) MarshalJSON() ([]byte, error) {
 
 func (o ApiResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Code) {
+	if !IsNil(o.Code) {
 		toSerialize["code"] = o.Code
 	}
-	if !isNil(o.Type) {
+	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
-	if !isNil(o.Message) {
+	if !IsNil(o.Message) {
 		toSerialize["message"] = o.Message
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
@@ -44,7 +44,7 @@ func NewAppleWithDefaults() *Apple {
 
 // GetCultivar returns the Cultivar field value if set, zero value otherwise.
 func (o *Apple) GetCultivar() string {
-	if o == nil || isNil(o.Cultivar) {
+	if o == nil || IsNil(o.Cultivar) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *Apple) GetCultivar() string {
 // GetCultivarOk returns a tuple with the Cultivar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Apple) GetCultivarOk() (*string, bool) {
-	if o == nil || isNil(o.Cultivar) {
+	if o == nil || IsNil(o.Cultivar) {
 		return nil, false
 	}
 	return o.Cultivar, true
@@ -62,7 +62,7 @@ func (o *Apple) GetCultivarOk() (*string, bool) {
 
 // HasCultivar returns a boolean if a field has been set.
 func (o *Apple) HasCultivar() bool {
-	if o != nil && !isNil(o.Cultivar) {
+	if o != nil && !IsNil(o.Cultivar) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o Apple) MarshalJSON() ([]byte, error) {
 
 func (o Apple) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Cultivar) {
+	if !IsNil(o.Cultivar) {
 		toSerialize["cultivar"] = o.Cultivar
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -70,7 +70,7 @@ func (o *AppleReq) SetCultivar(v string) {
 
 // GetMealy returns the Mealy field value if set, zero value otherwise.
 func (o *AppleReq) GetMealy() bool {
-	if o == nil || isNil(o.Mealy) {
+	if o == nil || IsNil(o.Mealy) {
 		var ret bool
 		return ret
 	}
@@ -80,7 +80,7 @@ func (o *AppleReq) GetMealy() bool {
 // GetMealyOk returns a tuple with the Mealy field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *AppleReq) GetMealyOk() (*bool, bool) {
-	if o == nil || isNil(o.Mealy) {
+	if o == nil || IsNil(o.Mealy) {
 		return nil, false
 	}
 	return o.Mealy, true
@@ -88,7 +88,7 @@ func (o *AppleReq) GetMealyOk() (*bool, bool) {
 
 // HasMealy returns a boolean if a field has been set.
 func (o *AppleReq) HasMealy() bool {
-	if o != nil && !isNil(o.Mealy) {
+	if o != nil && !IsNil(o.Mealy) {
 		return true
 	}
 
@@ -111,7 +111,7 @@ func (o AppleReq) MarshalJSON() ([]byte, error) {
 func (o AppleReq) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["cultivar"] = o.Cultivar
-	if !isNil(o.Mealy) {
+	if !IsNil(o.Mealy) {
 		toSerialize["mealy"] = o.Mealy
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
@@ -44,7 +44,7 @@ func NewArrayOfArrayOfNumberOnlyWithDefaults() *ArrayOfArrayOfNumberOnly {
 
 // GetArrayArrayNumber returns the ArrayArrayNumber field value if set, zero value otherwise.
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
-	if o == nil || isNil(o.ArrayArrayNumber) {
+	if o == nil || IsNil(o.ArrayArrayNumber) {
 		var ret [][]float32
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 // GetArrayArrayNumberOk returns a tuple with the ArrayArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
-	if o == nil || isNil(o.ArrayArrayNumber) {
+	if o == nil || IsNil(o.ArrayArrayNumber) {
 		return nil, false
 	}
 	return o.ArrayArrayNumber, true
@@ -62,7 +62,7 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 
 // HasArrayArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfArrayOfNumberOnly) HasArrayArrayNumber() bool {
-	if o != nil && !isNil(o.ArrayArrayNumber) {
+	if o != nil && !IsNil(o.ArrayArrayNumber) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o ArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 
 func (o ArrayOfArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.ArrayArrayNumber) {
+	if !IsNil(o.ArrayArrayNumber) {
 		toSerialize["ArrayArrayNumber"] = o.ArrayArrayNumber
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
@@ -44,7 +44,7 @@ func NewArrayOfNumberOnlyWithDefaults() *ArrayOfNumberOnly {
 
 // GetArrayNumber returns the ArrayNumber field value if set, zero value otherwise.
 func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
-	if o == nil || isNil(o.ArrayNumber) {
+	if o == nil || IsNil(o.ArrayNumber) {
 		var ret []float32
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 // GetArrayNumberOk returns a tuple with the ArrayNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
-	if o == nil || isNil(o.ArrayNumber) {
+	if o == nil || IsNil(o.ArrayNumber) {
 		return nil, false
 	}
 	return o.ArrayNumber, true
@@ -62,7 +62,7 @@ func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 
 // HasArrayNumber returns a boolean if a field has been set.
 func (o *ArrayOfNumberOnly) HasArrayNumber() bool {
-	if o != nil && !isNil(o.ArrayNumber) {
+	if o != nil && !IsNil(o.ArrayNumber) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o ArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
 
 func (o ArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.ArrayNumber) {
+	if !IsNil(o.ArrayNumber) {
 		toSerialize["ArrayNumber"] = o.ArrayNumber
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
@@ -46,7 +46,7 @@ func NewArrayTestWithDefaults() *ArrayTest {
 
 // GetArrayOfString returns the ArrayOfString field value if set, zero value otherwise.
 func (o *ArrayTest) GetArrayOfString() []string {
-	if o == nil || isNil(o.ArrayOfString) {
+	if o == nil || IsNil(o.ArrayOfString) {
 		var ret []string
 		return ret
 	}
@@ -56,7 +56,7 @@ func (o *ArrayTest) GetArrayOfString() []string {
 // GetArrayOfStringOk returns a tuple with the ArrayOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
-	if o == nil || isNil(o.ArrayOfString) {
+	if o == nil || IsNil(o.ArrayOfString) {
 		return nil, false
 	}
 	return o.ArrayOfString, true
@@ -64,7 +64,7 @@ func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 
 // HasArrayOfString returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayOfString() bool {
-	if o != nil && !isNil(o.ArrayOfString) {
+	if o != nil && !IsNil(o.ArrayOfString) {
 		return true
 	}
 
@@ -78,7 +78,7 @@ func (o *ArrayTest) SetArrayOfString(v []string) {
 
 // GetArrayArrayOfInteger returns the ArrayArrayOfInteger field value if set, zero value otherwise.
 func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
-	if o == nil || isNil(o.ArrayArrayOfInteger) {
+	if o == nil || IsNil(o.ArrayArrayOfInteger) {
 		var ret [][]int64
 		return ret
 	}
@@ -88,7 +88,7 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 // GetArrayArrayOfIntegerOk returns a tuple with the ArrayArrayOfInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
-	if o == nil || isNil(o.ArrayArrayOfInteger) {
+	if o == nil || IsNil(o.ArrayArrayOfInteger) {
 		return nil, false
 	}
 	return o.ArrayArrayOfInteger, true
@@ -96,7 +96,7 @@ func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 
 // HasArrayArrayOfInteger returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfInteger() bool {
-	if o != nil && !isNil(o.ArrayArrayOfInteger) {
+	if o != nil && !IsNil(o.ArrayArrayOfInteger) {
 		return true
 	}
 
@@ -110,7 +110,7 @@ func (o *ArrayTest) SetArrayArrayOfInteger(v [][]int64) {
 
 // GetArrayArrayOfModel returns the ArrayArrayOfModel field value if set, zero value otherwise.
 func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
-	if o == nil || isNil(o.ArrayArrayOfModel) {
+	if o == nil || IsNil(o.ArrayArrayOfModel) {
 		var ret [][]ReadOnlyFirst
 		return ret
 	}
@@ -120,7 +120,7 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 // GetArrayArrayOfModelOk returns a tuple with the ArrayArrayOfModel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
-	if o == nil || isNil(o.ArrayArrayOfModel) {
+	if o == nil || IsNil(o.ArrayArrayOfModel) {
 		return nil, false
 	}
 	return o.ArrayArrayOfModel, true
@@ -128,7 +128,7 @@ func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 
 // HasArrayArrayOfModel returns a boolean if a field has been set.
 func (o *ArrayTest) HasArrayArrayOfModel() bool {
-	if o != nil && !isNil(o.ArrayArrayOfModel) {
+	if o != nil && !IsNil(o.ArrayArrayOfModel) {
 		return true
 	}
 
@@ -150,13 +150,13 @@ func (o ArrayTest) MarshalJSON() ([]byte, error) {
 
 func (o ArrayTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.ArrayOfString) {
+	if !IsNil(o.ArrayOfString) {
 		toSerialize["array_of_string"] = o.ArrayOfString
 	}
-	if !isNil(o.ArrayArrayOfInteger) {
+	if !IsNil(o.ArrayArrayOfInteger) {
 		toSerialize["array_array_of_integer"] = o.ArrayArrayOfInteger
 	}
-	if !isNil(o.ArrayArrayOfModel) {
+	if !IsNil(o.ArrayArrayOfModel) {
 		toSerialize["array_array_of_model"] = o.ArrayArrayOfModel
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
@@ -44,7 +44,7 @@ func NewBananaWithDefaults() *Banana {
 
 // GetLengthCm returns the LengthCm field value if set, zero value otherwise.
 func (o *Banana) GetLengthCm() float32 {
-	if o == nil || isNil(o.LengthCm) {
+	if o == nil || IsNil(o.LengthCm) {
 		var ret float32
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *Banana) GetLengthCm() float32 {
 // GetLengthCmOk returns a tuple with the LengthCm field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Banana) GetLengthCmOk() (*float32, bool) {
-	if o == nil || isNil(o.LengthCm) {
+	if o == nil || IsNil(o.LengthCm) {
 		return nil, false
 	}
 	return o.LengthCm, true
@@ -62,7 +62,7 @@ func (o *Banana) GetLengthCmOk() (*float32, bool) {
 
 // HasLengthCm returns a boolean if a field has been set.
 func (o *Banana) HasLengthCm() bool {
-	if o != nil && !isNil(o.LengthCm) {
+	if o != nil && !IsNil(o.LengthCm) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o Banana) MarshalJSON() ([]byte, error) {
 
 func (o Banana) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.LengthCm) {
+	if !IsNil(o.LengthCm) {
 		toSerialize["lengthCm"] = o.LengthCm
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -70,7 +70,7 @@ func (o *BananaReq) SetLengthCm(v float32) {
 
 // GetSweet returns the Sweet field value if set, zero value otherwise.
 func (o *BananaReq) GetSweet() bool {
-	if o == nil || isNil(o.Sweet) {
+	if o == nil || IsNil(o.Sweet) {
 		var ret bool
 		return ret
 	}
@@ -80,7 +80,7 @@ func (o *BananaReq) GetSweet() bool {
 // GetSweetOk returns a tuple with the Sweet field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *BananaReq) GetSweetOk() (*bool, bool) {
-	if o == nil || isNil(o.Sweet) {
+	if o == nil || IsNil(o.Sweet) {
 		return nil, false
 	}
 	return o.Sweet, true
@@ -88,7 +88,7 @@ func (o *BananaReq) GetSweetOk() (*bool, bool) {
 
 // HasSweet returns a boolean if a field has been set.
 func (o *BananaReq) HasSweet() bool {
-	if o != nil && !isNil(o.Sweet) {
+	if o != nil && !IsNil(o.Sweet) {
 		return true
 	}
 
@@ -111,7 +111,7 @@ func (o BananaReq) MarshalJSON() ([]byte, error) {
 func (o BananaReq) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["lengthCm"] = o.LengthCm
-	if !isNil(o.Sweet) {
+	if !IsNil(o.Sweet) {
 		toSerialize["sweet"] = o.Sweet
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
@@ -50,7 +50,7 @@ func NewCapitalizationWithDefaults() *Capitalization {
 
 // GetSmallCamel returns the SmallCamel field value if set, zero value otherwise.
 func (o *Capitalization) GetSmallCamel() string {
-	if o == nil || isNil(o.SmallCamel) {
+	if o == nil || IsNil(o.SmallCamel) {
 		var ret string
 		return ret
 	}
@@ -60,7 +60,7 @@ func (o *Capitalization) GetSmallCamel() string {
 // GetSmallCamelOk returns a tuple with the SmallCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
-	if o == nil || isNil(o.SmallCamel) {
+	if o == nil || IsNil(o.SmallCamel) {
 		return nil, false
 	}
 	return o.SmallCamel, true
@@ -68,7 +68,7 @@ func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 
 // HasSmallCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallCamel() bool {
-	if o != nil && !isNil(o.SmallCamel) {
+	if o != nil && !IsNil(o.SmallCamel) {
 		return true
 	}
 
@@ -82,7 +82,7 @@ func (o *Capitalization) SetSmallCamel(v string) {
 
 // GetCapitalCamel returns the CapitalCamel field value if set, zero value otherwise.
 func (o *Capitalization) GetCapitalCamel() string {
-	if o == nil || isNil(o.CapitalCamel) {
+	if o == nil || IsNil(o.CapitalCamel) {
 		var ret string
 		return ret
 	}
@@ -92,7 +92,7 @@ func (o *Capitalization) GetCapitalCamel() string {
 // GetCapitalCamelOk returns a tuple with the CapitalCamel field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
-	if o == nil || isNil(o.CapitalCamel) {
+	if o == nil || IsNil(o.CapitalCamel) {
 		return nil, false
 	}
 	return o.CapitalCamel, true
@@ -100,7 +100,7 @@ func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 
 // HasCapitalCamel returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalCamel() bool {
-	if o != nil && !isNil(o.CapitalCamel) {
+	if o != nil && !IsNil(o.CapitalCamel) {
 		return true
 	}
 
@@ -114,7 +114,7 @@ func (o *Capitalization) SetCapitalCamel(v string) {
 
 // GetSmallSnake returns the SmallSnake field value if set, zero value otherwise.
 func (o *Capitalization) GetSmallSnake() string {
-	if o == nil || isNil(o.SmallSnake) {
+	if o == nil || IsNil(o.SmallSnake) {
 		var ret string
 		return ret
 	}
@@ -124,7 +124,7 @@ func (o *Capitalization) GetSmallSnake() string {
 // GetSmallSnakeOk returns a tuple with the SmallSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
-	if o == nil || isNil(o.SmallSnake) {
+	if o == nil || IsNil(o.SmallSnake) {
 		return nil, false
 	}
 	return o.SmallSnake, true
@@ -132,7 +132,7 @@ func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 
 // HasSmallSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasSmallSnake() bool {
-	if o != nil && !isNil(o.SmallSnake) {
+	if o != nil && !IsNil(o.SmallSnake) {
 		return true
 	}
 
@@ -146,7 +146,7 @@ func (o *Capitalization) SetSmallSnake(v string) {
 
 // GetCapitalSnake returns the CapitalSnake field value if set, zero value otherwise.
 func (o *Capitalization) GetCapitalSnake() string {
-	if o == nil || isNil(o.CapitalSnake) {
+	if o == nil || IsNil(o.CapitalSnake) {
 		var ret string
 		return ret
 	}
@@ -156,7 +156,7 @@ func (o *Capitalization) GetCapitalSnake() string {
 // GetCapitalSnakeOk returns a tuple with the CapitalSnake field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
-	if o == nil || isNil(o.CapitalSnake) {
+	if o == nil || IsNil(o.CapitalSnake) {
 		return nil, false
 	}
 	return o.CapitalSnake, true
@@ -164,7 +164,7 @@ func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 
 // HasCapitalSnake returns a boolean if a field has been set.
 func (o *Capitalization) HasCapitalSnake() bool {
-	if o != nil && !isNil(o.CapitalSnake) {
+	if o != nil && !IsNil(o.CapitalSnake) {
 		return true
 	}
 
@@ -178,7 +178,7 @@ func (o *Capitalization) SetCapitalSnake(v string) {
 
 // GetSCAETHFlowPoints returns the SCAETHFlowPoints field value if set, zero value otherwise.
 func (o *Capitalization) GetSCAETHFlowPoints() string {
-	if o == nil || isNil(o.SCAETHFlowPoints) {
+	if o == nil || IsNil(o.SCAETHFlowPoints) {
 		var ret string
 		return ret
 	}
@@ -188,7 +188,7 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 // GetSCAETHFlowPointsOk returns a tuple with the SCAETHFlowPoints field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
-	if o == nil || isNil(o.SCAETHFlowPoints) {
+	if o == nil || IsNil(o.SCAETHFlowPoints) {
 		return nil, false
 	}
 	return o.SCAETHFlowPoints, true
@@ -196,7 +196,7 @@ func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 
 // HasSCAETHFlowPoints returns a boolean if a field has been set.
 func (o *Capitalization) HasSCAETHFlowPoints() bool {
-	if o != nil && !isNil(o.SCAETHFlowPoints) {
+	if o != nil && !IsNil(o.SCAETHFlowPoints) {
 		return true
 	}
 
@@ -210,7 +210,7 @@ func (o *Capitalization) SetSCAETHFlowPoints(v string) {
 
 // GetATT_NAME returns the ATT_NAME field value if set, zero value otherwise.
 func (o *Capitalization) GetATT_NAME() string {
-	if o == nil || isNil(o.ATT_NAME) {
+	if o == nil || IsNil(o.ATT_NAME) {
 		var ret string
 		return ret
 	}
@@ -220,7 +220,7 @@ func (o *Capitalization) GetATT_NAME() string {
 // GetATT_NAMEOk returns a tuple with the ATT_NAME field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
-	if o == nil || isNil(o.ATT_NAME) {
+	if o == nil || IsNil(o.ATT_NAME) {
 		return nil, false
 	}
 	return o.ATT_NAME, true
@@ -228,7 +228,7 @@ func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 
 // HasATT_NAME returns a boolean if a field has been set.
 func (o *Capitalization) HasATT_NAME() bool {
-	if o != nil && !isNil(o.ATT_NAME) {
+	if o != nil && !IsNil(o.ATT_NAME) {
 		return true
 	}
 
@@ -250,22 +250,22 @@ func (o Capitalization) MarshalJSON() ([]byte, error) {
 
 func (o Capitalization) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.SmallCamel) {
+	if !IsNil(o.SmallCamel) {
 		toSerialize["smallCamel"] = o.SmallCamel
 	}
-	if !isNil(o.CapitalCamel) {
+	if !IsNil(o.CapitalCamel) {
 		toSerialize["CapitalCamel"] = o.CapitalCamel
 	}
-	if !isNil(o.SmallSnake) {
+	if !IsNil(o.SmallSnake) {
 		toSerialize["small_Snake"] = o.SmallSnake
 	}
-	if !isNil(o.CapitalSnake) {
+	if !IsNil(o.CapitalSnake) {
 		toSerialize["Capital_Snake"] = o.CapitalSnake
 	}
-	if !isNil(o.SCAETHFlowPoints) {
+	if !IsNil(o.SCAETHFlowPoints) {
 		toSerialize["SCA_ETH_Flow_Points"] = o.SCAETHFlowPoints
 	}
-	if !isNil(o.ATT_NAME) {
+	if !IsNil(o.ATT_NAME) {
 		toSerialize["ATT_NAME"] = o.ATT_NAME
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
@@ -50,7 +50,7 @@ func NewCatWithDefaults() *Cat {
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
 func (o *Cat) GetDeclawed() bool {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		var ret bool
 		return ret
 	}
@@ -60,7 +60,7 @@ func (o *Cat) GetDeclawed() bool {
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Cat) GetDeclawedOk() (*bool, bool) {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		return nil, false
 	}
 	return o.Declawed, true
@@ -68,7 +68,7 @@ func (o *Cat) GetDeclawedOk() (*bool, bool) {
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *Cat) HasDeclawed() bool {
-	if o != nil && !isNil(o.Declawed) {
+	if o != nil && !IsNil(o.Declawed) {
 		return true
 	}
 
@@ -98,7 +98,7 @@ func (o Cat) ToMap() (map[string]interface{}, error) {
 	if errAnimal != nil {
 		return map[string]interface{}{}, errAnimal
 	}
-	if !isNil(o.Declawed) {
+	if !IsNil(o.Declawed) {
 		toSerialize["declawed"] = o.Declawed
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat_all_of.go
@@ -44,7 +44,7 @@ func NewCatAllOfWithDefaults() *CatAllOf {
 
 // GetDeclawed returns the Declawed field value if set, zero value otherwise.
 func (o *CatAllOf) GetDeclawed() bool {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		var ret bool
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *CatAllOf) GetDeclawed() bool {
 // GetDeclawedOk returns a tuple with the Declawed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
-	if o == nil || isNil(o.Declawed) {
+	if o == nil || IsNil(o.Declawed) {
 		return nil, false
 	}
 	return o.Declawed, true
@@ -62,7 +62,7 @@ func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 
 // HasDeclawed returns a boolean if a field has been set.
 func (o *CatAllOf) HasDeclawed() bool {
-	if o != nil && !isNil(o.Declawed) {
+	if o != nil && !IsNil(o.Declawed) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o CatAllOf) MarshalJSON() ([]byte, error) {
 
 func (o CatAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Declawed) {
+	if !IsNil(o.Declawed) {
 		toSerialize["declawed"] = o.Declawed
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -48,7 +48,7 @@ func NewCategoryWithDefaults() *Category {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Category) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -58,7 +58,7 @@ func (o *Category) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Category) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -66,7 +66,7 @@ func (o *Category) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Category) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -112,7 +112,7 @@ func (o Category) MarshalJSON() ([]byte, error) {
 
 func (o Category) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
 	toSerialize["name"] = o.Name

--- a/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
@@ -44,7 +44,7 @@ func NewClassModelWithDefaults() *ClassModel {
 
 // GetClass returns the Class field value if set, zero value otherwise.
 func (o *ClassModel) GetClass() string {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *ClassModel) GetClass() string {
 // GetClassOk returns a tuple with the Class field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ClassModel) GetClassOk() (*string, bool) {
-	if o == nil || isNil(o.Class) {
+	if o == nil || IsNil(o.Class) {
 		return nil, false
 	}
 	return o.Class, true
@@ -62,7 +62,7 @@ func (o *ClassModel) GetClassOk() (*string, bool) {
 
 // HasClass returns a boolean if a field has been set.
 func (o *ClassModel) HasClass() bool {
-	if o != nil && !isNil(o.Class) {
+	if o != nil && !IsNil(o.Class) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o ClassModel) MarshalJSON() ([]byte, error) {
 
 func (o ClassModel) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Class) {
+	if !IsNil(o.Class) {
 		toSerialize["_class"] = o.Class
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_client.go
@@ -44,7 +44,7 @@ func NewClientWithDefaults() *Client {
 
 // GetClient returns the Client field value if set, zero value otherwise.
 func (o *Client) GetClient() string {
-	if o == nil || isNil(o.Client) {
+	if o == nil || IsNil(o.Client) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *Client) GetClient() string {
 // GetClientOk returns a tuple with the Client field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Client) GetClientOk() (*string, bool) {
-	if o == nil || isNil(o.Client) {
+	if o == nil || IsNil(o.Client) {
 		return nil, false
 	}
 	return o.Client, true
@@ -62,7 +62,7 @@ func (o *Client) GetClientOk() (*string, bool) {
 
 // HasClient returns a boolean if a field has been set.
 func (o *Client) HasClient() bool {
-	if o != nil && !isNil(o.Client) {
+	if o != nil && !IsNil(o.Client) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o Client) MarshalJSON() ([]byte, error) {
 
 func (o Client) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Client) {
+	if !IsNil(o.Client) {
 		toSerialize["client"] = o.Client
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
@@ -50,7 +50,7 @@ func NewDogWithDefaults() *Dog {
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
 func (o *Dog) GetBreed() string {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		var ret string
 		return ret
 	}
@@ -60,7 +60,7 @@ func (o *Dog) GetBreed() string {
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Dog) GetBreedOk() (*string, bool) {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		return nil, false
 	}
 	return o.Breed, true
@@ -68,7 +68,7 @@ func (o *Dog) GetBreedOk() (*string, bool) {
 
 // HasBreed returns a boolean if a field has been set.
 func (o *Dog) HasBreed() bool {
-	if o != nil && !isNil(o.Breed) {
+	if o != nil && !IsNil(o.Breed) {
 		return true
 	}
 
@@ -98,7 +98,7 @@ func (o Dog) ToMap() (map[string]interface{}, error) {
 	if errAnimal != nil {
 		return map[string]interface{}{}, errAnimal
 	}
-	if !isNil(o.Breed) {
+	if !IsNil(o.Breed) {
 		toSerialize["breed"] = o.Breed
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog_all_of.go
@@ -44,7 +44,7 @@ func NewDogAllOfWithDefaults() *DogAllOf {
 
 // GetBreed returns the Breed field value if set, zero value otherwise.
 func (o *DogAllOf) GetBreed() string {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *DogAllOf) GetBreed() string {
 // GetBreedOk returns a tuple with the Breed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *DogAllOf) GetBreedOk() (*string, bool) {
-	if o == nil || isNil(o.Breed) {
+	if o == nil || IsNil(o.Breed) {
 		return nil, false
 	}
 	return o.Breed, true
@@ -62,7 +62,7 @@ func (o *DogAllOf) GetBreedOk() (*string, bool) {
 
 // HasBreed returns a boolean if a field has been set.
 func (o *DogAllOf) HasBreed() bool {
-	if o != nil && !isNil(o.Breed) {
+	if o != nil && !IsNil(o.Breed) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o DogAllOf) MarshalJSON() ([]byte, error) {
 
 func (o DogAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Breed) {
+	if !IsNil(o.Breed) {
 		toSerialize["breed"] = o.Breed
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child.go
@@ -48,7 +48,7 @@ func NewDuplicatedPropChildWithDefaults() *DuplicatedPropChild {
 
 // GetDupProp returns the DupProp field value if set, zero value otherwise.
 func (o *DuplicatedPropChild) GetDupProp() string {
-	if o == nil || isNil(o.DupProp) {
+	if o == nil || IsNil(o.DupProp) {
 		var ret string
 		return ret
 	}
@@ -58,7 +58,7 @@ func (o *DuplicatedPropChild) GetDupProp() string {
 // GetDupPropOk returns a tuple with the DupProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *DuplicatedPropChild) GetDupPropOk() (*string, bool) {
-	if o == nil || isNil(o.DupProp) {
+	if o == nil || IsNil(o.DupProp) {
 		return nil, false
 	}
 	return o.DupProp, true
@@ -66,7 +66,7 @@ func (o *DuplicatedPropChild) GetDupPropOk() (*string, bool) {
 
 // HasDupProp returns a boolean if a field has been set.
 func (o *DuplicatedPropChild) HasDupProp() bool {
-	if o != nil && !isNil(o.DupProp) {
+	if o != nil && !IsNil(o.DupProp) {
 		return true
 	}
 
@@ -96,7 +96,7 @@ func (o DuplicatedPropChild) ToMap() (map[string]interface{}, error) {
 	if errDuplicatedPropParent != nil {
 		return map[string]interface{}{}, errDuplicatedPropParent
 	}
-	if !isNil(o.DupProp) {
+	if !IsNil(o.DupProp) {
 		toSerialize["dup-prop"] = o.DupProp
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child_all_of.go
@@ -45,7 +45,7 @@ func NewDuplicatedPropChildAllOfWithDefaults() *DuplicatedPropChildAllOf {
 
 // GetDupProp returns the DupProp field value if set, zero value otherwise.
 func (o *DuplicatedPropChildAllOf) GetDupProp() string {
-	if o == nil || isNil(o.DupProp) {
+	if o == nil || IsNil(o.DupProp) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *DuplicatedPropChildAllOf) GetDupProp() string {
 // GetDupPropOk returns a tuple with the DupProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *DuplicatedPropChildAllOf) GetDupPropOk() (*string, bool) {
-	if o == nil || isNil(o.DupProp) {
+	if o == nil || IsNil(o.DupProp) {
 		return nil, false
 	}
 	return o.DupProp, true
@@ -63,7 +63,7 @@ func (o *DuplicatedPropChildAllOf) GetDupPropOk() (*string, bool) {
 
 // HasDupProp returns a boolean if a field has been set.
 func (o *DuplicatedPropChildAllOf) HasDupProp() bool {
-	if o != nil && !isNil(o.DupProp) {
+	if o != nil && !IsNil(o.DupProp) {
 		return true
 	}
 
@@ -85,7 +85,7 @@ func (o DuplicatedPropChildAllOf) MarshalJSON() ([]byte, error) {
 
 func (o DuplicatedPropChildAllOf) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.DupProp) {
+	if !IsNil(o.DupProp) {
 		toSerialize["dup-prop"] = o.DupProp
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -45,7 +45,7 @@ func NewEnumArraysWithDefaults() *EnumArrays {
 
 // GetJustSymbol returns the JustSymbol field value if set, zero value otherwise.
 func (o *EnumArrays) GetJustSymbol() string {
-	if o == nil || isNil(o.JustSymbol) {
+	if o == nil || IsNil(o.JustSymbol) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *EnumArrays) GetJustSymbol() string {
 // GetJustSymbolOk returns a tuple with the JustSymbol field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
-	if o == nil || isNil(o.JustSymbol) {
+	if o == nil || IsNil(o.JustSymbol) {
 		return nil, false
 	}
 	return o.JustSymbol, true
@@ -63,7 +63,7 @@ func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 
 // HasJustSymbol returns a boolean if a field has been set.
 func (o *EnumArrays) HasJustSymbol() bool {
-	if o != nil && !isNil(o.JustSymbol) {
+	if o != nil && !IsNil(o.JustSymbol) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *EnumArrays) SetJustSymbol(v string) {
 
 // GetArrayEnum returns the ArrayEnum field value if set, zero value otherwise.
 func (o *EnumArrays) GetArrayEnum() []string {
-	if o == nil || isNil(o.ArrayEnum) {
+	if o == nil || IsNil(o.ArrayEnum) {
 		var ret []string
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *EnumArrays) GetArrayEnum() []string {
 // GetArrayEnumOk returns a tuple with the ArrayEnum field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
-	if o == nil || isNil(o.ArrayEnum) {
+	if o == nil || IsNil(o.ArrayEnum) {
 		return nil, false
 	}
 	return o.ArrayEnum, true
@@ -95,7 +95,7 @@ func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 
 // HasArrayEnum returns a boolean if a field has been set.
 func (o *EnumArrays) HasArrayEnum() bool {
-	if o != nil && !isNil(o.ArrayEnum) {
+	if o != nil && !IsNil(o.ArrayEnum) {
 		return true
 	}
 
@@ -117,10 +117,10 @@ func (o EnumArrays) MarshalJSON() ([]byte, error) {
 
 func (o EnumArrays) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.JustSymbol) {
+	if !IsNil(o.JustSymbol) {
 		toSerialize["just_symbol"] = o.JustSymbol
 	}
-	if !isNil(o.ArrayEnum) {
+	if !IsNil(o.ArrayEnum) {
 		toSerialize["array_enum"] = o.ArrayEnum
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -60,7 +60,7 @@ func NewEnumTestWithDefaults() *EnumTest {
 
 // GetEnumString returns the EnumString field value if set, zero value otherwise.
 func (o *EnumTest) GetEnumString() string {
-	if o == nil || isNil(o.EnumString) {
+	if o == nil || IsNil(o.EnumString) {
 		var ret string
 		return ret
 	}
@@ -70,7 +70,7 @@ func (o *EnumTest) GetEnumString() string {
 // GetEnumStringOk returns a tuple with the EnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumStringOk() (*string, bool) {
-	if o == nil || isNil(o.EnumString) {
+	if o == nil || IsNil(o.EnumString) {
 		return nil, false
 	}
 	return o.EnumString, true
@@ -78,7 +78,7 @@ func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 
 // HasEnumString returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumString() bool {
-	if o != nil && !isNil(o.EnumString) {
+	if o != nil && !IsNil(o.EnumString) {
 		return true
 	}
 
@@ -116,7 +116,7 @@ func (o *EnumTest) SetEnumStringRequired(v string) {
 
 // GetEnumInteger returns the EnumInteger field value if set, zero value otherwise.
 func (o *EnumTest) GetEnumInteger() int32 {
-	if o == nil || isNil(o.EnumInteger) {
+	if o == nil || IsNil(o.EnumInteger) {
 		var ret int32
 		return ret
 	}
@@ -126,7 +126,7 @@ func (o *EnumTest) GetEnumInteger() int32 {
 // GetEnumIntegerOk returns a tuple with the EnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.EnumInteger) {
+	if o == nil || IsNil(o.EnumInteger) {
 		return nil, false
 	}
 	return o.EnumInteger, true
@@ -134,7 +134,7 @@ func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 
 // HasEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumInteger() bool {
-	if o != nil && !isNil(o.EnumInteger) {
+	if o != nil && !IsNil(o.EnumInteger) {
 		return true
 	}
 
@@ -148,7 +148,7 @@ func (o *EnumTest) SetEnumInteger(v int32) {
 
 // GetEnumNumber returns the EnumNumber field value if set, zero value otherwise.
 func (o *EnumTest) GetEnumNumber() float64 {
-	if o == nil || isNil(o.EnumNumber) {
+	if o == nil || IsNil(o.EnumNumber) {
 		var ret float64
 		return ret
 	}
@@ -158,7 +158,7 @@ func (o *EnumTest) GetEnumNumber() float64 {
 // GetEnumNumberOk returns a tuple with the EnumNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
-	if o == nil || isNil(o.EnumNumber) {
+	if o == nil || IsNil(o.EnumNumber) {
 		return nil, false
 	}
 	return o.EnumNumber, true
@@ -166,7 +166,7 @@ func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 
 // HasEnumNumber returns a boolean if a field has been set.
 func (o *EnumTest) HasEnumNumber() bool {
-	if o != nil && !isNil(o.EnumNumber) {
+	if o != nil && !IsNil(o.EnumNumber) {
 		return true
 	}
 
@@ -180,7 +180,7 @@ func (o *EnumTest) SetEnumNumber(v float64) {
 
 // GetOuterEnum returns the OuterEnum field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EnumTest) GetOuterEnum() OuterEnum {
-	if o == nil || isNil(o.OuterEnum.Get()) {
+	if o == nil || IsNil(o.OuterEnum.Get()) {
 		var ret OuterEnum
 		return ret
 	}
@@ -222,7 +222,7 @@ func (o *EnumTest) UnsetOuterEnum() {
 
 // GetOuterEnumInteger returns the OuterEnumInteger field value if set, zero value otherwise.
 func (o *EnumTest) GetOuterEnumInteger() OuterEnumInteger {
-	if o == nil || isNil(o.OuterEnumInteger) {
+	if o == nil || IsNil(o.OuterEnumInteger) {
 		var ret OuterEnumInteger
 		return ret
 	}
@@ -232,7 +232,7 @@ func (o *EnumTest) GetOuterEnumInteger() OuterEnumInteger {
 // GetOuterEnumIntegerOk returns a tuple with the OuterEnumInteger field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumIntegerOk() (*OuterEnumInteger, bool) {
-	if o == nil || isNil(o.OuterEnumInteger) {
+	if o == nil || IsNil(o.OuterEnumInteger) {
 		return nil, false
 	}
 	return o.OuterEnumInteger, true
@@ -240,7 +240,7 @@ func (o *EnumTest) GetOuterEnumIntegerOk() (*OuterEnumInteger, bool) {
 
 // HasOuterEnumInteger returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumInteger() bool {
-	if o != nil && !isNil(o.OuterEnumInteger) {
+	if o != nil && !IsNil(o.OuterEnumInteger) {
 		return true
 	}
 
@@ -254,7 +254,7 @@ func (o *EnumTest) SetOuterEnumInteger(v OuterEnumInteger) {
 
 // GetOuterEnumDefaultValue returns the OuterEnumDefaultValue field value if set, zero value otherwise.
 func (o *EnumTest) GetOuterEnumDefaultValue() OuterEnumDefaultValue {
-	if o == nil || isNil(o.OuterEnumDefaultValue) {
+	if o == nil || IsNil(o.OuterEnumDefaultValue) {
 		var ret OuterEnumDefaultValue
 		return ret
 	}
@@ -264,7 +264,7 @@ func (o *EnumTest) GetOuterEnumDefaultValue() OuterEnumDefaultValue {
 // GetOuterEnumDefaultValueOk returns a tuple with the OuterEnumDefaultValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumDefaultValueOk() (*OuterEnumDefaultValue, bool) {
-	if o == nil || isNil(o.OuterEnumDefaultValue) {
+	if o == nil || IsNil(o.OuterEnumDefaultValue) {
 		return nil, false
 	}
 	return o.OuterEnumDefaultValue, true
@@ -272,7 +272,7 @@ func (o *EnumTest) GetOuterEnumDefaultValueOk() (*OuterEnumDefaultValue, bool) {
 
 // HasOuterEnumDefaultValue returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumDefaultValue() bool {
-	if o != nil && !isNil(o.OuterEnumDefaultValue) {
+	if o != nil && !IsNil(o.OuterEnumDefaultValue) {
 		return true
 	}
 
@@ -286,7 +286,7 @@ func (o *EnumTest) SetOuterEnumDefaultValue(v OuterEnumDefaultValue) {
 
 // GetOuterEnumIntegerDefaultValue returns the OuterEnumIntegerDefaultValue field value if set, zero value otherwise.
 func (o *EnumTest) GetOuterEnumIntegerDefaultValue() OuterEnumIntegerDefaultValue {
-	if o == nil || isNil(o.OuterEnumIntegerDefaultValue) {
+	if o == nil || IsNil(o.OuterEnumIntegerDefaultValue) {
 		var ret OuterEnumIntegerDefaultValue
 		return ret
 	}
@@ -296,7 +296,7 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValue() OuterEnumIntegerDefaultValu
 // GetOuterEnumIntegerDefaultValueOk returns a tuple with the OuterEnumIntegerDefaultValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (*OuterEnumIntegerDefaultValue, bool) {
-	if o == nil || isNil(o.OuterEnumIntegerDefaultValue) {
+	if o == nil || IsNil(o.OuterEnumIntegerDefaultValue) {
 		return nil, false
 	}
 	return o.OuterEnumIntegerDefaultValue, true
@@ -304,7 +304,7 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (*OuterEnumIntegerDefault
 
 // HasOuterEnumIntegerDefaultValue returns a boolean if a field has been set.
 func (o *EnumTest) HasOuterEnumIntegerDefaultValue() bool {
-	if o != nil && !isNil(o.OuterEnumIntegerDefaultValue) {
+	if o != nil && !IsNil(o.OuterEnumIntegerDefaultValue) {
 		return true
 	}
 
@@ -326,26 +326,26 @@ func (o EnumTest) MarshalJSON() ([]byte, error) {
 
 func (o EnumTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.EnumString) {
+	if !IsNil(o.EnumString) {
 		toSerialize["enum_string"] = o.EnumString
 	}
 	toSerialize["enum_string_required"] = o.EnumStringRequired
-	if !isNil(o.EnumInteger) {
+	if !IsNil(o.EnumInteger) {
 		toSerialize["enum_integer"] = o.EnumInteger
 	}
-	if !isNil(o.EnumNumber) {
+	if !IsNil(o.EnumNumber) {
 		toSerialize["enum_number"] = o.EnumNumber
 	}
 	if o.OuterEnum.IsSet() {
 		toSerialize["outerEnum"] = o.OuterEnum.Get()
 	}
-	if !isNil(o.OuterEnumInteger) {
+	if !IsNil(o.OuterEnumInteger) {
 		toSerialize["outerEnumInteger"] = o.OuterEnumInteger
 	}
-	if !isNil(o.OuterEnumDefaultValue) {
+	if !IsNil(o.OuterEnumDefaultValue) {
 		toSerialize["outerEnumDefaultValue"] = o.OuterEnumDefaultValue
 	}
-	if !isNil(o.OuterEnumIntegerDefaultValue) {
+	if !IsNil(o.OuterEnumIntegerDefaultValue) {
 		toSerialize["outerEnumIntegerDefaultValue"] = o.OuterEnumIntegerDefaultValue
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file.go
@@ -45,7 +45,7 @@ func NewFileWithDefaults() *File {
 
 // GetSourceURI returns the SourceURI field value if set, zero value otherwise.
 func (o *File) GetSourceURI() string {
-	if o == nil || isNil(o.SourceURI) {
+	if o == nil || IsNil(o.SourceURI) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *File) GetSourceURI() string {
 // GetSourceURIOk returns a tuple with the SourceURI field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *File) GetSourceURIOk() (*string, bool) {
-	if o == nil || isNil(o.SourceURI) {
+	if o == nil || IsNil(o.SourceURI) {
 		return nil, false
 	}
 	return o.SourceURI, true
@@ -63,7 +63,7 @@ func (o *File) GetSourceURIOk() (*string, bool) {
 
 // HasSourceURI returns a boolean if a field has been set.
 func (o *File) HasSourceURI() bool {
-	if o != nil && !isNil(o.SourceURI) {
+	if o != nil && !IsNil(o.SourceURI) {
 		return true
 	}
 
@@ -85,7 +85,7 @@ func (o File) MarshalJSON() ([]byte, error) {
 
 func (o File) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.SourceURI) {
+	if !IsNil(o.SourceURI) {
 		toSerialize["sourceURI"] = o.SourceURI
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
@@ -45,7 +45,7 @@ func NewFileSchemaTestClassWithDefaults() *FileSchemaTestClass {
 
 // GetFile returns the File field value if set, zero value otherwise.
 func (o *FileSchemaTestClass) GetFile() File {
-	if o == nil || isNil(o.File) {
+	if o == nil || IsNil(o.File) {
 		var ret File
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *FileSchemaTestClass) GetFile() File {
 // GetFileOk returns a tuple with the File field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
-	if o == nil || isNil(o.File) {
+	if o == nil || IsNil(o.File) {
 		return nil, false
 	}
 	return o.File, true
@@ -63,7 +63,7 @@ func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 
 // HasFile returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFile() bool {
-	if o != nil && !isNil(o.File) {
+	if o != nil && !IsNil(o.File) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *FileSchemaTestClass) SetFile(v File) {
 
 // GetFiles returns the Files field value if set, zero value otherwise.
 func (o *FileSchemaTestClass) GetFiles() []File {
-	if o == nil || isNil(o.Files) {
+	if o == nil || IsNil(o.Files) {
 		var ret []File
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 // GetFilesOk returns a tuple with the Files field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
-	if o == nil || isNil(o.Files) {
+	if o == nil || IsNil(o.Files) {
 		return nil, false
 	}
 	return o.Files, true
@@ -95,7 +95,7 @@ func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 
 // HasFiles returns a boolean if a field has been set.
 func (o *FileSchemaTestClass) HasFiles() bool {
-	if o != nil && !isNil(o.Files) {
+	if o != nil && !IsNil(o.Files) {
 		return true
 	}
 
@@ -117,10 +117,10 @@ func (o FileSchemaTestClass) MarshalJSON() ([]byte, error) {
 
 func (o FileSchemaTestClass) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.File) {
+	if !IsNil(o.File) {
 		toSerialize["file"] = o.File
 	}
-	if !isNil(o.Files) {
+	if !IsNil(o.Files) {
 		toSerialize["files"] = o.Files
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
@@ -48,7 +48,7 @@ func NewFooWithDefaults() *Foo {
 
 // GetBar returns the Bar field value if set, zero value otherwise.
 func (o *Foo) GetBar() string {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		var ret string
 		return ret
 	}
@@ -58,7 +58,7 @@ func (o *Foo) GetBar() string {
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Foo) GetBarOk() (*string, bool) {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		return nil, false
 	}
 	return o.Bar, true
@@ -66,7 +66,7 @@ func (o *Foo) GetBarOk() (*string, bool) {
 
 // HasBar returns a boolean if a field has been set.
 func (o *Foo) HasBar() bool {
-	if o != nil && !isNil(o.Bar) {
+	if o != nil && !IsNil(o.Bar) {
 		return true
 	}
 
@@ -88,7 +88,7 @@ func (o Foo) MarshalJSON() ([]byte, error) {
 
 func (o Foo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Bar) {
+	if !IsNil(o.Bar) {
 		toSerialize["bar"] = o.Bar
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -66,7 +66,7 @@ func NewFormatTestWithDefaults() *FormatTest {
 
 // GetInteger returns the Integer field value if set, zero value otherwise.
 func (o *FormatTest) GetInteger() int32 {
-	if o == nil || isNil(o.Integer) {
+	if o == nil || IsNil(o.Integer) {
 		var ret int32
 		return ret
 	}
@@ -76,7 +76,7 @@ func (o *FormatTest) GetInteger() int32 {
 // GetIntegerOk returns a tuple with the Integer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetIntegerOk() (*int32, bool) {
-	if o == nil || isNil(o.Integer) {
+	if o == nil || IsNil(o.Integer) {
 		return nil, false
 	}
 	return o.Integer, true
@@ -84,7 +84,7 @@ func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 
 // HasInteger returns a boolean if a field has been set.
 func (o *FormatTest) HasInteger() bool {
-	if o != nil && !isNil(o.Integer) {
+	if o != nil && !IsNil(o.Integer) {
 		return true
 	}
 
@@ -98,7 +98,7 @@ func (o *FormatTest) SetInteger(v int32) {
 
 // GetInt32 returns the Int32 field value if set, zero value otherwise.
 func (o *FormatTest) GetInt32() int32 {
-	if o == nil || isNil(o.Int32) {
+	if o == nil || IsNil(o.Int32) {
 		var ret int32
 		return ret
 	}
@@ -108,7 +108,7 @@ func (o *FormatTest) GetInt32() int32 {
 // GetInt32Ok returns a tuple with the Int32 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt32Ok() (*int32, bool) {
-	if o == nil || isNil(o.Int32) {
+	if o == nil || IsNil(o.Int32) {
 		return nil, false
 	}
 	return o.Int32, true
@@ -116,7 +116,7 @@ func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 
 // HasInt32 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt32() bool {
-	if o != nil && !isNil(o.Int32) {
+	if o != nil && !IsNil(o.Int32) {
 		return true
 	}
 
@@ -130,7 +130,7 @@ func (o *FormatTest) SetInt32(v int32) {
 
 // GetInt64 returns the Int64 field value if set, zero value otherwise.
 func (o *FormatTest) GetInt64() int64 {
-	if o == nil || isNil(o.Int64) {
+	if o == nil || IsNil(o.Int64) {
 		var ret int64
 		return ret
 	}
@@ -140,7 +140,7 @@ func (o *FormatTest) GetInt64() int64 {
 // GetInt64Ok returns a tuple with the Int64 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt64Ok() (*int64, bool) {
-	if o == nil || isNil(o.Int64) {
+	if o == nil || IsNil(o.Int64) {
 		return nil, false
 	}
 	return o.Int64, true
@@ -148,7 +148,7 @@ func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 
 // HasInt64 returns a boolean if a field has been set.
 func (o *FormatTest) HasInt64() bool {
-	if o != nil && !isNil(o.Int64) {
+	if o != nil && !IsNil(o.Int64) {
 		return true
 	}
 
@@ -186,7 +186,7 @@ func (o *FormatTest) SetNumber(v float32) {
 
 // GetFloat returns the Float field value if set, zero value otherwise.
 func (o *FormatTest) GetFloat() float32 {
-	if o == nil || isNil(o.Float) {
+	if o == nil || IsNil(o.Float) {
 		var ret float32
 		return ret
 	}
@@ -196,7 +196,7 @@ func (o *FormatTest) GetFloat() float32 {
 // GetFloatOk returns a tuple with the Float field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetFloatOk() (*float32, bool) {
-	if o == nil || isNil(o.Float) {
+	if o == nil || IsNil(o.Float) {
 		return nil, false
 	}
 	return o.Float, true
@@ -204,7 +204,7 @@ func (o *FormatTest) GetFloatOk() (*float32, bool) {
 
 // HasFloat returns a boolean if a field has been set.
 func (o *FormatTest) HasFloat() bool {
-	if o != nil && !isNil(o.Float) {
+	if o != nil && !IsNil(o.Float) {
 		return true
 	}
 
@@ -218,7 +218,7 @@ func (o *FormatTest) SetFloat(v float32) {
 
 // GetDouble returns the Double field value if set, zero value otherwise.
 func (o *FormatTest) GetDouble() float64 {
-	if o == nil || isNil(o.Double) {
+	if o == nil || IsNil(o.Double) {
 		var ret float64
 		return ret
 	}
@@ -228,7 +228,7 @@ func (o *FormatTest) GetDouble() float64 {
 // GetDoubleOk returns a tuple with the Double field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDoubleOk() (*float64, bool) {
-	if o == nil || isNil(o.Double) {
+	if o == nil || IsNil(o.Double) {
 		return nil, false
 	}
 	return o.Double, true
@@ -236,7 +236,7 @@ func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 
 // HasDouble returns a boolean if a field has been set.
 func (o *FormatTest) HasDouble() bool {
-	if o != nil && !isNil(o.Double) {
+	if o != nil && !IsNil(o.Double) {
 		return true
 	}
 
@@ -250,7 +250,7 @@ func (o *FormatTest) SetDouble(v float64) {
 
 // GetString returns the String field value if set, zero value otherwise.
 func (o *FormatTest) GetString() string {
-	if o == nil || isNil(o.String) {
+	if o == nil || IsNil(o.String) {
 		var ret string
 		return ret
 	}
@@ -260,7 +260,7 @@ func (o *FormatTest) GetString() string {
 // GetStringOk returns a tuple with the String field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetStringOk() (*string, bool) {
-	if o == nil || isNil(o.String) {
+	if o == nil || IsNil(o.String) {
 		return nil, false
 	}
 	return o.String, true
@@ -268,7 +268,7 @@ func (o *FormatTest) GetStringOk() (*string, bool) {
 
 // HasString returns a boolean if a field has been set.
 func (o *FormatTest) HasString() bool {
-	if o != nil && !isNil(o.String) {
+	if o != nil && !IsNil(o.String) {
 		return true
 	}
 
@@ -306,7 +306,7 @@ func (o *FormatTest) SetByte(v string) {
 
 // GetBinary returns the Binary field value if set, zero value otherwise.
 func (o *FormatTest) GetBinary() *os.File {
-	if o == nil || isNil(o.Binary) {
+	if o == nil || IsNil(o.Binary) {
 		var ret *os.File
 		return ret
 	}
@@ -316,7 +316,7 @@ func (o *FormatTest) GetBinary() *os.File {
 // GetBinaryOk returns a tuple with the Binary field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
-	if o == nil || isNil(o.Binary) {
+	if o == nil || IsNil(o.Binary) {
 		return nil, false
 	}
 	return o.Binary, true
@@ -324,7 +324,7 @@ func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 
 // HasBinary returns a boolean if a field has been set.
 func (o *FormatTest) HasBinary() bool {
-	if o != nil && !isNil(o.Binary) {
+	if o != nil && !IsNil(o.Binary) {
 		return true
 	}
 
@@ -362,7 +362,7 @@ func (o *FormatTest) SetDate(v string) {
 
 // GetDateTime returns the DateTime field value if set, zero value otherwise.
 func (o *FormatTest) GetDateTime() time.Time {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		var ret time.Time
 		return ret
 	}
@@ -372,7 +372,7 @@ func (o *FormatTest) GetDateTime() time.Time {
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		return nil, false
 	}
 	return o.DateTime, true
@@ -380,7 +380,7 @@ func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *FormatTest) HasDateTime() bool {
-	if o != nil && !isNil(o.DateTime) {
+	if o != nil && !IsNil(o.DateTime) {
 		return true
 	}
 
@@ -394,7 +394,7 @@ func (o *FormatTest) SetDateTime(v time.Time) {
 
 // GetUuid returns the Uuid field value if set, zero value otherwise.
 func (o *FormatTest) GetUuid() string {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		var ret string
 		return ret
 	}
@@ -404,7 +404,7 @@ func (o *FormatTest) GetUuid() string {
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetUuidOk() (*string, bool) {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		return nil, false
 	}
 	return o.Uuid, true
@@ -412,7 +412,7 @@ func (o *FormatTest) GetUuidOk() (*string, bool) {
 
 // HasUuid returns a boolean if a field has been set.
 func (o *FormatTest) HasUuid() bool {
-	if o != nil && !isNil(o.Uuid) {
+	if o != nil && !IsNil(o.Uuid) {
 		return true
 	}
 
@@ -450,7 +450,7 @@ func (o *FormatTest) SetPassword(v string) {
 
 // GetPatternWithDigits returns the PatternWithDigits field value if set, zero value otherwise.
 func (o *FormatTest) GetPatternWithDigits() string {
-	if o == nil || isNil(o.PatternWithDigits) {
+	if o == nil || IsNil(o.PatternWithDigits) {
 		var ret string
 		return ret
 	}
@@ -460,7 +460,7 @@ func (o *FormatTest) GetPatternWithDigits() string {
 // GetPatternWithDigitsOk returns a tuple with the PatternWithDigits field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetPatternWithDigitsOk() (*string, bool) {
-	if o == nil || isNil(o.PatternWithDigits) {
+	if o == nil || IsNil(o.PatternWithDigits) {
 		return nil, false
 	}
 	return o.PatternWithDigits, true
@@ -468,7 +468,7 @@ func (o *FormatTest) GetPatternWithDigitsOk() (*string, bool) {
 
 // HasPatternWithDigits returns a boolean if a field has been set.
 func (o *FormatTest) HasPatternWithDigits() bool {
-	if o != nil && !isNil(o.PatternWithDigits) {
+	if o != nil && !IsNil(o.PatternWithDigits) {
 		return true
 	}
 
@@ -482,7 +482,7 @@ func (o *FormatTest) SetPatternWithDigits(v string) {
 
 // GetPatternWithDigitsAndDelimiter returns the PatternWithDigitsAndDelimiter field value if set, zero value otherwise.
 func (o *FormatTest) GetPatternWithDigitsAndDelimiter() string {
-	if o == nil || isNil(o.PatternWithDigitsAndDelimiter) {
+	if o == nil || IsNil(o.PatternWithDigitsAndDelimiter) {
 		var ret string
 		return ret
 	}
@@ -492,7 +492,7 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiter() string {
 // GetPatternWithDigitsAndDelimiterOk returns a tuple with the PatternWithDigitsAndDelimiter field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (*string, bool) {
-	if o == nil || isNil(o.PatternWithDigitsAndDelimiter) {
+	if o == nil || IsNil(o.PatternWithDigitsAndDelimiter) {
 		return nil, false
 	}
 	return o.PatternWithDigitsAndDelimiter, true
@@ -500,7 +500,7 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (*string, bool) {
 
 // HasPatternWithDigitsAndDelimiter returns a boolean if a field has been set.
 func (o *FormatTest) HasPatternWithDigitsAndDelimiter() bool {
-	if o != nil && !isNil(o.PatternWithDigitsAndDelimiter) {
+	if o != nil && !IsNil(o.PatternWithDigitsAndDelimiter) {
 		return true
 	}
 
@@ -522,41 +522,41 @@ func (o FormatTest) MarshalJSON() ([]byte, error) {
 
 func (o FormatTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Integer) {
+	if !IsNil(o.Integer) {
 		toSerialize["integer"] = o.Integer
 	}
-	if !isNil(o.Int32) {
+	if !IsNil(o.Int32) {
 		toSerialize["int32"] = o.Int32
 	}
-	if !isNil(o.Int64) {
+	if !IsNil(o.Int64) {
 		toSerialize["int64"] = o.Int64
 	}
 	toSerialize["number"] = o.Number
-	if !isNil(o.Float) {
+	if !IsNil(o.Float) {
 		toSerialize["float"] = o.Float
 	}
-	if !isNil(o.Double) {
+	if !IsNil(o.Double) {
 		toSerialize["double"] = o.Double
 	}
-	if !isNil(o.String) {
+	if !IsNil(o.String) {
 		toSerialize["string"] = o.String
 	}
 	toSerialize["byte"] = o.Byte
-	if !isNil(o.Binary) {
+	if !IsNil(o.Binary) {
 		toSerialize["binary"] = o.Binary
 	}
 	toSerialize["date"] = o.Date
-	if !isNil(o.DateTime) {
+	if !IsNil(o.DateTime) {
 		toSerialize["dateTime"] = o.DateTime
 	}
-	if !isNil(o.Uuid) {
+	if !IsNil(o.Uuid) {
 		toSerialize["uuid"] = o.Uuid
 	}
 	toSerialize["password"] = o.Password
-	if !isNil(o.PatternWithDigits) {
+	if !IsNil(o.PatternWithDigits) {
 		toSerialize["pattern_with_digits"] = o.PatternWithDigits
 	}
-	if !isNil(o.PatternWithDigitsAndDelimiter) {
+	if !IsNil(o.PatternWithDigitsAndDelimiter) {
 		toSerialize["pattern_with_digits_and_delimiter"] = o.PatternWithDigitsAndDelimiter
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -45,7 +45,7 @@ func NewHasOnlyReadOnlyWithDefaults() *HasOnlyReadOnly {
 
 // GetBar returns the Bar field value if set, zero value otherwise.
 func (o *HasOnlyReadOnly) GetBar() string {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *HasOnlyReadOnly) GetBar() string {
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		return nil, false
 	}
 	return o.Bar, true
@@ -63,7 +63,7 @@ func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 
 // HasBar returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasBar() bool {
-	if o != nil && !isNil(o.Bar) {
+	if o != nil && !IsNil(o.Bar) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *HasOnlyReadOnly) SetBar(v string) {
 
 // GetFoo returns the Foo field value if set, zero value otherwise.
 func (o *HasOnlyReadOnly) GetFoo() string {
-	if o == nil || isNil(o.Foo) {
+	if o == nil || IsNil(o.Foo) {
 		var ret string
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 // GetFooOk returns a tuple with the Foo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
-	if o == nil || isNil(o.Foo) {
+	if o == nil || IsNil(o.Foo) {
 		return nil, false
 	}
 	return o.Foo, true
@@ -95,7 +95,7 @@ func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 
 // HasFoo returns a boolean if a field has been set.
 func (o *HasOnlyReadOnly) HasFoo() bool {
-	if o != nil && !isNil(o.Foo) {
+	if o != nil && !IsNil(o.Foo) {
 		return true
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
@@ -44,7 +44,7 @@ func NewHealthCheckResultWithDefaults() *HealthCheckResult {
 
 // GetNullableMessage returns the NullableMessage field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *HealthCheckResult) GetNullableMessage() string {
-	if o == nil || isNil(o.NullableMessage.Get()) {
+	if o == nil || IsNil(o.NullableMessage.Get()) {
 		var ret string
 		return ret
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_list.go
@@ -44,7 +44,7 @@ func NewListWithDefaults() *List {
 
 // GetVar123List returns the Var123List field value if set, zero value otherwise.
 func (o *List) GetVar123List() string {
-	if o == nil || isNil(o.Var123List) {
+	if o == nil || IsNil(o.Var123List) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *List) GetVar123List() string {
 // GetVar123ListOk returns a tuple with the Var123List field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *List) GetVar123ListOk() (*string, bool) {
-	if o == nil || isNil(o.Var123List) {
+	if o == nil || IsNil(o.Var123List) {
 		return nil, false
 	}
 	return o.Var123List, true
@@ -62,7 +62,7 @@ func (o *List) GetVar123ListOk() (*string, bool) {
 
 // HasVar123List returns a boolean if a field has been set.
 func (o *List) HasVar123List() bool {
-	if o != nil && !isNil(o.Var123List) {
+	if o != nil && !IsNil(o.Var123List) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o List) MarshalJSON() ([]byte, error) {
 
 func (o List) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Var123List) {
+	if !IsNil(o.Var123List) {
 		toSerialize["123-list"] = o.Var123List
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
@@ -46,7 +46,7 @@ func NewMapOfFileTestWithDefaults() *MapOfFileTest {
 
 // GetPropTest returns the PropTest field value if set, zero value otherwise.
 func (o *MapOfFileTest) GetPropTest() map[string]*os.File {
-	if o == nil || isNil(o.PropTest) {
+	if o == nil || IsNil(o.PropTest) {
 		var ret map[string]*os.File
 		return ret
 	}
@@ -56,7 +56,7 @@ func (o *MapOfFileTest) GetPropTest() map[string]*os.File {
 // GetPropTestOk returns a tuple with the PropTest field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapOfFileTest) GetPropTestOk() (*map[string]*os.File, bool) {
-	if o == nil || isNil(o.PropTest) {
+	if o == nil || IsNil(o.PropTest) {
 		return nil, false
 	}
 	return o.PropTest, true
@@ -64,7 +64,7 @@ func (o *MapOfFileTest) GetPropTestOk() (*map[string]*os.File, bool) {
 
 // HasPropTest returns a boolean if a field has been set.
 func (o *MapOfFileTest) HasPropTest() bool {
-	if o != nil && !isNil(o.PropTest) {
+	if o != nil && !IsNil(o.PropTest) {
 		return true
 	}
 
@@ -86,7 +86,7 @@ func (o MapOfFileTest) MarshalJSON() ([]byte, error) {
 
 func (o MapOfFileTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.PropTest) {
+	if !IsNil(o.PropTest) {
 		toSerialize["prop_test"] = o.PropTest
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
@@ -47,7 +47,7 @@ func NewMapTestWithDefaults() *MapTest {
 
 // GetMapMapOfString returns the MapMapOfString field value if set, zero value otherwise.
 func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
-	if o == nil || isNil(o.MapMapOfString) {
+	if o == nil || IsNil(o.MapMapOfString) {
 		var ret map[string]map[string]string
 		return ret
 	}
@@ -57,7 +57,7 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 // GetMapMapOfStringOk returns a tuple with the MapMapOfString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
-	if o == nil || isNil(o.MapMapOfString) {
+	if o == nil || IsNil(o.MapMapOfString) {
 		return nil, false
 	}
 	return o.MapMapOfString, true
@@ -65,7 +65,7 @@ func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 
 // HasMapMapOfString returns a boolean if a field has been set.
 func (o *MapTest) HasMapMapOfString() bool {
-	if o != nil && !isNil(o.MapMapOfString) {
+	if o != nil && !IsNil(o.MapMapOfString) {
 		return true
 	}
 
@@ -79,7 +79,7 @@ func (o *MapTest) SetMapMapOfString(v map[string]map[string]string) {
 
 // GetMapOfEnumString returns the MapOfEnumString field value if set, zero value otherwise.
 func (o *MapTest) GetMapOfEnumString() map[string]string {
-	if o == nil || isNil(o.MapOfEnumString) {
+	if o == nil || IsNil(o.MapOfEnumString) {
 		var ret map[string]string
 		return ret
 	}
@@ -89,7 +89,7 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 // GetMapOfEnumStringOk returns a tuple with the MapOfEnumString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
-	if o == nil || isNil(o.MapOfEnumString) {
+	if o == nil || IsNil(o.MapOfEnumString) {
 		return nil, false
 	}
 	return o.MapOfEnumString, true
@@ -97,7 +97,7 @@ func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 
 // HasMapOfEnumString returns a boolean if a field has been set.
 func (o *MapTest) HasMapOfEnumString() bool {
-	if o != nil && !isNil(o.MapOfEnumString) {
+	if o != nil && !IsNil(o.MapOfEnumString) {
 		return true
 	}
 
@@ -111,7 +111,7 @@ func (o *MapTest) SetMapOfEnumString(v map[string]string) {
 
 // GetDirectMap returns the DirectMap field value if set, zero value otherwise.
 func (o *MapTest) GetDirectMap() map[string]bool {
-	if o == nil || isNil(o.DirectMap) {
+	if o == nil || IsNil(o.DirectMap) {
 		var ret map[string]bool
 		return ret
 	}
@@ -121,7 +121,7 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 // GetDirectMapOk returns a tuple with the DirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
-	if o == nil || isNil(o.DirectMap) {
+	if o == nil || IsNil(o.DirectMap) {
 		return nil, false
 	}
 	return o.DirectMap, true
@@ -129,7 +129,7 @@ func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 
 // HasDirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasDirectMap() bool {
-	if o != nil && !isNil(o.DirectMap) {
+	if o != nil && !IsNil(o.DirectMap) {
 		return true
 	}
 
@@ -143,7 +143,7 @@ func (o *MapTest) SetDirectMap(v map[string]bool) {
 
 // GetIndirectMap returns the IndirectMap field value if set, zero value otherwise.
 func (o *MapTest) GetIndirectMap() map[string]bool {
-	if o == nil || isNil(o.IndirectMap) {
+	if o == nil || IsNil(o.IndirectMap) {
 		var ret map[string]bool
 		return ret
 	}
@@ -153,7 +153,7 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 // GetIndirectMapOk returns a tuple with the IndirectMap field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
-	if o == nil || isNil(o.IndirectMap) {
+	if o == nil || IsNil(o.IndirectMap) {
 		return nil, false
 	}
 	return o.IndirectMap, true
@@ -161,7 +161,7 @@ func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 
 // HasIndirectMap returns a boolean if a field has been set.
 func (o *MapTest) HasIndirectMap() bool {
-	if o != nil && !isNil(o.IndirectMap) {
+	if o != nil && !IsNil(o.IndirectMap) {
 		return true
 	}
 
@@ -183,16 +183,16 @@ func (o MapTest) MarshalJSON() ([]byte, error) {
 
 func (o MapTest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.MapMapOfString) {
+	if !IsNil(o.MapMapOfString) {
 		toSerialize["map_map_of_string"] = o.MapMapOfString
 	}
-	if !isNil(o.MapOfEnumString) {
+	if !IsNil(o.MapOfEnumString) {
 		toSerialize["map_of_enum_string"] = o.MapOfEnumString
 	}
-	if !isNil(o.DirectMap) {
+	if !IsNil(o.DirectMap) {
 		toSerialize["direct_map"] = o.DirectMap
 	}
-	if !isNil(o.IndirectMap) {
+	if !IsNil(o.IndirectMap) {
 		toSerialize["indirect_map"] = o.IndirectMap
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -47,7 +47,7 @@ func NewMixedPropertiesAndAdditionalPropertiesClassWithDefaults() *MixedProperti
 
 // GetUuid returns the Uuid field value if set, zero value otherwise.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		var ret string
 		return ret
 	}
@@ -57,7 +57,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 // GetUuidOk returns a tuple with the Uuid field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
-	if o == nil || isNil(o.Uuid) {
+	if o == nil || IsNil(o.Uuid) {
 		return nil, false
 	}
 	return o.Uuid, true
@@ -65,7 +65,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool
 
 // HasUuid returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasUuid() bool {
-	if o != nil && !isNil(o.Uuid) {
+	if o != nil && !IsNil(o.Uuid) {
 		return true
 	}
 
@@ -79,7 +79,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetUuid(v string) {
 
 // GetDateTime returns the DateTime field value if set, zero value otherwise.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		var ret time.Time
 		return ret
 	}
@@ -89,7 +89,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 // GetDateTimeOk returns a tuple with the DateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
-	if o == nil || isNil(o.DateTime) {
+	if o == nil || IsNil(o.DateTime) {
 		return nil, false
 	}
 	return o.DateTime, true
@@ -97,7 +97,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Tim
 
 // HasDateTime returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasDateTime() bool {
-	if o != nil && !isNil(o.DateTime) {
+	if o != nil && !IsNil(o.DateTime) {
 		return true
 	}
 
@@ -111,7 +111,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) SetDateTime(v time.Time) {
 
 // GetMap returns the Map field value if set, zero value otherwise.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal {
-	if o == nil || isNil(o.Map) {
+	if o == nil || IsNil(o.Map) {
 		var ret map[string]Animal
 		return ret
 	}
@@ -121,7 +121,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 // GetMapOk returns a tuple with the Map field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
-	if o == nil || isNil(o.Map) {
+	if o == nil || IsNil(o.Map) {
 		return nil, false
 	}
 	return o.Map, true
@@ -129,7 +129,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]An
 
 // HasMap returns a boolean if a field has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) HasMap() bool {
-	if o != nil && !isNil(o.Map) {
+	if o != nil && !IsNil(o.Map) {
 		return true
 	}
 
@@ -151,13 +151,13 @@ func (o MixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]byte, erro
 
 func (o MixedPropertiesAndAdditionalPropertiesClass) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Uuid) {
+	if !IsNil(o.Uuid) {
 		toSerialize["uuid"] = o.Uuid
 	}
-	if !isNil(o.DateTime) {
+	if !IsNil(o.DateTime) {
 		toSerialize["dateTime"] = o.DateTime
 	}
-	if !isNil(o.Map) {
+	if !IsNil(o.Map) {
 		toSerialize["map"] = o.Map
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -72,7 +72,7 @@ func (o *Name) SetName(v int32) {
 
 // GetSnakeCase returns the SnakeCase field value if set, zero value otherwise.
 func (o *Name) GetSnakeCase() int32 {
-	if o == nil || isNil(o.SnakeCase) {
+	if o == nil || IsNil(o.SnakeCase) {
 		var ret int32
 		return ret
 	}
@@ -82,7 +82,7 @@ func (o *Name) GetSnakeCase() int32 {
 // GetSnakeCaseOk returns a tuple with the SnakeCase field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Name) GetSnakeCaseOk() (*int32, bool) {
-	if o == nil || isNil(o.SnakeCase) {
+	if o == nil || IsNil(o.SnakeCase) {
 		return nil, false
 	}
 	return o.SnakeCase, true
@@ -90,7 +90,7 @@ func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 
 // HasSnakeCase returns a boolean if a field has been set.
 func (o *Name) HasSnakeCase() bool {
-	if o != nil && !isNil(o.SnakeCase) {
+	if o != nil && !IsNil(o.SnakeCase) {
 		return true
 	}
 
@@ -104,7 +104,7 @@ func (o *Name) SetSnakeCase(v int32) {
 
 // GetProperty returns the Property field value if set, zero value otherwise.
 func (o *Name) GetProperty() string {
-	if o == nil || isNil(o.Property) {
+	if o == nil || IsNil(o.Property) {
 		var ret string
 		return ret
 	}
@@ -114,7 +114,7 @@ func (o *Name) GetProperty() string {
 // GetPropertyOk returns a tuple with the Property field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Name) GetPropertyOk() (*string, bool) {
-	if o == nil || isNil(o.Property) {
+	if o == nil || IsNil(o.Property) {
 		return nil, false
 	}
 	return o.Property, true
@@ -122,7 +122,7 @@ func (o *Name) GetPropertyOk() (*string, bool) {
 
 // HasProperty returns a boolean if a field has been set.
 func (o *Name) HasProperty() bool {
-	if o != nil && !isNil(o.Property) {
+	if o != nil && !IsNil(o.Property) {
 		return true
 	}
 
@@ -136,7 +136,7 @@ func (o *Name) SetProperty(v string) {
 
 // GetVar123Number returns the Var123Number field value if set, zero value otherwise.
 func (o *Name) GetVar123Number() int32 {
-	if o == nil || isNil(o.Var123Number) {
+	if o == nil || IsNil(o.Var123Number) {
 		var ret int32
 		return ret
 	}
@@ -146,7 +146,7 @@ func (o *Name) GetVar123Number() int32 {
 // GetVar123NumberOk returns a tuple with the Var123Number field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Name) GetVar123NumberOk() (*int32, bool) {
-	if o == nil || isNil(o.Var123Number) {
+	if o == nil || IsNil(o.Var123Number) {
 		return nil, false
 	}
 	return o.Var123Number, true
@@ -154,7 +154,7 @@ func (o *Name) GetVar123NumberOk() (*int32, bool) {
 
 // HasVar123Number returns a boolean if a field has been set.
 func (o *Name) HasVar123Number() bool {
-	if o != nil && !isNil(o.Var123Number) {
+	if o != nil && !IsNil(o.Var123Number) {
 		return true
 	}
 
@@ -178,7 +178,7 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	// skip: snake_case is readOnly
-	if !isNil(o.Property) {
+	if !IsNil(o.Property) {
 		toSerialize["property"] = o.Property
 	}
 	// skip: 123Number is readOnly

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
@@ -44,7 +44,7 @@ func NewNullableAllOfWithDefaults() *NullableAllOf {
 
 // GetChild returns the Child field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableAllOf) GetChild() NullableAllOfChild {
-	if o == nil || isNil(o.Child.Get()) {
+	if o == nil || IsNil(o.Child.Get()) {
 		var ret NullableAllOfChild
 		return ret
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
@@ -44,7 +44,7 @@ func NewNullableAllOfChildWithDefaults() *NullableAllOfChild {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *NullableAllOfChild) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *NullableAllOfChild) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableAllOfChild) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -62,7 +62,7 @@ func (o *NullableAllOfChild) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *NullableAllOfChild) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o NullableAllOfChild) MarshalJSON() ([]byte, error) {
 
 func (o NullableAllOfChild) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
@@ -57,7 +57,7 @@ func NewNullableClassWithDefaults() *NullableClass {
 
 // GetIntegerProp returns the IntegerProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetIntegerProp() int32 {
-	if o == nil || isNil(o.IntegerProp.Get()) {
+	if o == nil || IsNil(o.IntegerProp.Get()) {
 		var ret int32
 		return ret
 	}
@@ -99,7 +99,7 @@ func (o *NullableClass) UnsetIntegerProp() {
 
 // GetNumberProp returns the NumberProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetNumberProp() float32 {
-	if o == nil || isNil(o.NumberProp.Get()) {
+	if o == nil || IsNil(o.NumberProp.Get()) {
 		var ret float32
 		return ret
 	}
@@ -141,7 +141,7 @@ func (o *NullableClass) UnsetNumberProp() {
 
 // GetBooleanProp returns the BooleanProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetBooleanProp() bool {
-	if o == nil || isNil(o.BooleanProp.Get()) {
+	if o == nil || IsNil(o.BooleanProp.Get()) {
 		var ret bool
 		return ret
 	}
@@ -183,7 +183,7 @@ func (o *NullableClass) UnsetBooleanProp() {
 
 // GetStringProp returns the StringProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetStringProp() string {
-	if o == nil || isNil(o.StringProp.Get()) {
+	if o == nil || IsNil(o.StringProp.Get()) {
 		var ret string
 		return ret
 	}
@@ -225,7 +225,7 @@ func (o *NullableClass) UnsetStringProp() {
 
 // GetDateProp returns the DateProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetDateProp() string {
-	if o == nil || isNil(o.DateProp.Get()) {
+	if o == nil || IsNil(o.DateProp.Get()) {
 		var ret string
 		return ret
 	}
@@ -267,7 +267,7 @@ func (o *NullableClass) UnsetDateProp() {
 
 // GetDatetimeProp returns the DatetimeProp field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *NullableClass) GetDatetimeProp() time.Time {
-	if o == nil || isNil(o.DatetimeProp.Get()) {
+	if o == nil || IsNil(o.DatetimeProp.Get()) {
 		var ret time.Time
 		return ret
 	}
@@ -320,7 +320,7 @@ func (o *NullableClass) GetArrayNullableProp() []map[string]interface{} {
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool) {
-	if o == nil || isNil(o.ArrayNullableProp) {
+	if o == nil || IsNil(o.ArrayNullableProp) {
 		return nil, false
 	}
 	return o.ArrayNullableProp, true
@@ -328,7 +328,7 @@ func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool
 
 // HasArrayNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayNullableProp() bool {
-	if o != nil && isNil(o.ArrayNullableProp) {
+	if o != nil && IsNil(o.ArrayNullableProp) {
 		return true
 	}
 
@@ -353,7 +353,7 @@ func (o *NullableClass) GetArrayAndItemsNullableProp() []*map[string]interface{}
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]*map[string]interface{}, bool) {
-	if o == nil || isNil(o.ArrayAndItemsNullableProp) {
+	if o == nil || IsNil(o.ArrayAndItemsNullableProp) {
 		return nil, false
 	}
 	return o.ArrayAndItemsNullableProp, true
@@ -361,7 +361,7 @@ func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]*map[string]interfac
 
 // HasArrayAndItemsNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayAndItemsNullableProp() bool {
-	if o != nil && isNil(o.ArrayAndItemsNullableProp) {
+	if o != nil && IsNil(o.ArrayAndItemsNullableProp) {
 		return true
 	}
 
@@ -375,7 +375,7 @@ func (o *NullableClass) SetArrayAndItemsNullableProp(v []*map[string]interface{}
 
 // GetArrayItemsNullable returns the ArrayItemsNullable field value if set, zero value otherwise.
 func (o *NullableClass) GetArrayItemsNullable() []*map[string]interface{} {
-	if o == nil || isNil(o.ArrayItemsNullable) {
+	if o == nil || IsNil(o.ArrayItemsNullable) {
 		var ret []*map[string]interface{}
 		return ret
 	}
@@ -385,7 +385,7 @@ func (o *NullableClass) GetArrayItemsNullable() []*map[string]interface{} {
 // GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetArrayItemsNullableOk() ([]*map[string]interface{}, bool) {
-	if o == nil || isNil(o.ArrayItemsNullable) {
+	if o == nil || IsNil(o.ArrayItemsNullable) {
 		return nil, false
 	}
 	return o.ArrayItemsNullable, true
@@ -393,7 +393,7 @@ func (o *NullableClass) GetArrayItemsNullableOk() ([]*map[string]interface{}, bo
 
 // HasArrayItemsNullable returns a boolean if a field has been set.
 func (o *NullableClass) HasArrayItemsNullable() bool {
-	if o != nil && !isNil(o.ArrayItemsNullable) {
+	if o != nil && !IsNil(o.ArrayItemsNullable) {
 		return true
 	}
 
@@ -418,7 +418,7 @@ func (o *NullableClass) GetObjectNullableProp() map[string]map[string]interface{
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interface{}, bool) {
-	if o == nil || isNil(o.ObjectNullableProp) {
+	if o == nil || IsNil(o.ObjectNullableProp) {
 		return map[string]map[string]interface{}{}, false
 	}
 	return o.ObjectNullableProp, true
@@ -426,7 +426,7 @@ func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interfa
 
 // HasObjectNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectNullableProp() bool {
-	if o != nil && isNil(o.ObjectNullableProp) {
+	if o != nil && IsNil(o.ObjectNullableProp) {
 		return true
 	}
 
@@ -451,7 +451,7 @@ func (o *NullableClass) GetObjectAndItemsNullableProp() map[string]map[string]in
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string]interface{}, bool) {
-	if o == nil || isNil(o.ObjectAndItemsNullableProp) {
+	if o == nil || IsNil(o.ObjectAndItemsNullableProp) {
 		return map[string]map[string]interface{}{}, false
 	}
 	return o.ObjectAndItemsNullableProp, true
@@ -459,7 +459,7 @@ func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string
 
 // HasObjectAndItemsNullableProp returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectAndItemsNullableProp() bool {
-	if o != nil && isNil(o.ObjectAndItemsNullableProp) {
+	if o != nil && IsNil(o.ObjectAndItemsNullableProp) {
 		return true
 	}
 
@@ -473,7 +473,7 @@ func (o *NullableClass) SetObjectAndItemsNullableProp(v map[string]map[string]in
 
 // GetObjectItemsNullable returns the ObjectItemsNullable field value if set, zero value otherwise.
 func (o *NullableClass) GetObjectItemsNullable() map[string]map[string]interface{} {
-	if o == nil || isNil(o.ObjectItemsNullable) {
+	if o == nil || IsNil(o.ObjectItemsNullable) {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
@@ -483,7 +483,7 @@ func (o *NullableClass) GetObjectItemsNullable() map[string]map[string]interface
 // GetObjectItemsNullableOk returns a tuple with the ObjectItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interface{}, bool) {
-	if o == nil || isNil(o.ObjectItemsNullable) {
+	if o == nil || IsNil(o.ObjectItemsNullable) {
 		return map[string]map[string]interface{}{}, false
 	}
 	return o.ObjectItemsNullable, true
@@ -491,7 +491,7 @@ func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interf
 
 // HasObjectItemsNullable returns a boolean if a field has been set.
 func (o *NullableClass) HasObjectItemsNullable() bool {
-	if o != nil && !isNil(o.ObjectItemsNullable) {
+	if o != nil && !IsNil(o.ObjectItemsNullable) {
 		return true
 	}
 
@@ -537,7 +537,7 @@ func (o NullableClass) ToMap() (map[string]interface{}, error) {
 	if o.ArrayAndItemsNullableProp != nil {
 		toSerialize["array_and_items_nullable_prop"] = o.ArrayAndItemsNullableProp
 	}
-	if !isNil(o.ArrayItemsNullable) {
+	if !IsNil(o.ArrayItemsNullable) {
 		toSerialize["array_items_nullable"] = o.ArrayItemsNullable
 	}
 	if o.ObjectNullableProp != nil {
@@ -546,7 +546,7 @@ func (o NullableClass) ToMap() (map[string]interface{}, error) {
 	if o.ObjectAndItemsNullableProp != nil {
 		toSerialize["object_and_items_nullable_prop"] = o.ObjectAndItemsNullableProp
 	}
-	if !isNil(o.ObjectItemsNullable) {
+	if !IsNil(o.ObjectItemsNullable) {
 		toSerialize["object_items_nullable"] = o.ObjectItemsNullable
 	}
 	return toSerialize, nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
@@ -44,7 +44,7 @@ func NewNumberOnlyWithDefaults() *NumberOnly {
 
 // GetJustNumber returns the JustNumber field value if set, zero value otherwise.
 func (o *NumberOnly) GetJustNumber() float32 {
-	if o == nil || isNil(o.JustNumber) {
+	if o == nil || IsNil(o.JustNumber) {
 		var ret float32
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *NumberOnly) GetJustNumber() float32 {
 // GetJustNumberOk returns a tuple with the JustNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.JustNumber) {
+	if o == nil || IsNil(o.JustNumber) {
 		return nil, false
 	}
 	return o.JustNumber, true
@@ -62,7 +62,7 @@ func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 
 // HasJustNumber returns a boolean if a field has been set.
 func (o *NumberOnly) HasJustNumber() bool {
-	if o != nil && !isNil(o.JustNumber) {
+	if o != nil && !IsNil(o.JustNumber) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o NumberOnly) MarshalJSON() ([]byte, error) {
 
 func (o NumberOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.JustNumber) {
+	if !IsNil(o.JustNumber) {
 		toSerialize["JustNumber"] = o.JustNumber
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
@@ -44,7 +44,7 @@ func NewOneOfPrimitiveTypeChildWithDefaults() *OneOfPrimitiveTypeChild {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *OneOfPrimitiveTypeChild) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *OneOfPrimitiveTypeChild) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OneOfPrimitiveTypeChild) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -62,7 +62,7 @@ func (o *OneOfPrimitiveTypeChild) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *OneOfPrimitiveTypeChild) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o OneOfPrimitiveTypeChild) MarshalJSON() ([]byte, error) {
 
 func (o OneOfPrimitiveTypeChild) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_order.go
@@ -55,7 +55,7 @@ func NewOrderWithDefaults() *Order {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Order) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -65,7 +65,7 @@ func (o *Order) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -73,7 +73,7 @@ func (o *Order) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Order) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -87,7 +87,7 @@ func (o *Order) SetId(v int64) {
 
 // GetPetId returns the PetId field value if set, zero value otherwise.
 func (o *Order) GetPetId() int64 {
-	if o == nil || isNil(o.PetId) {
+	if o == nil || IsNil(o.PetId) {
 		var ret int64
 		return ret
 	}
@@ -97,7 +97,7 @@ func (o *Order) GetPetId() int64 {
 // GetPetIdOk returns a tuple with the PetId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetPetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.PetId) {
+	if o == nil || IsNil(o.PetId) {
 		return nil, false
 	}
 	return o.PetId, true
@@ -105,7 +105,7 @@ func (o *Order) GetPetIdOk() (*int64, bool) {
 
 // HasPetId returns a boolean if a field has been set.
 func (o *Order) HasPetId() bool {
-	if o != nil && !isNil(o.PetId) {
+	if o != nil && !IsNil(o.PetId) {
 		return true
 	}
 
@@ -119,7 +119,7 @@ func (o *Order) SetPetId(v int64) {
 
 // GetQuantity returns the Quantity field value if set, zero value otherwise.
 func (o *Order) GetQuantity() int32 {
-	if o == nil || isNil(o.Quantity) {
+	if o == nil || IsNil(o.Quantity) {
 		var ret int32
 		return ret
 	}
@@ -129,7 +129,7 @@ func (o *Order) GetQuantity() int32 {
 // GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetQuantityOk() (*int32, bool) {
-	if o == nil || isNil(o.Quantity) {
+	if o == nil || IsNil(o.Quantity) {
 		return nil, false
 	}
 	return o.Quantity, true
@@ -137,7 +137,7 @@ func (o *Order) GetQuantityOk() (*int32, bool) {
 
 // HasQuantity returns a boolean if a field has been set.
 func (o *Order) HasQuantity() bool {
-	if o != nil && !isNil(o.Quantity) {
+	if o != nil && !IsNil(o.Quantity) {
 		return true
 	}
 
@@ -151,7 +151,7 @@ func (o *Order) SetQuantity(v int32) {
 
 // GetShipDate returns the ShipDate field value if set, zero value otherwise.
 func (o *Order) GetShipDate() time.Time {
-	if o == nil || isNil(o.ShipDate) {
+	if o == nil || IsNil(o.ShipDate) {
 		var ret time.Time
 		return ret
 	}
@@ -161,7 +161,7 @@ func (o *Order) GetShipDate() time.Time {
 // GetShipDateOk returns a tuple with the ShipDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetShipDateOk() (*time.Time, bool) {
-	if o == nil || isNil(o.ShipDate) {
+	if o == nil || IsNil(o.ShipDate) {
 		return nil, false
 	}
 	return o.ShipDate, true
@@ -169,7 +169,7 @@ func (o *Order) GetShipDateOk() (*time.Time, bool) {
 
 // HasShipDate returns a boolean if a field has been set.
 func (o *Order) HasShipDate() bool {
-	if o != nil && !isNil(o.ShipDate) {
+	if o != nil && !IsNil(o.ShipDate) {
 		return true
 	}
 
@@ -183,7 +183,7 @@ func (o *Order) SetShipDate(v time.Time) {
 
 // GetStatus returns the Status field value if set, zero value otherwise.
 func (o *Order) GetStatus() string {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		var ret string
 		return ret
 	}
@@ -193,7 +193,7 @@ func (o *Order) GetStatus() string {
 // GetStatusOk returns a tuple with the Status field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetStatusOk() (*string, bool) {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		return nil, false
 	}
 	return o.Status, true
@@ -201,7 +201,7 @@ func (o *Order) GetStatusOk() (*string, bool) {
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Order) HasStatus() bool {
-	if o != nil && !isNil(o.Status) {
+	if o != nil && !IsNil(o.Status) {
 		return true
 	}
 
@@ -215,7 +215,7 @@ func (o *Order) SetStatus(v string) {
 
 // GetComplete returns the Complete field value if set, zero value otherwise.
 func (o *Order) GetComplete() bool {
-	if o == nil || isNil(o.Complete) {
+	if o == nil || IsNil(o.Complete) {
 		var ret bool
 		return ret
 	}
@@ -225,7 +225,7 @@ func (o *Order) GetComplete() bool {
 // GetCompleteOk returns a tuple with the Complete field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Order) GetCompleteOk() (*bool, bool) {
-	if o == nil || isNil(o.Complete) {
+	if o == nil || IsNil(o.Complete) {
 		return nil, false
 	}
 	return o.Complete, true
@@ -233,7 +233,7 @@ func (o *Order) GetCompleteOk() (*bool, bool) {
 
 // HasComplete returns a boolean if a field has been set.
 func (o *Order) HasComplete() bool {
-	if o != nil && !isNil(o.Complete) {
+	if o != nil && !IsNil(o.Complete) {
 		return true
 	}
 
@@ -255,22 +255,22 @@ func (o Order) MarshalJSON() ([]byte, error) {
 
 func (o Order) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.PetId) {
+	if !IsNil(o.PetId) {
 		toSerialize["petId"] = o.PetId
 	}
-	if !isNil(o.Quantity) {
+	if !IsNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
-	if !isNil(o.ShipDate) {
+	if !IsNil(o.ShipDate) {
 		toSerialize["shipDate"] = o.ShipDate
 	}
-	if !isNil(o.Status) {
+	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
-	if !isNil(o.Complete) {
+	if !IsNil(o.Complete) {
 		toSerialize["complete"] = o.Complete
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
@@ -46,7 +46,7 @@ func NewOuterCompositeWithDefaults() *OuterComposite {
 
 // GetMyNumber returns the MyNumber field value if set, zero value otherwise.
 func (o *OuterComposite) GetMyNumber() float32 {
-	if o == nil || isNil(o.MyNumber) {
+	if o == nil || IsNil(o.MyNumber) {
 		var ret float32
 		return ret
 	}
@@ -56,7 +56,7 @@ func (o *OuterComposite) GetMyNumber() float32 {
 // GetMyNumberOk returns a tuple with the MyNumber field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
-	if o == nil || isNil(o.MyNumber) {
+	if o == nil || IsNil(o.MyNumber) {
 		return nil, false
 	}
 	return o.MyNumber, true
@@ -64,7 +64,7 @@ func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 
 // HasMyNumber returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyNumber() bool {
-	if o != nil && !isNil(o.MyNumber) {
+	if o != nil && !IsNil(o.MyNumber) {
 		return true
 	}
 
@@ -78,7 +78,7 @@ func (o *OuterComposite) SetMyNumber(v float32) {
 
 // GetMyString returns the MyString field value if set, zero value otherwise.
 func (o *OuterComposite) GetMyString() string {
-	if o == nil || isNil(o.MyString) {
+	if o == nil || IsNil(o.MyString) {
 		var ret string
 		return ret
 	}
@@ -88,7 +88,7 @@ func (o *OuterComposite) GetMyString() string {
 // GetMyStringOk returns a tuple with the MyString field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyStringOk() (*string, bool) {
-	if o == nil || isNil(o.MyString) {
+	if o == nil || IsNil(o.MyString) {
 		return nil, false
 	}
 	return o.MyString, true
@@ -96,7 +96,7 @@ func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 
 // HasMyString returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyString() bool {
-	if o != nil && !isNil(o.MyString) {
+	if o != nil && !IsNil(o.MyString) {
 		return true
 	}
 
@@ -110,7 +110,7 @@ func (o *OuterComposite) SetMyString(v string) {
 
 // GetMyBoolean returns the MyBoolean field value if set, zero value otherwise.
 func (o *OuterComposite) GetMyBoolean() bool {
-	if o == nil || isNil(o.MyBoolean) {
+	if o == nil || IsNil(o.MyBoolean) {
 		var ret bool
 		return ret
 	}
@@ -120,7 +120,7 @@ func (o *OuterComposite) GetMyBoolean() bool {
 // GetMyBooleanOk returns a tuple with the MyBoolean field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
-	if o == nil || isNil(o.MyBoolean) {
+	if o == nil || IsNil(o.MyBoolean) {
 		return nil, false
 	}
 	return o.MyBoolean, true
@@ -128,7 +128,7 @@ func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 
 // HasMyBoolean returns a boolean if a field has been set.
 func (o *OuterComposite) HasMyBoolean() bool {
-	if o != nil && !isNil(o.MyBoolean) {
+	if o != nil && !IsNil(o.MyBoolean) {
 		return true
 	}
 
@@ -150,13 +150,13 @@ func (o OuterComposite) MarshalJSON() ([]byte, error) {
 
 func (o OuterComposite) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.MyNumber) {
+	if !IsNil(o.MyNumber) {
 		toSerialize["my_number"] = o.MyNumber
 	}
-	if !isNil(o.MyString) {
+	if !IsNil(o.MyString) {
 		toSerialize["my_string"] = o.MyString
 	}
-	if !isNil(o.MyBoolean) {
+	if !IsNil(o.MyBoolean) {
 		toSerialize["my_boolean"] = o.MyBoolean
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -53,7 +53,7 @@ func NewPetWithDefaults() *Pet {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Pet) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -63,7 +63,7 @@ func (o *Pet) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -71,7 +71,7 @@ func (o *Pet) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Pet) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -85,7 +85,7 @@ func (o *Pet) SetId(v int64) {
 
 // GetCategory returns the Category field value if set, zero value otherwise.
 func (o *Pet) GetCategory() Category {
-	if o == nil || isNil(o.Category) {
+	if o == nil || IsNil(o.Category) {
 		var ret Category
 		return ret
 	}
@@ -95,7 +95,7 @@ func (o *Pet) GetCategory() Category {
 // GetCategoryOk returns a tuple with the Category field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetCategoryOk() (*Category, bool) {
-	if o == nil || isNil(o.Category) {
+	if o == nil || IsNil(o.Category) {
 		return nil, false
 	}
 	return o.Category, true
@@ -103,7 +103,7 @@ func (o *Pet) GetCategoryOk() (*Category, bool) {
 
 // HasCategory returns a boolean if a field has been set.
 func (o *Pet) HasCategory() bool {
-	if o != nil && !isNil(o.Category) {
+	if o != nil && !IsNil(o.Category) {
 		return true
 	}
 
@@ -165,7 +165,7 @@ func (o *Pet) SetPhotoUrls(v []string) {
 
 // GetTags returns the Tags field value if set, zero value otherwise.
 func (o *Pet) GetTags() []Tag {
-	if o == nil || isNil(o.Tags) {
+	if o == nil || IsNil(o.Tags) {
 		var ret []Tag
 		return ret
 	}
@@ -175,7 +175,7 @@ func (o *Pet) GetTags() []Tag {
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Pet) GetTagsOk() ([]Tag, bool) {
-	if o == nil || isNil(o.Tags) {
+	if o == nil || IsNil(o.Tags) {
 		return nil, false
 	}
 	return o.Tags, true
@@ -183,7 +183,7 @@ func (o *Pet) GetTagsOk() ([]Tag, bool) {
 
 // HasTags returns a boolean if a field has been set.
 func (o *Pet) HasTags() bool {
-	if o != nil && !isNil(o.Tags) {
+	if o != nil && !IsNil(o.Tags) {
 		return true
 	}
 
@@ -198,7 +198,7 @@ func (o *Pet) SetTags(v []Tag) {
 // GetStatus returns the Status field value if set, zero value otherwise.
 // Deprecated
 func (o *Pet) GetStatus() string {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		var ret string
 		return ret
 	}
@@ -209,7 +209,7 @@ func (o *Pet) GetStatus() string {
 // and a boolean to check if the value has been set.
 // Deprecated
 func (o *Pet) GetStatusOk() (*string, bool) {
-	if o == nil || isNil(o.Status) {
+	if o == nil || IsNil(o.Status) {
 		return nil, false
 	}
 	return o.Status, true
@@ -217,7 +217,7 @@ func (o *Pet) GetStatusOk() (*string, bool) {
 
 // HasStatus returns a boolean if a field has been set.
 func (o *Pet) HasStatus() bool {
-	if o != nil && !isNil(o.Status) {
+	if o != nil && !IsNil(o.Status) {
 		return true
 	}
 
@@ -240,18 +240,18 @@ func (o Pet) MarshalJSON() ([]byte, error) {
 
 func (o Pet) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.Category) {
+	if !IsNil(o.Category) {
 		toSerialize["category"] = o.Category
 	}
 	toSerialize["name"] = o.Name
 	toSerialize["photoUrls"] = o.PhotoUrls
-	if !isNil(o.Tags) {
+	if !IsNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
 	}
-	if !isNil(o.Status) {
+	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
@@ -45,7 +45,7 @@ func NewReadOnlyFirstWithDefaults() *ReadOnlyFirst {
 
 // GetBar returns the Bar field value if set, zero value otherwise.
 func (o *ReadOnlyFirst) GetBar() string {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		var ret string
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *ReadOnlyFirst) GetBar() string {
 // GetBarOk returns a tuple with the Bar field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
-	if o == nil || isNil(o.Bar) {
+	if o == nil || IsNil(o.Bar) {
 		return nil, false
 	}
 	return o.Bar, true
@@ -63,7 +63,7 @@ func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 
 // HasBar returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBar() bool {
-	if o != nil && !isNil(o.Bar) {
+	if o != nil && !IsNil(o.Bar) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *ReadOnlyFirst) SetBar(v string) {
 
 // GetBaz returns the Baz field value if set, zero value otherwise.
 func (o *ReadOnlyFirst) GetBaz() string {
-	if o == nil || isNil(o.Baz) {
+	if o == nil || IsNil(o.Baz) {
 		var ret string
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *ReadOnlyFirst) GetBaz() string {
 // GetBazOk returns a tuple with the Baz field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
-	if o == nil || isNil(o.Baz) {
+	if o == nil || IsNil(o.Baz) {
 		return nil, false
 	}
 	return o.Baz, true
@@ -95,7 +95,7 @@ func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 
 // HasBaz returns a boolean if a field has been set.
 func (o *ReadOnlyFirst) HasBaz() bool {
-	if o != nil && !isNil(o.Baz) {
+	if o != nil && !IsNil(o.Baz) {
 		return true
 	}
 
@@ -118,7 +118,7 @@ func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
 func (o ReadOnlyFirst) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	// skip: bar is readOnly
-	if !isNil(o.Baz) {
+	if !IsNil(o.Baz) {
 		toSerialize["baz"] = o.Baz
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
@@ -62,7 +62,7 @@ func NewReadOnlyWithDefaultWithDefaults() *ReadOnlyWithDefault {
 
 // GetProp1 returns the Prop1 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetProp1() string {
-	if o == nil || isNil(o.Prop1) {
+	if o == nil || IsNil(o.Prop1) {
 		var ret string
 		return ret
 	}
@@ -72,7 +72,7 @@ func (o *ReadOnlyWithDefault) GetProp1() string {
 // GetProp1Ok returns a tuple with the Prop1 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetProp1Ok() (*string, bool) {
-	if o == nil || isNil(o.Prop1) {
+	if o == nil || IsNil(o.Prop1) {
 		return nil, false
 	}
 	return o.Prop1, true
@@ -80,7 +80,7 @@ func (o *ReadOnlyWithDefault) GetProp1Ok() (*string, bool) {
 
 // HasProp1 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasProp1() bool {
-	if o != nil && !isNil(o.Prop1) {
+	if o != nil && !IsNil(o.Prop1) {
 		return true
 	}
 
@@ -94,7 +94,7 @@ func (o *ReadOnlyWithDefault) SetProp1(v string) {
 
 // GetProp2 returns the Prop2 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetProp2() string {
-	if o == nil || isNil(o.Prop2) {
+	if o == nil || IsNil(o.Prop2) {
 		var ret string
 		return ret
 	}
@@ -104,7 +104,7 @@ func (o *ReadOnlyWithDefault) GetProp2() string {
 // GetProp2Ok returns a tuple with the Prop2 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetProp2Ok() (*string, bool) {
-	if o == nil || isNil(o.Prop2) {
+	if o == nil || IsNil(o.Prop2) {
 		return nil, false
 	}
 	return o.Prop2, true
@@ -112,7 +112,7 @@ func (o *ReadOnlyWithDefault) GetProp2Ok() (*string, bool) {
 
 // HasProp2 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasProp2() bool {
-	if o != nil && !isNil(o.Prop2) {
+	if o != nil && !IsNil(o.Prop2) {
 		return true
 	}
 
@@ -126,7 +126,7 @@ func (o *ReadOnlyWithDefault) SetProp2(v string) {
 
 // GetProp3 returns the Prop3 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetProp3() string {
-	if o == nil || isNil(o.Prop3) {
+	if o == nil || IsNil(o.Prop3) {
 		var ret string
 		return ret
 	}
@@ -136,7 +136,7 @@ func (o *ReadOnlyWithDefault) GetProp3() string {
 // GetProp3Ok returns a tuple with the Prop3 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetProp3Ok() (*string, bool) {
-	if o == nil || isNil(o.Prop3) {
+	if o == nil || IsNil(o.Prop3) {
 		return nil, false
 	}
 	return o.Prop3, true
@@ -144,7 +144,7 @@ func (o *ReadOnlyWithDefault) GetProp3Ok() (*string, bool) {
 
 // HasProp3 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasProp3() bool {
-	if o != nil && !isNil(o.Prop3) {
+	if o != nil && !IsNil(o.Prop3) {
 		return true
 	}
 
@@ -158,7 +158,7 @@ func (o *ReadOnlyWithDefault) SetProp3(v string) {
 
 // GetBoolProp1 returns the BoolProp1 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetBoolProp1() bool {
-	if o == nil || isNil(o.BoolProp1) {
+	if o == nil || IsNil(o.BoolProp1) {
 		var ret bool
 		return ret
 	}
@@ -168,7 +168,7 @@ func (o *ReadOnlyWithDefault) GetBoolProp1() bool {
 // GetBoolProp1Ok returns a tuple with the BoolProp1 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetBoolProp1Ok() (*bool, bool) {
-	if o == nil || isNil(o.BoolProp1) {
+	if o == nil || IsNil(o.BoolProp1) {
 		return nil, false
 	}
 	return o.BoolProp1, true
@@ -176,7 +176,7 @@ func (o *ReadOnlyWithDefault) GetBoolProp1Ok() (*bool, bool) {
 
 // HasBoolProp1 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasBoolProp1() bool {
-	if o != nil && !isNil(o.BoolProp1) {
+	if o != nil && !IsNil(o.BoolProp1) {
 		return true
 	}
 
@@ -190,7 +190,7 @@ func (o *ReadOnlyWithDefault) SetBoolProp1(v bool) {
 
 // GetBoolProp2 returns the BoolProp2 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetBoolProp2() bool {
-	if o == nil || isNil(o.BoolProp2) {
+	if o == nil || IsNil(o.BoolProp2) {
 		var ret bool
 		return ret
 	}
@@ -200,7 +200,7 @@ func (o *ReadOnlyWithDefault) GetBoolProp2() bool {
 // GetBoolProp2Ok returns a tuple with the BoolProp2 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetBoolProp2Ok() (*bool, bool) {
-	if o == nil || isNil(o.BoolProp2) {
+	if o == nil || IsNil(o.BoolProp2) {
 		return nil, false
 	}
 	return o.BoolProp2, true
@@ -208,7 +208,7 @@ func (o *ReadOnlyWithDefault) GetBoolProp2Ok() (*bool, bool) {
 
 // HasBoolProp2 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasBoolProp2() bool {
-	if o != nil && !isNil(o.BoolProp2) {
+	if o != nil && !IsNil(o.BoolProp2) {
 		return true
 	}
 
@@ -222,7 +222,7 @@ func (o *ReadOnlyWithDefault) SetBoolProp2(v bool) {
 
 // GetIntProp1 returns the IntProp1 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetIntProp1() float32 {
-	if o == nil || isNil(o.IntProp1) {
+	if o == nil || IsNil(o.IntProp1) {
 		var ret float32
 		return ret
 	}
@@ -232,7 +232,7 @@ func (o *ReadOnlyWithDefault) GetIntProp1() float32 {
 // GetIntProp1Ok returns a tuple with the IntProp1 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetIntProp1Ok() (*float32, bool) {
-	if o == nil || isNil(o.IntProp1) {
+	if o == nil || IsNil(o.IntProp1) {
 		return nil, false
 	}
 	return o.IntProp1, true
@@ -240,7 +240,7 @@ func (o *ReadOnlyWithDefault) GetIntProp1Ok() (*float32, bool) {
 
 // HasIntProp1 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasIntProp1() bool {
-	if o != nil && !isNil(o.IntProp1) {
+	if o != nil && !IsNil(o.IntProp1) {
 		return true
 	}
 
@@ -254,7 +254,7 @@ func (o *ReadOnlyWithDefault) SetIntProp1(v float32) {
 
 // GetIntProp2 returns the IntProp2 field value if set, zero value otherwise.
 func (o *ReadOnlyWithDefault) GetIntProp2() float32 {
-	if o == nil || isNil(o.IntProp2) {
+	if o == nil || IsNil(o.IntProp2) {
 		var ret float32
 		return ret
 	}
@@ -264,7 +264,7 @@ func (o *ReadOnlyWithDefault) GetIntProp2() float32 {
 // GetIntProp2Ok returns a tuple with the IntProp2 field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetIntProp2Ok() (*float32, bool) {
-	if o == nil || isNil(o.IntProp2) {
+	if o == nil || IsNil(o.IntProp2) {
 		return nil, false
 	}
 	return o.IntProp2, true
@@ -272,7 +272,7 @@ func (o *ReadOnlyWithDefault) GetIntProp2Ok() (*float32, bool) {
 
 // HasIntProp2 returns a boolean if a field has been set.
 func (o *ReadOnlyWithDefault) HasIntProp2() bool {
-	if o != nil && !isNil(o.IntProp2) {
+	if o != nil && !IsNil(o.IntProp2) {
 		return true
 	}
 
@@ -296,15 +296,15 @@ func (o ReadOnlyWithDefault) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	// skip: prop1 is readOnly
 	// skip: prop2 is readOnly
-	if !isNil(o.Prop3) {
+	if !IsNil(o.Prop3) {
 		toSerialize["prop3"] = o.Prop3
 	}
 	// skip: boolProp1 is readOnly
-	if !isNil(o.BoolProp2) {
+	if !IsNil(o.BoolProp2) {
 		toSerialize["boolProp2"] = o.BoolProp2
 	}
 	// skip: intProp1 is readOnly
-	if !isNil(o.IntProp2) {
+	if !IsNil(o.IntProp2) {
 		toSerialize["intProp2"] = o.IntProp2
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_return.go
@@ -44,7 +44,7 @@ func NewReturnWithDefaults() *Return {
 
 // GetReturn returns the Return field value if set, zero value otherwise.
 func (o *Return) GetReturn() int32 {
-	if o == nil || isNil(o.Return) {
+	if o == nil || IsNil(o.Return) {
 		var ret int32
 		return ret
 	}
@@ -54,7 +54,7 @@ func (o *Return) GetReturn() int32 {
 // GetReturnOk returns a tuple with the Return field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Return) GetReturnOk() (*int32, bool) {
-	if o == nil || isNil(o.Return) {
+	if o == nil || IsNil(o.Return) {
 		return nil, false
 	}
 	return o.Return, true
@@ -62,7 +62,7 @@ func (o *Return) GetReturnOk() (*int32, bool) {
 
 // HasReturn returns a boolean if a field has been set.
 func (o *Return) HasReturn() bool {
-	if o != nil && !isNil(o.Return) {
+	if o != nil && !IsNil(o.Return) {
 		return true
 	}
 
@@ -84,7 +84,7 @@ func (o Return) MarshalJSON() ([]byte, error) {
 
 func (o Return) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Return) {
+	if !IsNil(o.Return) {
 		toSerialize["return"] = o.Return
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
@@ -45,7 +45,7 @@ func NewTagWithDefaults() *Tag {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *Tag) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -55,7 +55,7 @@ func (o *Tag) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Tag) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -63,7 +63,7 @@ func (o *Tag) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *Tag) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -77,7 +77,7 @@ func (o *Tag) SetId(v int64) {
 
 // GetName returns the Name field value if set, zero value otherwise.
 func (o *Tag) GetName() string {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
@@ -87,7 +87,7 @@ func (o *Tag) GetName() string {
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Tag) GetNameOk() (*string, bool) {
-	if o == nil || isNil(o.Name) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
 	return o.Name, true
@@ -95,7 +95,7 @@ func (o *Tag) GetNameOk() (*string, bool) {
 
 // HasName returns a boolean if a field has been set.
 func (o *Tag) HasName() bool {
-	if o != nil && !isNil(o.Name) {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
@@ -117,10 +117,10 @@ func (o Tag) MarshalJSON() ([]byte, error) {
 
 func (o Tag) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.Name) {
+	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_user.go
@@ -60,7 +60,7 @@ func NewUserWithDefaults() *User {
 
 // GetId returns the Id field value if set, zero value otherwise.
 func (o *User) GetId() int64 {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		var ret int64
 		return ret
 	}
@@ -70,7 +70,7 @@ func (o *User) GetId() int64 {
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetIdOk() (*int64, bool) {
-	if o == nil || isNil(o.Id) {
+	if o == nil || IsNil(o.Id) {
 		return nil, false
 	}
 	return o.Id, true
@@ -78,7 +78,7 @@ func (o *User) GetIdOk() (*int64, bool) {
 
 // HasId returns a boolean if a field has been set.
 func (o *User) HasId() bool {
-	if o != nil && !isNil(o.Id) {
+	if o != nil && !IsNil(o.Id) {
 		return true
 	}
 
@@ -92,7 +92,7 @@ func (o *User) SetId(v int64) {
 
 // GetUsername returns the Username field value if set, zero value otherwise.
 func (o *User) GetUsername() string {
-	if o == nil || isNil(o.Username) {
+	if o == nil || IsNil(o.Username) {
 		var ret string
 		return ret
 	}
@@ -102,7 +102,7 @@ func (o *User) GetUsername() string {
 // GetUsernameOk returns a tuple with the Username field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetUsernameOk() (*string, bool) {
-	if o == nil || isNil(o.Username) {
+	if o == nil || IsNil(o.Username) {
 		return nil, false
 	}
 	return o.Username, true
@@ -110,7 +110,7 @@ func (o *User) GetUsernameOk() (*string, bool) {
 
 // HasUsername returns a boolean if a field has been set.
 func (o *User) HasUsername() bool {
-	if o != nil && !isNil(o.Username) {
+	if o != nil && !IsNil(o.Username) {
 		return true
 	}
 
@@ -124,7 +124,7 @@ func (o *User) SetUsername(v string) {
 
 // GetFirstName returns the FirstName field value if set, zero value otherwise.
 func (o *User) GetFirstName() string {
-	if o == nil || isNil(o.FirstName) {
+	if o == nil || IsNil(o.FirstName) {
 		var ret string
 		return ret
 	}
@@ -134,7 +134,7 @@ func (o *User) GetFirstName() string {
 // GetFirstNameOk returns a tuple with the FirstName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetFirstNameOk() (*string, bool) {
-	if o == nil || isNil(o.FirstName) {
+	if o == nil || IsNil(o.FirstName) {
 		return nil, false
 	}
 	return o.FirstName, true
@@ -142,7 +142,7 @@ func (o *User) GetFirstNameOk() (*string, bool) {
 
 // HasFirstName returns a boolean if a field has been set.
 func (o *User) HasFirstName() bool {
-	if o != nil && !isNil(o.FirstName) {
+	if o != nil && !IsNil(o.FirstName) {
 		return true
 	}
 
@@ -156,7 +156,7 @@ func (o *User) SetFirstName(v string) {
 
 // GetLastName returns the LastName field value if set, zero value otherwise.
 func (o *User) GetLastName() string {
-	if o == nil || isNil(o.LastName) {
+	if o == nil || IsNil(o.LastName) {
 		var ret string
 		return ret
 	}
@@ -166,7 +166,7 @@ func (o *User) GetLastName() string {
 // GetLastNameOk returns a tuple with the LastName field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetLastNameOk() (*string, bool) {
-	if o == nil || isNil(o.LastName) {
+	if o == nil || IsNil(o.LastName) {
 		return nil, false
 	}
 	return o.LastName, true
@@ -174,7 +174,7 @@ func (o *User) GetLastNameOk() (*string, bool) {
 
 // HasLastName returns a boolean if a field has been set.
 func (o *User) HasLastName() bool {
-	if o != nil && !isNil(o.LastName) {
+	if o != nil && !IsNil(o.LastName) {
 		return true
 	}
 
@@ -188,7 +188,7 @@ func (o *User) SetLastName(v string) {
 
 // GetEmail returns the Email field value if set, zero value otherwise.
 func (o *User) GetEmail() string {
-	if o == nil || isNil(o.Email) {
+	if o == nil || IsNil(o.Email) {
 		var ret string
 		return ret
 	}
@@ -198,7 +198,7 @@ func (o *User) GetEmail() string {
 // GetEmailOk returns a tuple with the Email field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetEmailOk() (*string, bool) {
-	if o == nil || isNil(o.Email) {
+	if o == nil || IsNil(o.Email) {
 		return nil, false
 	}
 	return o.Email, true
@@ -206,7 +206,7 @@ func (o *User) GetEmailOk() (*string, bool) {
 
 // HasEmail returns a boolean if a field has been set.
 func (o *User) HasEmail() bool {
-	if o != nil && !isNil(o.Email) {
+	if o != nil && !IsNil(o.Email) {
 		return true
 	}
 
@@ -220,7 +220,7 @@ func (o *User) SetEmail(v string) {
 
 // GetPassword returns the Password field value if set, zero value otherwise.
 func (o *User) GetPassword() string {
-	if o == nil || isNil(o.Password) {
+	if o == nil || IsNil(o.Password) {
 		var ret string
 		return ret
 	}
@@ -230,7 +230,7 @@ func (o *User) GetPassword() string {
 // GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetPasswordOk() (*string, bool) {
-	if o == nil || isNil(o.Password) {
+	if o == nil || IsNil(o.Password) {
 		return nil, false
 	}
 	return o.Password, true
@@ -238,7 +238,7 @@ func (o *User) GetPasswordOk() (*string, bool) {
 
 // HasPassword returns a boolean if a field has been set.
 func (o *User) HasPassword() bool {
-	if o != nil && !isNil(o.Password) {
+	if o != nil && !IsNil(o.Password) {
 		return true
 	}
 
@@ -252,7 +252,7 @@ func (o *User) SetPassword(v string) {
 
 // GetPhone returns the Phone field value if set, zero value otherwise.
 func (o *User) GetPhone() string {
-	if o == nil || isNil(o.Phone) {
+	if o == nil || IsNil(o.Phone) {
 		var ret string
 		return ret
 	}
@@ -262,7 +262,7 @@ func (o *User) GetPhone() string {
 // GetPhoneOk returns a tuple with the Phone field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetPhoneOk() (*string, bool) {
-	if o == nil || isNil(o.Phone) {
+	if o == nil || IsNil(o.Phone) {
 		return nil, false
 	}
 	return o.Phone, true
@@ -270,7 +270,7 @@ func (o *User) GetPhoneOk() (*string, bool) {
 
 // HasPhone returns a boolean if a field has been set.
 func (o *User) HasPhone() bool {
-	if o != nil && !isNil(o.Phone) {
+	if o != nil && !IsNil(o.Phone) {
 		return true
 	}
 
@@ -284,7 +284,7 @@ func (o *User) SetPhone(v string) {
 
 // GetUserStatus returns the UserStatus field value if set, zero value otherwise.
 func (o *User) GetUserStatus() int32 {
-	if o == nil || isNil(o.UserStatus) {
+	if o == nil || IsNil(o.UserStatus) {
 		var ret int32
 		return ret
 	}
@@ -294,7 +294,7 @@ func (o *User) GetUserStatus() int32 {
 // GetUserStatusOk returns a tuple with the UserStatus field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetUserStatusOk() (*int32, bool) {
-	if o == nil || isNil(o.UserStatus) {
+	if o == nil || IsNil(o.UserStatus) {
 		return nil, false
 	}
 	return o.UserStatus, true
@@ -302,7 +302,7 @@ func (o *User) GetUserStatusOk() (*int32, bool) {
 
 // HasUserStatus returns a boolean if a field has been set.
 func (o *User) HasUserStatus() bool {
-	if o != nil && !isNil(o.UserStatus) {
+	if o != nil && !IsNil(o.UserStatus) {
 		return true
 	}
 
@@ -316,7 +316,7 @@ func (o *User) SetUserStatus(v int32) {
 
 // GetArbitraryObject returns the ArbitraryObject field value if set, zero value otherwise.
 func (o *User) GetArbitraryObject() map[string]interface{} {
-	if o == nil || isNil(o.ArbitraryObject) {
+	if o == nil || IsNil(o.ArbitraryObject) {
 		var ret map[string]interface{}
 		return ret
 	}
@@ -326,7 +326,7 @@ func (o *User) GetArbitraryObject() map[string]interface{} {
 // GetArbitraryObjectOk returns a tuple with the ArbitraryObject field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *User) GetArbitraryObjectOk() (map[string]interface{}, bool) {
-	if o == nil || isNil(o.ArbitraryObject) {
+	if o == nil || IsNil(o.ArbitraryObject) {
 		return map[string]interface{}{}, false
 	}
 	return o.ArbitraryObject, true
@@ -334,7 +334,7 @@ func (o *User) GetArbitraryObjectOk() (map[string]interface{}, bool) {
 
 // HasArbitraryObject returns a boolean if a field has been set.
 func (o *User) HasArbitraryObject() bool {
-	if o != nil && !isNil(o.ArbitraryObject) {
+	if o != nil && !IsNil(o.ArbitraryObject) {
 		return true
 	}
 
@@ -359,7 +359,7 @@ func (o *User) GetArbitraryNullableObject() map[string]interface{} {
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryNullableObjectOk() (map[string]interface{}, bool) {
-	if o == nil || isNil(o.ArbitraryNullableObject) {
+	if o == nil || IsNil(o.ArbitraryNullableObject) {
 		return map[string]interface{}{}, false
 	}
 	return o.ArbitraryNullableObject, true
@@ -367,7 +367,7 @@ func (o *User) GetArbitraryNullableObjectOk() (map[string]interface{}, bool) {
 
 // HasArbitraryNullableObject returns a boolean if a field has been set.
 func (o *User) HasArbitraryNullableObject() bool {
-	if o != nil && isNil(o.ArbitraryNullableObject) {
+	if o != nil && IsNil(o.ArbitraryNullableObject) {
 		return true
 	}
 
@@ -392,7 +392,7 @@ func (o *User) GetArbitraryTypeValue() interface{} {
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryTypeValueOk() (*interface{}, bool) {
-	if o == nil || isNil(o.ArbitraryTypeValue) {
+	if o == nil || IsNil(o.ArbitraryTypeValue) {
 		return nil, false
 	}
 	return &o.ArbitraryTypeValue, true
@@ -400,7 +400,7 @@ func (o *User) GetArbitraryTypeValueOk() (*interface{}, bool) {
 
 // HasArbitraryTypeValue returns a boolean if a field has been set.
 func (o *User) HasArbitraryTypeValue() bool {
-	if o != nil && isNil(o.ArbitraryTypeValue) {
+	if o != nil && IsNil(o.ArbitraryTypeValue) {
 		return true
 	}
 
@@ -425,7 +425,7 @@ func (o *User) GetArbitraryNullableTypeValue() interface{} {
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryNullableTypeValueOk() (*interface{}, bool) {
-	if o == nil || isNil(o.ArbitraryNullableTypeValue) {
+	if o == nil || IsNil(o.ArbitraryNullableTypeValue) {
 		return nil, false
 	}
 	return &o.ArbitraryNullableTypeValue, true
@@ -433,7 +433,7 @@ func (o *User) GetArbitraryNullableTypeValueOk() (*interface{}, bool) {
 
 // HasArbitraryNullableTypeValue returns a boolean if a field has been set.
 func (o *User) HasArbitraryNullableTypeValue() bool {
-	if o != nil && isNil(o.ArbitraryNullableTypeValue) {
+	if o != nil && IsNil(o.ArbitraryNullableTypeValue) {
 		return true
 	}
 
@@ -455,31 +455,31 @@ func (o User) MarshalJSON() ([]byte, error) {
 
 func (o User) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Id) {
+	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
-	if !isNil(o.Username) {
+	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
 	}
-	if !isNil(o.FirstName) {
+	if !IsNil(o.FirstName) {
 		toSerialize["firstName"] = o.FirstName
 	}
-	if !isNil(o.LastName) {
+	if !IsNil(o.LastName) {
 		toSerialize["lastName"] = o.LastName
 	}
-	if !isNil(o.Email) {
+	if !IsNil(o.Email) {
 		toSerialize["email"] = o.Email
 	}
-	if !isNil(o.Password) {
+	if !IsNil(o.Password) {
 		toSerialize["password"] = o.Password
 	}
-	if !isNil(o.Phone) {
+	if !IsNil(o.Phone) {
 		toSerialize["phone"] = o.Phone
 	}
-	if !isNil(o.UserStatus) {
+	if !IsNil(o.UserStatus) {
 		toSerialize["userStatus"] = o.UserStatus
 	}
-	if !isNil(o.ArbitraryObject) {
+	if !IsNil(o.ArbitraryObject) {
 		toSerialize["arbitraryObject"] = o.ArbitraryObject
 	}
 	if o.ArbitraryNullableObject != nil {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -47,7 +47,7 @@ func NewWhaleWithDefaults() *Whale {
 
 // GetHasBaleen returns the HasBaleen field value if set, zero value otherwise.
 func (o *Whale) GetHasBaleen() bool {
-	if o == nil || isNil(o.HasBaleen) {
+	if o == nil || IsNil(o.HasBaleen) {
 		var ret bool
 		return ret
 	}
@@ -57,7 +57,7 @@ func (o *Whale) GetHasBaleen() bool {
 // GetHasBaleenOk returns a tuple with the HasBaleen field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Whale) GetHasBaleenOk() (*bool, bool) {
-	if o == nil || isNil(o.HasBaleen) {
+	if o == nil || IsNil(o.HasBaleen) {
 		return nil, false
 	}
 	return o.HasBaleen, true
@@ -65,7 +65,7 @@ func (o *Whale) GetHasBaleenOk() (*bool, bool) {
 
 // HasHasBaleen returns a boolean if a field has been set.
 func (o *Whale) HasHasBaleen() bool {
-	if o != nil && !isNil(o.HasBaleen) {
+	if o != nil && !IsNil(o.HasBaleen) {
 		return true
 	}
 
@@ -79,7 +79,7 @@ func (o *Whale) SetHasBaleen(v bool) {
 
 // GetHasTeeth returns the HasTeeth field value if set, zero value otherwise.
 func (o *Whale) GetHasTeeth() bool {
-	if o == nil || isNil(o.HasTeeth) {
+	if o == nil || IsNil(o.HasTeeth) {
 		var ret bool
 		return ret
 	}
@@ -89,7 +89,7 @@ func (o *Whale) GetHasTeeth() bool {
 // GetHasTeethOk returns a tuple with the HasTeeth field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Whale) GetHasTeethOk() (*bool, bool) {
-	if o == nil || isNil(o.HasTeeth) {
+	if o == nil || IsNil(o.HasTeeth) {
 		return nil, false
 	}
 	return o.HasTeeth, true
@@ -97,7 +97,7 @@ func (o *Whale) GetHasTeethOk() (*bool, bool) {
 
 // HasHasTeeth returns a boolean if a field has been set.
 func (o *Whale) HasHasTeeth() bool {
-	if o != nil && !isNil(o.HasTeeth) {
+	if o != nil && !IsNil(o.HasTeeth) {
 		return true
 	}
 
@@ -143,10 +143,10 @@ func (o Whale) MarshalJSON() ([]byte, error) {
 
 func (o Whale) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.HasBaleen) {
+	if !IsNil(o.HasBaleen) {
 		toSerialize["hasBaleen"] = o.HasBaleen
 	}
-	if !isNil(o.HasTeeth) {
+	if !IsNil(o.HasTeeth) {
 		toSerialize["hasTeeth"] = o.HasTeeth
 	}
 	toSerialize["className"] = o.ClassName

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -46,7 +46,7 @@ func NewZebraWithDefaults() *Zebra {
 
 // GetType returns the Type field value if set, zero value otherwise.
 func (o *Zebra) GetType() string {
-	if o == nil || isNil(o.Type) {
+	if o == nil || IsNil(o.Type) {
 		var ret string
 		return ret
 	}
@@ -56,7 +56,7 @@ func (o *Zebra) GetType() string {
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Zebra) GetTypeOk() (*string, bool) {
-	if o == nil || isNil(o.Type) {
+	if o == nil || IsNil(o.Type) {
 		return nil, false
 	}
 	return o.Type, true
@@ -64,7 +64,7 @@ func (o *Zebra) GetTypeOk() (*string, bool) {
 
 // HasType returns a boolean if a field has been set.
 func (o *Zebra) HasType() bool {
-	if o != nil && !isNil(o.Type) {
+	if o != nil && !IsNil(o.Type) {
 		return true
 	}
 
@@ -110,7 +110,7 @@ func (o Zebra) MarshalJSON() ([]byte, error) {
 
 func (o Zebra) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !isNil(o.Type) {
+	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
 	toSerialize["className"] = o.ClassName

--- a/samples/openapi3/client/petstore/go/go-petstore/utils.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/utils.go
@@ -328,8 +328,8 @@ func (v *NullableTime) UnmarshalJSON(src []byte) error {
 	return json.Unmarshal(src, &v.value)
 }
 
-// isNil checks if an input is nil
-func isNil(i interface{}) bool {
+// IsNil checks if an input is nil
+func IsNil(i interface{}) bool {
 	if i == nil {
 		return true
 	}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Update `utils.mustache` to make `isNil` visible outside the package (ie renamed to `IsNil)

Fix #14623 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04)
