### PR TITLE
[Bug][Go] consider allOf schemas for rendering string default vaules

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -387,10 +387,29 @@ public class GoClientCodegen extends AbstractGoCodegen {
         }
     }
 
+    /**
+     * Determines if at least one of the allOf pieces of a schema are of type string
+     *
+     * @param p
+     * @return
+     */
+    private boolean isAllOfStringSchema(Schema schema) {
+        if (schema.getAllOf() != null) {
+            Iterator<Schema> it = schema.getAllOf().iterator();
+            while (it.hasNext()) {
+                Schema childSchema = ModelUtils.getReferencedSchema(this.openAPI, it.next());
+                if (ModelUtils.isStringSchema(childSchema)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     @Override
     public String toDefaultValue(Schema p) {
         p = ModelUtils.getReferencedSchema(this.openAPI, p);
-        if (ModelUtils.isStringSchema(p)) {
+        if (ModelUtils.isStringSchema(p) || isAllOfStringSchema(p)) {
             Object defaultObj = p.getDefault();
             if (defaultObj != null) {
                 if (defaultObj instanceof java.lang.String) {


### PR DESCRIPTION
Fixes #14665 See this issue for reproducer information.  This fix does resolve the mentioned issue, but I'm not certain if it is the correct approach.



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
