### PR TITLE
go server - use tabs instead of spaces

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -108,11 +108,11 @@ func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} heade
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if i != nil {
-        return json.NewEncoder(w).Encode(i)
-    }
+	if i != nil {
+		return json.NewEncoder(w).Encode(i)
+	}
 
-    return nil
+	return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -76,11 +76,11 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if i != nil {
-        return json.NewEncoder(w).Encode(i)
-    }
+	if i != nil {
+		return json.NewEncoder(w).Encode(i)
+	}
 
-    return nil
+	return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -72,11 +72,11 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if i != nil {
-        return json.NewEncoder(w).Encode(i)
-    }
+	if i != nil {
+		return json.NewEncoder(w).Encode(i)
+	}
 
-    return nil
+	return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file

--- a/samples/server/petstore/go-server-required/go/routers.go
+++ b/samples/server/petstore/go-server-required/go/routers.go
@@ -72,11 +72,11 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if i != nil {
-        return json.NewEncoder(w).Encode(i)
-    }
+	if i != nil {
+		return json.NewEncoder(w).Encode(i)
+	}
 
-    return nil
+	return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file


### PR DESCRIPTION
go server - use tabs instead of spaces
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04)
