### PR TITLE
[python-nextgen] use Any as type for free form object

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -611,9 +611,8 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
         } else if (cp.isUuid) {
             return cp.dataType;
         } else if (cp.isFreeFormObject) { // type: object
-            typingImports.add("Dict");
             typingImports.add("Any");
-            return "Dict[str, Any]";
+            return "Any";
         } else if (!cp.isPrimitiveType) {
             // add model prefix
             hasModelsToImport = true;
@@ -855,9 +854,8 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
         } else if (cp.isUuid) {
             return cp.dataType;
         } else if (cp.isFreeFormObject) { // type: object
-            typingImports.add("Dict");
             typingImports.add("Any");
-            return "Dict[str, Any]";
+            return "Any";
         } else if (!cp.isPrimitiveType || cp.isModel) { // model
             if (!cp.isCircularReference) {
                 // skip import if it's a circular reference

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/nullable_class.py
@@ -33,12 +33,12 @@ class NullableClass(BaseModel):
     string_prop: Optional[StrictStr] = None
     date_prop: Optional[date] = None
     datetime_prop: Optional[datetime] = None
-    array_nullable_prop: Optional[conlist(Dict[str, Any])] = None
-    array_and_items_nullable_prop: Optional[conlist(Dict[str, Any])] = None
-    array_items_nullable: Optional[conlist(Dict[str, Any])] = None
-    object_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
-    object_and_items_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
-    object_items_nullable: Optional[Dict[str, Dict[str, Any]]] = None
+    array_nullable_prop: Optional[conlist(Any)] = None
+    array_and_items_nullable_prop: Optional[conlist(Any)] = None
+    array_items_nullable: Optional[conlist(Any)] = None
+    object_nullable_prop: Optional[Dict[str, Any]] = None
+    object_and_items_nullable_prop: Optional[Dict[str, Any]] = None
+    object_items_nullable: Optional[Dict[str, Any]] = None
     __properties = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/nullable_class.py
@@ -33,12 +33,12 @@ class NullableClass(BaseModel):
     string_prop: Optional[StrictStr] = None
     date_prop: Optional[date] = None
     datetime_prop: Optional[datetime] = None
-    array_nullable_prop: Optional[conlist(Dict[str, Any])] = None
-    array_and_items_nullable_prop: Optional[conlist(Dict[str, Any])] = None
-    array_items_nullable: Optional[conlist(Dict[str, Any])] = None
-    object_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
-    object_and_items_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
-    object_items_nullable: Optional[Dict[str, Dict[str, Any]]] = None
+    array_nullable_prop: Optional[conlist(Any)] = None
+    array_and_items_nullable_prop: Optional[conlist(Any)] = None
+    array_items_nullable: Optional[conlist(Any)] = None
+    object_nullable_prop: Optional[Dict[str, Any]] = None
+    object_and_items_nullable_prop: Optional[Dict[str, Any]] = None
+    object_items_nullable: Optional[Dict[str, Any]] = None
     __properties = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 
     class Config:


### PR DESCRIPTION
This PR changes type for "object" from Dict[str, Any] to Any which is more convenient for such loosely defined attributes.

Thanks.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11)  @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02) @wing328