### PR TITLE
[python-nextgen] Add @overload for api methods to handle async requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/api.mustache
@@ -7,7 +7,8 @@ from __future__ import absolute_import
 import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
-from typing_extensions import Annotated
+from typing_extensions import Annotated{{#asyncio}}
+from typing import overload, Optional, Union, Awaitable{{/asyncio}}
 
 {{#imports}}
 {{import}}
@@ -34,8 +35,18 @@ class {{classname}}(object):
         self.api_client = api_client
 {{#operation}}
 
+{{#asyncio}}
+    @overload
+    async def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
+        ...
+
+    @overload
+    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}async_req: Optional[bool]=True, **kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
+        ...
+
+{{/asyncio}}
     @validate_arguments
-    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
+    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}{{#asyncio}}async_req: Optional[bool]=None, {{/asyncio}}**kwargs) -> {{#asyncio}}Union[{{{returnType}}}{{^returnType}}None{{/returnType}}, Awaitable[{{{returnType}}}{{^returnType}}None{{/returnType}}]]{{/asyncio}}{{^asyncio}}{{{returnType}}}{{^returnType}}None{{/returnType}}{{/asyncio}}:  # noqa: E501
         """{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 
 {{#notes}}
@@ -67,6 +78,10 @@ class {{classname}}(object):
         :rtype: {{returnType}}{{^returnType}}None{{/returnType}}
         """
         kwargs['_return_http_data_only'] = True
+{{#asyncio}}
+        if async_req is not None:
+            kwargs['async_req'] = async_req
+{{/asyncio}}
         return self.{{operationId}}_with_http_info({{#allParams}}{{paramName}}, {{/allParams}}**kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/another_fake_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from pydantic import Field
 
@@ -40,8 +41,16 @@ class AnotherFakeApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
+        ...
+
+    @overload
+    def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
+        ...
+
     @validate_arguments
-    def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
+    def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
         """To test special tags  # noqa: E501
 
         To test special tags and operation ID starting with number  # noqa: E501
@@ -69,6 +78,8 @@ class AnotherFakeApi(object):
         :rtype: Client
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/default_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from petstore_api.models.foo_get_default_response import FooGetDefaultResponse
 
@@ -38,8 +39,16 @@ class DefaultApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def foo_get(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
+        ...
+
+    @overload
+    def foo_get(self, async_req: Optional[bool]=True, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
+        ...
+
     @validate_arguments
-    def foo_get(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
+    def foo_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[FooGetDefaultResponse, Awaitable[FooGetDefaultResponse]]:  # noqa: E501
         """foo_get  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -64,6 +73,8 @@ class DefaultApi(object):
         :rtype: FooGetDefaultResponse
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.foo_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from datetime import date, datetime
 
@@ -50,8 +51,16 @@ class FakeApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def fake_health_get(self, **kwargs) -> HealthCheckResult:  # noqa: E501
+        ...
+
+    @overload
+    def fake_health_get(self, async_req: Optional[bool]=True, **kwargs) -> HealthCheckResult:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_health_get(self, **kwargs) -> HealthCheckResult:  # noqa: E501
+    def fake_health_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[HealthCheckResult, Awaitable[HealthCheckResult]]:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -76,6 +85,8 @@ class FakeApi(object):
         :rtype: HealthCheckResult
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
@@ -180,8 +191,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
+    def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -212,6 +231,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -335,8 +356,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
+        ...
+
+    @overload
+    def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> bool:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
+    def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[bool, Awaitable[bool]]:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
         Test serialization of outer boolean types  # noqa: E501
@@ -364,6 +393,8 @@ class FakeApi(object):
         :rtype: bool
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -482,8 +513,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
+        ...
+
+    @overload
+    def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> OuterComposite:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
+    def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[OuterComposite, Awaitable[OuterComposite]]:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
         Test serialization of object with outer number type  # noqa: E501
@@ -511,6 +550,8 @@ class FakeApi(object):
         :rtype: OuterComposite
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -629,8 +670,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
+        ...
+
+    @overload
+    def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> float:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
+    def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[float, Awaitable[float]]:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
         Test serialization of outer number types  # noqa: E501
@@ -658,6 +707,8 @@ class FakeApi(object):
         :rtype: float
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -776,8 +827,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
+        ...
+
+    @overload
+    def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> str:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
+    def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[str, Awaitable[str]]:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
         Test serialization of outer string types  # noqa: E501
@@ -805,6 +864,8 @@ class FakeApi(object):
         :rtype: str
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -923,8 +984,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
+        ...
+
+    @overload
+    def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], async_req: Optional[bool]=True, **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
+        ...
+
     @validate_arguments
-    def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
+    def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], async_req: Optional[bool]=None, **kwargs) -> Union[OuterObjectWithEnumProperty, Awaitable[OuterObjectWithEnumProperty]]:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
         Test serialization of enum (int) properties with examples  # noqa: E501
@@ -952,6 +1021,8 @@ class FakeApi(object):
         :rtype: OuterObjectWithEnumProperty
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1070,8 +1141,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_body_with_binary(self, body : Annotated[Optional[StrictStr], Field(..., description="image to upload")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_body_with_binary(self, body : Annotated[Optional[StrictStr], Field(..., description="image to upload")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_body_with_binary(self, body : Annotated[Optional[StrictStr], Field(..., description="image to upload")], **kwargs) -> None:  # noqa: E501
+    def test_body_with_binary(self, body : Annotated[Optional[StrictStr], Field(..., description="image to upload")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
         For this test, the body has to be a binary file.  # noqa: E501
@@ -1099,6 +1178,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1211,8 +1292,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
+    def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
         For this test, the body for this request must reference a schema named `File`.  # noqa: E501
@@ -1240,6 +1329,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1352,8 +1443,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_body_with_query_params(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_body_with_query_params(self, query : StrictStr, user : User, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_body_with_query_params(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
+    def test_body_with_query_params(self, query : StrictStr, user : User, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -1382,6 +1481,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1499,8 +1600,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
+        ...
+
+    @overload
+    def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
+    def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
         To test \"client\" model  # noqa: E501
@@ -1528,6 +1637,8 @@ class FakeApi(object):
         :rtype: Client
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1646,8 +1757,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
+    def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -1676,6 +1795,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1789,8 +1910,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_endpoint_parameters(self, number : Annotated[confloat(ge=543.2, le=32.1), Field(..., description="None")], double : Annotated[confloat(ge=123.4, le=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[StrictStr, Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(ge=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[StrictStr], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_endpoint_parameters(self, number : Annotated[confloat(ge=543.2, le=32.1), Field(..., description="None")], double : Annotated[confloat(ge=123.4, le=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[StrictStr, Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(ge=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[StrictStr], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_endpoint_parameters(self, number : Annotated[confloat(ge=543.2, le=32.1), Field(..., description="None")], double : Annotated[confloat(ge=123.4, le=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[StrictStr, Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(ge=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[StrictStr], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
+    def test_endpoint_parameters(self, number : Annotated[confloat(ge=543.2, le=32.1), Field(..., description="None")], double : Annotated[confloat(ge=123.4, le=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[StrictStr, Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(ge=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[StrictStr], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
@@ -1844,6 +1973,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -2034,8 +2165,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
+    def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
         Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -2073,6 +2212,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -2208,8 +2349,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> None:  # noqa: E501
+    def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
           # noqa: E501
@@ -2237,6 +2386,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -2349,8 +2500,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> None:  # noqa: E501
+    def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
           # noqa: E501
@@ -2380,6 +2539,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -2498,8 +2659,16 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
+    def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501
@@ -2539,6 +2708,8 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from pydantic import Field
 
@@ -40,8 +41,16 @@ class FakeClassnameTags123Api(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def test_classname(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
+        ...
+
+    @overload
+    def test_classname(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
+        ...
+
     @validate_arguments
-    def test_classname(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
+    def test_classname(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
         To test class name in snake case  # noqa: E501
@@ -69,6 +78,8 @@ class FakeClassnameTags123Api(object):
         :rtype: Client
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from pydantic import Field, StrictInt, StrictStr, conlist, validator
 
@@ -43,8 +44,16 @@ class PetApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
+    def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
           # noqa: E501
@@ -72,6 +81,8 @@ class PetApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -184,8 +195,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
+    def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
           # noqa: E501
@@ -215,6 +234,8 @@ class PetApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -326,8 +347,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
+        ...
+
+    @overload
+    def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], async_req: Optional[bool]=True, **kwargs) -> List[Pet]:  # noqa: E501
+        ...
+
     @validate_arguments
-    def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
+    def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], async_req: Optional[bool]=None, **kwargs) -> Union[List[Pet], Awaitable[List[Pet]]]:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
         Multiple status values can be provided with comma separated strings  # noqa: E501
@@ -355,6 +384,8 @@ class PetApi(object):
         :rtype: List[Pet]
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -468,8 +499,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
+        ...
+
+    @overload
+    def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], async_req: Optional[bool]=True, **kwargs) -> List[Pet]:  # noqa: E501
+        ...
+
     @validate_arguments
-    def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
+    def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], async_req: Optional[bool]=None, **kwargs) -> Union[List[Pet], Awaitable[List[Pet]]]:  # noqa: E501
         """Finds Pets by tags  # noqa: E501
 
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.  # noqa: E501
@@ -497,6 +536,8 @@ class PetApi(object):
         :rtype: List[Pet]
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -610,8 +651,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
+        ...
+
+    @overload
+    def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], async_req: Optional[bool]=True, **kwargs) -> Pet:  # noqa: E501
+        ...
+
     @validate_arguments
-    def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
+    def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], async_req: Optional[bool]=None, **kwargs) -> Union[Pet, Awaitable[Pet]]:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
         Returns a single pet  # noqa: E501
@@ -639,6 +688,8 @@ class PetApi(object):
         :rtype: Pet
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -752,8 +803,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
+    def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
           # noqa: E501
@@ -781,6 +840,8 @@ class PetApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -893,8 +954,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
+    def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
           # noqa: E501
@@ -926,6 +995,8 @@ class PetApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1050,8 +1121,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[StrictStr], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+        ...
+
+    @overload
+    def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[StrictStr], Field(description="file to upload")] = None, async_req: Optional[bool]=True, **kwargs) -> ApiResponse:  # noqa: E501
+        ...
+
     @validate_arguments
-    def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[StrictStr], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[StrictStr], Field(description="file to upload")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[ApiResponse, Awaitable[ApiResponse]]:  # noqa: E501
         """uploads an image  # noqa: E501
 
           # noqa: E501
@@ -1083,6 +1162,8 @@ class PetApi(object):
         :rtype: ApiResponse
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1213,8 +1294,16 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[StrictStr, Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+        ...
+
+    @overload
+    def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[StrictStr, Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, async_req: Optional[bool]=True, **kwargs) -> ApiResponse:  # noqa: E501
+        ...
+
     @validate_arguments
-    def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[StrictStr, Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[StrictStr, Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[ApiResponse, Awaitable[ApiResponse]]:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 
           # noqa: E501
@@ -1246,6 +1335,8 @@ class PetApi(object):
         :rtype: ApiResponse
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/store_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from pydantic import Field, StrictStr, conint
 
@@ -42,8 +43,16 @@ class StoreApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
+    def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors  # noqa: E501
@@ -71,6 +80,8 @@ class StoreApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -176,8 +187,16 @@ class StoreApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def get_inventory(self, **kwargs) -> Dict[str, int]:  # noqa: E501
+        ...
+
+    @overload
+    def get_inventory(self, async_req: Optional[bool]=True, **kwargs) -> Dict[str, int]:  # noqa: E501
+        ...
+
     @validate_arguments
-    def get_inventory(self, **kwargs) -> Dict[str, int]:  # noqa: E501
+    def get_inventory(self, async_req: Optional[bool]=None, **kwargs) -> Union[Dict[str, int], Awaitable[Dict[str, int]]]:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
         Returns a map of status codes to quantities  # noqa: E501
@@ -203,6 +222,8 @@ class StoreApi(object):
         :rtype: Dict[str, int]
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.get_inventory_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
@@ -308,8 +329,16 @@ class StoreApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
+        ...
+
+    @overload
+    def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], async_req: Optional[bool]=True, **kwargs) -> Order:  # noqa: E501
+        ...
+
     @validate_arguments
-    def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
+    def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], async_req: Optional[bool]=None, **kwargs) -> Union[Order, Awaitable[Order]]:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions  # noqa: E501
@@ -337,6 +366,8 @@ class StoreApi(object):
         :rtype: Order
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -450,8 +481,16 @@ class StoreApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
+        ...
+
+    @overload
+    def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], async_req: Optional[bool]=True, **kwargs) -> Order:  # noqa: E501
+        ...
+
     @validate_arguments
-    def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
+    def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], async_req: Optional[bool]=None, **kwargs) -> Union[Order, Awaitable[Order]]:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
           # noqa: E501
@@ -479,6 +518,8 @@ class StoreApi(object):
         :rtype: Order
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.place_order_with_http_info(order, **kwargs)  # noqa: E501
 
     @validate_arguments

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/user_api.py
@@ -16,6 +16,7 @@ import re  # noqa: F401
 
 from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
+from typing import overload, Optional, Union, Awaitable
 
 from pydantic import Field, StrictStr, conlist
 
@@ -40,8 +41,16 @@ class UserApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @overload
+    async def create_user(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def create_user(self, user : Annotated[User, Field(..., description="Created user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def create_user(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> None:  # noqa: E501
+    def create_user(self, user : Annotated[User, Field(..., description="Created user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Create user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -69,6 +78,8 @@ class UserApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.create_user_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -196,8 +207,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
+    def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
@@ -225,6 +244,8 @@ class UserApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -337,8 +358,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
+    def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
@@ -366,6 +395,8 @@ class UserApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -478,8 +509,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
+    def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -507,6 +546,8 @@ class UserApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -612,8 +653,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
+        ...
+
+    @overload
+    def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], async_req: Optional[bool]=True, **kwargs) -> User:  # noqa: E501
+        ...
+
     @validate_arguments
-    def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
+    def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], async_req: Optional[bool]=None, **kwargs) -> Union[User, Awaitable[User]]:  # noqa: E501
         """Get user by user name  # noqa: E501
 
           # noqa: E501
@@ -641,6 +690,8 @@ class UserApi(object):
         :rtype: User
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -754,8 +805,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
+        ...
+
+    @overload
+    def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], async_req: Optional[bool]=True, **kwargs) -> str:  # noqa: E501
+        ...
+
     @validate_arguments
-    def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
+    def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], async_req: Optional[bool]=None, **kwargs) -> Union[str, Awaitable[str]]:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
           # noqa: E501
@@ -785,6 +844,8 @@ class UserApi(object):
         :rtype: str
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
 
     @validate_arguments
@@ -903,8 +964,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def logout_user(self, **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def logout_user(self, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def logout_user(self, **kwargs) -> None:  # noqa: E501
+    def logout_user(self, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
           # noqa: E501
@@ -930,6 +999,8 @@ class UserApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.logout_user_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
@@ -1029,8 +1100,16 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
+    @overload
+    async def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> None:  # noqa: E501
+        ...
+
+    @overload
+    def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
+        ...
+
     @validate_arguments
-    def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> None:  # noqa: E501
+    def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Updated user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -1060,6 +1139,8 @@ class UserApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
+        if async_req is not None:
+            kwargs['async_req'] = async_req
         return self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
 
     @validate_arguments


### PR DESCRIPTION
This PR adds overloads for the API call methods so that python tooling can properly infer whether you are calling an asynchronous method or not. The whole thing is unfortunately a little counter-intuitive, as `async_req=True` means that the request will not be using async-await, but will run in a threadpool.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @spacether @krjakbrjak