### PR TITLE
Remove @JsonTypeName from jersey3 POJOs

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -14,9 +14,6 @@
   {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
 {{/vars}}
 })
-{{#isClassnameSanitized}}
-@JsonTypeName("{{name}}")
-{{/isClassnameSanitized}}
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Apple.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
   Apple.JSON_PROPERTY_CULTIVAR,
   Apple.JSON_PROPERTY_ORIGIN
 })
-@JsonTypeName("apple")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Apple {
   public static final String JSON_PROPERTY_CULTIVAR = "cultivar";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/AppleReq.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/AppleReq.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
   AppleReq.JSON_PROPERTY_CULTIVAR,
   AppleReq.JSON_PROPERTY_MEALY
 })
-@JsonTypeName("appleReq")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class AppleReq {
   public static final String JSON_PROPERTY_CULTIVAR = "cultivar";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Banana.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   Banana.JSON_PROPERTY_LENGTH_CM
 })
-@JsonTypeName("banana")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Banana {
   public static final String JSON_PROPERTY_LENGTH_CM = "lengthCm";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/BananaReq.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/BananaReq.java
@@ -34,7 +34,6 @@ import org.openapitools.client.JSON;
   BananaReq.JSON_PROPERTY_LENGTH_CM,
   BananaReq.JSON_PROPERTY_SWEET
 })
-@JsonTypeName("bananaReq")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class BananaReq {
   public static final String JSON_PROPERTY_LENGTH_CM = "lengthCm";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -32,7 +32,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   CatAllOf.JSON_PROPERTY_DECLAWED
 })
-@JsonTypeName("Cat_allOf")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
@@ -35,7 +35,6 @@ import org.openapitools.client.JSON;
   ChildCatAllOf.JSON_PROPERTY_NAME,
   ChildCatAllOf.JSON_PROPERTY_PET_TYPE
 })
-@JsonTypeName("ChildCat_allOf")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ChildCatAllOf {
   public static final String JSON_PROPERTY_NAME = "name";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -32,7 +32,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   DogAllOf.JSON_PROPERTY_BREED
 })
-@JsonTypeName("Dog_allOf")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -48,7 +48,6 @@ import org.openapitools.client.JSON;
   EnumTest.JSON_PROPERTY_OUTER_ENUM_DEFAULT_VALUE,
   EnumTest.JSON_PROPERTY_OUTER_ENUM_INTEGER_DEFAULT_VALUE
 })
-@JsonTypeName("Enum_Test")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class EnumTest {
   /**

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/FooGetDefaultResponse.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   FooGetDefaultResponse.JSON_PROPERTY_STRING
 })
-@JsonTypeName("_foo_get_default_response")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class FooGetDefaultResponse {
   public static final String JSON_PROPERTY_STRING = "string";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -52,7 +52,6 @@ import org.openapitools.client.JSON;
   FormatTest.JSON_PROPERTY_PATTERN_WITH_DIGITS,
   FormatTest.JSON_PROPERTY_PATTERN_WITH_DIGITS_AND_DELIMITER
 })
-@JsonTypeName("format_test")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
   HasOnlyReadOnly.JSON_PROPERTY_BAR,
   HasOnlyReadOnly.JSON_PROPERTY_FOO
 })
-@JsonTypeName("hasOnlyReadOnly")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
   Model200Response.JSON_PROPERTY_NAME,
   Model200Response.JSON_PROPERTY_PROPERTY_CLASS
 })
-@JsonTypeName("200_response")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -34,7 +34,6 @@ import org.openapitools.client.JSON;
   ModelApiResponse.JSON_PROPERTY_TYPE,
   ModelApiResponse.JSON_PROPERTY_MESSAGE
 })
-@JsonTypeName("ApiResponse")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -32,7 +32,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   ModelFile.JSON_PROPERTY_SOURCE_U_R_I
 })
-@JsonTypeName("File")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ModelFile {
   public static final String JSON_PROPERTY_SOURCE_U_R_I = "sourceURI";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelList.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelList.java
@@ -32,7 +32,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   ModelList.JSON_PROPERTY_123LIST
 })
-@JsonTypeName("List")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ModelList {
   public static final String JSON_PROPERTY_123LIST = "123-list";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -32,7 +32,6 @@ import org.openapitools.client.JSON;
 @JsonPropertyOrder({
   ModelReturn.JSON_PROPERTY_RETURN
 })
-@JsonTypeName("Return")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,6 @@ import org.openapitools.client.JSON;
   SpecialModelName.JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME,
   SpecialModelName.JSON_PROPERTY_SPECIAL_MODEL_NAME
 })
-@JsonTypeName("_special_model.name_")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Whale.java
@@ -34,7 +34,6 @@ import org.openapitools.client.JSON;
   Whale.JSON_PROPERTY_HAS_TEETH,
   Whale.JSON_PROPERTY_CLASS_NAME
 })
-@JsonTypeName("whale")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Whale {
   public static final String JSON_PROPERTY_HAS_BALEEN = "hasBaleen";

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Zebra.java
@@ -37,7 +37,6 @@ import org.openapitools.client.JSON;
   Zebra.JSON_PROPERTY_TYPE,
   Zebra.JSON_PROPERTY_CLASS_NAME
 })
-@JsonTypeName("zebra")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Zebra {
   /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
A sibling PR to https://github.com/OpenAPITools/openapi-generator/pull/14842, https://github.com/OpenAPITools/openapi-generator/pull/14852 and #14854. This PR removes the @JsonTypeName annotation from the jersey3 templates. I want to make some other changes that affect the handling of the @JsonTypeName annotation, and investigating those issues led to the conclusion that @JsonTypeName is unnecessary, as the name of the type is specified in the super class' @JsonSubTypes annotation wherever necessary.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)