### PR TITLE
Add new openapi-normalizer rule: ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -505,3 +505,10 @@ Example:
 ```
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_TAGS_FOR_ALL_OPERATIONS=true
 ```
+
+- `ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE`: when set to true, auto fix integer with maximum value 4294967295 (2^32-1) or long with 18446744073709551615 (2^64-1) by adding x-unsigned to the schema
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE=true
+```

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -76,6 +76,11 @@ public class OpenAPINormalizer {
     final String SET_TAGS_FOR_ALL_OPERATIONS = "SET_TAGS_FOR_ALL_OPERATIONS";
     String setTagsForAllOperations;
 
+    // when set to true, auto fix integer with maximum value 4294967295 (2^32-1) or long with 18446744073709551615 (2^64-1)
+    // by adding x-unsigned to the schema
+    final String ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE = "ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE";
+    boolean addUnsignedToIntegerWithInvalidMaxValue;
+
     // ============= end of rules =============
 
     /**
@@ -132,6 +137,9 @@ public class OpenAPINormalizer {
             setTagsForAllOperations = rules.get(SET_TAGS_FOR_ALL_OPERATIONS);
         }
 
+        if (enableAll || "true".equalsIgnoreCase(rules.get(ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE))) {
+            addUnsignedToIntegerWithInvalidMaxValue = true;
+        }
     }
 
     /**
@@ -367,6 +375,8 @@ public class OpenAPINormalizer {
             normalizeProperties(schema.getProperties(), visitedSchemas);
         } else if (schema instanceof BooleanSchema) {
             normalizeBooleanSchema(schema, visitedSchemas);
+        } else if (schema instanceof IntegerSchema) {
+            normalizeIntegerSchema(schema, visitedSchemas);
         } else if (schema instanceof Schema) {
             normalizeSchemaWithOnlyProperties(schema, visitedSchemas);
         } else {
@@ -378,6 +388,10 @@ public class OpenAPINormalizer {
 
     private void normalizeBooleanSchema(Schema schema, Set<Schema> visitedSchemas) {
         processSimplifyBooleanEnum(schema);
+    }
+
+    private void normalizeIntegerSchema(Schema schema, Set<Schema> visitedSchemas) {
+        processAddUnsignedToIntegerWithInvalidMaxValue(schema);
     }
 
     private void normalizeSchemaWithOnlyProperties(Schema schema, Set<Schema> visitedSchemas) {
@@ -671,6 +685,37 @@ public class OpenAPINormalizer {
             BooleanSchema bs = (BooleanSchema) schema;
             if (bs.getEnum() != null && !bs.getEnum().isEmpty()) { // enum defined
                 bs.setEnum(null);
+            }
+        }
+    }
+
+    /**
+     * If the schema is integer and the max value is invalid (out of bound)
+     * then add x-unsigned to use unsigned integer/long instead.
+     *
+     * @param schema Schema
+     * @return Schema
+     */
+    private void processAddUnsignedToIntegerWithInvalidMaxValue(Schema schema) {
+        if (!addUnsignedToIntegerWithInvalidMaxValue && !enableAll) {
+            return;
+        }
+
+        LOGGER.info("processAddUnsignedToIntegerWithInvalidMaxValue");
+        if (schema instanceof IntegerSchema) {
+            if (ModelUtils.isLongSchema(schema)) {
+                if ("18446744073709551615".equals(String.valueOf(schema.getMaximum())) &&
+                        "0".equals(String.valueOf(schema.getMinimum()))) {
+                    schema.addExtension("x-unsigned", true);
+                    LOGGER.info("fix long");
+                }
+            } else {
+                if ("4294967295".equals(String.valueOf(schema.getMaximum())) &&
+                        "0".equals(String.valueOf(schema.getMinimum()))) {
+                    schema.addExtension("x-unsigned", true);
+                    LOGGER.info("fix integer");
+
+                }
             }
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4471,4 +4471,30 @@ public class DefaultCodegenTest {
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().get(0), "core");
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().get(0), "core");
     }
+
+    @Test
+    public void testAddUnsignedToIntegerWithInvalidMaxValue() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml");
+
+        Schema person = openAPI.getComponents().getSchemas().get("Person");
+        assertNull(((Schema)person.getProperties().get("integer")).getExtensions());
+        assertNull(((Schema)person.getProperties().get("int32")).getExtensions());
+        assertNull(((Schema)person.getProperties().get("int64")).getExtensions());
+        assertNull(((Schema)person.getProperties().get("integer_max")).getExtensions());
+        assertNull(((Schema)person.getProperties().get("int32_max")).getExtensions());
+        assertNull(((Schema)person.getProperties().get("int64_max")).getExtensions());
+
+        Map<String, String> options = new HashMap<>();
+        options.put("ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE", "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema person2 = openAPI.getComponents().getSchemas().get("Person");
+        assertNull(((Schema)person2.getProperties().get("integer")).getExtensions());
+        assertNull(((Schema)person2.getProperties().get("int32")).getExtensions());
+        assertNull(((Schema)person2.getProperties().get("int64")).getExtensions());
+        assertTrue((Boolean)((Schema)person2.getProperties().get("integer_max")).getExtensions().get("x-unsigned"));
+        assertTrue((Boolean)((Schema)person2.getProperties().get("int32_max")).getExtensions().get("x-unsigned"));
+        assertTrue((Boolean)((Schema)person2.getProperties().get("int64_max")).getExtensions().get("x-unsigned"));
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml
@@ -1,0 +1,75 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /person/display/{personId}:
+    get:
+      tags:
+        - person
+        - basic
+      parameters:
+        - name: personId
+          in: path
+          required: true
+          description: The id of the person to retrieve
+          schema:
+            type: string
+      operationId: list
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+    delete:
+      tags:
+        - person
+      parameters:
+        - name: personId
+          in: path
+          required: true
+          description: The id of the person to retrieve
+          schema:
+            type: string
+      operationId: delete
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+components:
+  schemas:
+    Person:
+      description: person
+      type: object
+      properties:
+        integer:
+          type: integer
+        int32:
+          type: integer
+          format: int32 
+        int64:
+          type: integer
+          format: int64 
+        integer_max:
+          type: integer
+          minimum: 0
+          maximum: 4294967295 #(2^32)-1
+        int32_max:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 4294967295 #(2^32)-1
+        int64_max:
+          type: integer
+          format: int64
+          minimum: 0
+          maximum: 18446744073709551615 #(2^64)-1


### PR DESCRIPTION
To close https://github.com/OpenAPITools/openapi-generator/issues/14481


Add new openapi-normalizer rule: ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE

when set to true, auto fix integer with maximum value 4294967295 (2^32-1) or long with 18446744073709551615 (2^64-1) by adding x-unsigned to the schema

FYI. @OpenAPITools/generator-core-team 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

