### PR TITLE
Fix #14643: Iterate over collection to use correct string values for enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -112,7 +113,16 @@ namespace {{packageName}}.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -116,7 +117,16 @@ namespace Org.OpenAPITools.Client
             if (obj is bool boolean)
                 return boolean ? "true" : "false";
             if (obj is ICollection collection)
-                return string.Join(",", collection.Cast<object>());
+            {
+                var stringParameterList = new List<string>();
+                foreach (var item in collection)
+                {
+                    stringParameterList.Add(ParameterToString(item, configuration));
+                }
+
+
+                return string.Join(",", stringParameterList);
+            }
             if (obj is Enum && HasEnumMemberAttrValue(obj))
                 return GetEnumMemberAttrValue(obj);
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

As described in https://github.com/OpenAPITools/openapi-generator/issues/14643 the C# .NET Core [ClientUtils](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache#L115) are not considering the type of a collection resulting in invalid API calls.
This PR resolves the issue by iterating over the collection and checking each item before joining into a string.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@mandrean @shibayan @Blackclaws @lucamazzanti