### PR TITLE
[python-nextgen] add from_dict to model_anyof template in python-nextgen, fixes #14767

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
@@ -78,6 +78,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             raise ValueError("No match found when deserializing the JSON string into {{{classname}}} with anyOf schemas: {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: " + ", ".join(error_messages))
         else:
             return v
+
     @classmethod
     def from_dict(cls, obj: dict) -> {{{classname}}}:
         return cls.from_json(json.dumps(obj))

--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
@@ -78,6 +78,9 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             raise ValueError("No match found when deserializing the JSON string into {{{classname}}} with anyOf schemas: {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: " + ", ".join(error_messages))
         else:
             return v
+    @classmethod
+    def from_dict(cls, obj: dict) -> {{{classname}}}:
+        return cls.from_json(json.dumps(obj))
 
     @classmethod
     def from_json(cls, json_str: str) -> {{{classname}}}:


### PR DESCRIPTION
It adds method `from_dict` to model_anyof.mustache template of python-nextgen

Fixes #14767 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x]  Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@spacether @krjakbrjak @wing328 
