### PR TITLE
[csharp-netcore] Removed TryGet from deserialization methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
@@ -91,37 +91,26 @@
                         {{^isEnum}}
                         {{#isDouble}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDouble(out {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}});
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = utf8JsonReader.GetDouble();
                         {{/isDouble}}
                         {{#isDecimal}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}});
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = utf8JsonReader.GetDecimal();
                         {{/isDecimal}}
                         {{#isFloat}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetDouble(out double {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result);
-                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = (float){{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result;
-                            }
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = (float)utf8JsonReader.GetDouble();
                         {{/isFloat}}
                         {{#isLong}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGet{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int64(out {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}});
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = utf8JsonReader.Get{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int64();
                         {{/isLong}}
                         {{^isLong}}
                         {{^isFloat}}
                         {{^isDecimal}}
                         {{^isDouble}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {{#isNullable}}
-                            {
-                                utf8JsonReader.TryGet{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int32(out {{#vendorExtensions.x-unsigned}}u{{/vendorExtensions.x-unsigned}}int {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result);
-                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result;
-                            }
-                            {{/isNullable}}
-                            {{^isNullable}}
-                                utf8JsonReader.TryGet{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int32(out {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}});
-                            {{/isNullable}}
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = utf8JsonReader.Get{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int32();
                         {{/isDouble}}
                         {{/isDecimal}}
                         {{/isFloat}}
@@ -140,10 +129,7 @@
                         {{^isMap}}
                         {{#isNumeric}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGet{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int32(out {{#vendorExtensions.x-unsigned}}u{{/vendorExtensions.x-unsigned}}int {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result);
-                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = ({{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}}){{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result;
-                            }
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = ({{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}})utf8JsonReader.Get{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int32();
                         {{/isNumeric}}
                         {{^isNumeric}}
                             string {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue = utf8JsonReader.GetString();
@@ -158,15 +144,7 @@
                         {{/isEnum}}
                         {{#isUuid}}
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {{#isNullable}}
-                            {
-                                utf8JsonReader.TryGetGuid(out Guid {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result);
-                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}Result;
-                            }
-                            {{/isNullable}}
-                            {{^isNullable}}
-                                utf8JsonReader.TryGetGuid(out {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}});
-                            {{/isNullable}}
+                                {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = utf8JsonReader.GetGuid();
                         {{/isUuid}}
                         {{^isUuid}}
                         {{^isEnum}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "code":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out code);
+                                code = utf8JsonReader.GetInt32();
                             break;
                         case "message":
                             message = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "lengthCm":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out lengthCm);
+                                lengthCm = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "lengthCm":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out lengthCm);
+                                lengthCm = utf8JsonReader.GetDecimal();
                             break;
                         case "sweet":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -487,24 +487,15 @@ namespace Org.OpenAPITools.Model
                     {
                         case "enum_integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumIntegerResult);
-                                enumInteger = (EnumTest.EnumIntegerEnum)enumIntegerResult;
-                            }
+                                enumInteger = (EnumTest.EnumIntegerEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_integer_only":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumIntegerOnlyResult);
-                                enumIntegerOnly = (EnumTest.EnumIntegerOnlyEnum)enumIntegerOnlyResult;
-                            }
+                                enumIntegerOnly = (EnumTest.EnumIntegerOnlyEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumNumberResult);
-                                enumNumber = (EnumTest.EnumNumberEnum)enumNumberResult;
-                            }
+                                enumNumber = (EnumTest.EnumNumberEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_string":
                             string enumStringRawValue = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -487,30 +487,27 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "double":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDouble(out doubleProperty);
+                                doubleProperty = utf8JsonReader.GetDouble();
                             break;
                         case "float":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetDouble(out double floatPropertyResult);
-                                floatProperty = (float)floatPropertyResult;
-                            }
+                                floatProperty = (float)utf8JsonReader.GetDouble();
                             break;
                         case "int32":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out int32);
+                                int32 = utf8JsonReader.GetInt32();
                             break;
                         case "int64":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out int64);
+                                int64 = utf8JsonReader.GetInt64();
                             break;
                         case "integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out integer);
+                                integer = utf8JsonReader.GetInt32();
                             break;
                         case "number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out number);
+                                number = utf8JsonReader.GetDecimal();
                             break;
                         case "password":
                             password = utf8JsonReader.GetString();
@@ -526,15 +523,15 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "unsigned_integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetUInt32(out unsignedInteger);
+                                unsignedInteger = utf8JsonReader.GetUInt32();
                             break;
                         case "unsigned_long":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetUInt64(out unsignedLong);
+                                unsignedLong = utf8JsonReader.GetUInt64();
                             break;
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuid);
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -185,11 +185,11 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuid);
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         case "uuid_with_pattern":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuidWithPattern);
+                                uuidWithPattern = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "name":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out name);
+                                name = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
@@ -202,18 +202,18 @@ namespace Org.OpenAPITools.Model
                     {
                         case "name":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out nameProperty);
+                                nameProperty = utf8JsonReader.GetInt32();
                             break;
                         case "property":
                             property = utf8JsonReader.GetString();
                             break;
                         case "snake_case":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out snakeCase);
+                                snakeCase = utf8JsonReader.GetInt32();
                             break;
                         case "123Number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out _123number);
+                                _123number = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -271,17 +271,11 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "integer_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int integerPropResult);
-                                integerProp = integerPropResult;
-                            }
+                                integerProp = utf8JsonReader.GetInt32();
                             break;
                         case "number_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int numberPropResult);
-                                numberProp = numberPropResult;
-                            }
+                                numberProp = utf8JsonReader.GetInt32();
                             break;
                         case "object_and_items_nullable_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -118,10 +118,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetGuid(out Guid uuidResult);
-                                uuid = uuidResult;
-                            }
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "JustNumber":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out justNumber);
+                                justNumber = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out id);
+                                id = utf8JsonReader.GetDecimal();
                             break;
                         case "uuid":
                             uuid = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
@@ -260,15 +260,15 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "petId":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out petId);
+                                petId = utf8JsonReader.GetInt64();
                             break;
                         case "quantity":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out quantity);
+                                quantity = utf8JsonReader.GetInt32();
                             break;
                         case "shipDate":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -156,7 +156,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "my_number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out myNumber);
+                                myNumber = utf8JsonReader.GetDecimal();
                             break;
                         case "my_string":
                             myString = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
@@ -259,7 +259,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "return":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out returnProperty);
+                                returnProperty = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "$special[property.name]":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out specialPropertyName);
+                                specialPropertyName = utf8JsonReader.GetInt64();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
@@ -271,7 +271,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "lastName":
                             lastName = utf8JsonReader.GetString();
@@ -288,7 +288,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "userStatus":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out userStatus);
+                                userStatus = utf8JsonReader.GetInt32();
                             break;
                         case "username":
                             username = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "code":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out code);
+                                code = utf8JsonReader.GetInt32();
                             break;
                         case "message":
                             message = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "lengthCm":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out lengthCm);
+                                lengthCm = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "lengthCm":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out lengthCm);
+                                lengthCm = utf8JsonReader.GetDecimal();
                             break;
                         case "sweet":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
@@ -137,7 +137,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -485,24 +485,15 @@ namespace Org.OpenAPITools.Model
                     {
                         case "enum_integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumIntegerResult);
-                                enumInteger = (EnumTest.EnumIntegerEnum)enumIntegerResult;
-                            }
+                                enumInteger = (EnumTest.EnumIntegerEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_integer_only":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumIntegerOnlyResult);
-                                enumIntegerOnly = (EnumTest.EnumIntegerOnlyEnum)enumIntegerOnlyResult;
-                            }
+                                enumIntegerOnly = (EnumTest.EnumIntegerOnlyEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumNumberResult);
-                                enumNumber = (EnumTest.EnumNumberEnum)enumNumberResult;
-                            }
+                                enumNumber = (EnumTest.EnumNumberEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_string":
                             string enumStringRawValue = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -485,30 +485,27 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "double":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDouble(out doubleProperty);
+                                doubleProperty = utf8JsonReader.GetDouble();
                             break;
                         case "float":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetDouble(out double floatPropertyResult);
-                                floatProperty = (float)floatPropertyResult;
-                            }
+                                floatProperty = (float)utf8JsonReader.GetDouble();
                             break;
                         case "int32":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out int32);
+                                int32 = utf8JsonReader.GetInt32();
                             break;
                         case "int64":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out int64);
+                                int64 = utf8JsonReader.GetInt64();
                             break;
                         case "integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out integer);
+                                integer = utf8JsonReader.GetInt32();
                             break;
                         case "number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out number);
+                                number = utf8JsonReader.GetDecimal();
                             break;
                         case "password":
                             password = utf8JsonReader.GetString();
@@ -524,15 +521,15 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "unsigned_integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetUInt32(out unsignedInteger);
+                                unsignedInteger = utf8JsonReader.GetUInt32();
                             break;
                         case "unsigned_long":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetUInt64(out unsignedLong);
+                                unsignedLong = utf8JsonReader.GetUInt64();
                             break;
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuid);
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -183,11 +183,11 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuid);
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         case "uuid_with_pattern":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuidWithPattern);
+                                uuidWithPattern = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "name":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out name);
+                                name = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
@@ -200,18 +200,18 @@ namespace Org.OpenAPITools.Model
                     {
                         case "name":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out nameProperty);
+                                nameProperty = utf8JsonReader.GetInt32();
                             break;
                         case "property":
                             property = utf8JsonReader.GetString();
                             break;
                         case "snake_case":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out snakeCase);
+                                snakeCase = utf8JsonReader.GetInt32();
                             break;
                         case "123Number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out _123number);
+                                _123number = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -269,17 +269,11 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "integer_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int integerPropResult);
-                                integerProp = integerPropResult;
-                            }
+                                integerProp = utf8JsonReader.GetInt32();
                             break;
                         case "number_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int numberPropResult);
-                                numberProp = numberPropResult;
-                            }
+                                numberProp = utf8JsonReader.GetInt32();
                             break;
                         case "object_and_items_nullable_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -116,10 +116,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetGuid(out Guid uuidResult);
-                                uuid = uuidResult;
-                            }
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "JustNumber":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out justNumber);
+                                justNumber = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out id);
+                                id = utf8JsonReader.GetDecimal();
                             break;
                         case "uuid":
                             uuid = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
@@ -258,15 +258,15 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "petId":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out petId);
+                                petId = utf8JsonReader.GetInt64();
                             break;
                         case "quantity":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out quantity);
+                                quantity = utf8JsonReader.GetInt32();
                             break;
                         case "shipDate":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "my_number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out myNumber);
+                                myNumber = utf8JsonReader.GetDecimal();
                             break;
                         case "my_string":
                             myString = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -257,7 +257,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "return":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out returnProperty);
+                                returnProperty = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "$special[property.name]":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out specialPropertyName);
+                                specialPropertyName = utf8JsonReader.GetInt64();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -137,7 +137,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "lastName":
                             lastName = utf8JsonReader.GetString();
@@ -286,7 +286,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "userStatus":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out userStatus);
+                                userStatus = utf8JsonReader.GetInt32();
                             break;
                         case "username":
                             username = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/ChildAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/ChildAllOf.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "age":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out age);
+                                age = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "count":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out count);
+                                count = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "count":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out count);
+                                count = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "code":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out code);
+                                code = utf8JsonReader.GetInt32();
                             break;
                         case "message":
                             message = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "lengthCm":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out lengthCm);
+                                lengthCm = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "lengthCm":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out lengthCm);
+                                lengthCm = utf8JsonReader.GetDecimal();
                             break;
                         case "sweet":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
@@ -137,7 +137,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -485,24 +485,15 @@ namespace Org.OpenAPITools.Model
                     {
                         case "enum_integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumIntegerResult);
-                                enumInteger = (EnumTest.EnumIntegerEnum)enumIntegerResult;
-                            }
+                                enumInteger = (EnumTest.EnumIntegerEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_integer_only":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumIntegerOnlyResult);
-                                enumIntegerOnly = (EnumTest.EnumIntegerOnlyEnum)enumIntegerOnlyResult;
-                            }
+                                enumIntegerOnly = (EnumTest.EnumIntegerOnlyEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int enumNumberResult);
-                                enumNumber = (EnumTest.EnumNumberEnum)enumNumberResult;
-                            }
+                                enumNumber = (EnumTest.EnumNumberEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_string":
                             string enumStringRawValue = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -485,30 +485,27 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "double":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDouble(out doubleProperty);
+                                doubleProperty = utf8JsonReader.GetDouble();
                             break;
                         case "float":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetDouble(out double floatPropertyResult);
-                                floatProperty = (float)floatPropertyResult;
-                            }
+                                floatProperty = (float)utf8JsonReader.GetDouble();
                             break;
                         case "int32":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out int32);
+                                int32 = utf8JsonReader.GetInt32();
                             break;
                         case "int64":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out int64);
+                                int64 = utf8JsonReader.GetInt64();
                             break;
                         case "integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out integer);
+                                integer = utf8JsonReader.GetInt32();
                             break;
                         case "number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out number);
+                                number = utf8JsonReader.GetDecimal();
                             break;
                         case "password":
                             password = utf8JsonReader.GetString();
@@ -524,15 +521,15 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "unsigned_integer":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetUInt32(out unsignedInteger);
+                                unsignedInteger = utf8JsonReader.GetUInt32();
                             break;
                         case "unsigned_long":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetUInt64(out unsignedLong);
+                                unsignedLong = utf8JsonReader.GetUInt64();
                             break;
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuid);
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -183,11 +183,11 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuid);
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         case "uuid_with_pattern":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetGuid(out uuidWithPattern);
+                                uuidWithPattern = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "name":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out name);
+                                name = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
@@ -200,18 +200,18 @@ namespace Org.OpenAPITools.Model
                     {
                         case "name":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out nameProperty);
+                                nameProperty = utf8JsonReader.GetInt32();
                             break;
                         case "property":
                             property = utf8JsonReader.GetString();
                             break;
                         case "snake_case":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out snakeCase);
+                                snakeCase = utf8JsonReader.GetInt32();
                             break;
                         case "123Number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out _123number);
+                                _123number = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -269,17 +269,11 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "integer_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int integerPropResult);
-                                integerProp = integerPropResult;
-                            }
+                                integerProp = utf8JsonReader.GetInt32();
                             break;
                         case "number_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetInt32(out int numberPropResult);
-                                numberProp = numberPropResult;
-                            }
+                                numberProp = utf8JsonReader.GetInt32();
                             break;
                         case "object_and_items_nullable_prop":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -116,10 +116,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "uuid":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                            {
-                                utf8JsonReader.TryGetGuid(out Guid uuidResult);
-                                uuid = uuidResult;
-                            }
+                                uuid = utf8JsonReader.GetGuid();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "JustNumber":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out justNumber);
+                                justNumber = utf8JsonReader.GetDecimal();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out id);
+                                id = utf8JsonReader.GetDecimal();
                             break;
                         case "uuid":
                             uuid = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
@@ -258,15 +258,15 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "petId":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out petId);
+                                petId = utf8JsonReader.GetInt64();
                             break;
                         case "quantity":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out quantity);
+                                quantity = utf8JsonReader.GetInt32();
                             break;
                         case "shipDate":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -154,7 +154,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "my_number":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetDecimal(out myNumber);
+                                myNumber = utf8JsonReader.GetDecimal();
                             break;
                         case "my_string":
                             myString = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -257,7 +257,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "return":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out returnProperty);
+                                returnProperty = utf8JsonReader.GetInt32();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "$special[property.name]":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out specialPropertyName);
+                                specialPropertyName = utf8JsonReader.GetInt64();
                             break;
                         default:
                             break;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -137,7 +137,7 @@ namespace Org.OpenAPITools.Model
                     {
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "name":
                             name = utf8JsonReader.GetString();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
@@ -269,7 +269,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "id":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt64(out id);
+                                id = utf8JsonReader.GetInt64();
                             break;
                         case "lastName":
                             lastName = utf8JsonReader.GetString();
@@ -286,7 +286,7 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "userStatus":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                utf8JsonReader.TryGetInt32(out userStatus);
+                                userStatus = utf8JsonReader.GetInt32();
                             break;
                         case "username":
                             username = utf8JsonReader.GetString();


### PR DESCRIPTION
Removed TryGet from deserialization methods. This means the error will occur quicker and will not be hidden when the property is nullable.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/14964

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
