### PR TITLE
[C++][Pistache] Add some missing {{declspec}} on classes and functions

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-impl-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-impl-header.mustache
@@ -28,7 +28,7 @@ namespace {{apiNamespace}}
 {{#hasModelImport}}
 using namespace {{modelNamespace}};{{/hasModelImport}}
 
-class {{classname}}Impl : public {{apiNamespace}}::{{classname}} {
+class {{declspec}} {{classname}}Impl : public {{apiNamespace}}::{{classname}} {
 public:
     explicit {{classname}}Impl(const std::shared_ptr<Pistache::Rest::Router>& rtr);
     ~{{classname}}Impl() override = default;

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-header.mustache
@@ -75,10 +75,10 @@ public:
     void setValue({{{this}}} value);
     {{{this}}}::e{{{this}}} getEnumValue() const;
     void setEnumValue({{{this}}}::e{{{this}}} value);{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
-    friend void to_json(nlohmann::json& j, const {{classname}}& o);
-    friend void from_json(const nlohmann::json& j, {{classname}}& o);{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}
-    friend void to_json(nlohmann::json& j, const {{{this}}}& o);
-    friend void from_json(const nlohmann::json& j, {{{this}}}& o);{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
+    friend {{declspec}} void to_json(nlohmann::json& j, const {{classname}}& o);
+    friend {{declspec}} void from_json(const nlohmann::json& j, {{classname}}& o);{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}
+    friend {{declspec}} void to_json(nlohmann::json& j, const {{{this}}}& o);
+    friend {{declspec}} void from_json(const nlohmann::json& j, {{{this}}}& o);{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
 protected:
     {{#vars}}
     {{{dataType}}} m_{{name}};

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-header.mustache
@@ -17,7 +17,7 @@
 namespace {{modelNamespace}}
 {
 
-struct {{classname}}
+struct {{declspec}} {{classname}}
 {
     {{#isEnum}}{{#allowableValues}}
     enum e{{classname}} {
@@ -59,8 +59,8 @@ struct {{classname}}
     static {{classname}} from_json(const nlohmann::json& j);
 };
 
-void to_json(nlohmann::json& j, const {{classname}}& o);
-void from_json(const nlohmann::json& j, {{classname}}& o);
+{{declspec}} void to_json(nlohmann::json& j, const {{classname}}& o);
+{{declspec}} void from_json(const nlohmann::json& j, {{classname}}& o);
 
 
 } // namespace {{modelNamespace}}

--- a/samples/server/petstore/cpp-pistache/impl/PetApiImpl.h
+++ b/samples/server/petstore/cpp-pistache/impl/PetApiImpl.h
@@ -38,7 +38,7 @@ namespace org::openapitools::server::api
 
 using namespace org::openapitools::server::model;
 
-class PetApiImpl : public org::openapitools::server::api::PetApi {
+class  PetApiImpl : public org::openapitools::server::api::PetApi {
 public:
     explicit PetApiImpl(const std::shared_ptr<Pistache::Rest::Router>& rtr);
     ~PetApiImpl() override = default;

--- a/samples/server/petstore/cpp-pistache/impl/StoreApiImpl.h
+++ b/samples/server/petstore/cpp-pistache/impl/StoreApiImpl.h
@@ -38,7 +38,7 @@ namespace org::openapitools::server::api
 
 using namespace org::openapitools::server::model;
 
-class StoreApiImpl : public org::openapitools::server::api::StoreApi {
+class  StoreApiImpl : public org::openapitools::server::api::StoreApi {
 public:
     explicit StoreApiImpl(const std::shared_ptr<Pistache::Rest::Router>& rtr);
     ~StoreApiImpl() override = default;

--- a/samples/server/petstore/cpp-pistache/impl/UserApiImpl.h
+++ b/samples/server/petstore/cpp-pistache/impl/UserApiImpl.h
@@ -38,7 +38,7 @@ namespace org::openapitools::server::api
 
 using namespace org::openapitools::server::model;
 
-class UserApiImpl : public org::openapitools::server::api::UserApi {
+class  UserApiImpl : public org::openapitools::server::api::UserApi {
 public:
     explicit UserApiImpl(const std::shared_ptr<Pistache::Rest::Router>& rtr);
     ~UserApiImpl() override = default;

--- a/samples/server/petstore/cpp-pistache/model/ApiResponse.h
+++ b/samples/server/petstore/cpp-pistache/model/ApiResponse.h
@@ -80,8 +80,8 @@ public:
     bool messageIsSet() const;
     void unsetMessage();
 
-    friend void to_json(nlohmann::json& j, const ApiResponse& o);
-    friend void from_json(const nlohmann::json& j, ApiResponse& o);
+    friend  void to_json(nlohmann::json& j, const ApiResponse& o);
+    friend  void from_json(const nlohmann::json& j, ApiResponse& o);
 protected:
     int32_t m_Code;
     bool m_CodeIsSet;

--- a/samples/server/petstore/cpp-pistache/model/Category.h
+++ b/samples/server/petstore/cpp-pistache/model/Category.h
@@ -73,8 +73,8 @@ public:
     bool nameIsSet() const;
     void unsetName();
 
-    friend void to_json(nlohmann::json& j, const Category& o);
-    friend void from_json(const nlohmann::json& j, Category& o);
+    friend  void to_json(nlohmann::json& j, const Category& o);
+    friend  void from_json(const nlohmann::json& j, Category& o);
 protected:
     int64_t m_Id;
     bool m_IdIsSet;

--- a/samples/server/petstore/cpp-pistache/model/Order.h
+++ b/samples/server/petstore/cpp-pistache/model/Order.h
@@ -101,8 +101,8 @@ public:
     bool completeIsSet() const;
     void unsetComplete();
 
-    friend void to_json(nlohmann::json& j, const Order& o);
-    friend void from_json(const nlohmann::json& j, Order& o);
+    friend  void to_json(nlohmann::json& j, const Order& o);
+    friend  void from_json(const nlohmann::json& j, Order& o);
 protected:
     int64_t m_Id;
     bool m_IdIsSet;

--- a/samples/server/petstore/cpp-pistache/model/Pet.h
+++ b/samples/server/petstore/cpp-pistache/model/Pet.h
@@ -100,8 +100,8 @@ public:
     bool statusIsSet() const;
     void unsetStatus();
 
-    friend void to_json(nlohmann::json& j, const Pet& o);
-    friend void from_json(const nlohmann::json& j, Pet& o);
+    friend  void to_json(nlohmann::json& j, const Pet& o);
+    friend  void from_json(const nlohmann::json& j, Pet& o);
 protected:
     int64_t m_Id;
     bool m_IdIsSet;

--- a/samples/server/petstore/cpp-pistache/model/Tag.h
+++ b/samples/server/petstore/cpp-pistache/model/Tag.h
@@ -73,8 +73,8 @@ public:
     bool nameIsSet() const;
     void unsetName();
 
-    friend void to_json(nlohmann::json& j, const Tag& o);
-    friend void from_json(const nlohmann::json& j, Tag& o);
+    friend  void to_json(nlohmann::json& j, const Tag& o);
+    friend  void from_json(const nlohmann::json& j, Tag& o);
 protected:
     int64_t m_Id;
     bool m_IdIsSet;

--- a/samples/server/petstore/cpp-pistache/model/User.h
+++ b/samples/server/petstore/cpp-pistache/model/User.h
@@ -115,8 +115,8 @@ public:
     bool userStatusIsSet() const;
     void unsetUserStatus();
 
-    friend void to_json(nlohmann::json& j, const User& o);
-    friend void from_json(const nlohmann::json& j, User& o);
+    friend  void to_json(nlohmann::json& j, const User& o);
+    friend  void from_json(const nlohmann::json& j, User& o);
 protected:
     int64_t m_Id;
     bool m_IdIsSet;


### PR DESCRIPTION
The `{{declspec}}` annotations were not consistently applied and were missing on some classes and free functions.

Side note: the `declspec` and `defaultInclude` config options are not officially documented for the cpp-pistache-server generator, but they work correctly (aside the missing annotations). Not sure if something needs to be done on that front.

My use case is that I'm building my server and APIs in a shared library and while trying to use the model classes in my tests couldn't link to it since some of the model symbols (`to_json` and `from_json` in my case) were not exported (I'm using `declspec` and `defaultInclude` for the classical use case of exporting symbols).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
cc @ravinikam @stkrwork @etherealjoy @MartinDelille @muttleyxd