### PR TITLE
ktor-client add toString() for generic params

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -52,25 +52,25 @@ import com.fasterxml.jackson.databind.ObjectMapper
                         formData {
                     {{#formParams}}
                         {{#isFile}}
-                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}) }
                         {{/isFile}}
                         {{^isFile}}
                         {{^isArray}}
                         {{^isString}}
                         {{^isNumber}}
-                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}.toString()) }
+                        {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}.toString()) }
                         {{/isNumber}}
                         {{#isNumber}}
-                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}) }
                         {{/isNumber}}
                         {{/isString}}
                         {{#isString}}
-                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}) }
                         {{/isString}}
                         {{/isArray}}
                         {{#isArray}}
                         for (int i=0; i < {{paramName}}.size(); i++) {
-                            {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}.get(i).toString()) }
+                            {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}.get(i).toString()) }
                         }
                         {{/isArray}}
                         {{/isFile}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -51,14 +51,58 @@ import com.fasterxml.jackson.databind.ObjectMapper
                 {{#isMultipart}}
                         formData {
                     {{#formParams}}
-                        {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}) }
+                        {{#isFile}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{/isFile}}
+                        {{^isFile}}
+                        {{^isArray}}
+                        {{^isString}}
+                        {{^isNumber}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}.toString()) }
+                        {{/isNumber}}
+                        {{#isNumber}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{/isNumber}}
+                        {{/isString}}
+                        {{#isString}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{/isString}}
+                        {{/isArray}}
+                        {{#isArray}}
+                        for (int i=0; i < {{paramName}}.size(); i++) {
+                            {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}.get(i).toString()) }
+                        }
+                        {{/isArray}}
+                        {{/isFile}}
                     {{/formParams}}
                         }
                 {{/isMultipart}}
                 {{^isMultipart}}
                         ParametersBuilder().also {
                     {{#formParams}}
+                        {{#isFile}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{/isFile}}
+                        {{^isFile}}
+                        {{^isArray}}
+                        {{^isString}}
+                        {{^isNumber}}
                         {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}.toString()) }
+                        {{/isNumber}}
+                        {{#isNumber}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{/isNumber}}
+                        {{/isString}}
+                        {{#isString}}
+                        {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}) }
+                        {{/isString}}
+                        {{/isArray}}
+                        {{#isArray}}
+                        for (int i=0; i < {{paramName}}.size(); i++) {
+                            {{{paramName}}}?.apply { it.append("{{{baseName}}}", {{{paramName}}}.get(i).toString()) }
+                        }
+                        {{/isArray}}
+                        {{/isFile}}
                     {{/formParams}}
                         }.build()
                 {{/isMultipart}}

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -245,8 +245,8 @@ import java.text.DateFormat
 
             val localVariableBody = 
                         ParametersBuilder().also {
-                        name?.apply { it.append("name", name.toString()) }
-                        status?.apply { it.append("status", status.toString()) }
+                        name?.apply { it.append("name", name) }
+                        status?.apply { it.append("status", status) }
                         }.build()
 
             val localVariableQuery = mutableMapOf<String, List<String>>()
@@ -283,8 +283,8 @@ import java.text.DateFormat
 
             val localVariableBody = 
                         formData {
-                        additionalMetadata?.apply { append("additionalMetadata", additionalMetadata) }
-                        file?.apply { append("file", file) }
+                        additionalMetadata?.apply { it.append("additionalMetadata", additionalMetadata) }
+                        file?.apply { it.append("file", file) }
                         }
 
             val localVariableQuery = mutableMapOf<String, List<String>>()

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -283,8 +283,8 @@ import java.text.DateFormat
 
             val localVariableBody = 
                         formData {
-                        additionalMetadata?.apply { it.append("additionalMetadata", additionalMetadata) }
-                        file?.apply { it.append("file", file) }
+                        additionalMetadata?.apply { append("additionalMetadata", additionalMetadata) }
+                        file?.apply { append("file", file) }
                         }
 
             val localVariableQuery = mutableMapOf<String, List<String>>()

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -243,8 +243,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
             val localVariableBody = 
                         ParametersBuilder().also {
-                        name?.apply { it.append("name", name.toString()) }
-                        status?.apply { it.append("status", status.toString()) }
+                        name?.apply { it.append("name", name) }
+                        status?.apply { it.append("status", status) }
                         }.build()
 
             val localVariableQuery = mutableMapOf<String, List<String>>()
@@ -281,8 +281,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
             val localVariableBody = 
                         formData {
-                        additionalMetadata?.apply { append("additionalMetadata", additionalMetadata) }
-                        file?.apply { append("file", file) }
+                        additionalMetadata?.apply { it.append("additionalMetadata", additionalMetadata) }
+                        file?.apply { it.append("file", file) }
                         }
 
             val localVariableQuery = mutableMapOf<String, List<String>>()

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -281,8 +281,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
             val localVariableBody = 
                         formData {
-                        additionalMetadata?.apply { it.append("additionalMetadata", additionalMetadata) }
-                        file?.apply { it.append("file", file) }
+                        additionalMetadata?.apply { append("additionalMetadata", additionalMetadata) }
+                        file?.apply { append("file", file) }
                         }
 
             val localVariableQuery = mutableMapOf<String, List<String>>()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

ktor-client doesn't support building form request from arbitrary parameters: it will happily consume values of predefined types such as `String`, `Number` etc but will fail in runtime (!) at a given line in case of say `List<T>` or `Instant`.
https://github.com/ktorio/ktor/blob/fb161cd7d268f2c0f62982d82d9264ca920173ad/ktor-client/ktor-client-core/common/src/io/ktor/client/request/forms/formDsl.kt#L63

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @wing328 
