### PR TITLE
[Java][Spring] Added required header params to RequestMapping annotation. fixes #14837

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -49,6 +49,7 @@ public class CodegenOperation {
     public List<CodegenParameter> requiredParams = new ArrayList<CodegenParameter>();
     public List<CodegenParameter> optionalParams = new ArrayList<CodegenParameter>();
     public List<CodegenParameter> requiredAndNotNullableParams = new ArrayList<CodegenParameter>();
+    public ArrayList<CodegenParameter> requiredHeaderParams = new ArrayList<>();
     public List<CodegenSecurity> authMethods;
     public List<Tag> tags;
     public List<CodegenResponse> responses = new ArrayList<CodegenResponse>();
@@ -160,6 +161,15 @@ public class CodegenOperation {
 
     public boolean getHasRequiredAndNotNullableParams() {
         return nonEmpty(requiredAndNotNullableParams);
+    }
+
+    /**
+     * Check if there's at least one required header parameter
+     *
+     * @return true if any required header parameter exists, false otherwise
+     */
+    public boolean getHasRequiredHeaderParams(){
+        return nonEmpty(requiredHeaderParams);
     }
 
     /**
@@ -365,6 +375,7 @@ public class CodegenOperation {
         sb.append(", pathParams=").append(pathParams);
         sb.append(", queryParams=").append(queryParams);
         sb.append(", headerParams=").append(headerParams);
+        sb.append(", RequiredHeaderParams").append(requiredHeaderParams);
         sb.append(", formParams=").append(formParams);
         sb.append(", cookieParams=").append(cookieParams);
         sb.append(", requiredParams=").append(requiredParams);
@@ -415,6 +426,7 @@ public class CodegenOperation {
                 isRestfulShow == that.isRestfulShow &&
                 isRestfulCreate == that.isRestfulCreate &&
                 isRestfulUpdate == that.isRestfulUpdate &&
+                requiredHeaderParams == that.requiredHeaderParams &&
                 isRestfulDestroy == that.isRestfulDestroy &&
                 isRestful == that.isRestful &&
                 isDeprecated == that.isDeprecated &&
@@ -444,6 +456,7 @@ public class CodegenOperation {
                 Objects.equals(pathParams, that.pathParams) &&
                 Objects.equals(queryParams, that.queryParams) &&
                 Objects.equals(headerParams, that.headerParams) &&
+                Objects.equals(requiredHeaderParams, that.requiredHeaderParams) &&
                 Objects.equals(formParams, that.formParams) &&
                 Objects.equals(cookieParams, that.cookieParams) &&
                 Objects.equals(requiredParams, that.requiredParams) &&

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2288,6 +2288,17 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
     }
 
+    protected void handleRequiredHeaders(CodegenOperation operation){
+        if (operation.allParams.isEmpty()) {
+            return;
+        }
+        final ArrayList<CodegenParameter> headerParams = new ArrayList<>(operation.headerParams);
+
+        headerParams.stream()
+                .filter(codegenParameter -> codegenParameter.required)
+                .forEach(p -> operation.requiredHeaderParams.add(p));
+    }
+
     private boolean shouldBeImplicitHeader(CodegenParameter parameter) {
         return StringUtils.isNotBlank(implicitHeadersRegex) && parameter.baseName.matches(implicitHeadersRegex);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -805,6 +805,7 @@ public class SpringCodegen extends AbstractJavaCodegen
                 });
 
                 handleImplicitHeaders(operation);
+                handleRequiredHeaders(operation);
             }
             // The tag for the controller is the first tag of the first operation
             final CodegenOperation firstOperation = ops.get(0);

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -218,7 +218,8 @@ public interface {{classname}} {
         produces = "{{{vendorExtensions.x-accepts}}}"{{/hasProduces}}{{#hasConsumes}},
         consumes = "{{{vendorExtensions.x-content-type}}}"{{/hasConsumes}}{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}},
         produces = { {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }{{/hasProduces}}{{#hasConsumes}},
-        consumes = { {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }{{/hasConsumes}}{{/singleContentTypes}}
+        consumes = { {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }{{/hasConsumes}}{{/singleContentTypes}}{{#hasRequiredHeaderParams}},
+        headers = { {{#requiredHeaderParams}}"{{paramName}}"{{^-last}}, {{/-last}}{{/requiredHeaderParams}} }{{/hasRequiredHeaderParams}}
     )
     {{#jdk8-default-interface}}default {{/jdk8-default-interface}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{#delegate-method}}_{{/delegate-method}}{{operationId}}(
         {{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{>cookieParams}}{{^-last}},

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_14837.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_14837.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: Title
+  description: Title
+  version: 1.0.0
+paths:
+  /some/dummy/endpoint:
+    get:
+      tags:
+        - SomeTag
+      operationId: getSomeTag
+      parameters:
+        - name: firstqueryparam
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: secondqueryparam
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: firstHeaderParam
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: secondHeaderParam
+          in: header
+          required: false
+          schema:
+            type: integer
+        - name: thirdHeaderParam
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: fourthHeaderParam
+          in: header
+          required: false
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: OK
+


### PR DESCRIPTION
Adding Api operation versioning through header parameter to provide different behavior and/or extended response type of a resource for the JavaSpring server generator.

There are use cases where a different behavior is desired for an already consumed API operation (backward compatibility during a sunset period, etc.), where extending the resource type for new consumers and additional logic is required, having it controlled by a header parameter (instead of creating another resource).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
