### PR TITLE
Better handling of x-nullable in codegen property

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3877,8 +3877,12 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
 
+        // set isNullable using nullable or x-nullable in the schema
         if (referencedSchema.getNullable() != null) {
             property.isNullable = referencedSchema.getNullable();
+        } else if (referencedSchema.getExtensions() != null &&
+                referencedSchema.getExtensions().containsKey("x-nullable")) {
+            //property.isNullable = (Boolean) referencedSchema.getExtensions().get("x-nullable");
         }
 
         property.dataType = getTypeDeclaration(p);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3882,7 +3882,7 @@ public class DefaultCodegen implements CodegenConfig {
             property.isNullable = referencedSchema.getNullable();
         } else if (referencedSchema.getExtensions() != null &&
                 referencedSchema.getExtensions().containsKey("x-nullable")) {
-            //property.isNullable = (Boolean) referencedSchema.getExtensions().get("x-nullable");
+            property.isNullable = (Boolean) referencedSchema.getExtensions().get("x-nullable");
         }
 
         property.dataType = getTypeDeclaration(p);

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -451,6 +451,11 @@ components:
           type: array
           items:
             type: string
+        array_string_extension_nullable:
+          x-nullable: true
+          type: array
+          items:
+            type: string
         string_nullable:
           type: string
           nullable: true

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -466,6 +466,11 @@ components:
             type: string
           nullable: true
           type: array
+        array_string_extension_nullable:
+          items:
+            type: string
+          type: array
+          x-nullable: true
         string_nullable:
           nullable: true
           type: string

--- a/samples/client/echo_api/java/apache-httpclient/docs/DefaultValue.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/DefaultValue.md
@@ -14,6 +14,7 @@ to test the default value of properties
 |**arrayIntegerDefault** | **List&lt;Integer&gt;** |  |  [optional] |
 |**arrayString** | **List&lt;String&gt;** |  |  [optional] |
 |**arrayStringNullable** | **List&lt;String&gt;** |  |  [optional] |
+|**arrayStringExtensionNullable** | **List&lt;String&gt;** |  |  [optional] |
 |**stringNullable** | **String** |  |  [optional] |
 
 

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/model/DefaultValue.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/model/DefaultValue.java
@@ -43,6 +43,7 @@ import java.util.StringJoiner;
   DefaultValue.JSON_PROPERTY_ARRAY_INTEGER_DEFAULT,
   DefaultValue.JSON_PROPERTY_ARRAY_STRING,
   DefaultValue.JSON_PROPERTY_ARRAY_STRING_NULLABLE,
+  DefaultValue.JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE,
   DefaultValue.JSON_PROPERTY_STRING_NULLABLE
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -101,6 +102,9 @@ public class DefaultValue {
 
   public static final String JSON_PROPERTY_ARRAY_STRING_NULLABLE = "array_string_nullable";
   private JsonNullable<List<String>> arrayStringNullable = JsonNullable.<List<String>>undefined();
+
+  public static final String JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE = "array_string_extension_nullable";
+  private JsonNullable<List<String>> arrayStringExtensionNullable = JsonNullable.<List<String>>undefined();
 
   public static final String JSON_PROPERTY_STRING_NULLABLE = "string_nullable";
   private JsonNullable<String> stringNullable = JsonNullable.<String>undefined();
@@ -324,6 +328,52 @@ public class DefaultValue {
   }
 
 
+  public DefaultValue arrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = JsonNullable.<List<String>>of(arrayStringExtensionNullable);
+    
+    return this;
+  }
+
+  public DefaultValue addArrayStringExtensionNullableItem(String arrayStringExtensionNullableItem) {
+    if (this.arrayStringExtensionNullable == null || !this.arrayStringExtensionNullable.isPresent()) {
+      this.arrayStringExtensionNullable = JsonNullable.<List<String>>of(new ArrayList<>());
+    }
+    try {
+      this.arrayStringExtensionNullable.get().add(arrayStringExtensionNullableItem);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+  }
+
+   /**
+   * Get arrayStringExtensionNullable
+   * @return arrayStringExtensionNullable
+  **/
+  @javax.annotation.Nullable
+  @JsonIgnore
+
+  public List<String> getArrayStringExtensionNullable() {
+        return arrayStringExtensionNullable.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public JsonNullable<List<String>> getArrayStringExtensionNullable_JsonNullable() {
+    return arrayStringExtensionNullable;
+  }
+  
+  @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
+  public void setArrayStringExtensionNullable_JsonNullable(JsonNullable<List<String>> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+  }
+
+  public void setArrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = JsonNullable.<List<String>>of(arrayStringExtensionNullable);
+  }
+
+
   public DefaultValue stringNullable(String stringNullable) {
     this.stringNullable = JsonNullable.<String>of(stringNullable);
     
@@ -373,6 +423,7 @@ public class DefaultValue {
         Objects.equals(this.arrayIntegerDefault, defaultValue.arrayIntegerDefault) &&
         Objects.equals(this.arrayString, defaultValue.arrayString) &&
         equalsNullable(this.arrayStringNullable, defaultValue.arrayStringNullable) &&
+        equalsNullable(this.arrayStringExtensionNullable, defaultValue.arrayStringExtensionNullable) &&
         equalsNullable(this.stringNullable, defaultValue.stringNullable);
   }
 
@@ -382,7 +433,7 @@ public class DefaultValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, hashCodeNullable(arrayStringNullable), hashCodeNullable(stringNullable));
+    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, hashCodeNullable(arrayStringNullable), hashCodeNullable(arrayStringExtensionNullable), hashCodeNullable(stringNullable));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -402,6 +453,7 @@ public class DefaultValue {
     sb.append("    arrayIntegerDefault: ").append(toIndentedString(arrayIntegerDefault)).append("\n");
     sb.append("    arrayString: ").append(toIndentedString(arrayString)).append("\n");
     sb.append("    arrayStringNullable: ").append(toIndentedString(arrayStringNullable)).append("\n");
+    sb.append("    arrayStringExtensionNullable: ").append(toIndentedString(arrayStringExtensionNullable)).append("\n");
     sb.append("    stringNullable: ").append(toIndentedString(stringNullable)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -529,6 +581,20 @@ public class DefaultValue {
           joiner.add(String.format("%sarray_string_nullable%s%s=%s", prefix, suffix,
               "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
               URLEncoder.encode(String.valueOf(getArrayStringNullable().get(i)), "UTF-8").replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    // add `array_string_extension_nullable` to the URL query string
+    if (getArrayStringExtensionNullable() != null) {
+      for (int i = 0; i < getArrayStringExtensionNullable().size(); i++) {
+        try {
+          joiner.add(String.format("%sarray_string_extension_nullable%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(getArrayStringExtensionNullable().get(i)), "UTF-8").replaceAll("\\+", "%20")));
         } catch (UnsupportedEncodingException e) {
           // Should never happen, UTF-8 is always supported
           throw new RuntimeException(e);

--- a/samples/client/echo_api/java/apache-httpclient/src/test/java/org/openapitools/client/CustomTest.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/test/java/org/openapitools/client/CustomTest.java
@@ -220,7 +220,7 @@ public class CustomTest {
         Assert.assertNull(d.getArrayStringNullable());
         Assert.assertEquals(d.getArrayString().size(), 0);
 
-        Assert.assertEquals(apiClient.getObjectMapper().writeValueAsString(d), "{\"array_string_enum_ref_default\":[\"success\",\"failure\"],\"array_string_enum_default\":[\"success\",\"failure\"],\"array_string_default\":[\"failure\",\"skipped\"],\"array_integer_default\":[1,3],\"array_string\":[],\"array_string_nullable\":{\"present\":false},\"string_nullable\":{\"present\":false}}");
+        Assert.assertEquals(apiClient.getObjectMapper().writeValueAsString(d), "{\"array_string_enum_ref_default\":[\"success\",\"failure\"],\"array_string_enum_default\":[\"success\",\"failure\"],\"array_string_default\":[\"failure\",\"skipped\"],\"array_integer_default\":[1,3],\"array_string\":[],\"array_string_nullable\":{\"present\":false},\"array_string_extension_nullable\":{\"present\":false},\"string_nullable\":{\"present\":false}}");
     }
 
     @Test
@@ -248,7 +248,7 @@ public class CustomTest {
         Assert.assertNull(d.getArrayStringNullable());
         Assert.assertEquals(d.getArrayString().size(), 0);
 
-        Assert.assertEquals(apiClient.getObjectMapper().writeValueAsString(d), "{\"array_string_enum_ref_default\":[\"unclassified\"],\"array_string_enum_default\":[\"unclassified\"],\"array_string_default\":[\"failure\"],\"array_integer_default\":[1,3],\"array_string\":[],\"array_string_nullable\":{\"present\":false},\"string_nullable\":{\"present\":false}}");
+        Assert.assertEquals(apiClient.getObjectMapper().writeValueAsString(d), "{\"array_string_enum_ref_default\":[\"unclassified\"],\"array_string_enum_default\":[\"unclassified\"],\"array_string_default\":[\"failure\"],\"array_integer_default\":[1,3],\"array_string\":[],\"array_string_nullable\":{\"present\":false},\"array_string_extension_nullable\":{\"present\":false},\"string_nullable\":{\"present\":false}}");
     }
 
     @Test

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -466,6 +466,11 @@ components:
             type: string
           nullable: true
           type: array
+        array_string_extension_nullable:
+          items:
+            type: string
+          type: array
+          x-nullable: true
         string_nullable:
           nullable: true
           type: string

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/model/DefaultValue.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/model/DefaultValue.java
@@ -104,6 +104,10 @@ public class DefaultValue {
   @SerializedName(SERIALIZED_NAME_ARRAY_STRING_NULLABLE)
   private List<String> arrayStringNullable;
 
+  public static final String SERIALIZED_NAME_ARRAY_STRING_EXTENSION_NULLABLE = "array_string_extension_nullable";
+  @SerializedName(SERIALIZED_NAME_ARRAY_STRING_EXTENSION_NULLABLE)
+  private List<String> arrayStringExtensionNullable;
+
   public static final String SERIALIZED_NAME_STRING_NULLABLE = "string_nullable";
   @SerializedName(SERIALIZED_NAME_STRING_NULLABLE)
   private String stringNullable;
@@ -288,6 +292,33 @@ public class DefaultValue {
   }
 
 
+  public DefaultValue arrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+    return this;
+  }
+
+  public DefaultValue addArrayStringExtensionNullableItem(String arrayStringExtensionNullableItem) {
+    this.arrayStringExtensionNullable.add(arrayStringExtensionNullableItem);
+    return this;
+  }
+
+   /**
+   * Get arrayStringExtensionNullable
+   * @return arrayStringExtensionNullable
+  **/
+  @javax.annotation.Nullable
+
+  public List<String> getArrayStringExtensionNullable() {
+    return arrayStringExtensionNullable;
+  }
+
+
+  public void setArrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+  }
+
+
   public DefaultValue stringNullable(String stringNullable) {
     
     this.stringNullable = stringNullable;
@@ -325,6 +356,7 @@ public class DefaultValue {
         Objects.equals(this.arrayIntegerDefault, defaultValue.arrayIntegerDefault) &&
         Objects.equals(this.arrayString, defaultValue.arrayString) &&
         Objects.equals(this.arrayStringNullable, defaultValue.arrayStringNullable) &&
+        Objects.equals(this.arrayStringExtensionNullable, defaultValue.arrayStringExtensionNullable) &&
         Objects.equals(this.stringNullable, defaultValue.stringNullable);
   }
 
@@ -334,7 +366,7 @@ public class DefaultValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, arrayStringNullable, stringNullable);
+    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, arrayStringNullable, arrayStringExtensionNullable, stringNullable);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -354,6 +386,7 @@ public class DefaultValue {
     sb.append("    arrayIntegerDefault: ").append(toIndentedString(arrayIntegerDefault)).append("\n");
     sb.append("    arrayString: ").append(toIndentedString(arrayString)).append("\n");
     sb.append("    arrayStringNullable: ").append(toIndentedString(arrayStringNullable)).append("\n");
+    sb.append("    arrayStringExtensionNullable: ").append(toIndentedString(arrayStringExtensionNullable)).append("\n");
     sb.append("    stringNullable: ").append(toIndentedString(stringNullable)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -466,6 +466,11 @@ components:
             type: string
           nullable: true
           type: array
+        array_string_extension_nullable:
+          items:
+            type: string
+          type: array
+          x-nullable: true
         string_nullable:
           nullable: true
           type: string

--- a/samples/client/echo_api/java/native/docs/DefaultValue.md
+++ b/samples/client/echo_api/java/native/docs/DefaultValue.md
@@ -14,6 +14,7 @@ to test the default value of properties
 |**arrayIntegerDefault** | **List&lt;Integer&gt;** |  |  [optional] |
 |**arrayString** | **List&lt;String&gt;** |  |  [optional] |
 |**arrayStringNullable** | **List&lt;String&gt;** |  |  [optional] |
+|**arrayStringExtensionNullable** | **List&lt;String&gt;** |  |  [optional] |
 |**stringNullable** | **String** |  |  [optional] |
 
 

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/model/DefaultValue.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/model/DefaultValue.java
@@ -106,7 +106,7 @@ public class DefaultValue {
   private JsonNullable<List<String>> arrayStringNullable = JsonNullable.<List<String>>undefined();
 
   public static final String JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE = "array_string_extension_nullable";
-  private List<String> arrayStringExtensionNullable = new ArrayList<>();
+  private JsonNullable<List<String>> arrayStringExtensionNullable = JsonNullable.<List<String>>undefined();
 
   public static final String JSON_PROPERTY_STRING_NULLABLE = "string_nullable";
   private JsonNullable<String> stringNullable = JsonNullable.<String>undefined();
@@ -325,15 +325,19 @@ public class DefaultValue {
 
 
   public DefaultValue arrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
-    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+    this.arrayStringExtensionNullable = JsonNullable.<List<String>>of(arrayStringExtensionNullable);
     return this;
   }
 
   public DefaultValue addArrayStringExtensionNullableItem(String arrayStringExtensionNullableItem) {
-    if (this.arrayStringExtensionNullable == null) {
-      this.arrayStringExtensionNullable = new ArrayList<>();
+    if (this.arrayStringExtensionNullable == null || !this.arrayStringExtensionNullable.isPresent()) {
+      this.arrayStringExtensionNullable = JsonNullable.<List<String>>of(new ArrayList<>());
     }
-    this.arrayStringExtensionNullable.add(arrayStringExtensionNullableItem);
+    try {
+      this.arrayStringExtensionNullable.get().add(arrayStringExtensionNullableItem);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
     return this;
   }
 
@@ -342,18 +346,26 @@ public class DefaultValue {
    * @return arrayStringExtensionNullable
   **/
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonIgnore
 
   public List<String> getArrayStringExtensionNullable() {
-    return arrayStringExtensionNullable;
+        return arrayStringExtensionNullable.orElse(null);
   }
-
 
   @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setArrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+
+  public JsonNullable<List<String>> getArrayStringExtensionNullable_JsonNullable() {
+    return arrayStringExtensionNullable;
+  }
+  
+  @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
+  public void setArrayStringExtensionNullable_JsonNullable(JsonNullable<List<String>> arrayStringExtensionNullable) {
     this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+  }
+
+  public void setArrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = JsonNullable.<List<String>>of(arrayStringExtensionNullable);
   }
 
 
@@ -408,7 +420,7 @@ public class DefaultValue {
         Objects.equals(this.arrayIntegerDefault, defaultValue.arrayIntegerDefault) &&
         Objects.equals(this.arrayString, defaultValue.arrayString) &&
         equalsNullable(this.arrayStringNullable, defaultValue.arrayStringNullable) &&
-        Objects.equals(this.arrayStringExtensionNullable, defaultValue.arrayStringExtensionNullable) &&
+        equalsNullable(this.arrayStringExtensionNullable, defaultValue.arrayStringExtensionNullable) &&
         equalsNullable(this.stringNullable, defaultValue.stringNullable);
   }
 
@@ -418,7 +430,7 @@ public class DefaultValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, hashCodeNullable(arrayStringNullable), arrayStringExtensionNullable, hashCodeNullable(stringNullable));
+    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, hashCodeNullable(arrayStringNullable), hashCodeNullable(arrayStringExtensionNullable), hashCodeNullable(stringNullable));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/model/DefaultValue.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/model/DefaultValue.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   DefaultValue.JSON_PROPERTY_ARRAY_INTEGER_DEFAULT,
   DefaultValue.JSON_PROPERTY_ARRAY_STRING,
   DefaultValue.JSON_PROPERTY_ARRAY_STRING_NULLABLE,
+  DefaultValue.JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE,
   DefaultValue.JSON_PROPERTY_STRING_NULLABLE
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -103,6 +104,9 @@ public class DefaultValue {
 
   public static final String JSON_PROPERTY_ARRAY_STRING_NULLABLE = "array_string_nullable";
   private JsonNullable<List<String>> arrayStringNullable = JsonNullable.<List<String>>undefined();
+
+  public static final String JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE = "array_string_extension_nullable";
+  private List<String> arrayStringExtensionNullable = new ArrayList<>();
 
   public static final String JSON_PROPERTY_STRING_NULLABLE = "string_nullable";
   private JsonNullable<String> stringNullable = JsonNullable.<String>undefined();
@@ -320,6 +324,39 @@ public class DefaultValue {
   }
 
 
+  public DefaultValue arrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+    return this;
+  }
+
+  public DefaultValue addArrayStringExtensionNullableItem(String arrayStringExtensionNullableItem) {
+    if (this.arrayStringExtensionNullable == null) {
+      this.arrayStringExtensionNullable = new ArrayList<>();
+    }
+    this.arrayStringExtensionNullable.add(arrayStringExtensionNullableItem);
+    return this;
+  }
+
+   /**
+   * Get arrayStringExtensionNullable
+   * @return arrayStringExtensionNullable
+  **/
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<String> getArrayStringExtensionNullable() {
+    return arrayStringExtensionNullable;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ARRAY_STRING_EXTENSION_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setArrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+  }
+
+
   public DefaultValue stringNullable(String stringNullable) {
     this.stringNullable = JsonNullable.<String>of(stringNullable);
     return this;
@@ -371,6 +408,7 @@ public class DefaultValue {
         Objects.equals(this.arrayIntegerDefault, defaultValue.arrayIntegerDefault) &&
         Objects.equals(this.arrayString, defaultValue.arrayString) &&
         equalsNullable(this.arrayStringNullable, defaultValue.arrayStringNullable) &&
+        Objects.equals(this.arrayStringExtensionNullable, defaultValue.arrayStringExtensionNullable) &&
         equalsNullable(this.stringNullable, defaultValue.stringNullable);
   }
 
@@ -380,7 +418,7 @@ public class DefaultValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, hashCodeNullable(arrayStringNullable), hashCodeNullable(stringNullable));
+    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, hashCodeNullable(arrayStringNullable), arrayStringExtensionNullable, hashCodeNullable(stringNullable));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -400,6 +438,7 @@ public class DefaultValue {
     sb.append("    arrayIntegerDefault: ").append(toIndentedString(arrayIntegerDefault)).append("\n");
     sb.append("    arrayString: ").append(toIndentedString(arrayString)).append("\n");
     sb.append("    arrayStringNullable: ").append(toIndentedString(arrayStringNullable)).append("\n");
+    sb.append("    arrayStringExtensionNullable: ").append(toIndentedString(arrayStringExtensionNullable)).append("\n");
     sb.append("    stringNullable: ").append(toIndentedString(stringNullable)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -501,6 +540,15 @@ public class DefaultValue {
         joiner.add(String.format("%sarray_string_nullable%s%s=%s", prefix, suffix,
             "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
             URLEncoder.encode(String.valueOf(getArrayStringNullable().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+      }
+    }
+
+    // add `array_string_extension_nullable` to the URL query string
+    if (getArrayStringExtensionNullable() != null) {
+      for (int i = 0; i < getArrayStringExtensionNullable().size(); i++) {
+        joiner.add(String.format("%sarray_string_extension_nullable%s%s=%s", prefix, suffix,
+            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+            URLEncoder.encode(String.valueOf(getArrayStringExtensionNullable().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
       }
     }
 

--- a/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/CustomTest.java
+++ b/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/CustomTest.java
@@ -167,7 +167,9 @@ public class CustomTest {
         Assert.assertEquals(d.getArrayIntegerDefault().get(1), Integer.valueOf(3));
 
         Assert.assertNull(d.getArrayStringNullable());
+        Assert.assertNull(d.getArrayStringExtensionNullable());
         Assert.assertEquals(d.getArrayString().size(), 0);
+
 
         // test addItem
         d.addArrayStringEnumDefaultItem(DefaultValue.ArrayStringEnumDefaultEnum.UNCLASSIFIED);
@@ -209,6 +211,7 @@ public class CustomTest {
         Assert.assertEquals(d.getArrayIntegerDefault().get(1), Integer.valueOf(3));
 
         Assert.assertNull(d.getArrayStringNullable());
+        Assert.assertNull(d.getArrayStringExtensionNullable());
         Assert.assertEquals(d.getArrayString().size(), 0);
 
         Assert.assertEquals(apiClient.getObjectMapper().writeValueAsString(d), "{\"array_string_enum_ref_default\":[\"success\",\"failure\"],\"array_string_enum_default\":[\"success\",\"failure\"],\"array_string_default\":[\"failure\",\"skipped\"],\"array_integer_default\":[1,3],\"array_string\":[]}");
@@ -237,6 +240,7 @@ public class CustomTest {
         Assert.assertEquals(d.getArrayIntegerDefault().get(1), Integer.valueOf(3));
 
         Assert.assertNull(d.getArrayStringNullable());
+        Assert.assertNull(d.getArrayStringExtensionNullable());
         Assert.assertEquals(d.getArrayString().size(), 0);
 
         Assert.assertEquals(apiClient.getObjectMapper().writeValueAsString(d), "{\"array_string_enum_ref_default\":[\"unclassified\"],\"array_string_enum_default\":[\"unclassified\"],\"array_string_default\":[\"failure\"],\"array_integer_default\":[1,3],\"array_string\":[]}");

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -466,6 +466,11 @@ components:
             type: string
           nullable: true
           type: array
+        array_string_extension_nullable:
+          items:
+            type: string
+          type: array
+          x-nullable: true
         string_nullable:
           nullable: true
           type: string

--- a/samples/client/echo_api/java/okhttp-gson/docs/DefaultValue.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/DefaultValue.md
@@ -14,6 +14,7 @@ to test the default value of properties
 |**arrayIntegerDefault** | **List&lt;Integer&gt;** |  |  [optional] |
 |**arrayString** | **List&lt;String&gt;** |  |  [optional] |
 |**arrayStringNullable** | **List&lt;String&gt;** |  |  [optional] |
+|**arrayStringExtensionNullable** | **List&lt;String&gt;** |  |  [optional] |
 |**stringNullable** | **String** |  |  [optional] |
 
 

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/model/DefaultValue.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/model/DefaultValue.java
@@ -125,6 +125,10 @@ public class DefaultValue {
   @SerializedName(SERIALIZED_NAME_ARRAY_STRING_NULLABLE)
   private List<String> arrayStringNullable;
 
+  public static final String SERIALIZED_NAME_ARRAY_STRING_EXTENSION_NULLABLE = "array_string_extension_nullable";
+  @SerializedName(SERIALIZED_NAME_ARRAY_STRING_EXTENSION_NULLABLE)
+  private List<String> arrayStringExtensionNullable;
+
   public static final String SERIALIZED_NAME_STRING_NULLABLE = "string_nullable";
   @SerializedName(SERIALIZED_NAME_STRING_NULLABLE)
   private String stringNullable;
@@ -309,6 +313,33 @@ public class DefaultValue {
   }
 
 
+  public DefaultValue arrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+    return this;
+  }
+
+  public DefaultValue addArrayStringExtensionNullableItem(String arrayStringExtensionNullableItem) {
+    this.arrayStringExtensionNullable.add(arrayStringExtensionNullableItem);
+    return this;
+  }
+
+   /**
+   * Get arrayStringExtensionNullable
+   * @return arrayStringExtensionNullable
+  **/
+  @javax.annotation.Nullable
+
+  public List<String> getArrayStringExtensionNullable() {
+    return arrayStringExtensionNullable;
+  }
+
+
+  public void setArrayStringExtensionNullable(List<String> arrayStringExtensionNullable) {
+    this.arrayStringExtensionNullable = arrayStringExtensionNullable;
+  }
+
+
   public DefaultValue stringNullable(String stringNullable) {
     
     this.stringNullable = stringNullable;
@@ -347,6 +378,7 @@ public class DefaultValue {
         Objects.equals(this.arrayIntegerDefault, defaultValue.arrayIntegerDefault) &&
         Objects.equals(this.arrayString, defaultValue.arrayString) &&
         Objects.equals(this.arrayStringNullable, defaultValue.arrayStringNullable) &&
+        Objects.equals(this.arrayStringExtensionNullable, defaultValue.arrayStringExtensionNullable) &&
         Objects.equals(this.stringNullable, defaultValue.stringNullable);
   }
 
@@ -356,7 +388,7 @@ public class DefaultValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, arrayStringNullable, stringNullable);
+    return Objects.hash(arrayStringEnumRefDefault, arrayStringEnumDefault, arrayStringDefault, arrayIntegerDefault, arrayString, arrayStringNullable, arrayStringExtensionNullable, stringNullable);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -376,6 +408,7 @@ public class DefaultValue {
     sb.append("    arrayIntegerDefault: ").append(toIndentedString(arrayIntegerDefault)).append("\n");
     sb.append("    arrayString: ").append(toIndentedString(arrayString)).append("\n");
     sb.append("    arrayStringNullable: ").append(toIndentedString(arrayStringNullable)).append("\n");
+    sb.append("    arrayStringExtensionNullable: ").append(toIndentedString(arrayStringExtensionNullable)).append("\n");
     sb.append("    stringNullable: ").append(toIndentedString(stringNullable)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -405,6 +438,7 @@ public class DefaultValue {
     openapiFields.add("array_integer_default");
     openapiFields.add("array_string");
     openapiFields.add("array_string_nullable");
+    openapiFields.add("array_string_extension_nullable");
     openapiFields.add("string_nullable");
 
     // a set of required properties/fields (JSON key names)
@@ -454,6 +488,10 @@ public class DefaultValue {
       // ensure the optional json data is an array if present
       if (jsonObj.get("array_string_nullable") != null && !jsonObj.get("array_string_nullable").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `array_string_nullable` to be an array in the JSON string but got `%s`", jsonObj.get("array_string_nullable").toString()));
+      }
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("array_string_extension_nullable") != null && !jsonObj.get("array_string_extension_nullable").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field `array_string_extension_nullable` to be an array in the JSON string but got `%s`", jsonObj.get("array_string_extension_nullable").toString()));
       }
       if ((jsonObj.get("string_nullable") != null && !jsonObj.get("string_nullable").isJsonNull()) && !jsonObj.get("string_nullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `string_nullable` to be a primitive type in the JSON string but got `%s`", jsonObj.get("string_nullable").toString()));

--- a/samples/client/echo_api/python-nextgen/docs/DefaultValue.md
+++ b/samples/client/echo_api/python-nextgen/docs/DefaultValue.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **array_integer_default** | **List[int]** |  | [optional] [default to [1,3]]
 **array_string** | **List[str]** |  | [optional] 
 **array_string_nullable** | **List[str]** |  | [optional] 
+**array_string_extension_nullable** | **List[str]** |  | [optional] 
 **string_nullable** | **str** |  | [optional] 
 
 ## Example

--- a/samples/client/echo_api/python-nextgen/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/models/default_value.py
@@ -34,8 +34,9 @@ class DefaultValue(BaseModel):
     array_integer_default: Optional[List[StrictInt]] = None
     array_string: Optional[List[StrictStr]] = None
     array_string_nullable: Optional[List[StrictStr]] = None
+    array_string_extension_nullable: Optional[List[StrictStr]] = None
     string_nullable: Optional[StrictStr] = None
-    __properties = ["array_string_enum_ref_default", "array_string_enum_default", "array_string_default", "array_integer_default", "array_string", "array_string_nullable", "string_nullable"]
+    __properties = ["array_string_enum_ref_default", "array_string_enum_default", "array_string_default", "array_integer_default", "array_string", "array_string_nullable", "array_string_extension_nullable", "string_nullable"]
 
     @validator('array_string_enum_default')
     def array_string_enum_default_validate_enum(cls, v):
@@ -73,6 +74,10 @@ class DefaultValue(BaseModel):
         if self.array_string_nullable is None:
             _dict['array_string_nullable'] = None
 
+        # set to None if array_string_extension_nullable (nullable) is None
+        if self.array_string_extension_nullable is None:
+            _dict['array_string_extension_nullable'] = None
+
         # set to None if string_nullable (nullable) is None
         if self.string_nullable is None:
             _dict['string_nullable'] = None
@@ -95,6 +100,7 @@ class DefaultValue(BaseModel):
             "array_integer_default": obj.get("array_integer_default"),
             "array_string": obj.get("array_string"),
             "array_string_nullable": obj.get("array_string_nullable"),
+            "array_string_extension_nullable": obj.get("array_string_extension_nullable"),
             "string_nullable": obj.get("string_nullable")
         })
         return _obj


### PR DESCRIPTION
set `isNulalble` accordingly if x-nullable is set

FYI. @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
