### PR TITLE
[Enhancement] [Gradle Plugin] Allow templates from classpath

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -164,6 +164,10 @@ apply plugin: 'org.openapi.generator'
 |None
 |The template directory holding a custom template.
 
+|templateResourcePath
+|String
+|Directory with mustache templates via resource path. This option will overwrite any option defined in `templateDir`
+
 |auth
 |String
 |None

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -99,6 +99,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     inputSpec.set(generate.inputSpec)
                     remoteInputSpec.set(generate.remoteInputSpec)
                     templateDir.set(generate.templateDir)
+                    templateResourcePath.set(generate.templateResourcePath)
                     auth.set(generate.auth)
                     globalProperties.set(generate.globalProperties)
                     configFile.set(generate.configFile)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -65,6 +65,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val templateDir = project.objects.property<String?>()
 
     /**
+     * The template location (which may be a directory or a classpath location) holding custom templates.
+     */
+    val templateResourcePath = project.objects.property<String?>()
+
+    /**
      * Adds authorization headers when fetching the OpenAPI definitions remotely.
      * Pass in a URL-encoded string of name:header with a comma separating multiple values
      */

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -128,6 +128,13 @@ open class GenerateTask : DefaultTask() {
     val templateDir = project.objects.property<String?>()
 
     /**
+     * Resource path containing template files.
+     */
+    @Optional
+    @Input
+    val templateResourcePath = project.objects.property<String?>()
+
+    /**
      * Adds authorization headers when fetching the OpenAPI definitions remotely.
      * Pass in a URL-encoded string of name:header with a comma separating multiple values
      */
@@ -647,6 +654,13 @@ open class GenerateTask : DefaultTask() {
             }
 
             templateDir.ifNotEmpty { value ->
+                configurator.setTemplateDir(value)
+            }
+
+            templateResourcePath.ifNotEmpty { value ->
+                templateDir.ifNotEmpty {
+                    logger.warn("Both templateDir and templateResourcePath were configured. templateResourcePath overwrites templateDir.")
+                }
                 configurator.setTemplateDir(value)
             }
 


### PR DESCRIPTION
Enhance the Gradle plugin to support loading templates from the classpath. This is already a feature of the Maven plugin, and this PR uses the same approach.