### PR TITLE
[openapi-normalizer] add a new rule to set tags for all operations

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -498,3 +498,10 @@ Example:
 ```
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer KEEP_ONLY_FIRST_TAG_IN_OPERATION=true
 ```
+
+- `SET_TAGS_FOR_ALL_OPERATIONS`: when set to a string value, tags in all operatinos will reset to the string value provided.
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_TAGS_FOR_ALL_OPERATIONS=true
+```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -491,3 +491,10 @@ Example:
 ```
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
 ```
+
+- `KEEP_ONLY_FIRST_TAG_IN_OPERATION`: when set to `true`, only keep the first tag in operation if there are more than one tag defined.
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer KEEP_ONLY_FIRST_TAG_IN_OPERATION=true
+```

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -72,7 +72,7 @@ public class OpenAPINormalizer {
     final String SIMPLIFY_BOOLEAN_ENUM = "SIMPLIFY_BOOLEAN_ENUM";
     boolean simplifyBooleanEnum;
 
-    // when set to true, boolean enum will be converted to just boolean
+    // when set to a string value, tags in all operations will be reset to the string value provided
     final String SET_TAGS_FOR_ALL_OPERATIONS = "SET_TAGS_FOR_ALL_OPERATIONS";
     String setTagsForAllOperations;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -559,6 +559,11 @@ public class OpenAPINormalizer {
             return schema;
         }
 
+        if (schema.getAnyOf() == null) {
+            // ComposedSchema, Schema with `type: null`
+            return schema;
+        }
+
         Schema s0 = null, s1 = null;
         if (schema.getAnyOf().size() == 2) {
             s0 = ModelUtils.unaliasSchema(openAPI, (Schema) schema.getAnyOf().get(0));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -39,7 +39,7 @@ public class OpenAPINormalizer {
     final Logger LOGGER = LoggerFactory.getLogger(OpenAPINormalizer.class);
 
     // ============= a list of rules =============
-    // when set to true, all rules are enabled
+    // when set to true, all rules (true or false) are enabled
     final String ALL = "ALL";
     boolean enableAll;
 
@@ -71,6 +71,10 @@ public class OpenAPINormalizer {
     // when set to true, boolean enum will be converted to just boolean
     final String SIMPLIFY_BOOLEAN_ENUM = "SIMPLIFY_BOOLEAN_ENUM";
     boolean simplifyBooleanEnum;
+
+    // when set to true, boolean enum will be converted to just boolean
+    final String SET_TAGS_FOR_ALL_OPERATIONS = "SET_TAGS_FOR_ALL_OPERATIONS";
+    String setTagsForAllOperations;
 
     // ============= end of rules =============
 
@@ -123,6 +127,11 @@ public class OpenAPINormalizer {
         if (enableAll || "true".equalsIgnoreCase(rules.get(SIMPLIFY_BOOLEAN_ENUM))) {
             simplifyBooleanEnum = true;
         }
+
+        if (StringUtils.isNotEmpty(rules.get(SET_TAGS_FOR_ALL_OPERATIONS))) {
+            setTagsForAllOperations = rules.get(SET_TAGS_FOR_ALL_OPERATIONS);
+        }
+
     }
 
     /**
@@ -186,6 +195,8 @@ public class OpenAPINormalizer {
      */
     private void normalizeOperation(Operation operation) {
         processKeepOnlyFirstTagInOperation(operation);
+
+        processSetTagsForAllOperations(operation);
     }
 
     /**
@@ -499,6 +510,20 @@ public class OpenAPINormalizer {
             operation.setTags(null);
             operation.addTagsItem(firstTag);
         }
+    }
+
+    /**
+     * Set the tag name for all operations
+     *
+     * @param operation Operation
+     */
+    private void processSetTagsForAllOperations(Operation operation) {
+        if (StringUtils.isEmpty(setTagsForAllOperations)) {
+            return;
+        }
+
+        operation.setTags(null);
+        operation.addTagsItem(setTagsForAllOperations);
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4453,4 +4453,22 @@ public class DefaultCodegenTest {
         BooleanSchema bs2 = (BooleanSchema) schema.getProperties().get("boolean_enum");
         assertNull(bs2.getEnum()); //ensure the enum has been erased
     }
+
+    @Test
+    public void testOpenAPINormalizerSetTagsInAllOperations() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml");
+
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().size(), 2);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().size(), 1);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SET_TAGS_FOR_ALL_OPERATIONS", "core");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().size(), 1);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().size(), 1);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().get(0), "core");
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().get(0), "core");
+    }
 }


### PR DESCRIPTION
add a new rule to set tags for all operations

FYI @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

