### PR TITLE
[python-nextgen] fix enum default value

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -125,7 +125,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
     }
 
 
-
     /**
      * Return the default value of the property
      *
@@ -285,7 +284,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
     }
 
     private String toExampleValueRecursive(Schema schema, List<Schema> includedSchemas, int indentation) {
-        boolean cycleFound = includedSchemas.stream().filter(s->schema.equals(s)).count() > 1;
+        boolean cycleFound = includedSchemas.stream().filter(s -> schema.equals(s)).count() > 1;
         if (cycleFound) {
             return "";
         }
@@ -716,5 +715,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.PYTHON; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.PYTHON;
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1630,6 +1630,14 @@ components:
             - UPPER
             - lower
             - ''
+        enum_integer_default:
+          type: integer
+          format: int32
+          enum:
+            - 1
+            - 5
+            - 14
+          default: 5
         enum_integer:
           type: integer
           format: int32

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/EnumTest.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enum_string** | **str** |  | [optional] 
 **enum_string_required** | **str** |  | 
+**enum_integer_default** | **int** |  | [optional] [default to 5]
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
@@ -32,13 +32,14 @@ class EnumTest(BaseModel):
     """
     enum_string: Optional[StrictStr] = None
     enum_string_required: StrictStr = ...
+    enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[float] = None
     outer_enum: Optional[OuterEnum] = Field(None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(None, alias="outerEnumIntegerDefaultValue")
-    __properties = ["enum_string", "enum_string_required", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')
     def enum_string_validate_enum(cls, v):
@@ -53,6 +54,15 @@ class EnumTest(BaseModel):
     def enum_string_required_validate_enum(cls, v):
         if v not in ('UPPER', 'lower', ''):
             raise ValueError("must validate the enum values ('UPPER', 'lower', '')")
+        return v
+
+    @validator('enum_integer_default')
+    def enum_integer_default_validate_enum(cls, v):
+        if v is None:
+            return v
+
+        if v not in (1, 5, 14):
+            raise ValueError("must validate the enum values (1, 5, 14)")
         return v
 
     @validator('enum_integer')
@@ -114,6 +124,7 @@ class EnumTest(BaseModel):
         _obj = EnumTest.parse_obj({
             "enum_string": obj.get("enum_string"),
             "enum_string_required": obj.get("enum_string_required"),
+            "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,
             "enum_integer": obj.get("enum_integer"),
             "enum_number": obj.get("enum_number"),
             "outer_enum": obj.get("outerEnum"),

--- a/samples/openapi3/client/petstore/python-nextgen/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/EnumTest.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enum_string** | **str** |  | [optional] 
 **enum_string_required** | **str** |  | 
+**enum_integer_default** | **int** |  | [optional] [default to 5]
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
@@ -32,6 +32,7 @@ class EnumTest(BaseModel):
     """
     enum_string: Optional[StrictStr] = None
     enum_string_required: StrictStr = ...
+    enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[StrictFloat] = None
     outer_enum: Optional[OuterEnum] = Field(None, alias="outerEnum")
@@ -39,7 +40,7 @@ class EnumTest(BaseModel):
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(None, alias="outerEnumIntegerDefaultValue")
     additional_properties: Dict[str, Any] = {}
-    __properties = ["enum_string", "enum_string_required", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')
     def enum_string_validate_enum(cls, v):
@@ -54,6 +55,15 @@ class EnumTest(BaseModel):
     def enum_string_required_validate_enum(cls, v):
         if v not in ('UPPER', 'lower', ''):
             raise ValueError("must validate the enum values ('UPPER', 'lower', '')")
+        return v
+
+    @validator('enum_integer_default')
+    def enum_integer_default_validate_enum(cls, v):
+        if v is None:
+            return v
+
+        if v not in (1, 5, 14):
+            raise ValueError("must validate the enum values (1, 5, 14)")
         return v
 
     @validator('enum_integer')
@@ -121,6 +131,7 @@ class EnumTest(BaseModel):
         _obj = EnumTest.parse_obj({
             "enum_string": obj.get("enum_string"),
             "enum_string_required": obj.get("enum_string_required"),
+            "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,
             "enum_integer": obj.get("enum_integer"),
             "enum_number": obj.get("enum_number"),
             "outer_enum": obj.get("outerEnum"),

--- a/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
@@ -382,3 +382,8 @@ class ModelTests(unittest.TestCase):
         ## Serializing json  
         #json_object = json.dumps(dictionary) 
         #self.assertEqual(json_object, "")
+
+    def test_inline_enum_default(self):
+        enum_test = petstore_api.EnumTest(enum_string_required="lower")
+        self.assertEqual(enum_test.enum_integer_default, 5)
+


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/14581

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)
