### PR TITLE
Minor bug fix in openapi normalizer

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1975,11 +1975,12 @@ public class ModelUtils {
      */
     public static boolean hasCommonAttributesDefined(Schema schema) {
         if (schema.getNullable() != null || schema.getDefault() != null ||
-                schema.getMinimum() != null || schema.getMinimum() != null ||
+                schema.getMinimum() != null || schema.getMaximum() != null ||
                 schema.getExclusiveMaximum() != null || schema.getExclusiveMinimum() != null ||
                 schema.getMinLength() != null || schema.getMaxLength() != null ||
                 schema.getMinItems() != null || schema.getMaxItems() != null ||
-                schema.getReadOnly() != null || schema.getWriteOnly() != null) {
+                schema.getReadOnly() != null || schema.getWriteOnly() != null ||
+                schema.getPattern() != null) {
             return true;
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -239,12 +239,12 @@ public class OpenAPINormalizerTest {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml");
 
         Schema person = openAPI.getComponents().getSchemas().get("Person");
-        assertNull(((Schema)person.getProperties().get("integer")).getExtensions());
-        assertNull(((Schema)person.getProperties().get("int32")).getExtensions());
-        assertNull(((Schema)person.getProperties().get("int64")).getExtensions());
-        assertNull(((Schema)person.getProperties().get("integer_max")).getExtensions());
-        assertNull(((Schema)person.getProperties().get("int32_max")).getExtensions());
-        assertNull(((Schema)person.getProperties().get("int64_max")).getExtensions());
+        assertNull(((Schema) person.getProperties().get("integer")).getExtensions());
+        assertNull(((Schema) person.getProperties().get("int32")).getExtensions());
+        assertNull(((Schema) person.getProperties().get("int64")).getExtensions());
+        assertNull(((Schema) person.getProperties().get("integer_max")).getExtensions());
+        assertNull(((Schema) person.getProperties().get("int32_max")).getExtensions());
+        assertNull(((Schema) person.getProperties().get("int64_max")).getExtensions());
 
         Map<String, String> options = new HashMap<>();
         options.put("ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE", "true");
@@ -252,12 +252,12 @@ public class OpenAPINormalizerTest {
         openAPINormalizer.normalize();
 
         Schema person2 = openAPI.getComponents().getSchemas().get("Person");
-        assertNull(((Schema)person2.getProperties().get("integer")).getExtensions());
-        assertNull(((Schema)person2.getProperties().get("int32")).getExtensions());
-        assertNull(((Schema)person2.getProperties().get("int64")).getExtensions());
-        assertTrue((Boolean)((Schema)person2.getProperties().get("integer_max")).getExtensions().get("x-unsigned"));
-        assertTrue((Boolean)((Schema)person2.getProperties().get("int32_max")).getExtensions().get("x-unsigned"));
-        assertTrue((Boolean)((Schema)person2.getProperties().get("int64_max")).getExtensions().get("x-unsigned"));
+        assertNull(((Schema) person2.getProperties().get("integer")).getExtensions());
+        assertNull(((Schema) person2.getProperties().get("int32")).getExtensions());
+        assertNull(((Schema) person2.getProperties().get("int64")).getExtensions());
+        assertTrue((Boolean) ((Schema) person2.getProperties().get("integer_max")).getExtensions().get("x-unsigned"));
+        assertTrue((Boolean) ((Schema) person2.getProperties().get("int32_max")).getExtensions().get("x-unsigned"));
+        assertTrue((Boolean) ((Schema) person2.getProperties().get("int64_max")).getExtensions().get("x-unsigned"));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -194,6 +194,29 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
+    public void testOpenAPINormalizerSimplifyBooleanEnumWithComposedSchema() {
+        // to test the rule SIMPLIFY_BOOLEAN_ENUM
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/simplifyBooleanEnum_test.yaml");
+
+        Schema schema = openAPI.getComponents().getSchemas().get("ComposedSchemaBooleanEnumTest");
+        assertEquals(schema.getProperties().size(), 3);
+        assertTrue(schema.getProperties().get("boolean_enum") instanceof BooleanSchema);
+        BooleanSchema bs = (BooleanSchema) schema.getProperties().get("boolean_enum");
+        assertEquals(bs.getEnum().size(), 2);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SIMPLIFY_BOOLEAN_ENUM", "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema schema3 = openAPI.getComponents().getSchemas().get("ComposedSchemaBooleanEnumTest");
+        assertEquals(schema.getProperties().size(), 3);
+        assertTrue(schema.getProperties().get("boolean_enum") instanceof BooleanSchema);
+        BooleanSchema bs2 = (BooleanSchema) schema.getProperties().get("boolean_enum");
+        assertNull(bs2.getEnum()); //ensure the enum has been erased
+    }
+
+    @Test
     public void testOpenAPINormalizerSetTagsInAllOperations() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml");
 

--- a/modules/openapi-generator/src/test/resources/3_0/simplifyBooleanEnum_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/simplifyBooleanEnum_test.yaml
@@ -41,3 +41,21 @@ components:
           enum:
             - true
             - false
+    ComposedSchemaBooleanEnumTest:
+      description: a model to with boolean enum property
+      type: object
+      oneOf:
+        - type: string
+        - type: integer
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+        boolean_enum:
+          type: boolean
+          enum:
+            - true
+            - false


### PR DESCRIPTION
- minor refactoring
- fix bug in composed schema with proper processing of properties
- tested locally 
- added a test
- fix a bug in `ModelUtils.hasCommonAttributesDefined`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @OpenAPITools/generator-core-team 