### PR TITLE
[dart][dart-dio] Add deprecations on models and fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/analysis_options.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/analysis_options.mustache
@@ -8,3 +8,5 @@ analyzer:
   exclude:
     - test/*.dart{{#useJsonSerializable}}
     - lib/src/model/*.g.dart{{/useJsonSerializable}}
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_header.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_header.mustache
@@ -6,5 +6,8 @@
 /// * [{{{name}}}] {{#description}}- {{{.}}}{{/description}}
 {{/allVars}}
 {{/hasVars}}
+{{#isDeprecated}}
+@Deprecated('{{{classname}}} has been deprecated')
+{{/isDeprecated}}
 @BuiltValue({{#vendorExtensions.x-is-parent}}instantiable: false{{/vendorExtensions.x-is-parent}})
 abstract class {{classname}} {{^allOf}}{{^vendorExtensions.x-is-parent}}implements {{/vendorExtensions.x-is-parent}}{{/allOf}}{{#allOf}}{{#-first}}implements {{/-first}}{{/allOf}}{{#allOf}}{{{.}}}{{^-last}}, {{/-last}}{{/allOf}}{{^vendorExtensions.x-is-parent}}{{#allOf}}{{#-first}}, {{/-first}}{{/allOf}}{{/vendorExtensions.x-is-parent}}{{^vendorExtensions.x-is-parent}}Built<{{classname}}, {{classname}}Builder>{{/vendorExtensions.x-is-parent}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_members.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_members.mustache
@@ -3,6 +3,9 @@
   {{#description}}
   /// {{{.}}}
   {{/description}}
+  {{#isDeprecated}}
+  @Deprecated('{{{name}}} has been deprecated')
+  {{/isDeprecated}}
   @BuiltValueField(wireName: r'{{baseName}}')
   {{>serialization/built_value/variable_type}}{{^isNullable}}{{^required}}?{{/required}}{{/isNullable}} get {{name}};
   {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
@@ -4,6 +4,9 @@ import 'package:built_value/serializer.dart';
 
 part '{{classFilename}}.g.dart';
 
+{{#isDeprecated}}
+@Deprecated('{{{classname}}} has been deprecated')
+{{/isDeprecated}}
 class {{classname}} extends EnumClass {
 
   {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
@@ -1,3 +1,6 @@
+{{#isDeprecated}}
+@Deprecated('{{{enumName}}} has been deprecated')
+{{/isDeprecated}}
 class {{{enumName}}} extends EnumClass {
 
   {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
@@ -11,6 +11,9 @@ part '{{classFilename}}.g.dart';
 
 {{/parentModel}}
 
+{{#isDeprecated}}
+@Deprecated('{{{classname}}} has been deprecated')
+{{/isDeprecated}}
 @JsonSerializable(
   checked: true,
   createToJson: true,
@@ -32,6 +35,9 @@ class {{{classname}}} {
           // maximum: {{{maximum}}}
       {{/maximum}}
   {{/isEnum}}
+  {{#isDeprecated}}
+  @Deprecated('{{{name}}} has been deprecated')
+  {{/isDeprecated}}
   {{^isBinary}}
   @JsonKey(
     {{#defaultValue}}defaultValue: {{{defaultValue}}},{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum.mustache
@@ -1,6 +1,9 @@
 import 'package:json_annotation/json_annotation.dart';
 
 {{#description}}/// {{{description}}}{{/description}}
+{{#isDeprecated}}
+@Deprecated('{{{classname}}} has been deprecated')
+{{/isDeprecated}}
 enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/enum_inline.mustache
@@ -1,5 +1,8 @@
 {{#enumName}}
 {{#description}}/// {{{description}}}{{/description}}
+{{#isDeprecated}}
+@Deprecated('{{{enumName}}} has been deprecated')
+{{/isDeprecated}}
 enum {{{ enumName }}} {
 {{#allowableValues}}
 {{#enumVars}}

--- a/samples/openapi3/client/petstore/dart-dio/oneof/analysis_options.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/analysis_options.yaml
@@ -7,3 +7,5 @@ analyzer:
     implicit-casts: false
   exclude:
     - test/*.dart
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/analysis_options.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/analysis_options.yaml
@@ -7,3 +7,5 @@ analyzer:
     implicit-casts: false
   exclude:
     - test/*.dart
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/analysis_options.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/analysis_options.yaml
@@ -7,3 +7,5 @@ analyzer:
     implicit-casts: false
   exclude:
     - test/*.dart
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/analysis_options.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/analysis_options.yaml
@@ -8,3 +8,5 @@ analyzer:
   exclude:
     - test/*.dart
     - lib/src/model/*.g.dart
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/deprecated_object.dart
@@ -8,6 +8,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'deprecated_object.g.dart';
 
 
+@Deprecated('DeprecatedObject has been deprecated')
 @JsonSerializable(
   checked: true,
   createToJson: true,
@@ -21,6 +22,7 @@ class DeprecatedObject {
      this.name,
   });
 
+  @Deprecated('name has been deprecated')
   @JsonKey(
     
     name: r'name',

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/analysis_options.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/analysis_options.yaml
@@ -7,3 +7,5 @@ analyzer:
     implicit-casts: false
   exclude:
     - test/*.dart
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/deprecated_object.dart
@@ -12,8 +12,10 @@ part 'deprecated_object.g.dart';
 ///
 /// Properties:
 /// * [name] 
+@Deprecated('DeprecatedObject has been deprecated')
 @BuiltValue()
 abstract class DeprecatedObject implements Built<DeprecatedObject, DeprecatedObjectBuilder> {
+  @Deprecated('name has been deprecated')
   @BuiltValueField(wireName: r'name')
   String? get name;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Closes #13818

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)
