### PR TITLE
[python-nextgen] switch union order to have StrictStr first

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -583,7 +583,7 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
             if (allowStringInDateTimeParameters) {
                 pydanticImports.add("StrictStr");
                 typingImports.add("Union");
-                return String.format(Locale.ROOT, "Union[%s, StrictStr]", cp.dataType);
+                return String.format(Locale.ROOT, "Union[StrictStr, %s]", cp.dataType);
             } else {
                 return cp.dataType;
             }

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/query_api.py
@@ -45,7 +45,7 @@ class QueryApi(object):
         self.api_client = api_client
 
     @validate_arguments
-    def test_query_datetime_date_string(self, datetime_query : Optional[Union[datetime, StrictStr]] = None, date_query : Optional[Union[date, StrictStr]] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
+    def test_query_datetime_date_string(self, datetime_query : Optional[Union[StrictStr, datetime]] = None, date_query : Optional[Union[StrictStr, date]] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -80,7 +80,7 @@ class QueryApi(object):
         return self.test_query_datetime_date_string_with_http_info(datetime_query, date_query, string_query, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[Union[datetime, StrictStr]] = None, date_query : Optional[Union[date, StrictStr]] = None, string_query : Optional[StrictStr] = None, **kwargs):  # noqa: E501
+    def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[Union[StrictStr, datetime]] = None, date_query : Optional[Union[StrictStr, date]] = None, string_query : Optional[StrictStr] = None, **kwargs):  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501


### PR DESCRIPTION
- switch union order to have StrictStr first when the allowStringInDateTimeParameters option is enabled.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)