### PR TITLE
Fix toUrlQuery string method in anyOf models in java native client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
@@ -195,4 +195,166 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     {{/anyOf}}
+
+{{#supportUrlQuery}}
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @return URL query string
+   */
+  public String toUrlQueryString() {
+    return toUrlQueryString(null);
+  }
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    String suffix = "";
+    String containerSuffix = "";
+    String containerPrefix = "";
+    if (prefix == null) {
+      // style=form, explode=true, e.g. /pet?name=cat&type=manx
+      prefix = "";
+    } else {
+      // deepObject style e.g. /pet?id[name]=cat&id[type]=manx
+      prefix = prefix + "[";
+      suffix = "]";
+      containerSuffix = "]";
+      containerPrefix = "[";
+    }
+
+    StringJoiner joiner = new StringJoiner("&");
+
+    {{#composedSchemas.oneOf}}
+    if (getActualInstance() instanceof {{{dataType}}}) {
+        {{#isArray}}
+        {{#items.isPrimitiveType}}
+        {{#uniqueItems}}
+        if (getActualInstance() != null) {
+          int i = 0;
+          for ({{items.dataType}} _item : ({{{dataType}}})getActualInstance()) {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                URLEncoder.encode(String.valueOf(_item), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+          }
+          i++;
+        }
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        if (getActualInstance() != null) {
+          for (int i = 0; i < (({{{dataType}}})getActualInstance()).size(); i++) {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                URLEncoder.encode(String.valueOf(getActualInstance().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+          }
+        }
+        {{/uniqueItems}}
+        {{/items.isPrimitiveType}}
+        {{^items.isPrimitiveType}}
+        {{#items.isModel}}
+        {{#uniqueItems}}
+        if (getActualInstance() != null) {
+          int i = 0;
+          for ({{items.dataType}} _item : ({{{dataType}}})getActualInstance()) {
+            if (_item != null) {
+              joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
+            }
+          }
+          i++;
+        }
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        if (getActualInstance() != null) {
+          for (int i = 0; i < (({{{dataType}}})getActualInstance()).size(); i++) {
+            if ((({{{dataType}}})getActualInstance()).get(i) != null) {
+              joiner.add((({{{items.dataType}}})getActualInstance()).get(i).toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
+            }
+          }
+        }
+        {{/uniqueItems}}
+        {{/items.isModel}}
+        {{^items.isModel}}
+        {{#uniqueItems}}
+        if (getActualInstance() != null) {
+          int i = 0;
+          for ({{items.dataType}} _item : ({{{dataType}}})getActualInstance()) {
+            if (_item != null) {
+              joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  URLEncoder.encode(String.valueOf(_item), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+            }
+            i++;
+          }
+        }
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        if (getActualInstance() != null) {
+          for (int i = 0; i < (({{{dataType}}})getActualInstance()).size(); i++) {
+            if (getActualInstance().get(i) != null) {
+              joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  URLEncoder.encode(String.valueOf((({{{dataType}}})getActualInstance()).get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+            }
+          }
+        }
+        {{/uniqueItems}}
+        {{/items.isModel}}
+        {{/items.isPrimitiveType}}
+        {{/isArray}}
+        {{^isArray}}
+        {{#isMap}}
+        {{#items.isPrimitiveType}}
+        if (getActualInstance() != null) {
+          for (String _key : (({{{dataType}}})getActualInstance()).keySet()) {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+                getActualInstance().get(_key), URLEncoder.encode(String.valueOf((({{{dataType}}})getActualInstance()).get(_key)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+          }
+        }
+        {{/items.isPrimitiveType}}
+        {{^items.isPrimitiveType}}
+        if (getActualInstance() != null) {
+          for (String _key : (({{{dataType}}})getActualInstance()).keySet()) {
+            if ((({{{dataType}}})getActualInstance()).get(_key) != null) {
+              joiner.add((({{{items.dataType}}})getActualInstance()).get(_key).toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, _key, containerSuffix))));
+            }
+          }
+        }
+        {{/items.isPrimitiveType}}
+        {{/isMap}}
+        {{^isMap}}
+        {{#isPrimitiveType}}
+        if (getActualInstance() != null) {
+          joiner.add(String.format("%s{{{baseName}}}%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getActualInstance()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        }
+        {{/isPrimitiveType}}
+        {{^isPrimitiveType}}
+        {{#isModel}}
+        if (getActualInstance() != null) {
+          joiner.add((({{{dataType}}})getActualInstance()).toUrlQueryString(prefix + "{{{baseName}}}" + suffix));
+        }
+        {{/isModel}}
+        {{^isModel}}
+        if (getActualInstance() != null) {
+          joiner.add(String.format("%s{{{baseName}}}%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getActualInstance()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        }
+        {{/isModel}}
+        {{/isPrimitiveType}}
+        {{/isMap}}
+        {{/isArray}}
+        return joiner.toString();
+    }
+    {{/composedSchemas.oneOf}}
+    return null;
+  }
+{{/supportUrlQuery}}
+
 }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -204,5 +204,42 @@ public class GmFruit extends AbstractOpenApiSchema {
         return (Banana)super.getActualInstance();
     }
 
+
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @return URL query string
+   */
+  public String toUrlQueryString() {
+    return toUrlQueryString(null);
+  }
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    String suffix = "";
+    String containerSuffix = "";
+    String containerPrefix = "";
+    if (prefix == null) {
+      // style=form, explode=true, e.g. /pet?name=cat&type=manx
+      prefix = "";
+    } else {
+      // deepObject style e.g. /pet?id[name]=cat&id[type]=manx
+      prefix = prefix + "[";
+      suffix = "]";
+      containerSuffix = "]";
+      containerPrefix = "[";
+    }
+
+    StringJoiner joiner = new StringJoiner("&");
+
+    return null;
+  }
+
 }
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -204,5 +204,42 @@ public class GmFruit extends AbstractOpenApiSchema {
         return (Banana)super.getActualInstance();
     }
 
+
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @return URL query string
+   */
+  public String toUrlQueryString() {
+    return toUrlQueryString(null);
+  }
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    String suffix = "";
+    String containerSuffix = "";
+    String containerPrefix = "";
+    if (prefix == null) {
+      // style=form, explode=true, e.g. /pet?name=cat&type=manx
+      prefix = "";
+    } else {
+      // deepObject style e.g. /pet?id[name]=cat&id[type]=manx
+      prefix = prefix + "[";
+      suffix = "]";
+      containerSuffix = "]";
+      containerPrefix = "[";
+    }
+
+    StringJoiner joiner = new StringJoiner("&");
+
+    return null;
+  }
+
 }
 


### PR DESCRIPTION
Fix toUrlQuery string method in anyOf models in java native client

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
