### PR TITLE
Add 'endsWith' handlebars helper function

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/handlebars/StringHelpers.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/handlebars/StringHelpers.java
@@ -10,7 +10,7 @@ import java.util.Locale;
 public enum StringHelpers implements Helper<Object> {
 
     /**
-     * Indicates the string starts with the defined value.
+     * Indicates whether the string starts with the given value.
      * For example:
      *
      * <pre>
@@ -39,8 +39,6 @@ public enum StringHelpers implements Helper<Object> {
      * <pre>
      *   {{startsWith a b yes='y' no='n'}}
      * </pre>
-     *
-     * If value is "handlebars.java", the output will be "Handlebars.java".
      */
     startsWith {
         @Override
@@ -52,6 +50,60 @@ public enum StringHelpers implements Helper<Object> {
 
             boolean caseInsensitive = options.hash("insensitive", false);
             boolean result = caseInsensitive ? value.toString().toLowerCase(Locale.ROOT).startsWith(match.toLowerCase(Locale.ROOT)) : value.toString().startsWith(match);
+
+            if (options.tagType == TagType.SECTION) {
+                return result ? options.fn() : options.inverse();
+            }
+
+            return result
+                    ? options.hash("yes", true)
+                    : options.hash("no", false);
+        }
+    },
+
+    /**
+     * Indicates whether the string ends with the given value.
+     * For example:
+     *
+     * <pre>
+     * {{endsWith a b ["insensitive"]}}
+     * </pre>
+     *
+     * <pre>
+     * {{endsWith a text='b' [insensitive=true]}}
+     * </pre>
+     *
+     * Render 'yes' or 'no':
+     * <pre>
+     *   {{#endsWith a b}}
+     *     yes
+     *   {{else}}
+     *     no
+     *   {{/endsWith}}
+     * </pre>
+     *
+     * Render 'true' or 'false':
+     * <pre>
+     *   {{endsWith a b}}
+     * </pre>
+     *
+     * Render 'y' or 'n':
+     * <pre>
+     *   {{endsWith a b yes='y' no='n'}}
+     * </pre>
+     */
+    endsWith {
+        @Override
+        public Object apply(Object value, Options options) throws IOException {
+            String match = options.param(0, options.hash("text", ""));
+            if (match.length() < 1) {
+                return false;
+            }
+
+            boolean caseInsensitive = options.hash("insensitive", false);
+            boolean result = caseInsensitive
+                    ? value.toString().toLowerCase(Locale.ROOT).endsWith(match.toLowerCase(Locale.ROOT))
+                    : value.toString().endsWith(match);
 
             if (options.tagType == TagType.SECTION) {
                 return result ? options.fn() : options.inverse();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/handlebars/StringHelpersTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/handlebars/StringHelpersTest.java
@@ -83,4 +83,53 @@ public class StringHelpersTest {
         template = "{{startsWith asdf b yes='y' no='n'}}";
         evaluate(data, template, "n");
     }
+
+    @Test(description = "Handlebars StringHelpers.endsWith, section")
+    public void endsWithSectionalTest() throws IOException {
+        HashMap<String, Object> data = new HashMap<String, Object>() {{
+            put("asdf", "asdf");
+            put("f", "f");
+            put("b", "b");
+        }};
+
+        String template = "{{~#endsWith asdf df ~}}yes{{~else~}}no{{~/endsWith~}}";
+        evaluate(data, template, "yes");
+
+        template = "{{~#endsWith asdf b ~}}yes{{~else~}}no{{~/endsWith~}}";
+        evaluate(data, template, "no");
+    }
+
+    @Test(description = "Handlebars StringHelpers.endsWith")
+    public void endsWithTest() throws IOException {
+        HashMap<String, Object> data = new HashMap<String, Object>() {{
+            put("asdf", "asdf");
+            put("ASDF", "ASDF");
+            put("f", "f");
+            put("b", "b");
+        }};
+        evaluate(data, "{{endsWith asdf f}}", "true");
+        evaluate(data, "{{endsWith asdf b}}", "false");
+        evaluate(data, "{{endsWith ASDF f insensitive=true }}", "true");
+        evaluate(data, "{{endsWith ASDF f insensitive=false }}", "false");
+        evaluate(data, "{{endsWith ASDF 'f' insensitive=true }}", "true");
+        evaluate(data, "{{endsWith ASDF b insensitive=true }}", "false");
+        evaluate(data, "{{endsWith ASDF 'b' insensitive=true }}", "false");
+        evaluate(data, "{{endsWith ASDF insensitive=true text='f'}}", "true");
+        evaluate(data, "{{endsWith ASDF insensitive=true text='f' yes='✓' no='✘'}}", "✓");
+        evaluate(data, "{{endsWith ASDF insensitive=false text='f' yes='✓' no='✘'}}", "✘");
+    }
+
+    @Test(description = "Handlebars StringHelpers.endsWith, yes/no override")
+    public void endsWithYesOverrideTest() throws IOException {
+        HashMap<String, Object> data = new HashMap<String, Object>() {{
+            put("asdf", "asdf");
+            put("f", "f");
+            put("b", "b");
+        }};
+        String template = "{{endsWith asdf f yes='y' no='n'}}";
+        evaluate(data, template, "y");
+
+        template = "{{endsWith asdf b yes='y' no='n'}}";
+        evaluate(data, template, "n");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/handlebars/StringHelpersTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/handlebars/StringHelpersTest.java
@@ -88,7 +88,7 @@ public class StringHelpersTest {
     public void endsWithSectionalTest() throws IOException {
         HashMap<String, Object> data = new HashMap<String, Object>() {{
             put("asdf", "asdf");
-            put("f", "f");
+            put("df", "df");
             put("b", "b");
         }};
 


### PR DESCRIPTION
This PR adds a `.handlebars` helper `endsWith` (a mirror version of the existing `startsWith` helper).

Closes: #14633
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
