### PR TITLE
Fix issue #907 by ensuring the parameters is properly "exploded"

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -120,8 +120,10 @@ public class {{classname}} {
         final MultiValueMap<String, String> localVarCookieParams = new LinkedMultiValueMap<String, String>();
         final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();{{#hasQueryParams}}
 
-        {{#queryParams}}localVarQueryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));{{^-last}}
-        {{/-last}}{{/queryParams}}{{/hasQueryParams}}{{#hasHeaderParams}}
+{{#queryParams}}{{#isExplode}}{{#hasVars}}{{#vars}}        localVarQueryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
+{{/vars}}{{/hasVars}}{{^hasVars}}        localVarQueryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+{{/hasVars}}{{/isExplode}}{{^isExplode}}        localVarQueryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+{{/isExplode}}{{/queryParams}}{{/hasQueryParams}}{{#hasHeaderParams}}
 
         {{#headerParams}}if ({{paramName}} != null)
         localVarHeaderParams.add("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^-last}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+import lombok.SneakyThrows;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
@@ -1872,6 +1873,50 @@ public class JavaClientCodegenTest {
         assertFileNotContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"), "@JsonSubTypes.Type(value = Cat.class, name = \"Cat\")");
         assertFileNotContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"), "@JsonSubTypes.Type(value = Dog.class, name = \"Dog\")");
         assertFileNotContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"), "@JsonSubTypes.Type(value = Lizard.class, name = \"Lizard\")");
+    }
+
+    @Test
+    public void shouldProperlyExplodeRestTemplateQueryParameters_issue907() {
+
+        final Map<String, File> files = generateFromContract(
+                "src/test/resources/3_0/java/explode-query-parameter.yaml",
+                JavaClientCodegen.RESTTEMPLATE
+        );
+
+        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                .printFileContent()
+                .assertMethod("searchWithHttpInfo")
+                .bodyContainsLines("localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"regular-param\", regularParam));")
+                .bodyContainsLines("localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someString\", objectParam.getSomeString()));")
+                .bodyContainsLines("localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someBoolean\", objectParam.getSomeBoolean()));")
+                .bodyContainsLines("localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someInteger\", objectParam.getSomeInteger()));")
+        ;
+    }
+
+    private static Map<String, File> generateFromContract(final String pathToSpecification, final String library) {
+        return generateFromContract(pathToSpecification, library, new HashMap<>());
+    }
+
+    @SneakyThrows
+    private static Map<String, File> generateFromContract(
+            final String pathToSpecification,
+            final String library,
+            final Map<String, Object> properties
+    ) {
+        final File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setLibrary(library)
+                .setAdditionalProperties(properties)
+                .setInputSpec(pathToSpecification)
+                .setOutputDir(output.getAbsolutePath());
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        final DefaultGenerator generator = new DefaultGenerator();
+        return generator.opts(clientOptInput).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/java/explode-query-parameter.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/explode-query-parameter.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.3
+info:
+  title: Explode query params
+  description: "Explode query params"
+  version: "1.0.0"
+servers:
+  - url: http://localhost:8080
+paths:
+  /api/search:
+    get:
+      operationId: Search
+      parameters:
+        - name: regular-param
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: object-param
+          in: query
+          required: true
+          schema:
+            type: object
+            properties:
+              someString:
+                type: string
+              someBoolean:
+                type: boolean
+              someInteger:
+                type: integer
+      responses:
+        '200':
+          description: Some description.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeReturnValue'
+components:
+  schemas:
+    SomeReturnValue:
+      type: object
+      required:
+        - someValue
+      properties:
+        someValue:
+          type: string

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
@@ -186,6 +186,7 @@ public class PetApi {
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };
@@ -239,6 +240,7 @@ public class PetApi {
         final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/api/UserApi.java
@@ -328,6 +328,7 @@ public class UserApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/api/PetApi.java
@@ -186,6 +186,7 @@ public class PetApi {
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };
@@ -239,6 +240,7 @@ public class PetApi {
         final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/api/UserApi.java
@@ -328,6 +328,7 @@ public class UserApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -349,6 +349,7 @@ public class FakeApi {
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
 
+
         final String[] localVarAccepts = {  };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -575,6 +576,7 @@ public class FakeApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
 
+
         if (enumHeaderStringArray != null)
         localVarHeaderParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
         if (enumHeaderString != null)
@@ -654,6 +656,7 @@ public class FakeApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
+
 
         if (requiredBooleanGroup != null)
         localVarHeaderParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -838,6 +841,7 @@ public class FakeApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
+
 
         final String[] localVarAccepts = {  };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/PetApi.java
@@ -186,6 +186,7 @@ public class PetApi {
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };
@@ -239,6 +240,7 @@ public class PetApi {
         final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
@@ -322,6 +322,7 @@ public class UserApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -349,6 +349,7 @@ public class FakeApi {
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
 
+
         final String[] localVarAccepts = {  };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -575,6 +576,7 @@ public class FakeApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
 
+
         if (enumHeaderStringArray != null)
         localVarHeaderParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
         if (enumHeaderString != null)
@@ -654,6 +656,7 @@ public class FakeApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
+
 
         if (requiredBooleanGroup != null)
         localVarHeaderParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -838,6 +841,7 @@ public class FakeApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
+
 
         final String[] localVarAccepts = {  };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/PetApi.java
@@ -186,6 +186,7 @@ public class PetApi {
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };
@@ -239,6 +240,7 @@ public class PetApi {
         final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
 
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
+
 
         final String[] localVarAccepts = { 
             "application/xml", "application/json"

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
@@ -322,6 +322,7 @@ public class UserApi {
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
 
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
          };


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

This PR ensures that an exploded query parameter is properly handled by the java-resttemplate code generator, fixing https://github.com/OpenAPITools/openapi-generator/issues/907