### PR TITLE
[CI] try to fix bitrise deprecation warning

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,7 +10,7 @@ trigger_map:
 workflows:
   primary:
     steps:
-    - git-clone@6.2.1: {}
+    - git-clone@8.0.0: {}
     - brew-install@0.12.1:
         inputs:
         - packages: maven
@@ -42,4 +42,4 @@ workflows:
 
 meta:
   bitrise.io:
-    stack: osx-xcode-14.1.x
+    stack: osx-xcode-14.2.x

--- a/samples/client/petstore/swift5/alamofireLibrary/pom.xml
+++ b/samples/client/petstore/swift5/alamofireLibrary/pom.xml
@@ -41,3 +41,4 @@
         </plugins>
     </build>
 </project>
+

--- a/samples/client/petstore/swift5/swift5_test_all.sh
+++ b/samples/client/petstore/swift5/swift5_test_all.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 DIRECTORY=`dirname $0`


### PR DESCRIPTION
Try to fix bitrise warning `This workflow is using a deprecated stack. Change your build stack, or your builds will not work after Mar 13`

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)