### PR TITLE
[python-nextgen] Add datetime, date format support

### DIFF
--- a/docs/generators/python-nextgen.md
+++ b/docs/generators/python-nextgen.md
@@ -20,6 +20,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |allowStringInDateTimeParameters|Allow string as input to datetime/date parameters for backward compartibility.| |false|
+|dateFormat|date format for query parameters| |%Y-%m-%d|
+|datetimeFormat|datetime format for query parameters| |%Y-%m-%dT%H:%M:%S%z|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |floatStrictType|Use strict type for float, i.e. StrictFloat or confloat(strict=true, ...)| |true|
 |generateSourceCodeOnly|Specifies that only a library source code is to be generated.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -48,6 +48,8 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
     public static final String RECURSION_LIMIT = "recursionLimit";
     public static final String ALLOW_STRING_IN_DATETIME_PARAMETERS = "allowStringInDateTimeParameters";
     public static final String FLOAT_STRICT_TYPE = "floatStrictType";
+    public static final String DATETIME_FORMAT = "datetimeFormat";
+    public static final String DATE_FORMAT = "dateFormat";
 
     protected String packageUrl;
     protected String apiDocPath = "docs" + File.separator;
@@ -56,6 +58,8 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
     protected boolean allowStringInDateTimeParameters = false; // use StrictStr instead of datetime in parameters
     protected boolean floatStrictType = true;
+    protected String datetimeFormat = "%Y-%m-%d %H:%M:%S.%f";
+    protected String dateFormat = "%Y-%m-%d";
 
     protected Map<Character, String> regexModifiers;
 
@@ -171,6 +175,10 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
                 .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(FLOAT_STRICT_TYPE, "Use strict type for float, i.e. StrictFloat or confloat(strict=true, ...)")
                 .defaultValue(Boolean.TRUE.toString()));
+        cliOptions.add(new CliOption(DATETIME_FORMAT, "datetime format for query parameters")
+                .defaultValue("%Y-%m-%dT%H:%M:%S%z"));
+        cliOptions.add(new CliOption(DATE_FORMAT, "date format for query parameters")
+                .defaultValue("%Y-%m-%d"));
 
         supportedLibraries.put("urllib3", "urllib3-based client");
         supportedLibraries.put("asyncio", "asyncio-based client");
@@ -272,6 +280,18 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
 
         if (additionalProperties.containsKey(FLOAT_STRICT_TYPE)) {
             setFloatStrictType(convertPropertyToBooleanAndWriteBack(FLOAT_STRICT_TYPE));
+        }
+
+        if (additionalProperties.containsKey(DATETIME_FORMAT)) {
+            setDatetimeFormat((String) additionalProperties.get(DATETIME_FORMAT));
+        } else {
+            additionalProperties.put(DATETIME_FORMAT, datetimeFormat);
+        }
+
+        if (additionalProperties.containsKey(DATE_FORMAT)) {
+            setDateFormat((String) additionalProperties.get(DATE_FORMAT));
+        } else {
+            additionalProperties.put(DATE_FORMAT, dateFormat);
         }
 
         String modelPath = packagePath() + File.separatorChar + modelPackage.replace('.', File.separatorChar);
@@ -1388,5 +1408,13 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
 
     public void setFloatStrictType(boolean floatStrictType) {
         this.floatStrictType = floatStrictType;
+    }
+
+    public void setDatetimeFormat(String datetimeFormat) {
+        this.datetimeFormat = datetimeFormat;
+    }
+
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -58,7 +58,7 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
     protected boolean allowStringInDateTimeParameters = false; // use StrictStr instead of datetime in parameters
     protected boolean floatStrictType = true;
-    protected String datetimeFormat = "%Y-%m-%dT%H:%M:%S%Z";
+    protected String datetimeFormat = "%Y-%m-%dT%H:%M:%S.%f%z";
     protected String dateFormat = "%Y-%m-%d";
 
     protected Map<Character, String> regexModifiers;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -58,7 +58,7 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
     protected boolean allowStringInDateTimeParameters = false; // use StrictStr instead of datetime in parameters
     protected boolean floatStrictType = true;
-    protected String datetimeFormat = "%Y-%m-%d %H:%M:%S.%f";
+    protected String datetimeFormat = "%Y-%m-%dT%H:%M:%S%Z";
     protected String dateFormat = "%Y-%m-%d";
 
     protected Map<Character, String> regexModifiers;

--- a/modules/openapi-generator/src/main/resources/python-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/api.mustache
@@ -165,24 +165,45 @@ class {{classname}}(object):
             {{#isArray}}
             _collection_formats['{{baseName}}'] = '{{collectionFormat}}'
             {{/isArray}}
+
 {{/pathParams}}
 
         # process the query parameters
         _query_params = []
 {{#queryParams}}
         if _params.get('{{paramName}}') is not None:  # noqa: E501
-            _query_params.append(('{{baseName}}', _params['{{paramName}}'])){{#isArray}}
-            _collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isArray}}
-{{/queryParams}}
+            {{#isDateTime}}
+            if isinstance(_params['{{paramName}}'], datetime):
+                _query_params.append(('{{baseName}}', _params['{{paramName}}'].strftime(self.api_client.configuration.datetime_format)))
+            else:
+                _query_params.append(('{{baseName}}', _params['{{paramName}}']))
+            {{/isDateTime}}
+            {{^isDateTime}}
+            {{#isDate}}
+            if isinstance(_params['{{paramName}}'], datetime):
+                _query_parame.append(('{{baseName}}', _params['{{paramName}}'].strftime(self.api_client.configuration.date_format)))
+            else:
+                _query_params.append(('{{baseName}}', _params['{{paramName}}']))
+            {{/isDate}}
+            {{^isDate}}
+            _query_params.append(('{{baseName}}', _params['{{paramName}}']))
+            {{/isDate}}
+            {{/isDateTime}}
+            {{#isArray}}
+            _collection_formats['{{baseName}}'] = '{{collectionFormat}}'
+            {{/isArray}}
 
+{{/queryParams}}
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
 {{#headerParams}}
         if _params['{{paramName}}']:
-            _header_params['{{baseName}}'] = _params['{{paramName}}']{{#isArray}}
-            _collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isArray}}
-{{/headerParams}}
+            _header_params['{{baseName}}'] = _params['{{paramName}}']
+            {{#isArray}}
+            _collection_formats['{{baseName}}'] = '{{collectionFormat}}'
+            {{/isArray}}
 
+{{/headerParams}}
         # process the form parameters
         _form_params = []
         _files = {}
@@ -197,15 +218,15 @@ class {{classname}}(object):
             {{#isArray}}
             _collection_formats['{{baseName}}'] = '{{collectionFormat}}'
             {{/isArray}}
-{{/formParams}}
 
+{{/formParams}}
         # process the body parameter
         _body_params = None
 {{#bodyParam}}
         if _params['{{paramName}}']:
             _body_params = _params['{{paramName}}']
-{{/bodyParam}}
 
+{{/bodyParam}}
         {{#hasProduces}}
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(

--- a/modules/openapi-generator/src/main/resources/python-nextgen/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/api_client.mustache
@@ -566,7 +566,7 @@ class ApiClient(object):
                     new_params.append(
                         (k, delimiter.join(quote(str(value)) for value in v)))
             else:
-                new_params.append((k, v))
+                new_params.append((k, quote(str(v))))
 
         return "&".join(["=".join(item) for item in new_params])
 

--- a/modules/openapi-generator/src/main/resources/python-nextgen/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/configuration.mustache
@@ -285,6 +285,14 @@ conf = {{{packageName}}}.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
+        self.datetime_format = "{{{datetimeFormat}}}"
+        """datetime format
+        """
+
+        self.date_format = "{{{dateFormat}}}"
+        """date format
+        """
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         result = cls.__new__(cls)

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
@@ -145,14 +145,11 @@ class BodyApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -295,14 +292,11 @@ class BodyApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/form_api.py
@@ -154,23 +154,22 @@ class FormApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['integer_form']:
             _form_params.append(('integer_form', _params['integer_form']))
+
         if _params['boolean_form']:
             _form_params.append(('boolean_form', _params['boolean_form']))
+
         if _params['string_form']:
             _form_params.append(('string_form', _params['string_form']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/header_api.py
@@ -154,23 +154,22 @@ class HeaderApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
         if _params['integer_header']:
             _header_params['integer_header'] = _params['integer_header']
+
         if _params['boolean_header']:
             _header_params['boolean_header'] = _params['boolean_header']
+
         if _params['string_header']:
             _header_params['string_header'] = _params['string_header']
 
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/path_api.py
@@ -146,22 +146,20 @@ class PathApi(object):
         _path_params = {}
         if _params['path_string']:
             _path_params['path_string'] = _params['path_string']
+
         if _params['path_integer']:
             _path_params['path_integer'] = _params['path_integer']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/query_api.py
@@ -157,22 +157,27 @@ class QueryApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('datetime_query') is not None:  # noqa: E501
-            _query_params.append(('datetime_query', _params['datetime_query']))
+            if isinstance(_params['datetime_query'], datetime):
+                _query_params.append(('datetime_query', _params['datetime_query'].strftime(self.api_client.configuration.datetime_format)))
+            else:
+                _query_params.append(('datetime_query', _params['datetime_query']))
+
         if _params.get('date_query') is not None:  # noqa: E501
-            _query_params.append(('date_query', _params['date_query']))
+            if isinstance(_params['date_query'], datetime):
+                _query_parame.append(('date_query', _params['date_query'].strftime(self.api_client.configuration.date_format)))
+            else:
+                _query_params.append(('date_query', _params['date_query']))
+
         if _params.get('string_query') is not None:  # noqa: E501
             _query_params.append(('string_query', _params['string_query']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501
@@ -315,21 +320,20 @@ class QueryApi(object):
         _query_params = []
         if _params.get('integer_query') is not None:  # noqa: E501
             _query_params.append(('integer_query', _params['integer_query']))
+
         if _params.get('boolean_query') is not None:  # noqa: E501
             _query_params.append(('boolean_query', _params['boolean_query']))
+
         if _params.get('string_query') is not None:  # noqa: E501
             _query_params.append(('string_query', _params['string_query']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501
@@ -465,14 +469,11 @@ class QueryApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501
@@ -608,14 +609,11 @@ class QueryApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501
@@ -751,14 +749,11 @@ class QueryApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501
@@ -894,14 +889,11 @@ class QueryApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501
@@ -1037,14 +1029,11 @@ class QueryApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['text/plain'])  # noqa: E501

--- a/samples/client/echo_api/python-nextgen/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api_client.py
@@ -543,7 +543,7 @@ class ApiClient(object):
                     new_params.append(
                         (k, delimiter.join(quote(str(value)) for value in v)))
             else:
-                new_params.append((k, v))
+                new_params.append((k, quote(str(v))))
 
         return "&".join(["=".join(item) for item in new_params])
 

--- a/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
@@ -175,7 +175,7 @@ class Configuration(object):
         """Options to pass down to the underlying urllib3 socket
         """
 
-        self.datetime_format = "%Y-%m-%dT%H:%M:%S%Z"
+        self.datetime_format = "%Y-%m-%dT%H:%M:%S.%f%z"
         """datetime format
         """
 

--- a/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
@@ -175,7 +175,7 @@ class Configuration(object):
         """Options to pass down to the underlying urllib3 socket
         """
 
-        self.datetime_format = "%Y-%m-%d %H:%M:%S.%f"
+        self.datetime_format = "%Y-%m-%dT%H:%M:%S%Z"
         """datetime format
         """
 

--- a/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
@@ -175,6 +175,14 @@ class Configuration(object):
         """Options to pass down to the underlying urllib3 socket
         """
 
+        self.datetime_format = "%Y-%m-%d %H:%M:%S.%f"
+        """datetime format
+        """
+
+        self.date_format = "%Y-%m-%d"
+        """date format
+        """
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         result = cls.__new__(cls)

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -38,7 +38,7 @@ class TestManual(unittest.TestCase):
         # Test query parameter(s)
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20%20Sun%2019:20:30UTC-05:00&date_query=2013-10-20&string_query=string_query_example")
+        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20%20Sun%2019%3A20%3A30UTC-05%3A00&date_query=2013-10-20&string_query=string_query_example")
 
     def testDateTimeQueryWithDateTime(self):
         api_instance = openapi_client.QueryApi()
@@ -49,7 +49,7 @@ class TestManual(unittest.TestCase):
         # Test query parameter(s)
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20%2019:20:30.000000&date_query=2013-10-20&string_query=string_query_example")
+        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19%3A20%3A30UTC-05%3A00&date_query=2013-10-20&string_query=string_query_example")
 
     def testDateTimeQueryWithString(self):
         api_instance = openapi_client.QueryApi()
@@ -60,7 +60,7 @@ class TestManual(unittest.TestCase):
         # Test query parameter(s)
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=19:20:30%202013-10-20&date_query=2013-10-20&string_query=string_query_example")
+        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=19%3A20%3A30%202013-10-20&date_query=2013-10-20&string_query=string_query_example")
 
 class EchoServerResponseParser():
     def __init__(self, http_response):

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -49,7 +49,7 @@ class TestManual(unittest.TestCase):
         # Test query parameter(s)
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19%3A20%3A30UTC-05%3A00&date_query=2013-10-20&string_query=string_query_example")
+        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19%3A20%3A30.000000-0500&date_query=2013-10-20&string_query=string_query_example")
 
     def testDateTimeQueryWithString(self):
         api_instance = openapi_client.QueryApi()

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -28,16 +28,28 @@ class TestManual(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def testDateTimeQueryWithDateTimeFormat(self):
+        api_instance = openapi_client.QueryApi()
+        api_instance.api_client.configuration.datetime_format = "%Y-%m-%d %a %H:%M:%S%Z"
+        datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30-05:00') # datetime |  (optional)
+        date_query = '2013-10-20' # date |  (optional)
+        string_query = 'string_query_example' # str |  (optional)
+
+        # Test query parameter(s)
+        api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
+        e = EchoServerResponseParser(api_response)
+        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20%20Sun%2019:20:30UTC-05:00&date_query=2013-10-20&string_query=string_query_example")
+
     def testDateTimeQueryWithDateTime(self):
         api_instance = openapi_client.QueryApi()
-        datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30+01:00') # datetime |  (optional)
+        datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30-05:00') # datetime |  (optional)
         date_query = '2013-10-20' # date |  (optional)
         string_query = 'string_query_example' # str |  (optional)
     
         # Test query parameter(s)
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19:20:30+01:00&date_query=2013-10-20&string_query=string_query_example")
+        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20%2019:20:30.000000&date_query=2013-10-20&string_query=string_query_example")
 
     def testDateTimeQueryWithString(self):
         api_instance = openapi_client.QueryApi()

--- a/samples/client/petstore/python-legacy/tests/test_pet_api.py
+++ b/samples/client/petstore/python-legacy/tests/test_pet_api.py
@@ -217,7 +217,8 @@ class PetApiTests(unittest.TestCase):
     def test_add_pet_and_get_pet_by_id(self):
         self.pet_api.add_pet(self.pet)
 
-        fetched = self.pet_api.get_pet_by_id(pet_id=self.pet.id)
+        import datetime
+        fetched = self.pet_api.get_pet_by_id(pet_id=self.pet.id, date_time_text_xyz=datetime.datetime(2010, 12, 25, 0, 0))
         self.assertIsNotNone(fetched)
         self.assertEqual(self.pet.id, fetched.id)
         self.assertIsNotNone(fetched.category)

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/another_fake_api.py
@@ -142,14 +142,11 @@ class AnotherFakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['client']:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/default_api.py
@@ -133,17 +133,13 @@ class DefaultApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
@@ -145,17 +145,13 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
@@ -305,7 +301,6 @@ class FakeApi(object):
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -442,14 +437,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -592,14 +584,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['outer_composite']:
@@ -742,14 +731,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -892,14 +878,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -1042,14 +1025,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['outer_object_with_enum_property']:
@@ -1192,14 +1172,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -1336,14 +1313,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['file_schema_test_class']:
@@ -1488,11 +1462,9 @@ class FakeApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -1629,14 +1601,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['client']:
@@ -1783,20 +1752,21 @@ class FakeApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('date_time_query') is not None:  # noqa: E501
-            _query_params.append(('date_time_query', _params['date_time_query']))
+            if isinstance(_params['date_time_query'], datetime):
+                _query_params.append(('date_time_query', _params['date_time_query'].strftime(self.api_client.configuration.datetime_format)))
+            else:
+                _query_params.append(('date_time_query', _params['date_time_query']))
+
         if _params.get('str_query') is not None:  # noqa: E501
             _query_params.append(('str_query', _params['str_query']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -1986,45 +1956,55 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['integer']:
             _form_params.append(('integer', _params['integer']))
+
         if _params['int32']:
             _form_params.append(('int32', _params['int32']))
+
         if _params['int64']:
             _form_params.append(('int64', _params['int64']))
+
         if _params['number']:
             _form_params.append(('number', _params['number']))
+
         if _params['float']:
             _form_params.append(('float', _params['float']))
+
         if _params['double']:
             _form_params.append(('double', _params['double']))
+
         if _params['string']:
             _form_params.append(('string', _params['string']))
+
         if _params['pattern_without_delimiter']:
             _form_params.append(('pattern_without_delimiter', _params['pattern_without_delimiter']))
+
         if _params['byte']:
             _form_params.append(('byte', _params['byte']))
+
         if _params['binary']:
             _files['binary'] = _params['binary']
+
         if _params['var_date']:
             _form_params.append(('date', _params['var_date']))
+
         if _params['date_time']:
             _form_params.append(('dateTime', _params['date_time']))
+
         if _params['password']:
             _form_params.append(('password', _params['password']))
+
         if _params['param_callback']:
             _form_params.append(('callback', _params['param_callback']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Content-Type`
         _content_types_list = _params.get('_content_type',
             self.api_client.select_header_content_type(
@@ -2183,10 +2163,13 @@ class FakeApi(object):
         _query_params = []
         if _params.get('required_string_group') is not None:  # noqa: E501
             _query_params.append(('required_string_group', _params['required_string_group']))
+
         if _params.get('required_int64_group') is not None:  # noqa: E501
             _query_params.append(('required_int64_group', _params['required_int64_group']))
+
         if _params.get('string_group') is not None:  # noqa: E501
             _query_params.append(('string_group', _params['string_group']))
+
         if _params.get('int64_group') is not None:  # noqa: E501
             _query_params.append(('int64_group', _params['int64_group']))
 
@@ -2194,16 +2177,15 @@ class FakeApi(object):
         _header_params = dict(_params.get('_headers', {}))
         if _params['required_boolean_group']:
             _header_params['required_boolean_group'] = _params['required_boolean_group']
+
         if _params['boolean_group']:
             _header_params['boolean_group'] = _params['boolean_group']
 
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = ['bearer_test']  # noqa: E501
 
@@ -2328,14 +2310,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['request_body']:
@@ -2477,21 +2456,19 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['param']:
             _form_params.append(('param', _params['param']))
+
         if _params['param2']:
             _form_params.append(('param2', _params['param2']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Content-Type`
         _content_types_list = _params.get('_content_type',
             self.api_client.select_header_content_type(
@@ -2656,33 +2633,36 @@ class FakeApi(object):
         if _params.get('pipe') is not None:  # noqa: E501
             _query_params.append(('pipe', _params['pipe']))
             _collection_formats['pipe'] = 'pipes'
+
         if _params.get('ioutil') is not None:  # noqa: E501
             _query_params.append(('ioutil', _params['ioutil']))
             _collection_formats['ioutil'] = 'csv'
+
         if _params.get('http') is not None:  # noqa: E501
             _query_params.append(('http', _params['http']))
             _collection_formats['http'] = 'ssv'
+
         if _params.get('url') is not None:  # noqa: E501
             _query_params.append(('url', _params['url']))
             _collection_formats['url'] = 'csv'
+
         if _params.get('context') is not None:  # noqa: E501
             _query_params.append(('context', _params['context']))
             _collection_formats['context'] = 'multi'
+
         if _params.get('language') is not None:  # noqa: E501
             _query_params.append(('language', _params['language']))
+
         if _params.get('allow_empty') is not None:  # noqa: E501
             _query_params.append(('allowEmpty', _params['allow_empty']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -142,14 +142,11 @@ class FakeClassnameTags123Api(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['client']:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
@@ -145,14 +145,11 @@ class PetApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -294,9 +291,9 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
         if _params['api_key']:
@@ -305,10 +302,8 @@ class PetApi(object):
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = ['petstore_auth']  # noqa: E501
 
@@ -439,14 +434,11 @@ class PetApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -584,14 +576,11 @@ class PetApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -723,19 +712,16 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -868,14 +854,11 @@ class PetApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -1022,23 +1005,22 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['name']:
             _form_params.append(('name', _params['name']))
+
         if _params['status']:
             _form_params.append(('status', _params['status']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Content-Type`
         _content_types_list = _params.get('_content_type',
             self.api_client.select_header_content_type(
@@ -1180,23 +1162,22 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['additional_metadata']:
             _form_params.append(('additionalMetadata', _params['additional_metadata']))
+
         if _params['file']:
             _files['file'] = _params['file']
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
@@ -1344,23 +1325,22 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['additional_metadata']:
             _form_params.append(('additionalMetadata', _params['additional_metadata']))
+
         if _params['required_file']:
             _files['requiredFile'] = _params['required_file']
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/store_api.py
@@ -144,19 +144,16 @@ class StoreApi(object):
         if _params['order_id']:
             _path_params['order_id'] = _params['order_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -276,17 +273,13 @@ class StoreApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
@@ -417,19 +410,16 @@ class StoreApi(object):
         if _params['order_id']:
             _path_params['order_id'] = _params['order_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -562,14 +552,11 @@ class StoreApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['order']:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/user_api.py
@@ -158,14 +158,11 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -303,14 +300,11 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -447,14 +441,11 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -591,19 +582,16 @@ class UserApi(object):
         if _params['username']:
             _path_params['username'] = _params['username']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -728,19 +716,16 @@ class UserApi(object):
         if _params['username']:
             _path_params['username'] = _params['username']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -880,19 +865,17 @@ class UserApi(object):
         _query_params = []
         if _params.get('username') is not None:  # noqa: E501
             _query_params.append(('username', _params['username']))
+
         if _params.get('password') is not None:  # noqa: E501
             _query_params.append(('password', _params['password']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -1019,17 +1002,13 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -1159,16 +1138,14 @@ class UserApi(object):
         if _params['username']:
             _path_params['username'] = _params['username']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api_client.py
@@ -543,7 +543,7 @@ class ApiClient(object):
                     new_params.append(
                         (k, delimiter.join(quote(str(value)) for value in v)))
             else:
-                new_params.append((k, v))
+                new_params.append((k, quote(str(v))))
 
         return "&".join(["=".join(item) for item in new_params])
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
@@ -256,7 +256,7 @@ conf = petstore_api.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
-        self.datetime_format = "%Y-%m-%d %H:%M:%S.%f"
+        self.datetime_format = "%Y-%m-%dT%H:%M:%S%Z"
         """datetime format
         """
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
@@ -256,6 +256,14 @@ conf = petstore_api.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
+        self.datetime_format = "%Y-%m-%d %H:%M:%S.%f"
+        """datetime format
+        """
+
+        self.date_format = "%Y-%m-%d"
+        """date format
+        """
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         result = cls.__new__(cls)

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
@@ -256,7 +256,7 @@ conf = petstore_api.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
-        self.datetime_format = "%Y-%m-%dT%H:%M:%S%Z"
+        self.datetime_format = "%Y-%m-%dT%H:%M:%S.%f%z"
         """datetime format
         """
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/another_fake_api.py
@@ -142,14 +142,11 @@ class AnotherFakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['client']:

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/default_api.py
@@ -133,17 +133,13 @@ class DefaultApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_api.py
@@ -145,17 +145,13 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
@@ -305,7 +301,6 @@ class FakeApi(object):
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -442,14 +437,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -592,14 +584,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['outer_composite']:
@@ -742,14 +731,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -892,14 +878,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -1042,14 +1025,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['outer_object_with_enum_property']:
@@ -1192,14 +1172,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['body']:
@@ -1336,14 +1313,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['file_schema_test_class']:
@@ -1488,11 +1462,9 @@ class FakeApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -1629,14 +1601,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['client']:
@@ -1783,20 +1752,21 @@ class FakeApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('date_time_query') is not None:  # noqa: E501
-            _query_params.append(('date_time_query', _params['date_time_query']))
+            if isinstance(_params['date_time_query'], datetime):
+                _query_params.append(('date_time_query', _params['date_time_query'].strftime(self.api_client.configuration.datetime_format)))
+            else:
+                _query_params.append(('date_time_query', _params['date_time_query']))
+
         if _params.get('str_query') is not None:  # noqa: E501
             _query_params.append(('str_query', _params['str_query']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -1986,45 +1956,55 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['integer']:
             _form_params.append(('integer', _params['integer']))
+
         if _params['int32']:
             _form_params.append(('int32', _params['int32']))
+
         if _params['int64']:
             _form_params.append(('int64', _params['int64']))
+
         if _params['number']:
             _form_params.append(('number', _params['number']))
+
         if _params['float']:
             _form_params.append(('float', _params['float']))
+
         if _params['double']:
             _form_params.append(('double', _params['double']))
+
         if _params['string']:
             _form_params.append(('string', _params['string']))
+
         if _params['pattern_without_delimiter']:
             _form_params.append(('pattern_without_delimiter', _params['pattern_without_delimiter']))
+
         if _params['byte']:
             _form_params.append(('byte', _params['byte']))
+
         if _params['binary']:
             _files['binary'] = _params['binary']
+
         if _params['var_date']:
             _form_params.append(('date', _params['var_date']))
+
         if _params['date_time']:
             _form_params.append(('dateTime', _params['date_time']))
+
         if _params['password']:
             _form_params.append(('password', _params['password']))
+
         if _params['param_callback']:
             _form_params.append(('callback', _params['param_callback']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Content-Type`
         _content_types_list = _params.get('_content_type',
             self.api_client.select_header_content_type(
@@ -2183,10 +2163,13 @@ class FakeApi(object):
         _query_params = []
         if _params.get('required_string_group') is not None:  # noqa: E501
             _query_params.append(('required_string_group', _params['required_string_group']))
+
         if _params.get('required_int64_group') is not None:  # noqa: E501
             _query_params.append(('required_int64_group', _params['required_int64_group']))
+
         if _params.get('string_group') is not None:  # noqa: E501
             _query_params.append(('string_group', _params['string_group']))
+
         if _params.get('int64_group') is not None:  # noqa: E501
             _query_params.append(('int64_group', _params['int64_group']))
 
@@ -2194,16 +2177,15 @@ class FakeApi(object):
         _header_params = dict(_params.get('_headers', {}))
         if _params['required_boolean_group']:
             _header_params['required_boolean_group'] = _params['required_boolean_group']
+
         if _params['boolean_group']:
             _header_params['boolean_group'] = _params['boolean_group']
 
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = ['bearer_test']  # noqa: E501
 
@@ -2328,14 +2310,11 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['request_body']:
@@ -2477,21 +2456,19 @@ class FakeApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['param']:
             _form_params.append(('param', _params['param']))
+
         if _params['param2']:
             _form_params.append(('param2', _params['param2']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Content-Type`
         _content_types_list = _params.get('_content_type',
             self.api_client.select_header_content_type(
@@ -2656,33 +2633,36 @@ class FakeApi(object):
         if _params.get('pipe') is not None:  # noqa: E501
             _query_params.append(('pipe', _params['pipe']))
             _collection_formats['pipe'] = 'pipes'
+
         if _params.get('ioutil') is not None:  # noqa: E501
             _query_params.append(('ioutil', _params['ioutil']))
             _collection_formats['ioutil'] = 'csv'
+
         if _params.get('http') is not None:  # noqa: E501
             _query_params.append(('http', _params['http']))
             _collection_formats['http'] = 'ssv'
+
         if _params.get('url') is not None:  # noqa: E501
             _query_params.append(('url', _params['url']))
             _collection_formats['url'] = 'csv'
+
         if _params.get('context') is not None:  # noqa: E501
             _query_params.append(('context', _params['context']))
             _collection_formats['context'] = 'multi'
+
         if _params.get('language') is not None:  # noqa: E501
             _query_params.append(('language', _params['language']))
+
         if _params.get('allow_empty') is not None:  # noqa: E501
             _query_params.append(('allowEmpty', _params['allow_empty']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_classname_tags123_api.py
@@ -142,14 +142,11 @@ class FakeClassnameTags123Api(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['client']:

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/pet_api.py
@@ -145,14 +145,11 @@ class PetApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -294,9 +291,9 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
         if _params['api_key']:
@@ -305,10 +302,8 @@ class PetApi(object):
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = ['petstore_auth']  # noqa: E501
 
@@ -439,14 +434,11 @@ class PetApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -584,14 +576,11 @@ class PetApi(object):
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -723,19 +712,16 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -868,14 +854,11 @@ class PetApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['pet']:
@@ -1022,23 +1005,22 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['name']:
             _form_params.append(('name', _params['name']))
+
         if _params['status']:
             _form_params.append(('status', _params['status']))
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Content-Type`
         _content_types_list = _params.get('_content_type',
             self.api_client.select_header_content_type(
@@ -1180,23 +1162,22 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['additional_metadata']:
             _form_params.append(('additionalMetadata', _params['additional_metadata']))
+
         if _params['file']:
             _files['file'] = _params['file']
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
@@ -1344,23 +1325,22 @@ class PetApi(object):
         if _params['pet_id']:
             _path_params['petId'] = _params['pet_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
         if _params['additional_metadata']:
             _form_params.append(('additionalMetadata', _params['additional_metadata']))
+
         if _params['required_file']:
             _files['requiredFile'] = _params['required_file']
 
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/store_api.py
@@ -144,19 +144,16 @@ class StoreApi(object):
         if _params['order_id']:
             _path_params['order_id'] = _params['order_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -276,17 +273,13 @@ class StoreApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/json'])  # noqa: E501
@@ -417,19 +410,16 @@ class StoreApi(object):
         if _params['order_id']:
             _path_params['order_id'] = _params['order_id']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -562,14 +552,11 @@ class StoreApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['order']:

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/user_api.py
@@ -158,14 +158,11 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -303,14 +300,11 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -447,14 +441,11 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:
@@ -591,19 +582,16 @@ class UserApi(object):
         if _params['username']:
             _path_params['username'] = _params['username']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -728,19 +716,16 @@ class UserApi(object):
         if _params['username']:
             _path_params['username'] = _params['username']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -880,19 +865,17 @@ class UserApi(object):
         _query_params = []
         if _params.get('username') is not None:  # noqa: E501
             _query_params.append(('username', _params['username']))
+
         if _params.get('password') is not None:  # noqa: E501
             _query_params.append(('password', _params['password']))
 
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # set the HTTP header `Accept`
         _header_params['Accept'] = self.api_client.select_header_accept(
             ['application/xml', 'application/json'])  # noqa: E501
@@ -1019,17 +1002,13 @@ class UserApi(object):
 
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
-
         # authentication setting
         _auth_settings = []  # noqa: E501
 
@@ -1159,16 +1138,14 @@ class UserApi(object):
         if _params['username']:
             _path_params['username'] = _params['username']
 
+
         # process the query parameters
         _query_params = []
-
         # process the header parameters
         _header_params = dict(_params.get('_headers', {}))
-
         # process the form parameters
         _form_params = []
         _files = {}
-
         # process the body parameter
         _body_params = None
         if _params['user']:

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api_client.py
@@ -542,7 +542,7 @@ class ApiClient(object):
                     new_params.append(
                         (k, delimiter.join(quote(str(value)) for value in v)))
             else:
-                new_params.append((k, v))
+                new_params.append((k, quote(str(v))))
 
         return "&".join(["=".join(item) for item in new_params])
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
@@ -260,7 +260,7 @@ conf = petstore_api.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
-        self.datetime_format = "%Y-%m-%dT%H:%M:%S%Z"
+        self.datetime_format = "%Y-%m-%dT%H:%M:%S.%f%z"
         """datetime format
         """
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
@@ -260,7 +260,7 @@ conf = petstore_api.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
-        self.datetime_format = "%Y-%m-%d %H:%M:%S.%f"
+        self.datetime_format = "%Y-%m-%dT%H:%M:%S%Z"
         """datetime format
         """
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
@@ -260,6 +260,14 @@ conf = petstore_api.Configuration(
         """Options to pass down to the underlying urllib3 socket
         """
 
+        self.datetime_format = "%Y-%m-%d %H:%M:%S.%f"
+        """datetime format
+        """
+
+        self.date_format = "%Y-%m-%d"
+        """date format
+        """
+
     def __deepcopy__(self, memo):
         cls = self.__class__
         result = cls.__new__(cls)


### PR DESCRIPTION
- Add datetime, date format support in python nextgen via 2 additional options: `datetimeFormat`, `dateFormat`
- default to `isoformat` to make it backward compatible with python-legacy


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)
