### PR TITLE
[Fix] take referenced types into account for enum defaults (fixes #14689)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6314,6 +6314,12 @@ public class DefaultCodegen implements CodegenConfig {
         if (var.mostInnerItems != null) {
             allowableValues = var.mostInnerItems.allowableValues;
         }
+        
+        // handle typical referenced enum type with default specified in var
+        if (allowableValues == null && var.getComposedSchemas() != null && var.getComposedSchemas().getAllOf() != null
+                && var.getComposedSchemas().getAllOf().size() == 1) {
+            allowableValues = var.getComposedSchemas().getAllOf().get(0).getAllowableValues();
+        }
 
         if (allowableValues == null) {
             return;


### PR DESCRIPTION
Attempt to resolve a regression in 6.3.0 related to default's for referenced enums.

fixes #14689

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
