### PR TITLE
[java][jersey] Remove double brace initialization and some more jersey cleanup

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -820,6 +820,11 @@ public class DefaultGenerator implements Generator {
             bundle.put("hasServers", true);
         }
 
+        boolean hasOperationServers = allOperations != null && allOperations.stream()
+                .flatMap(om -> om.getOperations().getOperation().stream())
+                .anyMatch(o -> o.servers != null && !o.servers.isEmpty());
+        bundle.put("hasOperationServers", hasOperationServers);
+
         if (openAPI.getExternalDocs() != null) {
             bundle.put("externalDocs", openAPI.getExternalDocs());
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -83,8 +83,8 @@ import {{invokerPackage}}.auth.OAuth;
  */
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "{{{basePath}}}";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -178,8 +178,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   {{/hasOperationServers}}
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -216,7 +216,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     setUserAgent("{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/java{{/httpUserAgent}}");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     {{#authMethods}}
     if (authMap != null) {
@@ -262,7 +262,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();{{#authMethods}}{{#vendorExtensions.x-auth-id-alias}}
+    authenticationLookup = new HashMap<>();{{#authMethods}}{{#vendorExtensions.x-auth-id-alias}}
     authenticationLookup.put("{{name}}", "{{.}}");{{/vendorExtensions.x-auth-id-alias}}{{/authMethods}}
   }
 
@@ -857,7 +857,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1452,10 +1452,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -83,6 +83,8 @@ import {{invokerPackage}}.auth.OAuth;
  */
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "{{{basePath}}}";
@@ -916,14 +918,13 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -105,15 +105,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
                           new SimpleEntry<>("{{{name}}}", new ServerVariable(
                                   "{{{description}}}{{^description}}No description provided{{/description}}",
                                   "{{{defaultValue}}}",
-                                  {{#enumValues}}
-                                  {{#-first}}
-                                  new LinkedHashSet<>(Arrays.asList(
-                                  {{/-first}}
-                                          "{{{.}}}"{{^-last}},{{/-last}}
-                                  {{#-last}}
-                                  ))
-                                  {{/-last}}
-                                  {{/enumValues}}
+                                  new LinkedHashSet<>({{#enumValues}}{{#-first}}Arrays.asList({{/-first}}
+                                          "{{{.}}}"{{^-last}},{{/-last}}{{#-last}}
+                                  ){{/-last}}{{/enumValues}})
                           )){{^-last}},{{/-last}}
                   {{#-last}}
                   ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
@@ -153,18 +147,12 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
                             new SimpleEntry<>("{{{name}}}", new ServerVariable(
                                     "{{{description}}}{{^description}}No description provided{{/description}}",
                                     "{{{defaultValue}}}",
-                                    {{#enumValues}}
-                                    {{#-first}}
-                                    new LinkedHashSet<>(Arrays.asList(
-                                    {{/-first}}
-                                            "{{{.}}}"{{^-last}},{{/-last}}
-                                    {{#-last}}
-                                    ))
-                                    {{/-last}}
-                                    {{/enumValues}}
+                                    new LinkedHashSet<>({{#enumValues}}{{#-first}}Arrays.asList({{/-first}}
+                                            "{{{.}}}"{{^-last}},{{/-last}}{{#-last}}
+                                    ){{/-last}}{{/enumValues}})
                             )){{^-last}},{{/-last}}
                     {{#-last}}
-                    collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+                    ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
                     {{/-last}}
                     {{/variables}}
             ){{^-last}},{{/-last}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -972,11 +972,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -45,11 +46,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 {{#jsr310}}
 import java.time.OffsetDateTime;
 {{/jsr310}}
@@ -85,72 +89,95 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
-{{/-first}}    new ServerConfiguration(
-      "{{{url}}}",
-      "{{{description}}}{{^description}}No description provided{{/description}}",
-      new HashMap<String, ServerVariable>(){{#variables}}{{#-first}} {{
-{{/-first}}        put("{{{name}}}", new ServerVariable(
-          "{{{description}}}{{^description}}No description provided{{/description}}",
-          "{{{defaultValue}}}",
-          new HashSet<String>(
-          {{#enumValues}}
-          {{#-first}}
-            Arrays.asList(
-          {{/-first}}
-              "{{{.}}}"{{^-last}},{{/-last}}
-          {{#-last}}
-            )
-          {{/-last}}
-          {{/enumValues}}
-          )
-        ));
-      {{#-last}}
-      }}{{/-last}}{{/variables}}
-    ){{^-last}},{{/-last}}
+  protected List<ServerConfiguration> servers = new ArrayList<>({{#servers}}{{#-first}}Arrays.asList(
+{{/-first}}          new ServerConfiguration(
+                  "{{{url}}}",
+                  "{{{description}}}{{^description}}No description provided{{/description}}",
+                  {{^variables}}
+                  new LinkedHashMap<>()
+                  {{/variables}}
+                  {{#variables}}
+                  {{#-first}}
+                  Stream.<Entry<String, ServerVariable>>of(
+                  {{/-first}}
+                          new SimpleEntry<>("{{{name}}}", new ServerVariable(
+                                  "{{{description}}}{{^description}}No description provided{{/description}}",
+                                  "{{{defaultValue}}}",
+                                  {{#enumValues}}
+                                  {{#-first}}
+                                  new LinkedHashSet<>(Arrays.asList(
+                                  {{/-first}}
+                                          "{{{.}}}"{{^-last}},{{/-last}}
+                                  {{#-last}}
+                                  ))
+                                  {{/-last}}
+                                  {{/enumValues}}
+                          )){{^-last}},{{/-last}}
+                  {{#-last}}
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+                  {{/-last}}
+                  {{/variables}}
+          ){{^-last}},{{/-last}}
   {{#-last}}
   ){{/-last}}{{/servers}});
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
+  {{^hasOperationServers}}
+  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
+  {{/hasOperationServers}}
+  {{#hasOperationServers}}
+  protected Map<String, List<ServerConfiguration>> operationServers;
+
+  {
+    Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
     {{#apiInfo}}
     {{#apis}}
     {{#operations}}
     {{#operation}}
     {{#servers}}
     {{#-first}}
-    put("{{{classname}}}.{{{operationId}}}", new ArrayList<ServerConfiguration>(Arrays.asList(
+    operationServers.put("{{{classname}}}.{{{operationId}}}", new ArrayList<>(Arrays.asList(
     {{/-first}}
-      new ServerConfiguration(
-        "{{{url}}}",
-        "{{{description}}}{{^description}}No description provided{{/description}}",
-        new HashMap<String, ServerVariable>(){{#variables}}{{#-first}} {{
-{{/-first}}          put("{{{name}}}", new ServerVariable(
-            "{{{description}}}{{^description}}No description provided{{/description}}",
-            "{{{defaultValue}}}",
-            new HashSet<String>(
-            {{#enumValues}}
-            {{#-first}}
-              Arrays.asList(
-            {{/-first}}
-                "{{{.}}}"{{^-last}},{{/-last}}
-            {{#-last}}
-              )
-            {{/-last}}
-            {{/enumValues}}
-            )
-          ));
-        {{#-last}}
-        }}{{/-last}}{{/variables}}
-      ){{^-last}},{{/-last}}
+            new ServerConfiguration(
+                    "{{{url}}}",
+                    "{{{description}}}{{^description}}No description provided{{/description}}",
+                    {{^variables}}
+                    new LinkedHashMap<>()
+                    {{/variables}}
+                    {{#variables}}
+                    {{#-first}}
+                    Stream.<Entry<String, ServerVariable>>of(
+                    {{/-first}}
+                            new SimpleEntry<>("{{{name}}}", new ServerVariable(
+                                    "{{{description}}}{{^description}}No description provided{{/description}}",
+                                    "{{{defaultValue}}}",
+                                    {{#enumValues}}
+                                    {{#-first}}
+                                    new LinkedHashSet<>(Arrays.asList(
+                                    {{/-first}}
+                                            "{{{.}}}"{{^-last}},{{/-last}}
+                                    {{#-last}}
+                                    ))
+                                    {{/-last}}
+                                    {{/enumValues}}
+                            )){{^-last}},{{/-last}}
+                    {{#-last}}
+                    collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+                    {{/-last}}
+                    {{/variables}}
+            ){{^-last}},{{/-last}}
     {{#-last}}
-    )));{{/-last}}
+    )));
+    {{/-last}}
     {{/servers}}
     {{/operation}}
     {{/operations}}
     {{/apis}}
     {{/apiInfo}}
-  }};
+    this.operationServers = operationServers;
+  }
+
+  {{/hasOperationServers}}
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -935,8 +935,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -956,8 +956,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -971,10 +971,11 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1249,20 +1250,22 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        {{#hasHttpSignatureMethods}}
-        serializeToString(body, formParams, contentType, isBodyNullable),
-        {{/hasHttpSignatureMethods}}
-        {{^hasHttpSignatureMethods}}
-        null,
-        {{/hasHttpSignatureMethods}}
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          {{#hasHttpSignatureMethods}}
+          serializeToString(body, formParams, contentType, isBodyNullable),
+          {{/hasHttpSignatureMethods}}
+          {{^hasHttpSignatureMethods}}
+          null,
+          {{/hasHttpSignatureMethods}}
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1280,7 +1283,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
       {{#hasOAuthMethods}}
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/JSON.mustache
@@ -76,7 +76,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -96,7 +96,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -205,12 +205,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/additional_properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/additional_properties.mustache
@@ -13,7 +13,7 @@
   @JsonAnySetter
   public {{classname}} putAdditionalProperty(String key, {{{.}}} value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, {{{.}}}>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -99,7 +99,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in anyOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public {{classname}}() {
         super("anyOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
@@ -134,7 +134,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
         {{#discriminator}}
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         {{#mappedModels}}
         mappings.put("{{mappingName}}", {{modelName}}.class);
         {{/mappedModels}}
@@ -166,7 +166,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
         {{/isNullable}}
         {{#anyOf}}
-        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -131,7 +131,7 @@ public class {{classname}} {
     {{#hasPathParams}}
     // Path parameters
     String localVarPath = "{{{path}}}"{{#pathParams}}
-            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}})){{/pathParams}};
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}{{^isString}}.toString(){{/isString}})){{/pathParams}};
 
     {{/hasPathParams}}
     {{#queryParams}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -128,11 +128,10 @@ public class {{classname}} {
       .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params
-    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
-    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}HashMap<String, String>();
-    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}HashMap<String, String>();
-    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}HashMap<String, Object>();
-
+    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<>();
+    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}HashMap<>();
+    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}HashMap<>();
+    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}HashMap<>();
     {{#queryParams}}
     localVarQueryParams.addAll(apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}}));
     {{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -14,6 +14,7 @@ import {{javaxPackage}}.ws.rs.core.GenericType;
 {{^fullJavaUtil}}
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -116,57 +117,84 @@ public class {{classname}} {
   @Deprecated
   {{/isDeprecated}}
   public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
-    Object localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
-    {{#allParams}}{{#required}}
-    // verify the required parameter '{{paramName}}' is set
+    {{#hasRequiredParams}}
+    // Check required parameters
+    {{#allParams}}
+    {{#required}}
     if ({{paramName}} == null) {
       throw new ApiException(400, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
     }
-    {{/required}}{{/allParams}}
-    // create path and map variables
+    {{/required}}
+    {{/allParams}}
+
+    {{/hasRequiredParams}}
+    {{#hasPathParams}}
+    // Path parameters
     String localVarPath = "{{{path}}}"{{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}})){{/pathParams}};
 
-    // query params
-    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<>();
-    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}HashMap<>();
-    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}HashMap<>();
-    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}HashMap<>();
+    {{/hasPathParams}}
     {{#queryParams}}
+    {{#-first}}
+    // Query parameters
+    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<>(
+            apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}})
+    );
+    {{/-first}}
+    {{^-first}}
     localVarQueryParams.addAll(apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}}));
+    {{/-first}}
+    {{#-last}}
+
+    {{/-last}}
     {{/queryParams}}
+    {{#headerParams}}
+    {{#-first}}
+    // Header parameters
+    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarHeaderParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^required}}
+    }{{/required}}
+    {{#-last}}
 
-    {{#headerParams}}if ({{paramName}} != null)
-      localVarHeaderParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));
+    {{/-last}}
     {{/headerParams}}
+    {{#cookieParams}}
+    {{#-first}}
+    // Cookie parameters
+    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarCookieParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^required}}
+    }{{/required}}
+    {{#-last}}
 
-    {{#cookieParams}}if ({{paramName}} != null)
-      localVarCookieParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));
+    {{/-last}}
     {{/cookieParams}}
+    {{#formParams}}
+    {{#-first}}
+    // Form parameters
+    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarFormParams.put("{{baseName}}", {{paramName}});{{^required}}
+    }{{/required}}
+    {{#-last}}
 
-    {{#formParams}}if ({{paramName}} != null)
-      localVarFormParams.put("{{baseName}}", {{paramName}});
+    {{/-last}}
     {{/formParams}}
-
-    final String[] localVarAccepts = {
-      {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}} };
-
+    String localVarAccept = apiClient.selectHeaderAccept({{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}});
+    String localVarContentType = apiClient.selectHeaderContentType({{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}});
+    {{#hasAuthMethods}}
+    String[] localVarAuthNames = {{=% %=}}new String[] {%#authMethods%"%name%"%^-last%, %/-last%%/authMethods%};%={{ }}=%
+    {{/hasAuthMethods}}
     {{#returnType}}
     GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};
-
     {{/returnType}}
-    return apiClient.invokeAPI("{{classname}}.{{operationId}}", localVarPath, "{{httpMethod}}", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
+    return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{path}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
+                               {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
+                               {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }
   {{#vendorExtensions.x-group-parameters}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -60,7 +60,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             {{#useOneOfDiscriminatorLookup}}
             {{#discriminator}}
             {{classname}} new{{classname}} = new {{classname}}();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("{{{propertyBaseName}}}");
             switch (discriminatorValue) {
             {{#mappedModels}}
@@ -132,7 +132,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public {{classname}}() {
         super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
@@ -167,7 +167,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
         {{#discriminator}}
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         {{#mappedModels}}
         mappings.put("{{mappingName}}", {{modelName}}.class);
         {{/mappedModels}}
@@ -199,7 +199,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
         {{/isNullable}}
         {{#oneOf}}
-        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -389,7 +389,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     return 0;
   }
 
-  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<>() {
     public {{classname}} createFromParcel(Parcel in) {
 {{#model}}
 {{#isArray}}
@@ -408,14 +408,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   };
 {{/parcelableModel}}
 {{#discriminator}}
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  {{#mappedModels}}
-  mappings.put("{{mappingName}}", {{modelName}}.class);
-  {{/mappedModels}}
-  mappings.put("{{name}}", {{classname}}.class);
-  JSON.registerDiscriminator({{classname}}.class, "{{propertyBaseName}}", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    {{#mappedModels}}
+    mappings.put("{{mappingName}}", {{modelName}}.class);
+    {{/mappedModels}}
+    mappings.put("{{name}}", {{classname}}.class);
+    JSON.registerDiscriminator({{classname}}.class, "{{propertyBaseName}}", mappings);
+  }
 {{/discriminator}}
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -83,8 +83,8 @@ import {{invokerPackage}}.auth.OAuth;
  */
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "{{{basePath}}}";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -178,8 +178,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   {{/hasOperationServers}}
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -216,7 +216,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     setUserAgent("{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/java{{/httpUserAgent}}");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     {{#authMethods}}
     if (authMap != null) {
@@ -262,7 +262,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();{{#authMethods}}{{#vendorExtensions.x-auth-id-alias}}
+    authenticationLookup = new HashMap<>();{{#authMethods}}{{#vendorExtensions.x-auth-id-alias}}
     authenticationLookup.put("{{name}}", "{{.}}");{{/vendorExtensions.x-auth-id-alias}}{{/authMethods}}
   }
 
@@ -857,7 +857,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1452,10 +1452,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -83,6 +83,8 @@ import {{invokerPackage}}.auth.OAuth;
  */
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "{{{basePath}}}";
@@ -916,14 +918,13 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -105,15 +105,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
                           new SimpleEntry<>("{{{name}}}", new ServerVariable(
                                   "{{{description}}}{{^description}}No description provided{{/description}}",
                                   "{{{defaultValue}}}",
-                                  {{#enumValues}}
-                                  {{#-first}}
-                                  new LinkedHashSet<>(Arrays.asList(
-                                  {{/-first}}
-                                          "{{{.}}}"{{^-last}},{{/-last}}
-                                  {{#-last}}
-                                  ))
-                                  {{/-last}}
-                                  {{/enumValues}}
+                                  new LinkedHashSet<>({{#enumValues}}{{#-first}}Arrays.asList({{/-first}}
+                                          "{{{.}}}"{{^-last}},{{/-last}}{{#-last}}
+                                  ){{/-last}}{{/enumValues}})
                           )){{^-last}},{{/-last}}
                   {{#-last}}
                   ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
@@ -153,18 +147,12 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
                             new SimpleEntry<>("{{{name}}}", new ServerVariable(
                                     "{{{description}}}{{^description}}No description provided{{/description}}",
                                     "{{{defaultValue}}}",
-                                    {{#enumValues}}
-                                    {{#-first}}
-                                    new LinkedHashSet<>(Arrays.asList(
-                                    {{/-first}}
-                                            "{{{.}}}"{{^-last}},{{/-last}}
-                                    {{#-last}}
-                                    ))
-                                    {{/-last}}
-                                    {{/enumValues}}
+                                    new LinkedHashSet<>({{#enumValues}}{{#-first}}Arrays.asList({{/-first}}
+                                            "{{{.}}}"{{^-last}},{{/-last}}{{#-last}}
+                                    ){{/-last}}{{/enumValues}})
                             )){{^-last}},{{/-last}}
                     {{#-last}}
-                    collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+                    ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
                     {{/-last}}
                     {{/variables}}
             ){{^-last}},{{/-last}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -972,11 +972,10 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -45,11 +46,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 {{#jsr310}}
 import java.time.OffsetDateTime;
 {{/jsr310}}
@@ -85,72 +89,95 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
-{{/-first}}    new ServerConfiguration(
-      "{{{url}}}",
-      "{{{description}}}{{^description}}No description provided{{/description}}",
-      new HashMap<String, ServerVariable>(){{#variables}}{{#-first}} {{
-{{/-first}}        put("{{{name}}}", new ServerVariable(
-          "{{{description}}}{{^description}}No description provided{{/description}}",
-          "{{{defaultValue}}}",
-          new HashSet<String>(
-          {{#enumValues}}
-          {{#-first}}
-            Arrays.asList(
-          {{/-first}}
-              "{{{.}}}"{{^-last}},{{/-last}}
-          {{#-last}}
-            )
-          {{/-last}}
-          {{/enumValues}}
-          )
-        ));
-      {{#-last}}
-      }}{{/-last}}{{/variables}}
-    ){{^-last}},{{/-last}}
+  protected List<ServerConfiguration> servers = new ArrayList<>({{#servers}}{{#-first}}Arrays.asList(
+{{/-first}}          new ServerConfiguration(
+                  "{{{url}}}",
+                  "{{{description}}}{{^description}}No description provided{{/description}}",
+                  {{^variables}}
+                  new LinkedHashMap<>()
+                  {{/variables}}
+                  {{#variables}}
+                  {{#-first}}
+                  Stream.<Entry<String, ServerVariable>>of(
+                  {{/-first}}
+                          new SimpleEntry<>("{{{name}}}", new ServerVariable(
+                                  "{{{description}}}{{^description}}No description provided{{/description}}",
+                                  "{{{defaultValue}}}",
+                                  {{#enumValues}}
+                                  {{#-first}}
+                                  new LinkedHashSet<>(Arrays.asList(
+                                  {{/-first}}
+                                          "{{{.}}}"{{^-last}},{{/-last}}
+                                  {{#-last}}
+                                  ))
+                                  {{/-last}}
+                                  {{/enumValues}}
+                          )){{^-last}},{{/-last}}
+                  {{#-last}}
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+                  {{/-last}}
+                  {{/variables}}
+          ){{^-last}},{{/-last}}
   {{#-last}}
   ){{/-last}}{{/servers}});
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
+  {{^hasOperationServers}}
+  protected Map<String, List<ServerConfiguration>> operationServers = new LinkedHashMap<>();
+  {{/hasOperationServers}}
+  {{#hasOperationServers}}
+  protected Map<String, List<ServerConfiguration>> operationServers;
+
+  {
+    Map<String, List<ServerConfiguration>> operationServers = new LinkedHashMap<>();
     {{#apiInfo}}
     {{#apis}}
     {{#operations}}
     {{#operation}}
     {{#servers}}
     {{#-first}}
-    put("{{{classname}}}.{{{operationId}}}", new ArrayList<ServerConfiguration>(Arrays.asList(
+    operationServers.put("{{{classname}}}.{{{operationId}}}", new ArrayList<>(Arrays.asList(
     {{/-first}}
-      new ServerConfiguration(
-        "{{{url}}}",
-        "{{{description}}}{{^description}}No description provided{{/description}}",
-        new HashMap<String, ServerVariable>(){{#variables}}{{#-first}} {{
-{{/-first}}          put("{{{name}}}", new ServerVariable(
-            "{{{description}}}{{^description}}No description provided{{/description}}",
-            "{{{defaultValue}}}",
-            new HashSet<String>(
-            {{#enumValues}}
-            {{#-first}}
-              Arrays.asList(
-            {{/-first}}
-                "{{{.}}}"{{^-last}},{{/-last}}
-            {{#-last}}
-              )
-            {{/-last}}
-            {{/enumValues}}
-            )
-          ));
-        {{#-last}}
-        }}{{/-last}}{{/variables}}
-      ){{^-last}},{{/-last}}
+            new ServerConfiguration(
+                    "{{{url}}}",
+                    "{{{description}}}{{^description}}No description provided{{/description}}",
+                    {{^variables}}
+                    new LinkedHashMap<>()
+                    {{/variables}}
+                    {{#variables}}
+                    {{#-first}}
+                    Stream.<Entry<String, ServerVariable>>of(
+                    {{/-first}}
+                            new SimpleEntry<>("{{{name}}}", new ServerVariable(
+                                    "{{{description}}}{{^description}}No description provided{{/description}}",
+                                    "{{{defaultValue}}}",
+                                    {{#enumValues}}
+                                    {{#-first}}
+                                    new LinkedHashSet<>(Arrays.asList(
+                                    {{/-first}}
+                                            "{{{.}}}"{{^-last}},{{/-last}}
+                                    {{#-last}}
+                                    ))
+                                    {{/-last}}
+                                    {{/enumValues}}
+                            )){{^-last}},{{/-last}}
+                    {{#-last}}
+                    collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+                    {{/-last}}
+                    {{/variables}}
+            ){{^-last}},{{/-last}}
     {{#-last}}
-    )));{{/-last}}
+    )));
+    {{/-last}}
     {{/servers}}
     {{/operation}}
     {{/operations}}
     {{/apis}}
     {{/apiInfo}}
-  }};
+    this.operationServers = operationServers;
+  }
+
+  {{/hasOperationServers}}
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -935,8 +935,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -956,8 +956,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -971,10 +971,11 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1249,20 +1250,22 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        {{#hasHttpSignatureMethods}}
-        serializeToString(body, formParams, contentType, isBodyNullable),
-        {{/hasHttpSignatureMethods}}
-        {{^hasHttpSignatureMethods}}
-        null,
-        {{/hasHttpSignatureMethods}}
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          {{#hasHttpSignatureMethods}}
+          serializeToString(body, formParams, contentType, isBodyNullable),
+          {{/hasHttpSignatureMethods}}
+          {{^hasHttpSignatureMethods}}
+          null,
+          {{/hasHttpSignatureMethods}}
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1280,7 +1283,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
       {{#hasOAuthMethods}}
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/JSON.mustache
@@ -76,7 +76,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -96,7 +96,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -205,12 +205,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/additional_properties.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/additional_properties.mustache
@@ -13,7 +13,7 @@
   @JsonAnySetter
   public {{classname}} putAdditionalProperty(String key, {{{.}}} value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, {{{.}}}>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
@@ -99,7 +99,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in anyOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public {{classname}}() {
         super("anyOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
@@ -134,7 +134,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
         {{#discriminator}}
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         {{#mappedModels}}
         mappings.put("{{mappingName}}", {{modelName}}.class);
         {{/mappedModels}}
@@ -166,7 +166,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
         {{/isNullable}}
         {{#anyOf}}
-        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -131,7 +131,7 @@ public class {{classname}} {
     {{#hasPathParams}}
     // Path parameters
     String localVarPath = "{{{path}}}"{{#pathParams}}
-            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}})){{/pathParams}};
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}{{^isString}}.toString(){{/isString}})){{/pathParams}};
 
     {{/hasPathParams}}
     {{#queryParams}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -128,10 +128,10 @@ public class {{classname}} {
       .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params
-    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
-    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}HashMap<String, String>();
-    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}HashMap<String, String>();
-    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}HashMap<String, Object>();
+    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<>();
+    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}HashMap<>();
+    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}HashMap<>();
+    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}HashMap<>();
 
     {{#queryParams}}
     localVarQueryParams.addAll(apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}}));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -14,6 +14,7 @@ import {{javaxPackage}}.ws.rs.core.GenericType;
 {{^fullJavaUtil}}
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -116,58 +117,84 @@ public class {{classname}} {
   @Deprecated
   {{/isDeprecated}}
   public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
-    Object localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
-    {{#allParams}}{{#required}}
-    // verify the required parameter '{{paramName}}' is set
+    {{#hasRequiredParams}}
+    // Check required parameters
+    {{#allParams}}
+    {{#required}}
     if ({{paramName}} == null) {
       throw new ApiException(400, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
     }
-    {{/required}}{{/allParams}}
-    // create path and map variables
+    {{/required}}
+    {{/allParams}}
+
+    {{/hasRequiredParams}}
+    {{#hasPathParams}}
+    // Path parameters
     String localVarPath = "{{{path}}}"{{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}})){{/pathParams}};
 
-    // query params
-    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<>();
-    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}HashMap<>();
-    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}HashMap<>();
-    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}HashMap<>();
-
+    {{/hasPathParams}}
     {{#queryParams}}
+    {{#-first}}
+    // Query parameters
+    {{javaUtilPrefix}}List<Pair> localVarQueryParams = new {{javaUtilPrefix}}ArrayList<>(
+            apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}})
+    );
+    {{/-first}}
+    {{^-first}}
     localVarQueryParams.addAll(apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}}));
+    {{/-first}}
+    {{#-last}}
+
+    {{/-last}}
     {{/queryParams}}
+    {{#headerParams}}
+    {{#-first}}
+    // Header parameters
+    {{javaUtilPrefix}}Map<String, String> localVarHeaderParams = new {{javaUtilPrefix}}LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarHeaderParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^required}}
+    }{{/required}}
+    {{#-last}}
 
-    {{#headerParams}}if ({{paramName}} != null)
-      localVarHeaderParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));
+    {{/-last}}
     {{/headerParams}}
+    {{#cookieParams}}
+    {{#-first}}
+    // Cookie parameters
+    {{javaUtilPrefix}}Map<String, String> localVarCookieParams = new {{javaUtilPrefix}}LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarCookieParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^required}}
+    }{{/required}}
+    {{#-last}}
 
-    {{#cookieParams}}if ({{paramName}} != null)
-      localVarCookieParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));
+    {{/-last}}
     {{/cookieParams}}
+    {{#formParams}}
+    {{#-first}}
+    // Form parameters
+    {{javaUtilPrefix}}Map<String, Object> localVarFormParams = new {{javaUtilPrefix}}LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarFormParams.put("{{baseName}}", {{paramName}});{{^required}}
+    }{{/required}}
+    {{#-last}}
 
-    {{#formParams}}if ({{paramName}} != null)
-      localVarFormParams.put("{{baseName}}", {{paramName}});
+    {{/-last}}
     {{/formParams}}
-
-    final String[] localVarAccepts = {
-      {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}} };
-
+    String localVarAccept = apiClient.selectHeaderAccept({{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}});
+    String localVarContentType = apiClient.selectHeaderContentType({{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}});
+    {{#hasAuthMethods}}
+    String[] localVarAuthNames = {{=% %=}}new String[] {%#authMethods%"%name%"%^-last%, %/-last%%/authMethods%};%={{ }}=%
+    {{/hasAuthMethods}}
     {{#returnType}}
     GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};
-
     {{/returnType}}
-    return apiClient.invokeAPI("{{classname}}.{{operationId}}", localVarPath, "{{httpMethod}}", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
+    return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{path}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
+                               {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
+                               {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }
   {{#vendorExtensions.x-group-parameters}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/oneof_model.mustache
@@ -132,7 +132,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public {{classname}}() {
         super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
@@ -167,7 +167,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
         {{#discriminator}}
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         {{#mappedModels}}
         mappings.put("{{mappingName}}", {{modelName}}.class);
         {{/mappedModels}}
@@ -199,7 +199,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
         {{/isNullable}}
         {{#oneOf}}
-        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -389,7 +389,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     return 0;
   }
 
-  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<>() {
     public {{classname}} createFromParcel(Parcel in) {
 {{#model}}
 {{#isArray}}
@@ -408,14 +408,14 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   };
 {{/parcelableModel}}
 {{#discriminator}}
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  {{#mappedModels}}
-  mappings.put("{{mappingName}}", {{modelName}}.class);
-  {{/mappedModels}}
-  mappings.put("{{name}}", {{classname}}.class);
-  JSON.registerDiscriminator({{classname}}.class, "{{propertyBaseName}}", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    {{#mappedModels}}
+    mappings.put("{{mappingName}}", {{modelName}}.class);
+    {{/mappedModels}}
+    mappings.put("{{name}}", {{classname}}.class);
+    JSON.registerDiscriminator({{classname}}.class, "{{propertyBaseName}}", mappings);
+  }
 {{/discriminator}}
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -832,8 +832,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -853,8 +853,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -868,10 +868,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1146,15 +1147,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        null,
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          null,
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1171,7 +1174,7 @@ public class ApiClient extends JavaTimeFormatter {
       final int statusCode = response.getStatusInfo().getStatusCode();
 
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -74,8 +74,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -90,8 +90,8 @@ public class ApiClient extends JavaTimeFormatter {
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
   protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     if (authMap != null) {
       auth = authMap.get("petstore_auth");
@@ -166,7 +166,7 @@ public class ApiClient extends JavaTimeFormatter {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
   }
 
   /**
@@ -754,7 +754,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1342,10 +1342,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -869,11 +869,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -43,11 +44,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -76,17 +80,16 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "http://petstore.swagger.io:80/v2",
-      "No description provided",
-      new HashMap<String, ServerVariable>()
-    )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "http://petstore.swagger.io:80/v2",
+                  "No description provided",
+                  new LinkedHashMap<>()
+          )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-  }};
+  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -74,6 +74,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
@@ -813,14 +815,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -84,7 +84,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -193,12 +193,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -85,11 +85,10 @@ public class AnotherFakeApi {
     String localVarPath = "/another-fake/dummy";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,16 @@ public class AnotherFakeApi {
      </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling call123testSpecialTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/another-fake/dummy";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", "/another-fake/dummy", "PATCH", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -92,11 +92,10 @@ public class FakeApi {
     String localVarPath = "/fake/create_xml_item";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -152,11 +151,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/boolean";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -214,11 +212,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/composite";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -276,11 +273,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/number";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -338,11 +334,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/string";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -404,11 +399,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-file-schema";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -475,11 +469,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-query-params";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
 
     
@@ -541,11 +534,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -650,11 +642,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -753,11 +744,10 @@ if (paramCallback != null)
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "enum_query_string_array", enumQueryStringArray));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
@@ -813,11 +803,10 @@ private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredString
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
@@ -1000,11 +989,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/inline-additionalProperties";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -1071,11 +1059,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/jsonFormData";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -1167,11 +1154,10 @@ if (param2 != null)
     String localVarPath = "/fake/test-query-parameters";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -20,6 +20,7 @@ import org.openapitools.client.model.XmlItem;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,40 +82,16 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
-    Object localVarPostBody = xmlItem;
-    
-    // verify the required parameter 'xmlItem' is set
+    // Check required parameters
     if (xmlItem == null) {
       throw new ApiException(400, "Missing the required parameter 'xmlItem' when calling createXmlItem");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/create_xml_item";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16");
+    return apiClient.invokeAPI("FakeApi.createXmlItem", "/fake/create_xml_item", "POST", new ArrayList<>(), xmlItem,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -145,37 +122,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/boolean";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", "/fake/outer/boolean", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -206,37 +158,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/composite";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", "/fake/outer/composite", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -267,37 +194,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/number";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", "/fake/outer/number", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -328,37 +230,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/string";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", "/fake/outer/string", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -388,40 +265,16 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testBodyWithFileSchema");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-file-schema";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", "/fake/body-with-file-schema", "PUT", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -453,46 +306,24 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'query' is set
+    // Check required parameters
     if (query == null) {
       throw new ApiException(400, "Missing the required parameter 'query' when calling testBodyWithQueryParams");
     }
-    
-    // verify the required parameter 'body' is set
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testBodyWithQueryParams");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-query-params";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "query", query)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", "/fake/body-with-query-params", "PUT", localVarQueryParams, body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -523,42 +354,17 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testClientModel");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.testClientModel", "/fake", "PATCH", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -616,82 +422,62 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, LocalDateTime dateTime, String password, String paramCallback) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'number' is set
+    // Check required parameters
     if (number == null) {
       throw new ApiException(400, "Missing the required parameter 'number' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_double' is set
     if (_double == null) {
       throw new ApiException(400, "Missing the required parameter '_double' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter 'patternWithoutDelimiter' is set
     if (patternWithoutDelimiter == null) {
       throw new ApiException(400, "Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_byte' is set
     if (_byte == null) {
       throw new ApiException(400, "Missing the required parameter '_byte' when calling testEndpointParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (integer != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (integer != null) {
       localVarFormParams.put("integer", integer);
-if (int32 != null)
+    }
+    if (int32 != null) {
       localVarFormParams.put("int32", int32);
-if (int64 != null)
+    }
+    if (int64 != null) {
       localVarFormParams.put("int64", int64);
-if (number != null)
-      localVarFormParams.put("number", number);
-if (_float != null)
+    }
+    localVarFormParams.put("number", number);
+    if (_float != null) {
       localVarFormParams.put("float", _float);
-if (_double != null)
-      localVarFormParams.put("double", _double);
-if (string != null)
+    }
+    localVarFormParams.put("double", _double);
+    if (string != null) {
       localVarFormParams.put("string", string);
-if (patternWithoutDelimiter != null)
-      localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
-if (_byte != null)
-      localVarFormParams.put("byte", _byte);
-if (binary != null)
+    }
+    localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
+    localVarFormParams.put("byte", _byte);
+    if (binary != null) {
       localVarFormParams.put("binary", binary);
-if (date != null)
+    }
+    if (date != null) {
       localVarFormParams.put("date", date);
-if (dateTime != null)
+    }
+    if (dateTime != null) {
       localVarFormParams.put("dateTime", dateTime);
-if (password != null)
+    }
+    if (password != null) {
       localVarFormParams.put("password", password);
-if (paramCallback != null)
+    }
+    if (paramCallback != null) {
       localVarFormParams.put("callback", paramCallback);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "http_basic_test" };
-
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"http_basic_test"};
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", "/fake", "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -738,102 +524,71 @@ if (paramCallback != null)
      </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "enum_query_string_array", enumQueryStringArray));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "enum_query_string_array", enumQueryStringArray)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_double", enumQueryDouble));
 
-    if (enumHeaderStringArray != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (enumHeaderStringArray != null) {
       localVarHeaderParams.put("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-if (enumHeaderString != null)
+    }
+    if (enumHeaderString != null) {
       localVarHeaderParams.put("enum_header_string", apiClient.parameterToString(enumHeaderString));
+    }
 
-    
-    if (enumFormStringArray != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (enumFormStringArray != null) {
       localVarFormParams.put("enum_form_string_array", enumFormStringArray);
-if (enumFormString != null)
+    }
+    if (enumFormString != null) {
       localVarFormParams.put("enum_form_string", enumFormString);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", "/fake", "GET", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'requiredStringGroup' is set
+    // Check required parameters
     if (requiredStringGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredBooleanGroup' is set
     if (requiredBooleanGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredInt64Group' is set
     if (requiredInt64Group == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "required_string_group", requiredStringGroup)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "int64_group", int64Group));
 
-    if (requiredBooleanGroup != null)
-      localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-if (booleanGroup != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
+    if (booleanGroup != null) {
       localVarHeaderParams.put("boolean_group", apiClient.parameterToString(booleanGroup));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", "/fake", "DELETE", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 
   public class APItestGroupParametersRequest {
@@ -978,40 +733,16 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
-    Object localVarPostBody = param;
-    
-    // verify the required parameter 'param' is set
+    // Check required parameters
     if (param == null) {
       throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/inline-additionalProperties";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", "/fake/inline-additionalProperties", "POST", new ArrayList<>(), param,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * test json serialization of form data
@@ -1043,49 +774,24 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'param' is set
+    // Check required parameters
     if (param == null) {
       throw new ApiException(400, "Missing the required parameter 'param' when calling testJsonFormData");
     }
-    
-    // verify the required parameter 'param2' is set
     if (param2 == null) {
       throw new ApiException(400, "Missing the required parameter 'param2' when calling testJsonFormData");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/jsonFormData";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    localVarFormParams.put("param", param);
+    localVarFormParams.put("param2", param2);
 
-    
-    
-    if (param != null)
-      localVarFormParams.put("param", param);
-if (param2 != null)
-      localVarFormParams.put("param2", param2);
-
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", "/fake/jsonFormData", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -1123,64 +829,36 @@ if (param2 != null)
      </table>
    */
   public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'pipe' is set
+    // Check required parameters
     if (pipe == null) {
       throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'ioutil' is set
     if (ioutil == null) {
       throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'http' is set
     if (http == null) {
       throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'url' is set
     if (url == null) {
       throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'context' is set
     if (context == null) {
       throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/test-query-parameters";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "pipe", pipe)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", "/fake/test-query-parameters", "PUT", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,17 @@ public class FakeClassnameTags123Api {
      </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testClassname");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake_classname_test";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key_query"};
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", "/fake_classname_test", "PATCH", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -85,11 +85,10 @@ public class FakeClassnameTags123Api {
     String localVarPath = "/fake_classname_test";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,39 +79,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling addPet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.addPet", "/pet", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -145,42 +123,26 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    if (apiKey != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (apiKey != null) {
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", new ArrayList<>(), null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -214,42 +176,22 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'status' is set
+    // Check required parameters
     if (status == null) {
       throw new ApiException(400, "Missing the required parameter 'status' when calling findPetsByStatus");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByStatus";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "status", status)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", "/pet/findByStatus", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -287,42 +229,22 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'tags' is set
+    // Check required parameters
     if (tags == null) {
       throw new ApiException(400, "Missing the required parameter 'tags' when calling findPetsByTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByTags";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "tags", tags)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<Set<Pet>> localVarReturnType = new GenericType<Set<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByTags", "/pet/findByTags", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -358,42 +280,21 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -430,39 +331,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling updatePet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePet", "/pet", "PUT", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -497,44 +375,29 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (name != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (name != null) {
       localVarFormParams.put("name", name);
-if (status != null)
+    }
+    if (status != null) {
       localVarFormParams.put("status", status);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -570,46 +433,30 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (_file != null)
+    }
+    if (_file != null) {
       localVarFormParams.put("file", _file);
+    }
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -645,51 +492,31 @@ if (_file != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
     }
-    
-    // verify the required parameter 'requiredFile' is set
     if (requiredFile == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (requiredFile != null)
-      localVarFormParams.put("requiredFile", requiredFile);
+    }
+    localVarFormParams.put("requiredFile", requiredFile);
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
@@ -89,11 +89,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -158,11 +157,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     if (apiKey != null)
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
@@ -227,11 +225,10 @@ public class PetApi {
     String localVarPath = "/pet/findByStatus";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
 
     
@@ -301,11 +298,10 @@ public class PetApi {
     String localVarPath = "/pet/findByTags";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
 
     
@@ -374,11 +370,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -446,11 +441,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -515,11 +509,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -589,11 +582,10 @@ if (status != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -670,11 +662,10 @@ if (_file != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
@@ -130,7 +130,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Header parameters
     Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
@@ -287,7 +287,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -382,7 +382,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -440,7 +440,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -502,7 +502,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -166,7 +166,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Order;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,41 +76,20 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Returns pet inventories by status
@@ -138,36 +118,12 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/store/inventory";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("StoreApi.getInventory", "/store/inventory", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -203,43 +159,21 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Place an order for a pet
@@ -272,41 +206,16 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling placeOrder");
     }
-    
-    // create path and map variables
-    String localVarPath = "/store/order";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.placeOrder", "/store/order", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -87,11 +87,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -145,11 +144,10 @@ public class StoreApi {
     String localVarPath = "/store/inventory";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -217,11 +215,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -286,11 +283,10 @@ public class StoreApi {
     String localVarPath = "/store/order";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,6 +13,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,40 +75,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling createUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.createUser", "/user", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -137,40 +114,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling createUsersWithArrayInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithArray";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", "/user/createWithArray", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -200,40 +153,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling createUsersWithListInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithList";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", "/user/createWithList", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Delete user
@@ -265,41 +194,20 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Get user by user name
@@ -334,43 +242,21 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs user into the system
@@ -405,49 +291,26 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling loginUser");
     }
-    
-    // verify the required parameter 'password' is set
     if (password == null) {
       throw new ApiException(400, "Missing the required parameter 'password' when calling loginUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/login";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "username", username)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.loginUser", "/user/login", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs out current logged in user session
@@ -475,35 +338,11 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/user/logout";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.logoutUser", "/user/logout", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Updated user
@@ -537,45 +376,22 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
     }
-    
-    // verify the required parameter 'body' is set
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling updateUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
@@ -85,11 +85,10 @@ public class UserApi {
     String localVarPath = "/user";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -149,11 +148,10 @@ public class UserApi {
     String localVarPath = "/user/createWithArray";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -213,11 +211,10 @@ public class UserApi {
     String localVarPath = "/user/createWithList";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -280,11 +277,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -350,11 +346,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -426,11 +421,10 @@ public class UserApi {
     String localVarPath = "/user/login";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
@@ -487,11 +481,10 @@ public class UserApi {
     String localVarPath = "/user/logout";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -561,11 +554,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesAnyType {
   @JsonAnySetter
   public AdditionalPropertiesAnyType putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesArray {
   @JsonAnySetter
   public AdditionalPropertiesArray putAdditionalProperty(String key, List value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, List>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesBoolean {
   @JsonAnySetter
   public AdditionalPropertiesBoolean putAdditionalProperty(String key, Boolean value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Boolean>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesInteger {
   @JsonAnySetter
   public AdditionalPropertiesInteger putAdditionalProperty(String key, Integer value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Integer>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesNumber {
   @JsonAnySetter
   public AdditionalPropertiesNumber putAdditionalProperty(String key, BigDecimal value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, BigDecimal>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesObject {
   @JsonAnySetter
   public AdditionalPropertiesObject putAdditionalProperty(String key, Map value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Map>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesString {
   @JsonAnySetter
   public AdditionalPropertiesString putAdditionalProperty(String key, String value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, String>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Animal.java
@@ -153,14 +153,14 @@ public class Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("BigCat", BigCat.class);
-  mappings.put("Cat", Cat.class);
-  mappings.put("Dog", Dog.class);
-  mappings.put("Animal", Animal.class);
-  JSON.registerDiscriminator(Animal.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("BigCat", BigCat.class);
+    mappings.put("Cat", Cat.class);
+    mappings.put("Dog", Dog.class);
+    mappings.put("Animal", Animal.class);
+    JSON.registerDiscriminator(Animal.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/BigCat.java
@@ -156,11 +156,11 @@ public class BigCat extends Cat {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("BigCat", BigCat.class);
-  JSON.registerDiscriminator(BigCat.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("BigCat", BigCat.class);
+    JSON.registerDiscriminator(BigCat.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Cat.java
@@ -121,12 +121,12 @@ public class Cat extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("BigCat", BigCat.class);
-  mappings.put("Cat", Cat.class);
-  JSON.registerDiscriminator(Cat.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("BigCat", BigCat.class);
+    mappings.put("Cat", Cat.class);
+    JSON.registerDiscriminator(Cat.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Dog.java
@@ -117,11 +117,11 @@ public class Dog extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Dog", Dog.class);
-  JSON.registerDiscriminator(Dog.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Dog", Dog.class);
+    JSON.registerDiscriminator(Dog.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -832,8 +832,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -853,8 +853,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -868,10 +868,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1146,15 +1147,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        null,
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          null,
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1171,7 +1174,7 @@ public class ApiClient extends JavaTimeFormatter {
       final int statusCode = response.getStatusInfo().getStatusCode();
 
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -74,8 +74,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -90,8 +90,8 @@ public class ApiClient extends JavaTimeFormatter {
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
   protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     if (authMap != null) {
       auth = authMap.get("petstore_auth");
@@ -166,7 +166,7 @@ public class ApiClient extends JavaTimeFormatter {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
   }
 
   /**
@@ -754,7 +754,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1342,10 +1342,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -869,11 +869,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -43,11 +44,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -76,17 +80,16 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "http://petstore.swagger.io:80/v2",
-      "No description provided",
-      new HashMap<String, ServerVariable>()
-    )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "http://petstore.swagger.io:80/v2",
+                  "No description provided",
+                  new LinkedHashMap<>()
+          )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-  }};
+  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -74,6 +74,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
@@ -813,14 +815,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -84,7 +84,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -193,12 +193,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -85,11 +85,10 @@ public class AnotherFakeApi {
     String localVarPath = "/another-fake/dummy";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,16 @@ public class AnotherFakeApi {
      </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling call123testSpecialTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/another-fake/dummy";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", "/another-fake/dummy", "PATCH", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -20,6 +20,7 @@ import org.openapitools.client.model.XmlItem;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,40 +82,16 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
-    Object localVarPostBody = xmlItem;
-    
-    // verify the required parameter 'xmlItem' is set
+    // Check required parameters
     if (xmlItem == null) {
       throw new ApiException(400, "Missing the required parameter 'xmlItem' when calling createXmlItem");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/create_xml_item";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.createXmlItem", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16");
+    return apiClient.invokeAPI("FakeApi.createXmlItem", "/fake/create_xml_item", "POST", new ArrayList<>(), xmlItem,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -145,37 +122,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/boolean";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", "/fake/outer/boolean", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -206,37 +158,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/composite";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", "/fake/outer/composite", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -267,37 +194,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/number";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", "/fake/outer/number", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -328,37 +230,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/string";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", "/fake/outer/string", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -388,40 +265,16 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testBodyWithFileSchema");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-file-schema";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", "/fake/body-with-file-schema", "PUT", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -453,46 +306,24 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'query' is set
+    // Check required parameters
     if (query == null) {
       throw new ApiException(400, "Missing the required parameter 'query' when calling testBodyWithQueryParams");
     }
-    
-    // verify the required parameter 'body' is set
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testBodyWithQueryParams");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-query-params";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "query", query)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", "/fake/body-with-query-params", "PUT", localVarQueryParams, body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -523,42 +354,17 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testClientModel");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.testClientModel", "/fake", "PATCH", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -616,82 +422,62 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'number' is set
+    // Check required parameters
     if (number == null) {
       throw new ApiException(400, "Missing the required parameter 'number' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_double' is set
     if (_double == null) {
       throw new ApiException(400, "Missing the required parameter '_double' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter 'patternWithoutDelimiter' is set
     if (patternWithoutDelimiter == null) {
       throw new ApiException(400, "Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_byte' is set
     if (_byte == null) {
       throw new ApiException(400, "Missing the required parameter '_byte' when calling testEndpointParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (integer != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (integer != null) {
       localVarFormParams.put("integer", integer);
-if (int32 != null)
+    }
+    if (int32 != null) {
       localVarFormParams.put("int32", int32);
-if (int64 != null)
+    }
+    if (int64 != null) {
       localVarFormParams.put("int64", int64);
-if (number != null)
-      localVarFormParams.put("number", number);
-if (_float != null)
+    }
+    localVarFormParams.put("number", number);
+    if (_float != null) {
       localVarFormParams.put("float", _float);
-if (_double != null)
-      localVarFormParams.put("double", _double);
-if (string != null)
+    }
+    localVarFormParams.put("double", _double);
+    if (string != null) {
       localVarFormParams.put("string", string);
-if (patternWithoutDelimiter != null)
-      localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
-if (_byte != null)
-      localVarFormParams.put("byte", _byte);
-if (binary != null)
+    }
+    localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
+    localVarFormParams.put("byte", _byte);
+    if (binary != null) {
       localVarFormParams.put("binary", binary);
-if (date != null)
+    }
+    if (date != null) {
       localVarFormParams.put("date", date);
-if (dateTime != null)
+    }
+    if (dateTime != null) {
       localVarFormParams.put("dateTime", dateTime);
-if (password != null)
+    }
+    if (password != null) {
       localVarFormParams.put("password", password);
-if (paramCallback != null)
+    }
+    if (paramCallback != null) {
       localVarFormParams.put("callback", paramCallback);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "http_basic_test" };
-
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"http_basic_test"};
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", "/fake", "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -738,102 +524,71 @@ if (paramCallback != null)
      </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "enum_query_string_array", enumQueryStringArray));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "enum_query_string_array", enumQueryStringArray)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_double", enumQueryDouble));
 
-    if (enumHeaderStringArray != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (enumHeaderStringArray != null) {
       localVarHeaderParams.put("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-if (enumHeaderString != null)
+    }
+    if (enumHeaderString != null) {
       localVarHeaderParams.put("enum_header_string", apiClient.parameterToString(enumHeaderString));
+    }
 
-    
-    if (enumFormStringArray != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (enumFormStringArray != null) {
       localVarFormParams.put("enum_form_string_array", enumFormStringArray);
-if (enumFormString != null)
+    }
+    if (enumFormString != null) {
       localVarFormParams.put("enum_form_string", enumFormString);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", "/fake", "GET", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'requiredStringGroup' is set
+    // Check required parameters
     if (requiredStringGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredBooleanGroup' is set
     if (requiredBooleanGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredInt64Group' is set
     if (requiredInt64Group == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "required_string_group", requiredStringGroup)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "int64_group", int64Group));
 
-    if (requiredBooleanGroup != null)
-      localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-if (booleanGroup != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
+    if (booleanGroup != null) {
       localVarHeaderParams.put("boolean_group", apiClient.parameterToString(booleanGroup));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", "/fake", "DELETE", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 
   public class APItestGroupParametersRequest {
@@ -978,40 +733,16 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
-    Object localVarPostBody = param;
-    
-    // verify the required parameter 'param' is set
+    // Check required parameters
     if (param == null) {
       throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/inline-additionalProperties";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", "/fake/inline-additionalProperties", "POST", new ArrayList<>(), param,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * test json serialization of form data
@@ -1043,49 +774,24 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'param' is set
+    // Check required parameters
     if (param == null) {
       throw new ApiException(400, "Missing the required parameter 'param' when calling testJsonFormData");
     }
-    
-    // verify the required parameter 'param2' is set
     if (param2 == null) {
       throw new ApiException(400, "Missing the required parameter 'param2' when calling testJsonFormData");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/jsonFormData";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    localVarFormParams.put("param", param);
+    localVarFormParams.put("param2", param2);
 
-    
-    
-    if (param != null)
-      localVarFormParams.put("param", param);
-if (param2 != null)
-      localVarFormParams.put("param2", param2);
-
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", "/fake/jsonFormData", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -1123,64 +829,36 @@ if (param2 != null)
      </table>
    */
   public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'pipe' is set
+    // Check required parameters
     if (pipe == null) {
       throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'ioutil' is set
     if (ioutil == null) {
       throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'http' is set
     if (http == null) {
       throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'url' is set
     if (url == null) {
       throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'context' is set
     if (context == null) {
       throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/test-query-parameters";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "pipe", pipe)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", "/fake/test-query-parameters", "PUT", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -92,11 +92,10 @@ public class FakeApi {
     String localVarPath = "/fake/create_xml_item";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -152,11 +151,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/boolean";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -214,11 +212,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/composite";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -276,11 +273,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/number";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -338,11 +334,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/string";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -404,11 +399,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-file-schema";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -475,11 +469,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-query-params";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
 
     
@@ -541,11 +534,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -650,11 +642,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -753,11 +744,10 @@ if (paramCallback != null)
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "enum_query_string_array", enumQueryStringArray));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
@@ -813,11 +803,10 @@ private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredString
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
@@ -1000,11 +989,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/inline-additionalProperties";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -1071,11 +1059,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/jsonFormData";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -1167,11 +1154,10 @@ if (param2 != null)
     String localVarPath = "/fake/test-query-parameters";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,17 @@ public class FakeClassnameTags123Api {
      </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling testClassname");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake_classname_test";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key_query"};
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", "/fake_classname_test", "PATCH", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -85,11 +85,10 @@ public class FakeClassnameTags123Api {
     String localVarPath = "/fake_classname_test";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,39 +79,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling addPet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.addPet", "/pet", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -145,42 +123,26 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    if (apiKey != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (apiKey != null) {
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", new ArrayList<>(), null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -214,42 +176,22 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'status' is set
+    // Check required parameters
     if (status == null) {
       throw new ApiException(400, "Missing the required parameter 'status' when calling findPetsByStatus");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByStatus";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "status", status)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", "/pet/findByStatus", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -287,42 +229,22 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'tags' is set
+    // Check required parameters
     if (tags == null) {
       throw new ApiException(400, "Missing the required parameter 'tags' when calling findPetsByTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByTags";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "tags", tags)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<Set<Pet>> localVarReturnType = new GenericType<Set<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByTags", "/pet/findByTags", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -358,42 +280,21 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -430,39 +331,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling updatePet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePet", "/pet", "PUT", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -497,44 +375,29 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (name != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (name != null) {
       localVarFormParams.put("name", name);
-if (status != null)
+    }
+    if (status != null) {
       localVarFormParams.put("status", status);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -570,46 +433,30 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (_file != null)
+    }
+    if (_file != null) {
       localVarFormParams.put("file", _file);
+    }
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -645,51 +492,31 @@ if (_file != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
     }
-    
-    // verify the required parameter 'requiredFile' is set
     if (requiredFile == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (requiredFile != null)
-      localVarFormParams.put("requiredFile", requiredFile);
+    }
+    localVarFormParams.put("requiredFile", requiredFile);
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -89,11 +89,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -158,11 +157,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     if (apiKey != null)
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
@@ -227,11 +225,10 @@ public class PetApi {
     String localVarPath = "/pet/findByStatus";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
 
     
@@ -301,11 +298,10 @@ public class PetApi {
     String localVarPath = "/pet/findByTags";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
 
     
@@ -374,11 +370,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -446,11 +441,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -515,11 +509,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -589,11 +582,10 @@ if (status != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -670,11 +662,10 @@ if (_file != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -130,7 +130,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Header parameters
     Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
@@ -287,7 +287,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -382,7 +382,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -440,7 +440,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -502,7 +502,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -166,7 +166,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Order;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,41 +76,20 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Returns pet inventories by status
@@ -138,36 +118,12 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/store/inventory";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("StoreApi.getInventory", "/store/inventory", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -203,43 +159,21 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Place an order for a pet
@@ -272,41 +206,16 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling placeOrder");
     }
-    
-    // create path and map variables
-    String localVarPath = "/store/order";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.placeOrder", "/store/order", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -87,11 +87,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -145,11 +144,10 @@ public class StoreApi {
     String localVarPath = "/store/inventory";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -217,11 +215,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -286,11 +283,10 @@ public class StoreApi {
     String localVarPath = "/store/order";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,6 +13,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,40 +75,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling createUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.createUser", "/user", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -137,40 +114,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling createUsersWithArrayInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithArray";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", "/user/createWithArray", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -200,40 +153,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'body' is set
+    // Check required parameters
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling createUsersWithListInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithList";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", "/user/createWithList", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Delete user
@@ -265,41 +194,20 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Get user by user name
@@ -334,43 +242,21 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs user into the system
@@ -405,49 +291,26 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling loginUser");
     }
-    
-    // verify the required parameter 'password' is set
     if (password == null) {
       throw new ApiException(400, "Missing the required parameter 'password' when calling loginUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/login";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "username", username)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.loginUser", "/user/login", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs out current logged in user session
@@ -475,35 +338,11 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/user/logout";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.logoutUser", "/user/logout", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Updated user
@@ -537,45 +376,22 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
     }
-    
-    // verify the required parameter 'body' is set
     if (body == null) {
       throw new ApiException(400, "Missing the required parameter 'body' when calling updateUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -85,11 +85,10 @@ public class UserApi {
     String localVarPath = "/user";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -149,11 +148,10 @@ public class UserApi {
     String localVarPath = "/user/createWithArray";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -213,11 +211,10 @@ public class UserApi {
     String localVarPath = "/user/createWithList";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -280,11 +277,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -350,11 +346,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -426,11 +421,10 @@ public class UserApi {
     String localVarPath = "/user/login";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
@@ -487,11 +481,10 @@ public class UserApi {
     String localVarPath = "/user/logout";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -561,11 +554,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesAnyType {
   @JsonAnySetter
   public AdditionalPropertiesAnyType putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesArray {
   @JsonAnySetter
   public AdditionalPropertiesArray putAdditionalProperty(String key, List value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, List>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesBoolean {
   @JsonAnySetter
   public AdditionalPropertiesBoolean putAdditionalProperty(String key, Boolean value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Boolean>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesInteger {
   @JsonAnySetter
   public AdditionalPropertiesInteger putAdditionalProperty(String key, Integer value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Integer>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesNumber {
   @JsonAnySetter
   public AdditionalPropertiesNumber putAdditionalProperty(String key, BigDecimal value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, BigDecimal>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -83,7 +83,7 @@ public class AdditionalPropertiesObject {
   @JsonAnySetter
   public AdditionalPropertiesObject putAdditionalProperty(String key, Map value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Map>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -82,7 +82,7 @@ public class AdditionalPropertiesString {
   @JsonAnySetter
   public AdditionalPropertiesString putAdditionalProperty(String key, String value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, String>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -153,14 +153,14 @@ public class Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("BigCat", BigCat.class);
-  mappings.put("Cat", Cat.class);
-  mappings.put("Dog", Dog.class);
-  mappings.put("Animal", Animal.class);
-  JSON.registerDiscriminator(Animal.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("BigCat", BigCat.class);
+    mappings.put("Cat", Cat.class);
+    mappings.put("Dog", Dog.class);
+    mappings.put("Animal", Animal.class);
+    JSON.registerDiscriminator(Animal.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCat.java
@@ -156,11 +156,11 @@ public class BigCat extends Cat {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("BigCat", BigCat.class);
-  JSON.registerDiscriminator(BigCat.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("BigCat", BigCat.class);
+    JSON.registerDiscriminator(BigCat.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -121,12 +121,12 @@ public class Cat extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("BigCat", BigCat.class);
-  mappings.put("Cat", Cat.class);
-  JSON.registerDiscriminator(Cat.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("BigCat", BigCat.class);
+    mappings.put("Cat", Cat.class);
+    JSON.registerDiscriminator(Cat.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -117,11 +117,11 @@ public class Dog extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Dog", Dog.class);
-  JSON.registerDiscriminator(Dog.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Dog", Dog.class);
+    JSON.registerDiscriminator(Dog.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -914,8 +914,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -935,8 +935,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -950,10 +950,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1228,15 +1229,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          serializeToString(body, formParams, contentType, isBodyNullable),
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1253,7 +1256,7 @@ public class ApiClient extends JavaTimeFormatter {
       final int statusCode = response.getStatusInfo().getStatusCode();
 
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -75,6 +75,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
@@ -895,14 +897,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -75,8 +75,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -158,8 +158,8 @@ public class ApiClient extends JavaTimeFormatter {
     this.operationServers = operationServers;
   }
 
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -196,7 +196,7 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     if (authMap != null) {
       auth = authMap.get("petstore_auth");
@@ -248,7 +248,7 @@ public class ApiClient extends JavaTimeFormatter {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
   }
 
   /**
@@ -836,7 +836,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1424,10 +1424,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -951,11 +951,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -43,11 +44,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -77,86 +81,83 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "http://{server}.swagger.io:{port}/v2",
-      "petstore server",
-      new HashMap<String, ServerVariable>() {{
-        put("server", new ServerVariable(
-          "No description provided",
-          "petstore",
-          new HashSet<String>(
-            Arrays.asList(
-              "petstore",
-              "qa-petstore",
-              "dev-petstore"
-            )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "http://{server}.swagger.io:{port}/v2",
+                  "petstore server",
+                  Stream.<Entry<String, ServerVariable>>of(
+                          new SimpleEntry<>("server", new ServerVariable(
+                                  "No description provided",
+                                  "petstore",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "petstore",
+                                          "qa-petstore",
+                                          "dev-petstore"
+                                  ))
+                          )),
+                          new SimpleEntry<>("port", new ServerVariable(
+                                  "No description provided",
+                                  "80",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "80",
+                                          "8080"
+                                  ))
+                          ))
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+          ),
+          new ServerConfiguration(
+                  "https://localhost:8080/{version}",
+                  "The local server",
+                  Stream.<Entry<String, ServerVariable>>of(
+                          new SimpleEntry<>("version", new ServerVariable(
+                                  "No description provided",
+                                  "v2",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "v1",
+                                          "v2"
+                                  ))
+                          ))
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+          ),
+          new ServerConfiguration(
+                  "https://127.0.0.1/no_variable",
+                  "The local server without variables",
+                  new LinkedHashMap<>()
           )
-        ));
-        put("port", new ServerVariable(
-          "No description provided",
-          "80",
-          new HashSet<String>(
-            Arrays.asList(
-              "80",
-              "8080"
-            )
-          )
-        ));
-      }}
-    ),
-    new ServerConfiguration(
-      "https://localhost:8080/{version}",
-      "The local server",
-      new HashMap<String, ServerVariable>() {{
-        put("version", new ServerVariable(
-          "No description provided",
-          "v2",
-          new HashSet<String>(
-            Arrays.asList(
-              "v1",
-              "v2"
-            )
-          )
-        ));
-      }}
-    ),
-    new ServerConfiguration(
-      "https://127.0.0.1/no_variable",
-      "The local server without variables",
-      new HashMap<String, ServerVariable>()
-    )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-    put("PetApi.addPet", new ArrayList<ServerConfiguration>(Arrays.asList(
-      new ServerConfiguration(
-        "http://petstore.swagger.io/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      ),
+  protected Map<String, List<ServerConfiguration>> operationServers;
 
-      new ServerConfiguration(
-        "http://path-server-test.petstore.local/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      )
+  {
+    Map<String, List<ServerConfiguration>> operationServers = new LinkedHashMap<>();
+    operationServers.put("PetApi.addPet", new ArrayList<>(Arrays.asList(
+            new ServerConfiguration(
+                    "http://petstore.swagger.io/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            ),
+            new ServerConfiguration(
+                    "http://path-server-test.petstore.local/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            )
     )));
-    put("PetApi.updatePet", new ArrayList<ServerConfiguration>(Arrays.asList(
-      new ServerConfiguration(
-        "http://petstore.swagger.io/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      ),
+    operationServers.put("PetApi.updatePet", new ArrayList<>(Arrays.asList(
+            new ServerConfiguration(
+                    "http://petstore.swagger.io/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            ),
+            new ServerConfiguration(
+                    "http://path-server-test.petstore.local/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            )
+    )));
+    this.operationServers = operationServers;
+  }
 
-      new ServerConfiguration(
-        "http://path-server-test.petstore.local/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      )
-    )));
-  }};
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -84,7 +84,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -193,12 +193,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -85,10 +85,10 @@ public class AnotherFakeApi {
     String localVarPath = "/another-fake/dummy";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,42 +75,16 @@ public class AnotherFakeApi {
      </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
-    
-    // verify the required parameter 'client' is set
+    // Check required parameters
     if (client == null) {
       throw new ApiException(400, "Missing the required parameter 'client' when calling call123testSpecialTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/another-fake/dummy";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", "/another-fake/dummy", "PATCH", new ArrayList<>(), client,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.FooGetDefaultResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -72,37 +73,11 @@ public class DefaultApi {
      </table>
    */
   public ApiResponse<FooGetDefaultResponse> fooGetWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/foo";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<FooGetDefaultResponse> localVarReturnType = new GenericType<FooGetDefaultResponse>() {};
-
-    return apiClient.invokeAPI("DefaultApi.fooGet", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("DefaultApi.fooGet", "/foo", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -78,10 +78,10 @@ public class DefaultApi {
     String localVarPath = "/foo";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -21,6 +21,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,38 +82,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<HealthCheckResult> fakeHealthGetWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake/health";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<HealthCheckResult> localVarReturnType = new GenericType<HealthCheckResult>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeHealthGet", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeHealthGet", "/fake/health", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -143,38 +118,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/boolean";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", "/fake/outer/boolean", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -205,38 +154,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite) throws ApiException {
-    Object localVarPostBody = outerComposite;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/composite";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", "/fake/outer/composite", "POST", new ArrayList<>(), outerComposite,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -267,38 +190,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/number";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", "/fake/outer/number", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -329,38 +226,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/string";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", "/fake/outer/string", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Array of Enums
@@ -389,38 +260,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<List<OuterEnum>> getArrayOfEnumsWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake/array-of-enums";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<List<OuterEnum>> localVarReturnType = new GenericType<List<OuterEnum>>() {};
-
-    return apiClient.invokeAPI("FakeApi.getArrayOfEnums", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.getArrayOfEnums", "/fake/array-of-enums", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -450,41 +295,16 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass) throws ApiException {
-    Object localVarPostBody = fileSchemaTestClass;
-    
-    // verify the required parameter 'fileSchemaTestClass' is set
+    // Check required parameters
     if (fileSchemaTestClass == null) {
       throw new ApiException(400, "Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-file-schema";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", "/fake/body-with-file-schema", "PUT", new ArrayList<>(), fileSchemaTestClass,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -516,47 +336,24 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'query' is set
+    // Check required parameters
     if (query == null) {
       throw new ApiException(400, "Missing the required parameter 'query' when calling testBodyWithQueryParams");
     }
-    
-    // verify the required parameter 'user' is set
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling testBodyWithQueryParams");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-query-params";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "query", query)
+    );
 
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", "/fake/body-with-query-params", "PUT", localVarQueryParams, user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -587,43 +384,17 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
-    
-    // verify the required parameter 'client' is set
+    // Check required parameters
     if (client == null) {
       throw new ApiException(400, "Missing the required parameter 'client' when calling testClientModel");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.testClientModel", "/fake", "PATCH", new ArrayList<>(), client,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -681,83 +452,62 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'number' is set
+    // Check required parameters
     if (number == null) {
       throw new ApiException(400, "Missing the required parameter 'number' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_double' is set
     if (_double == null) {
       throw new ApiException(400, "Missing the required parameter '_double' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter 'patternWithoutDelimiter' is set
     if (patternWithoutDelimiter == null) {
       throw new ApiException(400, "Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_byte' is set
     if (_byte == null) {
       throw new ApiException(400, "Missing the required parameter '_byte' when calling testEndpointParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    if (integer != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (integer != null) {
       localVarFormParams.put("integer", integer);
-if (int32 != null)
+    }
+    if (int32 != null) {
       localVarFormParams.put("int32", int32);
-if (int64 != null)
+    }
+    if (int64 != null) {
       localVarFormParams.put("int64", int64);
-if (number != null)
-      localVarFormParams.put("number", number);
-if (_float != null)
+    }
+    localVarFormParams.put("number", number);
+    if (_float != null) {
       localVarFormParams.put("float", _float);
-if (_double != null)
-      localVarFormParams.put("double", _double);
-if (string != null)
+    }
+    localVarFormParams.put("double", _double);
+    if (string != null) {
       localVarFormParams.put("string", string);
-if (patternWithoutDelimiter != null)
-      localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
-if (_byte != null)
-      localVarFormParams.put("byte", _byte);
-if (binary != null)
+    }
+    localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
+    localVarFormParams.put("byte", _byte);
+    if (binary != null) {
       localVarFormParams.put("binary", binary);
-if (date != null)
+    }
+    if (date != null) {
       localVarFormParams.put("date", date);
-if (dateTime != null)
+    }
+    if (dateTime != null) {
       localVarFormParams.put("dateTime", dateTime);
-if (password != null)
+    }
+    if (password != null) {
       localVarFormParams.put("password", password);
-if (paramCallback != null)
+    }
+    if (paramCallback != null) {
       localVarFormParams.put("callback", paramCallback);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "http_basic_test" };
-
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"http_basic_test"};
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", "/fake", "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -804,103 +554,71 @@ if (paramCallback != null)
      </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "enum_query_string_array", enumQueryStringArray));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("multi", "enum_query_string_array", enumQueryStringArray)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_double", enumQueryDouble));
 
-    if (enumHeaderStringArray != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (enumHeaderStringArray != null) {
       localVarHeaderParams.put("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-if (enumHeaderString != null)
+    }
+    if (enumHeaderString != null) {
       localVarHeaderParams.put("enum_header_string", apiClient.parameterToString(enumHeaderString));
+    }
 
-    
-    if (enumFormStringArray != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (enumFormStringArray != null) {
       localVarFormParams.put("enum_form_string_array", enumFormStringArray);
-if (enumFormString != null)
+    }
+    if (enumFormString != null) {
       localVarFormParams.put("enum_form_string", enumFormString);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", "/fake", "GET", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'requiredStringGroup' is set
+    // Check required parameters
     if (requiredStringGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredBooleanGroup' is set
     if (requiredBooleanGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredInt64Group' is set
     if (requiredInt64Group == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "required_string_group", requiredStringGroup)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "int64_group", int64Group));
 
-    if (requiredBooleanGroup != null)
-      localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-if (booleanGroup != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
+    if (booleanGroup != null) {
       localVarHeaderParams.put("boolean_group", apiClient.parameterToString(booleanGroup));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "bearer_test" };
-
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"bearer_test"};
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", "/fake", "DELETE", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
 
@@ -1046,41 +764,16 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody) throws ApiException {
-    Object localVarPostBody = requestBody;
-    
-    // verify the required parameter 'requestBody' is set
+    // Check required parameters
     if (requestBody == null) {
       throw new ApiException(400, "Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/inline-additionalProperties";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", "/fake/inline-additionalProperties", "POST", new ArrayList<>(), requestBody,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * test json serialization of form data
@@ -1112,50 +805,24 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'param' is set
+    // Check required parameters
     if (param == null) {
       throw new ApiException(400, "Missing the required parameter 'param' when calling testJsonFormData");
     }
-    
-    // verify the required parameter 'param2' is set
     if (param2 == null) {
       throw new ApiException(400, "Missing the required parameter 'param2' when calling testJsonFormData");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/jsonFormData";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    localVarFormParams.put("param", param);
+    localVarFormParams.put("param2", param2);
 
-
-    
-    
-    if (param != null)
-      localVarFormParams.put("param", param);
-if (param2 != null)
-      localVarFormParams.put("param2", param2);
-
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", "/fake/jsonFormData", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -1193,65 +860,36 @@ if (param2 != null)
      </table>
    */
   public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'pipe' is set
+    // Check required parameters
     if (pipe == null) {
       throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'ioutil' is set
     if (ioutil == null) {
       throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'http' is set
     if (http == null) {
       throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'url' is set
     if (url == null) {
       throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'context' is set
     if (context == null) {
       throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/test-query-parameters";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "pipe", pipe));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("multi", "pipe", pipe)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", "/fake/test-query-parameters", "PUT", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -87,10 +87,10 @@ public class FakeApi {
     String localVarPath = "/fake/health";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -149,10 +149,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/boolean";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -211,10 +211,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/composite";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -273,10 +273,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/number";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -335,10 +335,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/string";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -395,10 +395,10 @@ public class FakeApi {
     String localVarPath = "/fake/array-of-enums";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -461,10 +461,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-file-schema";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -532,10 +532,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-query-params";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
 
@@ -598,10 +598,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -707,10 +707,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -810,10 +810,10 @@ if (paramCallback != null)
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "enum_query_string_array", enumQueryStringArray));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
@@ -870,10 +870,10 @@ private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredString
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
@@ -1057,10 +1057,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/inline-additionalProperties";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -1128,10 +1128,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/jsonFormData";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -1224,10 +1224,10 @@ if (param2 != null)
     String localVarPath = "/fake/test-query-parameters";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "pipe", pipe));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,42 +75,17 @@ public class FakeClassnameTags123Api {
      </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
-    
-    // verify the required parameter 'client' is set
+    // Check required parameters
     if (client == null) {
       throw new ApiException(400, "Missing the required parameter 'client' when calling testClassname");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake_classname_test";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key_query"};
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", "/fake_classname_test", "PATCH", new ArrayList<>(), client,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -85,10 +85,10 @@ public class FakeClassnameTags123Api {
     String localVarPath = "/fake_classname_test";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/PetApi.java
@@ -86,10 +86,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -153,10 +153,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     if (apiKey != null)
@@ -222,10 +222,10 @@ public class PetApi {
     String localVarPath = "/pet/findByStatus";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
 
@@ -296,10 +296,10 @@ public class PetApi {
     String localVarPath = "/pet/findByTags";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
 
@@ -369,10 +369,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -439,10 +439,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -508,10 +508,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -582,10 +582,10 @@ if (status != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -663,10 +663,10 @@ if (_file != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/PetApi.java
@@ -14,6 +14,7 @@ import org.openapitools.client.model.Pet;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,40 +76,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
-    
-    // verify the required parameter 'pet' is set
+    // Check required parameters
     if (pet == null) {
       throw new ApiException(400, "Missing the required parameter 'pet' when calling addPet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
+    return apiClient.invokeAPI("PetApi.addPet", "/pet", "POST", new ArrayList<>(), pet,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -141,43 +118,26 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    if (apiKey != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (apiKey != null) {
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", new ArrayList<>(), null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -211,43 +171,22 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'status' is set
+    // Check required parameters
     if (status == null) {
       throw new ApiException(400, "Missing the required parameter 'status' when calling findPetsByStatus");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByStatus";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "status", status)
+    );
 
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", "/pet/findByStatus", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -285,43 +224,22 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'tags' is set
+    // Check required parameters
     if (tags == null) {
       throw new ApiException(400, "Missing the required parameter 'tags' when calling findPetsByTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByTags";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "tags", tags)
+    );
 
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByTags", "/pet/findByTags", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -357,43 +275,21 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -428,40 +324,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
-    
-    // verify the required parameter 'pet' is set
+    // Check required parameters
     if (pet == null) {
       throw new ApiException(400, "Missing the required parameter 'pet' when calling updatePet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
+    return apiClient.invokeAPI("PetApi.updatePet", "/pet", "PUT", new ArrayList<>(), pet,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -496,45 +368,29 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    if (name != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (name != null) {
       localVarFormParams.put("name", name);
-if (status != null)
+    }
+    if (status != null) {
       localVarFormParams.put("status", status);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -570,47 +426,30 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (_file != null)
+    }
+    if (_file != null) {
       localVarFormParams.put("file", _file);
+    }
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -646,52 +485,31 @@ if (_file != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
     }
-    
-    // verify the required parameter 'requiredFile' is set
     if (requiredFile == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (requiredFile != null)
-      localVarFormParams.put("requiredFile", requiredFile);
+    }
+    localVarFormParams.put("requiredFile", requiredFile);
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/PetApi.java
@@ -125,7 +125,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Header parameters
     Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
@@ -282,7 +282,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -375,7 +375,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -433,7 +433,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -495,7 +495,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -87,10 +87,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -145,10 +145,10 @@ public class StoreApi {
     String localVarPath = "/store/inventory";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -217,10 +217,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -286,10 +286,10 @@ public class StoreApi {
     String localVarPath = "/store/order";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -166,7 +166,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Order;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,42 +76,20 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Returns pet inventories by status
@@ -139,37 +118,12 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/store/inventory";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("StoreApi.getInventory", "/store/inventory", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -205,44 +159,21 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Place an order for a pet
@@ -275,42 +206,16 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order order) throws ApiException {
-    Object localVarPostBody = order;
-    
-    // verify the required parameter 'order' is set
+    // Check required parameters
     if (order == null) {
       throw new ApiException(400, "Missing the required parameter 'order' when calling placeOrder");
     }
-    
-    // create path and map variables
-    String localVarPath = "/store/order";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.placeOrder", "/store/order", "POST", new ArrayList<>(), order,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,6 +13,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.createUser", "/user", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -138,41 +114,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUsersWithArrayInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithArray";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", "/user/createWithArray", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -202,41 +153,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUsersWithListInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithList";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", "/user/createWithList", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Delete user
@@ -268,42 +194,20 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Get user by user name
@@ -338,44 +242,21 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs user into the system
@@ -410,50 +291,26 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling loginUser");
     }
-    
-    // verify the required parameter 'password' is set
     if (password == null) {
       throw new ApiException(400, "Missing the required parameter 'password' when calling loginUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/login";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "username", username)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.loginUser", "/user/login", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs out current logged in user session
@@ -481,36 +338,11 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/user/logout";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.logoutUser", "/user/logout", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Updated user
@@ -544,46 +376,22 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
     }
-    
-    // verify the required parameter 'user' is set
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling updateUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/api/UserApi.java
@@ -85,10 +85,10 @@ public class UserApi {
     String localVarPath = "/user";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -149,10 +149,10 @@ public class UserApi {
     String localVarPath = "/user/createWithArray";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -213,10 +213,10 @@ public class UserApi {
     String localVarPath = "/user/createWithList";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -280,10 +280,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -350,10 +350,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -426,10 +426,10 @@ public class UserApi {
     String localVarPath = "/user/login";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
@@ -487,10 +487,10 @@ public class UserApi {
     String localVarPath = "/user/logout";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     
@@ -561,10 +561,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
 
     

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Animal.java
@@ -151,13 +151,13 @@ public class Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Cat", Cat.class);
-  mappings.put("Dog", Dog.class);
-  mappings.put("Animal", Animal.class);
-  JSON.registerDiscriminator(Animal.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Cat", Cat.class);
+    mappings.put("Dog", Dog.class);
+    mappings.put("Animal", Animal.class);
+    JSON.registerDiscriminator(Animal.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Cat.java
@@ -92,7 +92,7 @@ public class Cat extends Animal {
   @JsonAnySetter
   public Cat putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -160,11 +160,11 @@ public class Cat extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Cat", Cat.class);
-  JSON.registerDiscriminator(Cat.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Cat", Cat.class);
+    JSON.registerDiscriminator(Cat.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -135,7 +135,7 @@ public class ChildCat extends ParentPet {
   @JsonAnySetter
   public ChildCat putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -205,11 +205,11 @@ public class ChildCat extends ParentPet {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildCat", ChildCat.class);
-  JSON.registerDiscriminator(ChildCat.class, "pet_type", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildCat", ChildCat.class);
+    JSON.registerDiscriminator(ChildCat.class, "pet_type", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -111,7 +111,7 @@ public class ComplexQuadrilateral {
   @JsonAnySetter
   public ComplexQuadrilateral putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Dog.java
@@ -92,7 +92,7 @@ public class Dog extends Animal {
   @JsonAnySetter
   public Dog putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -160,11 +160,11 @@ public class Dog extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Dog", Dog.class);
-  JSON.registerDiscriminator(Dog.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Dog", Dog.class);
+    JSON.registerDiscriminator(Dog.class, "className", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Drawing.java
@@ -195,7 +195,7 @@ public class Drawing {
   @JsonAnySetter
   public Drawing putAdditionalProperty(String key, Fruit value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Fruit>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -111,7 +111,7 @@ public class EquilateralTriangle {
   @JsonAnySetter
   public EquilateralTriangle putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Fruit.java
@@ -162,7 +162,7 @@ public class Fruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Fruit() {
         super("oneOf", Boolean.FALSE);
@@ -201,12 +201,12 @@ public class Fruit extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -164,7 +164,7 @@ public class FruitReq extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public FruitReq() {
         super("oneOf", Boolean.TRUE);
@@ -208,12 +208,12 @@ public class FruitReq extends AbstractOpenApiSchema {
            return;
         }
 
-        if (JSON.isInstanceOf(AppleReq.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(AppleReq.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(BananaReq.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(BananaReq.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -122,7 +122,7 @@ public class GmFruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in anyOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public GmFruit() {
         super("anyOf", Boolean.FALSE);
@@ -161,12 +161,12 @@ public class GmFruit extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -120,13 +120,13 @@ public class GrandparentAnimal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildCat", ChildCat.class);
-  mappings.put("ParentPet", ParentPet.class);
-  mappings.put("GrandparentAnimal", GrandparentAnimal.class);
-  JSON.registerDiscriminator(GrandparentAnimal.class, "pet_type", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildCat", ChildCat.class);
+    mappings.put("ParentPet", ParentPet.class);
+    mappings.put("GrandparentAnimal", GrandparentAnimal.class);
+    JSON.registerDiscriminator(GrandparentAnimal.class, "pet_type", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Mammal.java
@@ -215,7 +215,7 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Mammal() {
         super("oneOf", Boolean.FALSE);
@@ -234,7 +234,7 @@ public class Mammal extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Mammal putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -294,7 +294,7 @@ public class Mammal extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Mammal.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Pig", Pig.class);
         mappings.put("whale", Whale.class);
         mappings.put("zebra", Zebra.class);
@@ -317,17 +317,17 @@ public class Mammal extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Pig.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Pig.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Whale.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Whale.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Zebra.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Zebra.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -556,7 +556,7 @@ public class NullableClass {
   @JsonAnySetter
   public NullableClass putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -186,7 +186,7 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public NullableShape() {
         super("oneOf", Boolean.TRUE);
@@ -205,7 +205,7 @@ public class NullableShape extends AbstractOpenApiSchema {
   @JsonAnySetter
   public NullableShape putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -258,7 +258,7 @@ public class NullableShape extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(NullableShape.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Quadrilateral", Quadrilateral.class);
         mappings.put("Triangle", Triangle.class);
         mappings.put("NullableShape", NullableShape.class);
@@ -285,12 +285,12 @@ public class NullableShape extends AbstractOpenApiSchema {
            return;
         }
 
-        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -67,7 +67,7 @@ public class ParentPet extends GrandparentAnimal {
   @JsonAnySetter
   public ParentPet putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -131,12 +131,12 @@ public class ParentPet extends GrandparentAnimal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildCat", ChildCat.class);
-  mappings.put("ParentPet", ParentPet.class);
-  JSON.registerDiscriminator(ParentPet.class, "pet_type", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildCat", ChildCat.class);
+    mappings.put("ParentPet", ParentPet.class);
+    JSON.registerDiscriminator(ParentPet.class, "pet_type", mappings);
+  }
 }
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Pig.java
@@ -184,7 +184,7 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Pig() {
         super("oneOf", Boolean.FALSE);
@@ -203,7 +203,7 @@ public class Pig extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Pig putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -256,7 +256,7 @@ public class Pig extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Pig.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("BasquePig", BasquePig.class);
         mappings.put("DanishPig", DanishPig.class);
         mappings.put("Pig", Pig.class);
@@ -278,12 +278,12 @@ public class Pig extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(BasquePig.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(BasquePig.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(DanishPig.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(DanishPig.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -184,7 +184,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Quadrilateral() {
         super("oneOf", Boolean.FALSE);
@@ -203,7 +203,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Quadrilateral putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -256,7 +256,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Quadrilateral.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("ComplexQuadrilateral", ComplexQuadrilateral.class);
         mappings.put("SimpleQuadrilateral", SimpleQuadrilateral.class);
         mappings.put("Quadrilateral", Quadrilateral.class);
@@ -278,12 +278,12 @@ public class Quadrilateral extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(ComplexQuadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(ComplexQuadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(SimpleQuadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(SimpleQuadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -111,7 +111,7 @@ public class ScaleneTriangle {
   @JsonAnySetter
   public ScaleneTriangle putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Shape.java
@@ -184,7 +184,7 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Shape() {
         super("oneOf", Boolean.FALSE);
@@ -203,7 +203,7 @@ public class Shape extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Shape putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -256,7 +256,7 @@ public class Shape extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Shape.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Quadrilateral", Quadrilateral.class);
         mappings.put("Triangle", Triangle.class);
         mappings.put("Shape", Shape.class);
@@ -278,12 +278,12 @@ public class Shape extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -186,7 +186,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public ShapeOrNull() {
         super("oneOf", Boolean.TRUE);
@@ -205,7 +205,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
   @JsonAnySetter
   public ShapeOrNull putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -258,7 +258,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(ShapeOrNull.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Quadrilateral", Quadrilateral.class);
         mappings.put("Triangle", Triangle.class);
         mappings.put("ShapeOrNull", ShapeOrNull.class);
@@ -285,12 +285,12 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
            return;
         }
 
-        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -111,7 +111,7 @@ public class SimpleQuadrilateral {
   @JsonAnySetter
   public SimpleQuadrilateral putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Triangle.java
@@ -215,7 +215,7 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Triangle() {
         super("oneOf", Boolean.FALSE);
@@ -234,7 +234,7 @@ public class Triangle extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Triangle putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -294,7 +294,7 @@ public class Triangle extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Triangle.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("EquilateralTriangle", EquilateralTriangle.class);
         mappings.put("IsoscelesTriangle", IsoscelesTriangle.class);
         mappings.put("ScaleneTriangle", ScaleneTriangle.class);
@@ -317,17 +317,17 @@ public class Triangle extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(EquilateralTriangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(EquilateralTriangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(IsoscelesTriangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(IsoscelesTriangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(ScaleneTriangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(ScaleneTriangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Zebra.java
@@ -149,7 +149,7 @@ public class Zebra {
   @JsonAnySetter
   public Zebra putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -777,11 +777,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -72,6 +72,8 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
@@ -721,14 +723,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -72,8 +72,8 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -120,8 +120,8 @@ public class ApiClient extends JavaTimeFormatter {
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
   protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -158,7 +158,7 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     if (authMap != null) {
       auth = authMap.get("api_key");
@@ -180,7 +180,7 @@ public class ApiClient extends JavaTimeFormatter {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
     authenticationLookup.put("api_key_query", "api_key");
   }
 
@@ -662,7 +662,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1234,10 +1234,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -42,11 +43,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -74,55 +78,48 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "http://{server}.swagger.io:{port}/v2",
-      "petstore server",
-      new HashMap<String, ServerVariable>() {{
-        put("server", new ServerVariable(
-          "No description provided",
-          "petstore",
-          new HashSet<String>(
-            Arrays.asList(
-              "petstore",
-              "qa-petstore",
-              "dev-petstore"
-            )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "http://{server}.swagger.io:{port}/v2",
+                  "petstore server",
+                  Stream.<Entry<String, ServerVariable>>of(
+                          new SimpleEntry<>("server", new ServerVariable(
+                                  "No description provided",
+                                  "petstore",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "petstore",
+                                          "qa-petstore",
+                                          "dev-petstore"
+                                  ))
+                          )),
+                          new SimpleEntry<>("port", new ServerVariable(
+                                  "No description provided",
+                                  "80",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "80",
+                                          "8080"
+                                  ))
+                          ))
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+          ),
+          new ServerConfiguration(
+                  "https://localhost:8080/{version}",
+                  "The local server",
+                  Stream.<Entry<String, ServerVariable>>of(
+                          new SimpleEntry<>("version", new ServerVariable(
+                                  "No description provided",
+                                  "v2",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "v1",
+                                          "v2"
+                                  ))
+                          ))
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
           )
-        ));
-        put("port", new ServerVariable(
-          "No description provided",
-          "80",
-          new HashSet<String>(
-            Arrays.asList(
-              "80",
-              "8080"
-            )
-          )
-        ));
-      }}
-    ),
-    new ServerConfiguration(
-      "https://localhost:8080/{version}",
-      "The local server",
-      new HashMap<String, ServerVariable>() {{
-        put("version", new ServerVariable(
-          "No description provided",
-          "v2",
-          new HashSet<String>(
-            Arrays.asList(
-              "v1",
-              "v2"
-            )
-          )
-        ));
-      }}
-    )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-  }};
+  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -740,8 +740,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -761,8 +761,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -776,10 +776,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1054,15 +1055,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        null,
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          null,
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
@@ -63,7 +63,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -83,7 +83,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -192,12 +192,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/api/UsageApi.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/api/UsageApi.java
@@ -77,11 +77,10 @@ public class UsageApi {
     String localVarPath = "/any";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -137,11 +136,10 @@ public class UsageApi {
     String localVarPath = "/both";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -197,11 +195,10 @@ public class UsageApi {
     String localVarPath = "/header";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -257,11 +254,10 @@ public class UsageApi {
     String localVarPath = "/query";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/api/UsageApi.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/api/UsageApi.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.GenericType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,36 +72,12 @@ public class UsageApi {
      </table>
    */
   public ApiResponse<Object> anyKeyWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/any";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key", "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key", "api_key_query"};
     GenericType<Object> localVarReturnType = new GenericType<Object>() {};
-
-    return apiClient.invokeAPI("UsageApi.anyKey", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("UsageApi.anyKey", "/any", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -130,36 +107,12 @@ public class UsageApi {
      </table>
    */
   public ApiResponse<Object> bothKeysWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/both";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key", "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key", "api_key_query"};
     GenericType<Object> localVarReturnType = new GenericType<Object>() {};
-
-    return apiClient.invokeAPI("UsageApi.bothKeys", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("UsageApi.bothKeys", "/both", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -189,36 +142,12 @@ public class UsageApi {
      </table>
    */
   public ApiResponse<Object> keyInHeaderWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/header";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Object> localVarReturnType = new GenericType<Object>() {};
-
-    return apiClient.invokeAPI("UsageApi.keyInHeader", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("UsageApi.keyInHeader", "/header", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -248,36 +177,12 @@ public class UsageApi {
      </table>
    */
   public ApiResponse<Object> keyInQueryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/query";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key_query"};
     GenericType<Object> localVarReturnType = new GenericType<Object>() {};
-
-    return apiClient.invokeAPI("UsageApi.keyInQuery", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("UsageApi.keyInQuery", "/query", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -72,8 +72,8 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://localhost";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -88,8 +88,8 @@ public class ApiClient extends JavaTimeFormatter {
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
   protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -126,13 +126,13 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
   }
 
   /**
@@ -613,7 +613,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1185,10 +1185,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -728,11 +728,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -691,8 +691,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -712,8 +712,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -727,10 +727,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1005,15 +1006,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        null,
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          null,
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -42,11 +43,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -74,17 +78,16 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "",
-      "No description provided",
-      new HashMap<String, ServerVariable>()
-    )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "",
+                  "No description provided",
+                  new LinkedHashMap<>()
+          )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-  }};
+  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -72,6 +72,8 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://localhost";
@@ -672,14 +674,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -84,7 +84,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -193,12 +193,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.MySchemaNameCharacters;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,36 +75,11 @@ public class DefaultApi {
      </table>
    */
   public ApiResponse<MySchemaNameCharacters> testPostWithHttpInfo(MySchemaNameCharacters mySchemaNameCharacters) throws ApiException {
-    Object localVarPostBody = mySchemaNameCharacters;
-    
-    // create path and map variables
-    String localVarPath = "/test";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<MySchemaNameCharacters> localVarReturnType = new GenericType<MySchemaNameCharacters>() {};
-
-    return apiClient.invokeAPI("DefaultApi.testPost", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("DefaultApi.testPost", "/test", "POST", new ArrayList<>(), mySchemaNameCharacters,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -80,11 +80,10 @@ public class DefaultApi {
     String localVarPath = "/test";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/ChildSchema.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/ChildSchema.java
@@ -92,7 +92,7 @@ public class ChildSchema extends Parent {
   @JsonAnySetter
   public ChildSchema putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -160,11 +160,11 @@ public class ChildSchema extends Parent {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildSchema", ChildSchema.class);
-  JSON.registerDiscriminator(ChildSchema.class, "objectType", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildSchema", ChildSchema.class);
+    JSON.registerDiscriminator(ChildSchema.class, "objectType", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/MySchemaNameCharacters.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/MySchemaNameCharacters.java
@@ -93,7 +93,7 @@ public class MySchemaNameCharacters extends Parent {
   @JsonAnySetter
   public MySchemaNameCharacters putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -161,11 +161,11 @@ public class MySchemaNameCharacters extends Parent {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("MySchemaName._-Characters", MySchemaNameCharacters.class);
-  JSON.registerDiscriminator(MySchemaNameCharacters.class, "objectType", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("MySchemaName._-Characters", MySchemaNameCharacters.class);
+    JSON.registerDiscriminator(MySchemaNameCharacters.class, "objectType", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/Parent.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/Parent.java
@@ -120,13 +120,13 @@ public class Parent {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildSchema", ChildSchema.class);
-  mappings.put("MySchemaName._-Characters", MySchemaNameCharacters.class);
-  mappings.put("Parent", Parent.class);
-  JSON.registerDiscriminator(Parent.class, "objectType", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildSchema", ChildSchema.class);
+    mappings.put("MySchemaName._-Characters", MySchemaNameCharacters.class);
+    mappings.put("Parent", Parent.class);
+    JSON.registerDiscriminator(Parent.class, "objectType", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -74,6 +74,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io/v2";
@@ -797,14 +799,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -74,8 +74,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io/v2";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -90,8 +90,8 @@ public class ApiClient extends JavaTimeFormatter {
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
   protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     if (authMap != null) {
       auth = authMap.get("petstore_auth");
@@ -150,7 +150,7 @@ public class ApiClient extends JavaTimeFormatter {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
   }
 
   /**
@@ -738,7 +738,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1326,10 +1326,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -43,11 +44,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -76,17 +80,16 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "http://petstore.swagger.io/v2",
-      "No description provided",
-      new HashMap<String, ServerVariable>()
-    )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "http://petstore.swagger.io/v2",
+                  "No description provided",
+                  new LinkedHashMap<>()
+          )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-  }};
+  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -816,8 +816,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -837,8 +837,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -852,10 +852,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1130,15 +1131,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        null,
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          null,
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1155,7 +1158,7 @@ public class ApiClient extends JavaTimeFormatter {
       final int statusCode = response.getStatusInfo().getStatusCode();
 
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -853,11 +853,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -84,7 +84,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -193,12 +193,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -129,7 +129,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Header parameters
     Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
@@ -286,7 +286,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -387,7 +387,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -445,7 +445,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -89,11 +89,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -158,11 +157,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     if (apiKey != null)
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
@@ -227,11 +225,10 @@ public class PetApi {
     String localVarPath = "/pet/findByStatus";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
 
     
@@ -301,11 +298,10 @@ public class PetApi {
     String localVarPath = "/pet/findByTags";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
 
     
@@ -374,11 +370,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -451,11 +446,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -522,11 +516,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -596,11 +589,10 @@ if (status != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -14,6 +14,7 @@ import org.openapitools.client.model.Pet;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,41 +79,17 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> addPetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
-    
-    // verify the required parameter 'pet' is set
+    // Check required parameters
     if (pet == null) {
       throw new ApiException(400, "Missing the required parameter 'pet' when calling addPet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.addPet", "/pet", "POST", new ArrayList<>(), pet,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -145,42 +122,26 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    if (apiKey != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (apiKey != null) {
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", new ArrayList<>(), null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -214,42 +175,22 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'status' is set
+    // Check required parameters
     if (status == null) {
       throw new ApiException(400, "Missing the required parameter 'status' when calling findPetsByStatus");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByStatus";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "status", status)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", "/pet/findByStatus", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -287,42 +228,22 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'tags' is set
+    // Check required parameters
     if (tags == null) {
       throw new ApiException(400, "Missing the required parameter 'tags' when calling findPetsByTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByTags";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "tags", tags)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByTags", "/pet/findByTags", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -358,42 +279,21 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -435,41 +335,17 @@ public class PetApi {
    * @see <a href="http://petstore.swagger.io/v2/doc/updatePet">Update an existing pet Documentation</a>
    */
   public ApiResponse<Pet> updatePetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
-    
-    // verify the required parameter 'pet' is set
+    // Check required parameters
     if (pet == null) {
       throw new ApiException(400, "Missing the required parameter 'pet' when calling updatePet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.updatePet", "/pet", "PUT", new ArrayList<>(), pet,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -504,44 +380,29 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (name != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (name != null) {
       localVarFormParams.put("name", name);
-if (status != null)
+    }
+    if (status != null) {
       localVarFormParams.put("status", status);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -577,46 +438,30 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (_file != null)
+    }
+    if (_file != null) {
       localVarFormParams.put("file", _file);
+    }
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Order;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,41 +76,20 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{orderId}"
-      .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{orderId}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Returns pet inventories by status
@@ -138,36 +118,12 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/store/inventory";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("StoreApi.getInventory", "/store/inventory", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -203,43 +159,21 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{orderId}"
-      .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{orderId}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Place an order for a pet
@@ -272,41 +206,16 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order order) throws ApiException {
-    Object localVarPostBody = order;
-    
-    // verify the required parameter 'order' is set
+    // Check required parameters
     if (order == null) {
       throw new ApiException(400, "Missing the required parameter 'order' when calling placeOrder");
     }
-    
-    // create path and map variables
-    String localVarPath = "/store/order";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.placeOrder", "/store/order", "POST", new ArrayList<>(), order,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -166,7 +166,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{orderId}"
-            .replaceAll("\\{orderId}", apiClient.escapeString(orderId));
+            .replaceAll("\\{orderId}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -87,11 +87,10 @@ public class StoreApi {
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -145,11 +144,10 @@ public class StoreApi {
     String localVarPath = "/store/inventory";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -217,11 +215,10 @@ public class StoreApi {
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -286,11 +283,10 @@ public class StoreApi {
     String localVarPath = "/store/order";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,6 +13,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,39 +75,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key"};
+    return apiClient.invokeAPI("UserApi.createUser", "/user", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -137,39 +115,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUsersWithArrayInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithArray";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key"};
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", "/user/createWithArray", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -200,39 +155,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUsersWithListInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithList";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key"};
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", "/user/createWithList", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -265,40 +197,20 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -334,43 +246,21 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs user into the system
@@ -405,49 +295,26 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling loginUser");
     }
-    
-    // verify the required parameter 'password' is set
     if (password == null) {
       throw new ApiException(400, "Missing the required parameter 'password' when calling loginUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/login";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "username", username)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.loginUser", "/user/login", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs out current logged in user session
@@ -475,34 +342,11 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/user/logout";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
+    return apiClient.invokeAPI("UserApi.logoutUser", "/user/logout", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -537,45 +381,23 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
     }
-    
-    // verify the required parameter 'user' is set
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling updateUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key"};
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
@@ -85,11 +85,10 @@ public class UserApi {
     String localVarPath = "/user";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -149,11 +148,10 @@ public class UserApi {
     String localVarPath = "/user/createWithArray";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -213,11 +211,10 @@ public class UserApi {
     String localVarPath = "/user/createWithList";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -280,11 +277,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -350,11 +346,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -426,11 +421,10 @@ public class UserApi {
     String localVarPath = "/user/login";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
@@ -487,11 +481,10 @@ public class UserApi {
     String localVarPath = "/user/logout";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -561,11 +554,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -914,8 +914,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Accept header to use. If the given array is empty,
    *   null will be returned (not to set the Accept header explicitly).
    */
-  public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) {
+  public String selectHeaderAccept(String... accepts) {
+    if (accepts == null || accepts.length == 0) {
       return null;
     }
     for (String accept : accepts) {
@@ -935,8 +935,8 @@ public class ApiClient extends JavaTimeFormatter {
    * @return The Content-Type header to use. If the given array is empty,
    *   JSON will be used.
    */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+  public String selectHeaderContentType(String... contentTypes) {
+    if (contentTypes == null || contentTypes.length == 0) {
       return "application/json";
     }
     for (String contentType : contentTypes) {
@@ -950,10 +950,11 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param str String
+   * @param object Any object to be turned into a String and escaped
    * @return Escaped string
    */
-  public String escapeString(String str) {
+  public String escapeString(Object object) {
+    String str = object.toString();
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {
@@ -1228,15 +1229,17 @@ public class ApiClient extends JavaTimeFormatter {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    // update different parameters (e.g. headers) for authentication
-    updateParamsForAuth(
-        authNames,
-        queryParams,
-        allHeaderParams,
-        cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
-        method,
-        target.getUri());
+    if (authNames != null) {
+      // update different parameters (e.g. headers) for authentication
+      updateParamsForAuth(
+          authNames,
+          queryParams,
+          allHeaderParams,
+          cookieParams,
+          serializeToString(body, formParams, contentType, isBodyNullable),
+          method,
+          target.getUri());
+    }
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1253,7 +1256,7 @@ public class ApiClient extends JavaTimeFormatter {
       final int statusCode = response.getStatusInfo().getStatusCode();
 
       // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
         for (String authName : authNames) {
           Authentication authentication = authentications.get(authName);
           if (authentication instanceof OAuth) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -75,6 +75,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
+  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
@@ -895,14 +897,13 @@ public class ApiClient extends JavaTimeFormatter {
    *   application/json; charset=UTF8
    *   APPLICATION/JSON
    *   application/vnd.company+json
-   * "* / *" is also default to JSON
+   * "*{@literal /}*" is also considered JSON by this method.
    *
    * @param mime MIME
    * @return True if the MIME type is JSON
    */
   public boolean isJsonMime(String mime) {
-    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+    return mime != null && (mime.equals("*/*") || JSON_MIME_PATTERN.matcher(mime).matches());
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -75,8 +75,8 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient extends JavaTimeFormatter {
-  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected Map<String, String> defaultHeaderMap = new HashMap<>();
+  protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
@@ -158,8 +158,8 @@ public class ApiClient extends JavaTimeFormatter {
     this.operationServers = operationServers;
   }
 
-  protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
-  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
+  protected Map<String, Integer> operationServerIndex = new HashMap<>();
+  protected Map<String, Map<String, String>> operationServerVariables = new HashMap<>();
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
@@ -196,7 +196,7 @@ public class ApiClient extends JavaTimeFormatter {
     setUserAgent("OpenAPI-Generator/1.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();
+    authentications = new HashMap<>();
     Authentication auth = null;
     if (authMap != null) {
       auth = authMap.get("petstore_auth");
@@ -248,7 +248,7 @@ public class ApiClient extends JavaTimeFormatter {
     authentications = Collections.unmodifiableMap(authentications);
 
     // Setup authentication lookup (key: authentication alias, value: authentication name)
-    authenticationLookup = new HashMap<String, String>();
+    authenticationLookup = new HashMap<>();
   }
 
   /**
@@ -836,7 +836,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @return List of pairs
    */
   public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
-    List<Pair> params = new ArrayList<Pair>();
+    List<Pair> params = new ArrayList<>();
 
     // preconditions
     if (name == null || name.isEmpty() || value == null) return params;
@@ -1424,10 +1424,10 @@ public class ApiClient extends JavaTimeFormatter {
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {
-    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    Map<String, List<String>> responseHeaders = new HashMap<>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
-      List<String> headers = new ArrayList<String>();
+      List<String> headers = new ArrayList<>();
       for (Object o : values) {
         headers.add(String.valueOf(o));
       }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -951,11 +951,10 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Escape the given string to be used as URL query value.
    *
-   * @param object Any object to be turned into a String and escaped
+   * @param str String
    * @return Escaped string
    */
-  public String escapeString(Object object) {
-    String str = object.toString();
+  public String escapeString(String str) {
     try {
       return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
     } catch (UnsupportedEncodingException e) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -43,11 +44,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.time.OffsetDateTime;
 
 import java.net.URLEncoder;
@@ -77,86 +81,83 @@ public class ApiClient extends JavaTimeFormatter {
   protected String userAgent;
   private static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
-  protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
-    new ServerConfiguration(
-      "http://{server}.swagger.io:{port}/v2",
-      "petstore server",
-      new HashMap<String, ServerVariable>() {{
-        put("server", new ServerVariable(
-          "No description provided",
-          "petstore",
-          new HashSet<String>(
-            Arrays.asList(
-              "petstore",
-              "qa-petstore",
-              "dev-petstore"
-            )
+  protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
+          new ServerConfiguration(
+                  "http://{server}.swagger.io:{port}/v2",
+                  "petstore server",
+                  Stream.<Entry<String, ServerVariable>>of(
+                          new SimpleEntry<>("server", new ServerVariable(
+                                  "No description provided",
+                                  "petstore",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "petstore",
+                                          "qa-petstore",
+                                          "dev-petstore"
+                                  ))
+                          )),
+                          new SimpleEntry<>("port", new ServerVariable(
+                                  "No description provided",
+                                  "80",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "80",
+                                          "8080"
+                                  ))
+                          ))
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+          ),
+          new ServerConfiguration(
+                  "https://localhost:8080/{version}",
+                  "The local server",
+                  Stream.<Entry<String, ServerVariable>>of(
+                          new SimpleEntry<>("version", new ServerVariable(
+                                  "No description provided",
+                                  "v2",
+                                  new LinkedHashSet<>(Arrays.asList(
+                                          "v1",
+                                          "v2"
+                                  ))
+                          ))
+                  ).collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> a, LinkedHashMap::new))
+          ),
+          new ServerConfiguration(
+                  "https://127.0.0.1/no_variable",
+                  "The local server without variables",
+                  new LinkedHashMap<>()
           )
-        ));
-        put("port", new ServerVariable(
-          "No description provided",
-          "80",
-          new HashSet<String>(
-            Arrays.asList(
-              "80",
-              "8080"
-            )
-          )
-        ));
-      }}
-    ),
-    new ServerConfiguration(
-      "https://localhost:8080/{version}",
-      "The local server",
-      new HashMap<String, ServerVariable>() {{
-        put("version", new ServerVariable(
-          "No description provided",
-          "v2",
-          new HashSet<String>(
-            Arrays.asList(
-              "v1",
-              "v2"
-            )
-          )
-        ));
-      }}
-    ),
-    new ServerConfiguration(
-      "https://127.0.0.1/no_variable",
-      "The local server without variables",
-      new HashMap<String, ServerVariable>()
-    )
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  protected Map<String, List<ServerConfiguration>> operationServers = new HashMap<String, List<ServerConfiguration>>() {{
-    put("PetApi.addPet", new ArrayList<ServerConfiguration>(Arrays.asList(
-      new ServerConfiguration(
-        "http://petstore.swagger.io/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      ),
+  protected Map<String, List<ServerConfiguration>> operationServers;
 
-      new ServerConfiguration(
-        "http://path-server-test.petstore.local/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      )
+  {
+    Map<String, List<ServerConfiguration>> operationServers = new HashMap<>();
+    operationServers.put("PetApi.addPet", new ArrayList<>(Arrays.asList(
+            new ServerConfiguration(
+                    "http://petstore.swagger.io/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            ),
+            new ServerConfiguration(
+                    "http://path-server-test.petstore.local/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            )
     )));
-    put("PetApi.updatePet", new ArrayList<ServerConfiguration>(Arrays.asList(
-      new ServerConfiguration(
-        "http://petstore.swagger.io/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      ),
+    operationServers.put("PetApi.updatePet", new ArrayList<>(Arrays.asList(
+            new ServerConfiguration(
+                    "http://petstore.swagger.io/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            ),
+            new ServerConfiguration(
+                    "http://path-server-test.petstore.local/v2",
+                    "No description provided",
+                    new LinkedHashMap<>()
+            )
+    )));
+    this.operationServers = operationServers;
+  }
 
-      new ServerConfiguration(
-        "http://path-server-test.petstore.local/v2",
-        "No description provided",
-        new HashMap<String, ServerVariable>()
-      )
-    )));
-  }};
   protected Map<String, Integer> operationServerIndex = new HashMap<String, Integer>();
   protected Map<String, Map<String, String>> operationServerVariables = new HashMap<String, Map<String, String>>();
   protected boolean debugging = false;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
   public static Class<?> getClassForElement(JsonNode node, Class<?> modelClass) {
     ClassDiscriminatorMapping cdm = modelDiscriminators.get(modelClass);
     if (cdm != null) {
-      return cdm.getClassForElement(node, new HashSet<Class<?>>());
+      return cdm.getClassForElement(node, new HashSet<>());
     }
     return null;
   }
@@ -84,7 +84,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     ClassDiscriminatorMapping(Class<?> cls, String propertyName, Map<String, Class<?>> mappings) {
       modelClass = cls;
       discriminatorName = propertyName;
-      discriminatorMappings = new HashMap<String, Class<?>>();
+      discriminatorMappings = new HashMap<>();
       if (mappings != null) {
         discriminatorMappings.putAll(mappings);
       }
@@ -193,12 +193,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,16 @@ public class AnotherFakeApi {
      </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
-    
-    // verify the required parameter 'client' is set
+    // Check required parameters
     if (client == null) {
       throw new ApiException(400, "Missing the required parameter 'client' when calling call123testSpecialTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/another-fake/dummy";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("AnotherFakeApi.call123testSpecialTags", "/another-fake/dummy", "PATCH", new ArrayList<>(), client,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -85,11 +85,10 @@ public class AnotherFakeApi {
     String localVarPath = "/another-fake/dummy";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -78,11 +78,10 @@ public class DefaultApi {
     String localVarPath = "/foo";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.FooGetDefaultResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -72,36 +73,11 @@ public class DefaultApi {
      </table>
    */
   public ApiResponse<FooGetDefaultResponse> fooGetWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/foo";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<FooGetDefaultResponse> localVarReturnType = new GenericType<FooGetDefaultResponse>() {};
-
-    return apiClient.invokeAPI("DefaultApi.fooGet", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("DefaultApi.fooGet", "/foo", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -87,11 +87,10 @@ public class FakeApi {
     String localVarPath = "/fake/health";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -149,11 +148,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/boolean";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -211,11 +209,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/composite";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -273,11 +270,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/number";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -335,11 +331,10 @@ public class FakeApi {
     String localVarPath = "/fake/outer/string";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -395,11 +390,10 @@ public class FakeApi {
     String localVarPath = "/fake/array-of-enums";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -461,11 +455,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-file-schema";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -532,11 +525,10 @@ public class FakeApi {
     String localVarPath = "/fake/body-with-query-params";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
 
     
@@ -598,11 +590,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -707,11 +698,10 @@ public class FakeApi {
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -810,11 +800,10 @@ if (paramCallback != null)
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "enum_query_string_array", enumQueryStringArray));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
@@ -870,11 +859,10 @@ private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredString
     String localVarPath = "/fake";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
@@ -1057,11 +1045,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/inline-additionalProperties";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -1128,11 +1115,10 @@ if (booleanGroup != null)
     String localVarPath = "/fake/jsonFormData";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -1224,11 +1210,10 @@ if (param2 != null)
     String localVarPath = "/fake/test-query-parameters";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "pipe", pipe));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -21,6 +21,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,37 +82,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<HealthCheckResult> fakeHealthGetWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake/health";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<HealthCheckResult> localVarReturnType = new GenericType<HealthCheckResult>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeHealthGet", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeHealthGet", "/fake/health", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -142,37 +118,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/boolean";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Boolean> localVarReturnType = new GenericType<Boolean>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterBooleanSerialize", "/fake/outer/boolean", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -203,37 +154,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite) throws ApiException {
-    Object localVarPostBody = outerComposite;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/composite";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<OuterComposite> localVarReturnType = new GenericType<OuterComposite>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterCompositeSerialize", "/fake/outer/composite", "POST", new ArrayList<>(), outerComposite,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -264,37 +190,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/number";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<BigDecimal> localVarReturnType = new GenericType<BigDecimal>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterNumberSerialize", "/fake/outer/number", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -325,37 +226,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-    Object localVarPostBody = body;
-    
-    // create path and map variables
-    String localVarPath = "/fake/outer/string";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "*/*"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("*/*");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.fakeOuterStringSerialize", "/fake/outer/string", "POST", new ArrayList<>(), body,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Array of Enums
@@ -384,37 +260,12 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<List<OuterEnum>> getArrayOfEnumsWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake/array-of-enums";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<List<OuterEnum>> localVarReturnType = new GenericType<List<OuterEnum>>() {};
-
-    return apiClient.invokeAPI("FakeApi.getArrayOfEnums", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.getArrayOfEnums", "/fake/array-of-enums", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * 
@@ -444,40 +295,16 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass) throws ApiException {
-    Object localVarPostBody = fileSchemaTestClass;
-    
-    // verify the required parameter 'fileSchemaTestClass' is set
+    // Check required parameters
     if (fileSchemaTestClass == null) {
       throw new ApiException(400, "Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-file-schema";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithFileSchema", "/fake/body-with-file-schema", "PUT", new ArrayList<>(), fileSchemaTestClass,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -509,46 +336,24 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'query' is set
+    // Check required parameters
     if (query == null) {
       throw new ApiException(400, "Missing the required parameter 'query' when calling testBodyWithQueryParams");
     }
-    
-    // verify the required parameter 'user' is set
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling testBodyWithQueryParams");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/body-with-query-params";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "query", query));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "query", query)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testBodyWithQueryParams", "/fake/body-with-query-params", "PUT", localVarQueryParams, user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * To test \&quot;client\&quot; model
@@ -579,42 +384,17 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
-    
-    // verify the required parameter 'client' is set
+    // Check required parameters
     if (client == null) {
       throw new ApiException(400, "Missing the required parameter 'client' when calling testClientModel");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeApi.testClientModel", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("FakeApi.testClientModel", "/fake", "PATCH", new ArrayList<>(), client,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -672,82 +452,62 @@ public class FakeApi {
      </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'number' is set
+    // Check required parameters
     if (number == null) {
       throw new ApiException(400, "Missing the required parameter 'number' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_double' is set
     if (_double == null) {
       throw new ApiException(400, "Missing the required parameter '_double' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter 'patternWithoutDelimiter' is set
     if (patternWithoutDelimiter == null) {
       throw new ApiException(400, "Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
     }
-    
-    // verify the required parameter '_byte' is set
     if (_byte == null) {
       throw new ApiException(400, "Missing the required parameter '_byte' when calling testEndpointParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (integer != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (integer != null) {
       localVarFormParams.put("integer", integer);
-if (int32 != null)
+    }
+    if (int32 != null) {
       localVarFormParams.put("int32", int32);
-if (int64 != null)
+    }
+    if (int64 != null) {
       localVarFormParams.put("int64", int64);
-if (number != null)
-      localVarFormParams.put("number", number);
-if (_float != null)
+    }
+    localVarFormParams.put("number", number);
+    if (_float != null) {
       localVarFormParams.put("float", _float);
-if (_double != null)
-      localVarFormParams.put("double", _double);
-if (string != null)
+    }
+    localVarFormParams.put("double", _double);
+    if (string != null) {
       localVarFormParams.put("string", string);
-if (patternWithoutDelimiter != null)
-      localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
-if (_byte != null)
-      localVarFormParams.put("byte", _byte);
-if (binary != null)
+    }
+    localVarFormParams.put("pattern_without_delimiter", patternWithoutDelimiter);
+    localVarFormParams.put("byte", _byte);
+    if (binary != null) {
       localVarFormParams.put("binary", binary);
-if (date != null)
+    }
+    if (date != null) {
       localVarFormParams.put("date", date);
-if (dateTime != null)
+    }
+    if (dateTime != null) {
       localVarFormParams.put("dateTime", dateTime);
-if (password != null)
+    }
+    if (password != null) {
       localVarFormParams.put("password", password);
-if (paramCallback != null)
+    }
+    if (paramCallback != null) {
       localVarFormParams.put("callback", paramCallback);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "http_basic_test" };
-
-    return apiClient.invokeAPI("FakeApi.testEndpointParameters", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"http_basic_test"};
+    return apiClient.invokeAPI("FakeApi.testEndpointParameters", "/fake", "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -794,101 +554,71 @@ if (paramCallback != null)
      </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/fake";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "enum_query_string_array", enumQueryStringArray));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("multi", "enum_query_string_array", enumQueryStringArray)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_string", enumQueryString));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_integer", enumQueryInteger));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "enum_query_double", enumQueryDouble));
 
-    if (enumHeaderStringArray != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (enumHeaderStringArray != null) {
       localVarHeaderParams.put("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
-if (enumHeaderString != null)
+    }
+    if (enumHeaderString != null) {
       localVarHeaderParams.put("enum_header_string", apiClient.parameterToString(enumHeaderString));
+    }
 
-    
-    if (enumFormStringArray != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (enumFormStringArray != null) {
       localVarFormParams.put("enum_form_string_array", enumFormStringArray);
-if (enumFormString != null)
+    }
+    if (enumFormString != null) {
       localVarFormParams.put("enum_form_string", enumFormString);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testEnumParameters", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testEnumParameters", "/fake", "GET", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
 
 private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'requiredStringGroup' is set
+    // Check required parameters
     if (requiredStringGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredBooleanGroup' is set
     if (requiredBooleanGroup == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
     }
-    
-    // verify the required parameter 'requiredInt64Group' is set
     if (requiredInt64Group == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_string_group", requiredStringGroup));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "required_string_group", requiredStringGroup)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "required_int64_group", requiredInt64Group));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "string_group", stringGroup));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "int64_group", int64Group));
 
-    if (requiredBooleanGroup != null)
-      localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
-if (booleanGroup != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    localVarHeaderParams.put("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
+    if (booleanGroup != null) {
       localVarHeaderParams.put("boolean_group", apiClient.parameterToString(booleanGroup));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "bearer_test" };
-
-    return apiClient.invokeAPI("FakeApi.testGroupParameters", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"bearer_test"};
+    return apiClient.invokeAPI("FakeApi.testGroupParameters", "/fake", "DELETE", localVarQueryParams, null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
 
@@ -1034,40 +764,16 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody) throws ApiException {
-    Object localVarPostBody = requestBody;
-    
-    // verify the required parameter 'requestBody' is set
+    // Check required parameters
     if (requestBody == null) {
       throw new ApiException(400, "Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/inline-additionalProperties";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("FakeApi.testInlineAdditionalProperties", "/fake/inline-additionalProperties", "POST", new ArrayList<>(), requestBody,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * test json serialization of form data
@@ -1099,49 +805,24 @@ if (booleanGroup != null)
      </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'param' is set
+    // Check required parameters
     if (param == null) {
       throw new ApiException(400, "Missing the required parameter 'param' when calling testJsonFormData");
     }
-    
-    // verify the required parameter 'param2' is set
     if (param2 == null) {
       throw new ApiException(400, "Missing the required parameter 'param2' when calling testJsonFormData");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/jsonFormData";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    localVarFormParams.put("param", param);
+    localVarFormParams.put("param2", param2);
 
-    
-    
-    if (param != null)
-      localVarFormParams.put("param", param);
-if (param2 != null)
-      localVarFormParams.put("param2", param2);
-
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testJsonFormData", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    return apiClient.invokeAPI("FakeApi.testJsonFormData", "/fake/jsonFormData", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * 
@@ -1179,64 +860,36 @@ if (param2 != null)
      </table>
    */
   public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'pipe' is set
+    // Check required parameters
     if (pipe == null) {
       throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'ioutil' is set
     if (ioutil == null) {
       throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'http' is set
     if (http == null) {
       throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'url' is set
     if (url == null) {
       throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
     }
-    
-    // verify the required parameter 'context' is set
     if (context == null) {
       throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake/test-query-parameters";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "pipe", pipe));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("multi", "pipe", pipe)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
     localVarQueryParams.addAll(apiClient.parameterToPairs("ssv", "http", http));
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
     localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("FakeApi.testQueryParameterCollectionFormat", "/fake/test-query-parameters", "PUT", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,41 +75,17 @@ public class FakeClassnameTags123Api {
      </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client client) throws ApiException {
-    Object localVarPostBody = client;
-    
-    // verify the required parameter 'client' is set
+    // Check required parameters
     if (client == null) {
       throw new ApiException(400, "Missing the required parameter 'client' when calling testClassname");
     }
-    
-    // create path and map variables
-    String localVarPath = "/fake_classname_test";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key_query" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    String[] localVarAuthNames = new String[] {"api_key_query"};
     GenericType<Client> localVarReturnType = new GenericType<Client>() {};
-
-    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", localVarPath, "PATCH", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("FakeClassnameTags123Api.testClassname", "/fake_classname_test", "PATCH", new ArrayList<>(), client,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -85,11 +85,10 @@ public class FakeClassnameTags123Api {
     String localVarPath = "/fake_classname_test";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -86,11 +86,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -153,11 +152,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     if (apiKey != null)
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
@@ -222,11 +220,10 @@ public class PetApi {
     String localVarPath = "/pet/findByStatus";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
 
     
@@ -296,11 +293,10 @@ public class PetApi {
     String localVarPath = "/pet/findByTags";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
 
     
@@ -369,11 +365,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -439,11 +434,10 @@ public class PetApi {
     String localVarPath = "/pet";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -508,11 +502,10 @@ public class PetApi {
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -582,11 +575,10 @@ if (status != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -663,11 +655,10 @@ if (_file != null)
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -14,6 +14,7 @@ import org.openapitools.client.model.Pet;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,39 +76,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
-    
-    // verify the required parameter 'pet' is set
+    // Check required parameters
     if (pet == null) {
       throw new ApiException(400, "Missing the required parameter 'pet' when calling addPet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
-    return apiClient.invokeAPI("PetApi.addPet", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
+    return apiClient.invokeAPI("PetApi.addPet", "/pet", "POST", new ArrayList<>(), pet,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -140,42 +118,26 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    if (apiKey != null)
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    if (apiKey != null) {
       localVarHeaderParams.put("api_key", apiClient.parameterToString(apiKey));
+    }
 
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.deletePet", localVarPath, "DELETE", new ArrayList<>(), null,
+                               localVarHeaderParams, new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -209,42 +171,22 @@ public class PetApi {
      </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'status' is set
+    // Check required parameters
     if (status == null) {
       throw new ApiException(400, "Missing the required parameter 'status' when calling findPetsByStatus");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByStatus";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "status", status));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "status", status)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByStatus", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByStatus", "/pet/findByStatus", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -282,42 +224,22 @@ public class PetApi {
    */
   @Deprecated
   public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'tags' is set
+    // Check required parameters
     if (tags == null) {
       throw new ApiException(400, "Missing the required parameter 'tags' when calling findPetsByTags");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet/findByTags";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "tags", tags));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("csv", "tags", tags)
+    );
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
     GenericType<List<Pet>> localVarReturnType = new GenericType<List<Pet>>() {};
-
-    return apiClient.invokeAPI("PetApi.findPetsByTags", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.findPetsByTags", "/pet/findByTags", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -353,42 +275,21 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Pet> localVarReturnType = new GenericType<Pet>() {};
-
-    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.getPetById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -423,39 +324,16 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet pet) throws ApiException {
-    Object localVarPostBody = pet;
-    
-    // verify the required parameter 'pet' is set
+    // Check required parameters
     if (pet == null) {
       throw new ApiException(400, "Missing the required parameter 'pet' when calling updatePet");
     }
-    
-    // create path and map variables
-    String localVarPath = "/pet";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json", "application/xml"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth", "http_signature_test" };
-
-    return apiClient.invokeAPI("PetApi.updatePet", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json", "application/xml");
+    String[] localVarAuthNames = new String[] {"petstore_auth", "http_signature_test"};
+    return apiClient.invokeAPI("PetApi.updatePet", "/pet", "PUT", new ArrayList<>(), pet,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -490,44 +368,29 @@ public class PetApi {
      </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (name != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (name != null) {
       localVarFormParams.put("name", name);
-if (status != null)
+    }
+    if (status != null) {
       localVarFormParams.put("status", status);
+    }
 
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
-    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/x-www-form-urlencoded");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
+    return apiClient.invokeAPI("PetApi.updatePetWithForm", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, null, false);
   }
   /**
@@ -563,46 +426,30 @@ if (status != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (_file != null)
+    }
+    if (_file != null) {
       localVarFormParams.put("file", _file);
+    }
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -638,51 +485,31 @@ if (_file != null)
      </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'petId' is set
+    // Check required parameters
     if (petId == null) {
       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
     }
-    
-    // verify the required parameter 'requiredFile' is set
     if (requiredFile == null) {
       throw new ApiException(400, "Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    if (additionalMetadata != null)
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    if (additionalMetadata != null) {
       localVarFormParams.put("additionalMetadata", additionalMetadata);
-if (requiredFile != null)
-      localVarFormParams.put("requiredFile", requiredFile);
+    }
+    localVarFormParams.put("requiredFile", requiredFile);
 
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "multipart/form-data"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "petstore_auth" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("multipart/form-data");
+    String[] localVarAuthNames = new String[] {"petstore_auth"};
     GenericType<ModelApiResponse> localVarReturnType = new GenericType<ModelApiResponse>() {};
-
-    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("PetApi.uploadFileWithRequiredFile", localVarPath, "POST", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), localVarFormParams, localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -125,7 +125,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Header parameters
     Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
@@ -282,7 +282,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();
@@ -375,7 +375,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -433,7 +433,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();
@@ -495,7 +495,7 @@ public class PetApi {
 
     // Path parameters
     String localVarPath = "/fake/{petId}/uploadImageWithRequiredFile"
-            .replaceAll("\\{petId}", apiClient.escapeString(petId));
+            .replaceAll("\\{petId}", apiClient.escapeString(petId.toString()));
 
     // Form parameters
     Map<String, Object> localVarFormParams = new LinkedHashMap<>();

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -166,7 +166,7 @@ public class StoreApi {
 
     // Path parameters
     String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId.toString()));
 
     String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
     String localVarContentType = apiClient.selectHeaderContentType();

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,6 +12,7 @@ import org.openapitools.client.model.Order;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,41 +76,20 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("StoreApi.deleteOrder", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Returns pet inventories by status
@@ -138,36 +118,12 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/store/inventory";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] { "api_key" };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
+    String[] localVarAuthNames = new String[] {"api_key"};
     GenericType<Map<String, Integer>> localVarReturnType = new GenericType<Map<String, Integer>>() {};
-
-    return apiClient.invokeAPI("StoreApi.getInventory", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
+    return apiClient.invokeAPI("StoreApi.getInventory", "/store/inventory", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
                                localVarAuthNames, localVarReturnType, false);
   }
   /**
@@ -203,43 +159,21 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'orderId' is set
+    // Check required parameters
     if (orderId == null) {
       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{order_id}", apiClient.escapeString(orderId));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.getOrderById", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Place an order for a pet
@@ -272,41 +206,16 @@ public class StoreApi {
      </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order order) throws ApiException {
-    Object localVarPostBody = order;
-    
-    // verify the required parameter 'order' is set
+    // Check required parameters
     if (order == null) {
       throw new ApiException(400, "Missing the required parameter 'order' when calling placeOrder");
     }
-    
-    // create path and map variables
-    String localVarPath = "/store/order";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
     GenericType<Order> localVarReturnType = new GenericType<Order>() {};
-
-    return apiClient.invokeAPI("StoreApi.placeOrder", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("StoreApi.placeOrder", "/store/order", "POST", new ArrayList<>(), order,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -87,11 +87,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -145,11 +144,10 @@ public class StoreApi {
     String localVarPath = "/store/inventory";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -217,11 +215,10 @@ public class StoreApi {
       .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -286,11 +283,10 @@ public class StoreApi {
     String localVarPath = "/store/order";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -85,11 +85,10 @@ public class UserApi {
     String localVarPath = "/user";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -149,11 +148,10 @@ public class UserApi {
     String localVarPath = "/user/createWithArray";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -213,11 +211,10 @@ public class UserApi {
     String localVarPath = "/user/createWithList";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -280,11 +277,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -350,11 +346,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -426,11 +421,10 @@ public class UserApi {
     String localVarPath = "/user/login";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
@@ -487,11 +481,10 @@ public class UserApi {
     String localVarPath = "/user/logout";
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     
@@ -561,11 +554,10 @@ public class UserApi {
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, String> localVarCookieParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
-
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    Map<String, String> localVarHeaderParams = new HashMap<>();
+    Map<String, String> localVarCookieParams = new HashMap<>();
+    Map<String, Object> localVarFormParams = new HashMap<>();
 
     
     

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,6 +13,7 @@ import org.openapitools.client.model.User;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,40 +75,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUser", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.createUser", "/user", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -137,40 +114,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUsersWithArrayInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithArray";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.createUsersWithArrayInput", "/user/createWithArray", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Creates list of users with given input array
@@ -200,40 +153,16 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'user' is set
+    // Check required parameters
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling createUsersWithListInput");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/createWithList";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.createUsersWithListInput", localVarPath, "POST", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.createUsersWithListInput", "/user/createWithList", "POST", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Delete user
@@ -265,41 +194,20 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.deleteUser", localVarPath, "DELETE", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Get user by user name
@@ -334,43 +242,21 @@ public class UserApi {
      </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<User> localVarReturnType = new GenericType<User>() {};
-
-    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.getUserByName", localVarPath, "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs user into the system
@@ -405,49 +291,26 @@ public class UserApi {
      </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling loginUser");
     }
-    
-    // verify the required parameter 'password' is set
     if (password == null) {
       throw new ApiException(400, "Missing the required parameter 'password' when calling loginUser");
     }
-    
-    // create path and map variables
-    String localVarPath = "/user/login";
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "username", username));
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("", "username", username)
+    );
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "password", password));
 
-    
-    
-    
-    final String[] localVarAccepts = {
-      "application/xml", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
+    String localVarAccept = apiClient.selectHeaderAccept("application/xml", "application/json");
+    String localVarContentType = apiClient.selectHeaderContentType();
     GenericType<String> localVarReturnType = new GenericType<String>() {};
-
-    return apiClient.invokeAPI("UserApi.loginUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, localVarReturnType, false);
+    return apiClient.invokeAPI("UserApi.loginUser", "/user/login", "GET", localVarQueryParams, null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, localVarReturnType, false);
   }
   /**
    * Logs out current logged in user session
@@ -475,35 +338,11 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/user/logout";
-
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.logoutUser", localVarPath, "GET", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType();
+    return apiClient.invokeAPI("UserApi.logoutUser", "/user/logout", "GET", new ArrayList<>(), null,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
   /**
    * Updated user
@@ -537,45 +376,22 @@ public class UserApi {
      </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User user) throws ApiException {
-    Object localVarPostBody = user;
-    
-    // verify the required parameter 'username' is set
+    // Check required parameters
     if (username == null) {
       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
     }
-    
-    // verify the required parameter 'user' is set
     if (user == null) {
       throw new ApiException(400, "Missing the required parameter 'user' when calling updateUser");
     }
-    
-    // create path and map variables
+
+    // Path parameters
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{username}", apiClient.escapeString(username));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<>();
-    Map<String, String> localVarHeaderParams = new HashMap<>();
-    Map<String, String> localVarCookieParams = new HashMap<>();
-    Map<String, Object> localVarFormParams = new HashMap<>();
-
-    
-    
-    
-    final String[] localVarAccepts = {
-      
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-    String[] localVarAuthNames = new String[] {  };
-
-    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", localVarQueryParams, localVarPostBody,
-                               localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType,
-                               localVarAuthNames, null, false);
+    String localVarAccept = apiClient.selectHeaderAccept();
+    String localVarContentType = apiClient.selectHeaderContentType("application/json");
+    return apiClient.invokeAPI("UserApi.updateUser", localVarPath, "PUT", new ArrayList<>(), user,
+                               new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>(), localVarAccept, localVarContentType,
+                               null, null, false);
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -151,13 +151,13 @@ public class Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Cat", Cat.class);
-  mappings.put("Dog", Dog.class);
-  mappings.put("Animal", Animal.class);
-  JSON.registerDiscriminator(Animal.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Cat", Cat.class);
+    mappings.put("Dog", Dog.class);
+    mappings.put("Animal", Animal.class);
+    JSON.registerDiscriminator(Animal.class, "className", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -92,7 +92,7 @@ public class Cat extends Animal {
   @JsonAnySetter
   public Cat putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -160,11 +160,11 @@ public class Cat extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Cat", Cat.class);
-  JSON.registerDiscriminator(Cat.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Cat", Cat.class);
+    JSON.registerDiscriminator(Cat.class, "className", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -135,7 +135,7 @@ public class ChildCat extends ParentPet {
   @JsonAnySetter
   public ChildCat putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -205,11 +205,11 @@ public class ChildCat extends ParentPet {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildCat", ChildCat.class);
-  JSON.registerDiscriminator(ChildCat.class, "pet_type", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildCat", ChildCat.class);
+    JSON.registerDiscriminator(ChildCat.class, "pet_type", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -111,7 +111,7 @@ public class ComplexQuadrilateral {
   @JsonAnySetter
   public ComplexQuadrilateral putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -92,7 +92,7 @@ public class Dog extends Animal {
   @JsonAnySetter
   public Dog putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -160,11 +160,11 @@ public class Dog extends Animal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("Dog", Dog.class);
-  JSON.registerDiscriminator(Dog.class, "className", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("Dog", Dog.class);
+    JSON.registerDiscriminator(Dog.class, "className", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
@@ -195,7 +195,7 @@ public class Drawing {
   @JsonAnySetter
   public Drawing putAdditionalProperty(String key, Fruit value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Fruit>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -111,7 +111,7 @@ public class EquilateralTriangle {
   @JsonAnySetter
   public EquilateralTriangle putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Fruit.java
@@ -162,7 +162,7 @@ public class Fruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Fruit() {
         super("oneOf", Boolean.FALSE);
@@ -201,12 +201,12 @@ public class Fruit extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -164,7 +164,7 @@ public class FruitReq extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public FruitReq() {
         super("oneOf", Boolean.TRUE);
@@ -208,12 +208,12 @@ public class FruitReq extends AbstractOpenApiSchema {
            return;
         }
 
-        if (JSON.isInstanceOf(AppleReq.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(AppleReq.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(BananaReq.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(BananaReq.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -122,7 +122,7 @@ public class GmFruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in anyOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public GmFruit() {
         super("anyOf", Boolean.FALSE);
@@ -161,12 +161,12 @@ public class GmFruit extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Apple.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Banana.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -120,13 +120,13 @@ public class GrandparentAnimal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildCat", ChildCat.class);
-  mappings.put("ParentPet", ParentPet.class);
-  mappings.put("GrandparentAnimal", GrandparentAnimal.class);
-  JSON.registerDiscriminator(GrandparentAnimal.class, "pet_type", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildCat", ChildCat.class);
+    mappings.put("ParentPet", ParentPet.class);
+    mappings.put("GrandparentAnimal", GrandparentAnimal.class);
+    JSON.registerDiscriminator(GrandparentAnimal.class, "pet_type", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
@@ -97,7 +97,7 @@ public class Mammal extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             Mammal newMammal = new Mammal();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("className");
             switch (discriminatorValue) {
                 case "Pig":
@@ -215,7 +215,7 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Mammal() {
         super("oneOf", Boolean.FALSE);
@@ -234,7 +234,7 @@ public class Mammal extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Mammal putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -294,7 +294,7 @@ public class Mammal extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Mammal.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Pig", Pig.class);
         mappings.put("whale", Whale.class);
         mappings.put("zebra", Zebra.class);
@@ -317,17 +317,17 @@ public class Mammal extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Pig.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Pig.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Whale.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Whale.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Zebra.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Zebra.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -556,7 +556,7 @@ public class NullableClass {
   @JsonAnySetter
   public NullableClass putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -96,7 +96,7 @@ public class NullableShape extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             NullableShape newNullableShape = new NullableShape();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("shapeType");
             switch (discriminatorValue) {
                 case "Quadrilateral":
@@ -186,7 +186,7 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public NullableShape() {
         super("oneOf", Boolean.TRUE);
@@ -205,7 +205,7 @@ public class NullableShape extends AbstractOpenApiSchema {
   @JsonAnySetter
   public NullableShape putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -258,7 +258,7 @@ public class NullableShape extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(NullableShape.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Quadrilateral", Quadrilateral.class);
         mappings.put("Triangle", Triangle.class);
         mappings.put("NullableShape", NullableShape.class);
@@ -285,12 +285,12 @@ public class NullableShape extends AbstractOpenApiSchema {
            return;
         }
 
-        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -67,7 +67,7 @@ public class ParentPet extends GrandparentAnimal {
   @JsonAnySetter
   public ParentPet putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -131,12 +131,12 @@ public class ParentPet extends GrandparentAnimal {
     return o.toString().replace("\n", "\n    ");
   }
 
-static {
-  // Initialize and register the discriminator mappings.
-  Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
-  mappings.put("ChildCat", ChildCat.class);
-  mappings.put("ParentPet", ParentPet.class);
-  JSON.registerDiscriminator(ParentPet.class, "pet_type", mappings);
-}
+  static {
+    // Initialize and register the discriminator mappings.
+    Map<String, Class<?>> mappings = new HashMap<>();
+    mappings.put("ChildCat", ChildCat.class);
+    mappings.put("ParentPet", ParentPet.class);
+    JSON.registerDiscriminator(ParentPet.class, "pet_type", mappings);
+  }
 }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
@@ -96,7 +96,7 @@ public class Pig extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             Pig newPig = new Pig();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("className");
             switch (discriminatorValue) {
                 case "BasquePig":
@@ -184,7 +184,7 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Pig() {
         super("oneOf", Boolean.FALSE);
@@ -203,7 +203,7 @@ public class Pig extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Pig putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -256,7 +256,7 @@ public class Pig extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Pig.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("BasquePig", BasquePig.class);
         mappings.put("DanishPig", DanishPig.class);
         mappings.put("Pig", Pig.class);
@@ -278,12 +278,12 @@ public class Pig extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(BasquePig.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(BasquePig.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(DanishPig.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(DanishPig.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -96,7 +96,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             Quadrilateral newQuadrilateral = new Quadrilateral();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("quadrilateralType");
             switch (discriminatorValue) {
                 case "ComplexQuadrilateral":
@@ -184,7 +184,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Quadrilateral() {
         super("oneOf", Boolean.FALSE);
@@ -203,7 +203,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Quadrilateral putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -256,7 +256,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Quadrilateral.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("ComplexQuadrilateral", ComplexQuadrilateral.class);
         mappings.put("SimpleQuadrilateral", SimpleQuadrilateral.class);
         mappings.put("Quadrilateral", Quadrilateral.class);
@@ -278,12 +278,12 @@ public class Quadrilateral extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(ComplexQuadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(ComplexQuadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(SimpleQuadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(SimpleQuadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -111,7 +111,7 @@ public class ScaleneTriangle {
   @JsonAnySetter
   public ScaleneTriangle putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
@@ -96,7 +96,7 @@ public class Shape extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             Shape newShape = new Shape();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("shapeType");
             switch (discriminatorValue) {
                 case "Quadrilateral":
@@ -184,7 +184,7 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Shape() {
         super("oneOf", Boolean.FALSE);
@@ -203,7 +203,7 @@ public class Shape extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Shape putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -256,7 +256,7 @@ public class Shape extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Shape.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Quadrilateral", Quadrilateral.class);
         mappings.put("Triangle", Triangle.class);
         mappings.put("Shape", Shape.class);
@@ -278,12 +278,12 @@ public class Shape extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -96,7 +96,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             ShapeOrNull newShapeOrNull = new ShapeOrNull();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("shapeType");
             switch (discriminatorValue) {
                 case "Quadrilateral":
@@ -186,7 +186,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public ShapeOrNull() {
         super("oneOf", Boolean.TRUE);
@@ -205,7 +205,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
   @JsonAnySetter
   public ShapeOrNull putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -258,7 +258,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(ShapeOrNull.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("Quadrilateral", Quadrilateral.class);
         mappings.put("Triangle", Triangle.class);
         mappings.put("ShapeOrNull", ShapeOrNull.class);
@@ -285,12 +285,12 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
            return;
         }
 
-        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Quadrilateral.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(Triangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -111,7 +111,7 @@ public class SimpleQuadrilateral {
   @JsonAnySetter
   public SimpleQuadrilateral putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
@@ -97,7 +97,7 @@ public class Triangle extends AbstractOpenApiSchema {
             JsonNode tree = jp.readValueAsTree();
             Object deserialized = null;
             Triangle newTriangle = new Triangle();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("triangleType");
             switch (discriminatorValue) {
                 case "EquilateralTriangle":
@@ -215,7 +215,7 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<>();
 
     public Triangle() {
         super("oneOf", Boolean.FALSE);
@@ -234,7 +234,7 @@ public class Triangle extends AbstractOpenApiSchema {
   @JsonAnySetter
   public Triangle putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;
@@ -294,7 +294,7 @@ public class Triangle extends AbstractOpenApiSchema {
         });
         JSON.registerDescendants(Triangle.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
-        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> mappings = new HashMap<>();
         mappings.put("EquilateralTriangle", EquilateralTriangle.class);
         mappings.put("IsoscelesTriangle", IsoscelesTriangle.class);
         mappings.put("ScaleneTriangle", ScaleneTriangle.class);
@@ -317,17 +317,17 @@ public class Triangle extends AbstractOpenApiSchema {
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (JSON.isInstanceOf(EquilateralTriangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(EquilateralTriangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(IsoscelesTriangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(IsoscelesTriangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }
 
-        if (JSON.isInstanceOf(ScaleneTriangle.class, instance, new HashSet<Class<?>>())) {
+        if (JSON.isInstanceOf(ScaleneTriangle.class, instance, new HashSet<>())) {
             super.setActualInstance(instance);
             return;
         }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Zebra.java
@@ -149,7 +149,7 @@ public class Zebra {
   @JsonAnySetter
   public Zebra putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
-        this.additionalProperties = new HashMap<String, Object>();
+        this.additionalProperties = new HashMap<>();
     }
     this.additionalProperties.put(key, value);
     return this;


### PR DESCRIPTION
Some general cleanups in the Jersey 2 & 3 client generators.

Mainly remove double brace initialization in generated code, otherwise it's mostly about making the generated code more readable.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
