### PR TITLE
[Java] [WebClient] [RestTemplate] Stop using org.springframework.util.Base64Utils in Java generators

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/HttpBasicAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/HttpBasicAuth.mustache
@@ -2,9 +2,9 @@ package {{invokerPackage}}.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 {{>generatedAnnotation}}
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/HttpBearerAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/auth/HttpBearerAuth.mustache
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 {{>generatedAnnotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBasicAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBasicAuth.mustache
@@ -2,9 +2,9 @@ package {{invokerPackage}}.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 {{>generatedAnnotation}}
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBearerAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/auth/HttpBearerAuth.mustache
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 {{>generatedAnnotation}}

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBasicAuth.java
@@ -2,9 +2,9 @@ package org.openapitools.client.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")


### PR DESCRIPTION
This utility class has been marked as deprecated for future removal since Spring 6.0.5. All Java generators, except WebClient and RestTemplate, are already using Base64 directly.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
