### PR TITLE
[typescript] Adds missing override modifier in RequiredError

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
@@ -37,7 +37,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/client/others/typescript/builds/with-unique-items/apis/baseapi.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/baseapi.ts
@@ -33,7 +33,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/baseapi.ts
@@ -30,7 +30,7 @@ export class BaseAPIRequestFactory {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }


### PR DESCRIPTION
@davidgamero @mkusaka

On Angular 14+ with Typescript 4.7+ the client code hits this Typescript error:

```
Error: node_modules/demo/apis/baseapi.ts:33:5 - error TS4114: This member must have an 'override' modifier because it overrides a member in the base class 'Error'.

33     name: "RequiredError" = "RequiredError";
```
This adds the modifier.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
