### PR TITLE
Add from_dict in model anyOf in python-nextgen

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
@@ -78,6 +78,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             raise ValueError("No match found when deserializing the JSON string into {{{classname}}} with anyOf schemas: {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: " + ", ".join(error_messages))
         else:
             return v
+
     @classmethod
     def from_dict(cls, obj: dict) -> {{{classname}}}:
         return cls.from_json(json.dumps(obj))

--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_anyof.mustache
@@ -78,6 +78,9 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             raise ValueError("No match found when deserializing the JSON string into {{{classname}}} with anyOf schemas: {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: " + ", ".join(error_messages))
         else:
             return v
+    @classmethod
+    def from_dict(cls, obj: dict) -> {{{classname}}}:
+        return cls.from_json(json.dumps(obj))
 
     @classmethod
     def from_json(cls, json_str: str) -> {{{classname}}}:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/any_of_color.py
@@ -70,6 +70,10 @@ class AnyOfColor(BaseModel):
             return v
 
     @classmethod
+    def from_dict(cls, obj: dict) -> AnyOfColor:
+        return cls.from_json(json.dumps(obj))
+
+    @classmethod
     def from_json(cls, json_str: str) -> AnyOfColor:
         """Returns the object represented by the json string"""
         instance = cls()

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/any_of_pig.py
@@ -64,6 +64,10 @@ class AnyOfPig(BaseModel):
             return v
 
     @classmethod
+    def from_dict(cls, obj: dict) -> AnyOfPig:
+        return cls.from_json(json.dumps(obj))
+
+    @classmethod
     def from_json(cls, json_str: str) -> AnyOfPig:
         """Returns the object represented by the json string"""
         instance = cls()

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/any_of_color.py
@@ -70,6 +70,10 @@ class AnyOfColor(BaseModel):
             return v
 
     @classmethod
+    def from_dict(cls, obj: dict) -> AnyOfColor:
+        return cls.from_json(json.dumps(obj))
+
+    @classmethod
     def from_json(cls, json_str: str) -> AnyOfColor:
         """Returns the object represented by the json string"""
         instance = cls()

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/any_of_pig.py
@@ -64,6 +64,10 @@ class AnyOfPig(BaseModel):
             return v
 
     @classmethod
+    def from_dict(cls, obj: dict) -> AnyOfPig:
+        return cls.from_json(json.dumps(obj))
+
+    @classmethod
     def from_json(cls, json_str: str) -> AnyOfPig:
         """Returns the object represented by the json string"""
         instance = cls()

--- a/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
@@ -161,6 +161,11 @@ class ModelTests(unittest.TestCase):
         p = petstore_api.Pig.from_json(json_str)
         self.assertIsInstance(p.actual_instance, petstore_api.BasquePig)
 
+        # test from_dict
+        json_dict = {"className": "BasquePig", "color": "red"}
+        p = petstore_api.Pig.from_dict(json_dict)
+        self.assertIsInstance(p.actual_instance, petstore_api.BasquePig)
+
         # test init
         basque_pig = p.actual_instance
         pig2 = petstore_api.Pig(actual_instance=basque_pig)
@@ -181,7 +186,7 @@ class ModelTests(unittest.TestCase):
             self.assertTrue(False)  # this line shouldn't execute
         except AttributeError as e:
             self.assertEqual(str(e), "'int' object has no attribute 'get'")
-        # comment out below as the error message is different using oneOf discriminator looku option
+        # comment out below as the error message is different using oneOf discriminator lookup option
         #except ValueError as e:
         #    error_message = (
         #        "No match found when deserializing the JSON string into Pig with oneOf schemas: BasquePig, DanishPig. "
@@ -212,6 +217,11 @@ class ModelTests(unittest.TestCase):
         # test from_json
         json_str = '{"className": "BasquePig", "color": "red"}'
         p = petstore_api.AnyOfPig.from_json(json_str)
+        self.assertIsInstance(p.actual_instance, petstore_api.BasquePig)
+
+        # test from_dict
+        json_dict = {"className": "BasquePig", "color": "red"}
+        p = petstore_api.AnyOfPig.from_dict(json_dict)
         self.assertIsInstance(p.actual_instance, petstore_api.BasquePig)
 
         # test init


### PR DESCRIPTION
based on https://github.com/OpenAPITools/openapi-generator/pull/14779 with updated samples and added tests.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)