### PR TITLE
[Kotlin][client] Do not use default locale in kotlin generated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -357,7 +357,7 @@ import com.squareup.moshi.adapter
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -392,7 +392,7 @@ import com.squareup.moshi.adapter
         val response = client.newCall(request).execute()
         {{/useCoroutines}}
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -172,7 +172,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -170,7 +170,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -189,7 +189,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -172,7 +172,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -172,7 +172,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -170,7 +170,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -189,7 +189,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -172,7 +172,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -172,7 +172,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -190,7 +190,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -209,7 +209,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -190,7 +190,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -209,7 +209,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -196,7 +196,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -215,7 +215,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -193,7 +193,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -223,7 +223,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             })
         }
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ internal open class ApiClient(val baseUrl: String, val client: OkHttpClient = de
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ internal open class ApiClient(val baseUrl: String, val client: OkHttpClient = de
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -189,7 +189,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -208,7 +208,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -172,7 +172,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -191,7 +191,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val contentType = if (headers[ContentType] != null) {
             // TODO: support multiple contentType options here.
-            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.US)
         } else {
             null
         }
@@ -210,7 +210,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
 
         val response = client.newCall(request).execute()
 
-        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.US)
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         return when {


### PR DESCRIPTION
Using default locale for non-user visible text transformations is not safe and can result in bugs, in particular with Turkish locale.

More details in
https://mattryall.net/blog/the-infamous-turkish-locale-bug
