### PR TITLE
[csharp-netcore] Moved null checks from constructor to JsonConverter

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
@@ -170,6 +170,21 @@
                 }
             }
 
+            {{#nonNullableVars}}
+            {{#-first}}
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            {{/-first}}
+            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
+                throw new ArgumentNullException(nameof({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}), "Property is required for class {{classname}}.");
+
+            {{#-last}}
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            {{/-last}}
+            {{/nonNullableVars}}
             {{#composedSchemas.oneOf}}
             if ({{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}Deserialized)
                 return new {{classname}}({{#lambda.joinWithComma}}{{#lambda.camelcase_param}}{{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}{{/lambda.camelcase_param}}  {{#model.composedSchemas.allOf}}{{^isInherited}}{{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}{{/isInherited}}{{/model.composedSchemas.allOf}}{{#model.composedSchemas.anyOf}}{{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}  {{/model.composedSchemas.anyOf}}{{#allVars}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}  {{/allVars}}{{/lambda.joinWithComma}});

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/modelGeneric.mustache
@@ -22,21 +22,6 @@
         [JsonConstructor]
         {{#readWriteVars}}{{#-first}}public{{/-first}}{{/readWriteVars}}{{^readWriteVars}}internal{{/readWriteVars}} {{classname}}({{#lambda.joinWithComma}}{{{dataType}}}{{#isNullable}}{{nrt?}}{{/isNullable}} {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}  {{#model.composedSchemas.allOf}}{{^isInherited}}{{{dataType}}} {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}  {{/isInherited}}{{/model.composedSchemas.allOf}}{{#model.composedSchemas.anyOf}}{{{dataType}}}{{#isNullable}}{{nrt?}}{{/isNullable}} {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}  {{/model.composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{#parentModel.composedSchemas.oneOf}}{{#lambda.camelcase_param}}{{parent}}{{/lambda.camelcase_param}}.{{#lambda.titlecase}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.titlecase}}  {{/parentModel.composedSchemas.oneOf}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
-            {{#nonNullableVars}}
-            {{#-first}}
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            {{/-first}}
-            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
-                throw new ArgumentNullException(nameof({{name}}));
-
-            {{#-last}}
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            {{/-last}}
-            {{/nonNullableVars}}
             {{#lambda.titlecase}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.titlecase}} = {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}};
             {{#composedSchemas.allOf}}
             {{#lambda.titlecase}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.titlecase}} = {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}};
@@ -70,21 +55,6 @@
         [JsonConstructor]
         {{#readWriteVars}}{{#-first}}public{{/-first}}{{/readWriteVars}}{{^readWriteVars}}internal{{/readWriteVars}} {{classname}}({{#lambda.joinWithComma}}{{#composedSchemas.allOf}}{{^isInherited}}{{{dataType}}} {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}  {{/isInherited}}{{/composedSchemas.allOf}}{{#composedSchemas.anyOf}}{{{dataType}}}{{#isNullable}}{{nrt?}}{{/isNullable}} {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}}  {{/composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
-            {{#nonNullableVars}}
-            {{#-first}}
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            {{/-first}}
-            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null)
-                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null.");
-
-            {{#-last}}
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            {{/-last}}
-            {{/nonNullableVars}}
             {{#composedSchemas.allOf}}
             {{^isInherited}}
             {{#lambda.titlecase}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.titlecase}} = {{#lambda.camelcase_param}}{{baseType}}{{#isArray}}{{{dataFormat}}}{{/isArray}}{{/lambda.camelcase_param}};

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Activity.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (activityOutputs == null)
-                throw new ArgumentNullException("activityOutputs is a required property for Activity and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ActivityOutputs = activityOutputs;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (activityOutputs == null)
+                throw new ArgumentNullException(nameof(activityOutputs), "Property is required for class Activity.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ActivityOutputElementRepresentation(string prop1, Object prop2)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (prop1 == null)
-                throw new ArgumentNullException("prop1 is a required property for ActivityOutputElementRepresentation and cannot be null.");
-
-            if (prop2 == null)
-                throw new ArgumentNullException("prop2 is a required property for ActivityOutputElementRepresentation and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Prop1 = prop1;
             Prop2 = prop2;
         }
@@ -149,6 +137,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (prop1 == null)
+                throw new ArgumentNullException(nameof(prop1), "Property is required for class ActivityOutputElementRepresentation.");
+
+            if (prop2 == null)
+                throw new ArgumentNullException(nameof(prop2), "Property is required for class ActivityOutputElementRepresentation.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -44,33 +44,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AdditionalPropertiesClass(Object emptyMap, Dictionary<string, Dictionary<string, string>> mapOfMapProperty, Dictionary<string, string> mapProperty, Object mapWithUndeclaredPropertiesAnytype1, Object mapWithUndeclaredPropertiesAnytype2, Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3, Dictionary<string, string> mapWithUndeclaredPropertiesString, Object? anytype1 = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mapProperty == null)
-                throw new ArgumentNullException("mapProperty is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapOfMapProperty == null)
-                throw new ArgumentNullException("mapOfMapProperty is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype1 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype2 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype3 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (emptyMap == null)
-                throw new ArgumentNullException("emptyMap is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesString is a required property for AdditionalPropertiesClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EmptyMap = emptyMap;
             MapOfMapProperty = mapOfMapProperty;
             MapProperty = mapProperty;
@@ -250,6 +223,33 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mapProperty == null)
+                throw new ArgumentNullException(nameof(mapProperty), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapOfMapProperty == null)
+                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype1 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype2 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype3 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+
+            if (emptyMap == null)
+                throw new ArgumentNullException(nameof(emptyMap), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesString == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AdditionalPropertiesClass(emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString, anytype1);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Animal.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Animal(string className, string color = "red")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null.");
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for Animal and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             Color = color;
         }
@@ -158,6 +146,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Animal.");
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Animal.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Animal(className, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -39,21 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ApiResponse(int code, string message, string type)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (code == null)
-                throw new ArgumentNullException("code is a required property for ApiResponse and cannot be null.");
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for ApiResponse and cannot be null.");
-
-            if (message == null)
-                throw new ArgumentNullException("message is a required property for ApiResponse and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Code = code;
             Message = message;
             Type = type;
@@ -165,6 +150,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (code == null)
+                throw new ArgumentNullException(nameof(code), "Property is required for class ApiResponse.");
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class ApiResponse.");
+
+            if (message == null)
+                throw new ArgumentNullException(nameof(message), "Property is required for class ApiResponse.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Apple(string cultivar, string origin)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (cultivar == null)
-                throw new ArgumentNullException("cultivar is a required property for Apple and cannot be null.");
-
-            if (origin == null)
-                throw new ArgumentNullException("origin is a required property for Apple and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Cultivar = cultivar;
             Origin = origin;
         }
@@ -162,6 +150,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (cultivar == null)
+                throw new ArgumentNullException(nameof(cultivar), "Property is required for class Apple.");
+
+            if (origin == null)
+                throw new ArgumentNullException(nameof(origin), "Property is required for class Apple.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Apple(cultivar, origin);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AppleReq(string cultivar, bool mealy)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (cultivar == null)
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null.");
-
-            if (mealy == null)
-                throw new ArgumentNullException("mealy is a required property for AppleReq and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Cultivar = cultivar;
             Mealy = mealy;
         }
@@ -142,6 +130,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (cultivar == null)
+                throw new ArgumentNullException(nameof(cultivar), "Property is required for class AppleReq.");
+
+            if (mealy == null)
+                throw new ArgumentNullException(nameof(mealy), "Property is required for class AppleReq.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AppleReq(cultivar, mealy);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayArrayNumber == null)
-                throw new ArgumentNullException("arrayArrayNumber is a required property for ArrayOfArrayOfNumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayArrayNumber = arrayArrayNumber;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayArrayNumber == null)
+                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayOfNumberOnly(List<decimal> arrayNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayNumber == null)
-                throw new ArgumentNullException("arrayNumber is a required property for ArrayOfNumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayNumber = arrayNumber;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayNumber == null)
+                throw new ArgumentNullException(nameof(arrayNumber), "Property is required for class ArrayOfNumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -39,21 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayTest(List<List<long>> arrayArrayOfInteger, List<List<ReadOnlyFirst>> arrayArrayOfModel, List<string> arrayOfString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayOfString == null)
-                throw new ArgumentNullException("arrayOfString is a required property for ArrayTest and cannot be null.");
-
-            if (arrayArrayOfInteger == null)
-                throw new ArgumentNullException("arrayArrayOfInteger is a required property for ArrayTest and cannot be null.");
-
-            if (arrayArrayOfModel == null)
-                throw new ArgumentNullException("arrayArrayOfModel is a required property for ArrayTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayArrayOfInteger = arrayArrayOfInteger;
             ArrayArrayOfModel = arrayArrayOfModel;
             ArrayOfString = arrayOfString;
@@ -167,6 +152,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayOfString == null)
+                throw new ArgumentNullException(nameof(arrayOfString), "Property is required for class ArrayTest.");
+
+            if (arrayArrayOfInteger == null)
+                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is required for class ArrayTest.");
+
+            if (arrayArrayOfModel == null)
+                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is required for class ArrayTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Banana(decimal lengthCm)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (lengthCm == null)
-                throw new ArgumentNullException("lengthCm is a required property for Banana and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             LengthCm = lengthCm;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (lengthCm == null)
+                throw new ArgumentNullException(nameof(lengthCm), "Property is required for class Banana.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public BananaReq(decimal lengthCm, bool sweet)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (lengthCm == null)
-                throw new ArgumentNullException("lengthCm is a required property for BananaReq and cannot be null.");
-
-            if (sweet == null)
-                throw new ArgumentNullException("sweet is a required property for BananaReq and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             LengthCm = lengthCm;
             Sweet = sweet;
         }
@@ -143,6 +131,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (lengthCm == null)
+                throw new ArgumentNullException(nameof(lengthCm), "Property is required for class BananaReq.");
+
+            if (sweet == null)
+                throw new ArgumentNullException(nameof(sweet), "Property is required for class BananaReq.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new BananaReq(lengthCm, sweet);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public BasquePig(string className)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class BasquePig.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new BasquePig(className);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -42,30 +42,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Capitalization(string aTTNAME, string capitalCamel, string capitalSnake, string sCAETHFlowPoints, string smallCamel, string smallSnake)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (smallCamel == null)
-                throw new ArgumentNullException("smallCamel is a required property for Capitalization and cannot be null.");
-
-            if (capitalCamel == null)
-                throw new ArgumentNullException("capitalCamel is a required property for Capitalization and cannot be null.");
-
-            if (smallSnake == null)
-                throw new ArgumentNullException("smallSnake is a required property for Capitalization and cannot be null.");
-
-            if (capitalSnake == null)
-                throw new ArgumentNullException("capitalSnake is a required property for Capitalization and cannot be null.");
-
-            if (sCAETHFlowPoints == null)
-                throw new ArgumentNullException("sCAETHFlowPoints is a required property for Capitalization and cannot be null.");
-
-            if (aTTNAME == null)
-                throw new ArgumentNullException("aTTNAME is a required property for Capitalization and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ATT_NAME = aTTNAME;
             CapitalCamel = capitalCamel;
             CapitalSnake = capitalSnake;
@@ -213,6 +189,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (smallCamel == null)
+                throw new ArgumentNullException(nameof(smallCamel), "Property is required for class Capitalization.");
+
+            if (capitalCamel == null)
+                throw new ArgumentNullException(nameof(capitalCamel), "Property is required for class Capitalization.");
+
+            if (smallSnake == null)
+                throw new ArgumentNullException(nameof(smallSnake), "Property is required for class Capitalization.");
+
+            if (capitalSnake == null)
+                throw new ArgumentNullException(nameof(capitalSnake), "Property is required for class Capitalization.");
+
+            if (sCAETHFlowPoints == null)
+                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is required for class Capitalization.");
+
+            if (aTTNAME == null)
+                throw new ArgumentNullException(nameof(aTTNAME), "Property is required for class Capitalization.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public CatAllOf(bool declawed)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (declawed == null)
-                throw new ArgumentNullException("declawed is a required property for CatAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Declawed = declawed;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (declawed == null)
+                throw new ArgumentNullException(nameof(declawed), "Property is required for class CatAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new CatAllOf(declawed);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Category(long id, string name = "default-name")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Category and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Category and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             Name = name;
         }
@@ -149,6 +137,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Category.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Category.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Category(id, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCatAllOf(string name, PetTypeEnum petType = PetTypeEnum.ChildCat)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for ChildCatAllOf and cannot be null.");
-
-            if (petType == null)
-                throw new ArgumentNullException("petType is a required property for ChildCatAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Name = name;
             PetType = petType;
         }
@@ -188,6 +176,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class ChildCatAllOf.");
+
+            if (petType == null)
+                throw new ArgumentNullException(nameof(petType), "Property is required for class ChildCatAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ChildCatAllOf(name, petType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ClassModel(string classProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (classProperty == null)
-                throw new ArgumentNullException("classProperty is a required property for ClassModel and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassProperty = classProperty;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (classProperty == null)
+                throw new ArgumentNullException(nameof(classProperty), "Property is required for class ClassModel.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ClassModel(classProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DanishPig(string className)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class DanishPig.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DanishPig(className);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DateOnlyClass(DateTime dateOnlyProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (dateOnlyProperty == null)
-                throw new ArgumentNullException("dateOnlyProperty is a required property for DateOnlyClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DateOnlyProperty = dateOnlyProperty;
         }
 
@@ -139,6 +130,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (dateOnlyProperty == null)
+                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is required for class DateOnlyClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DeprecatedObject(string name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for DeprecatedObject and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Name = name;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class DeprecatedObject.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DogAllOf(string breed)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (breed == null)
-                throw new ArgumentNullException("breed is a required property for DogAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Breed = breed;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (breed == null)
+                throw new ArgumentNullException(nameof(breed), "Property is required for class DogAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DogAllOf(breed);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Drawing.cs
@@ -40,21 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Drawing(Shape mainShape, ShapeOrNull shapeOrNull, List<Shape> shapes, NullableShape? nullableShape = default) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mainShape == null)
-                throw new ArgumentNullException("mainShape is a required property for Drawing and cannot be null.");
-
-            if (shapeOrNull == null)
-                throw new ArgumentNullException("shapeOrNull is a required property for Drawing and cannot be null.");
-
-            if (shapes == null)
-                throw new ArgumentNullException("shapes is a required property for Drawing and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             MainShape = mainShape;
             ShapeOrNull = shapeOrNull;
             Shapes = shapes;
@@ -175,6 +160,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mainShape == null)
+                throw new ArgumentNullException(nameof(mainShape), "Property is required for class Drawing.");
+
+            if (shapeOrNull == null)
+                throw new ArgumentNullException(nameof(shapeOrNull), "Property is required for class Drawing.");
+
+            if (shapes == null)
+                throw new ArgumentNullException(nameof(shapes), "Property is required for class Drawing.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Drawing(mainShape, shapeOrNull, shapes, nullableShape);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public EnumArrays(List<EnumArrays.ArrayEnumEnum> arrayEnum, JustSymbolEnum justSymbol)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (justSymbol == null)
-                throw new ArgumentNullException("justSymbol is a required property for EnumArrays and cannot be null.");
-
-            if (arrayEnum == null)
-                throw new ArgumentNullException("arrayEnum is a required property for EnumArrays and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayEnum = arrayEnum;
             JustSymbol = justSymbol;
         }
@@ -250,6 +238,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (justSymbol == null)
+                throw new ArgumentNullException(nameof(justSymbol), "Property is required for class EnumArrays.");
+
+            if (arrayEnum == null)
+                throw new ArgumentNullException(nameof(arrayEnum), "Property is required for class EnumArrays.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -45,36 +45,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public EnumTest(EnumIntegerEnum enumInteger, EnumIntegerOnlyEnum enumIntegerOnly, EnumNumberEnum enumNumber, EnumStringEnum enumString, EnumStringRequiredEnum enumStringRequired, OuterEnumDefaultValue outerEnumDefaultValue, OuterEnumInteger outerEnumInteger, OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue, OuterEnum? outerEnum = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (enumString == null)
-                throw new ArgumentNullException("enumString is a required property for EnumTest and cannot be null.");
-
-            if (enumStringRequired == null)
-                throw new ArgumentNullException("enumStringRequired is a required property for EnumTest and cannot be null.");
-
-            if (enumInteger == null)
-                throw new ArgumentNullException("enumInteger is a required property for EnumTest and cannot be null.");
-
-            if (enumIntegerOnly == null)
-                throw new ArgumentNullException("enumIntegerOnly is a required property for EnumTest and cannot be null.");
-
-            if (enumNumber == null)
-                throw new ArgumentNullException("enumNumber is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumInteger == null)
-                throw new ArgumentNullException("outerEnumInteger is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumDefaultValue == null)
-                throw new ArgumentNullException("outerEnumDefaultValue is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumIntegerDefaultValue == null)
-                throw new ArgumentNullException("outerEnumIntegerDefaultValue is a required property for EnumTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EnumInteger = enumInteger;
             EnumIntegerOnly = enumIntegerOnly;
             EnumNumber = enumNumber;
@@ -526,6 +496,36 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (enumString == null)
+                throw new ArgumentNullException(nameof(enumString), "Property is required for class EnumTest.");
+
+            if (enumStringRequired == null)
+                throw new ArgumentNullException(nameof(enumStringRequired), "Property is required for class EnumTest.");
+
+            if (enumInteger == null)
+                throw new ArgumentNullException(nameof(enumInteger), "Property is required for class EnumTest.");
+
+            if (enumIntegerOnly == null)
+                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is required for class EnumTest.");
+
+            if (enumNumber == null)
+                throw new ArgumentNullException(nameof(enumNumber), "Property is required for class EnumTest.");
+
+            if (outerEnumInteger == null)
+                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is required for class EnumTest.");
+
+            if (outerEnumDefaultValue == null)
+                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is required for class EnumTest.");
+
+            if (outerEnumIntegerDefaultValue == null)
+                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is required for class EnumTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new EnumTest(enumInteger, enumIntegerOnly, enumNumber, enumString, enumStringRequired, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue, outerEnum);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/File.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public File(string sourceURI)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (sourceURI == null)
-                throw new ArgumentNullException("sourceURI is a required property for File and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             SourceURI = sourceURI;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (sourceURI == null)
+                throw new ArgumentNullException(nameof(sourceURI), "Property is required for class File.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FileSchemaTestClass(File file, List<File> files)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (file == null)
-                throw new ArgumentNullException("file is a required property for FileSchemaTestClass and cannot be null.");
-
-            if (files == null)
-                throw new ArgumentNullException("files is a required property for FileSchemaTestClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             File = file;
             Files = files;
         }
@@ -150,6 +138,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (file == null)
+                throw new ArgumentNullException(nameof(file), "Property is required for class FileSchemaTestClass.");
+
+            if (files == null)
+                throw new ArgumentNullException(nameof(files), "Property is required for class FileSchemaTestClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Foo.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Foo(string bar = "bar")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for Foo and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class Foo.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FooGetDefaultResponse(Foo stringProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (stringProperty == null)
-                throw new ArgumentNullException("stringProperty is a required property for FooGetDefaultResponse and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             StringProperty = stringProperty;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (stringProperty == null)
+                throw new ArgumentNullException(nameof(stringProperty), "Property is required for class FooGetDefaultResponse.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FooGetDefaultResponse(stringProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -54,66 +54,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FormatTest(System.IO.Stream binary, byte[] byteProperty, DateTime date, DateTime dateTime, decimal decimalProperty, double doubleProperty, float floatProperty, int int32, long int64, int integer, decimal number, string password, string patternWithDigits, string patternWithDigitsAndDelimiter, string stringProperty, uint unsignedInteger, ulong unsignedLong, Guid uuid)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (integer == null)
-                throw new ArgumentNullException("integer is a required property for FormatTest and cannot be null.");
-
-            if (int32 == null)
-                throw new ArgumentNullException("int32 is a required property for FormatTest and cannot be null.");
-
-            if (unsignedInteger == null)
-                throw new ArgumentNullException("unsignedInteger is a required property for FormatTest and cannot be null.");
-
-            if (int64 == null)
-                throw new ArgumentNullException("int64 is a required property for FormatTest and cannot be null.");
-
-            if (unsignedLong == null)
-                throw new ArgumentNullException("unsignedLong is a required property for FormatTest and cannot be null.");
-
-            if (number == null)
-                throw new ArgumentNullException("number is a required property for FormatTest and cannot be null.");
-
-            if (floatProperty == null)
-                throw new ArgumentNullException("floatProperty is a required property for FormatTest and cannot be null.");
-
-            if (doubleProperty == null)
-                throw new ArgumentNullException("doubleProperty is a required property for FormatTest and cannot be null.");
-
-            if (decimalProperty == null)
-                throw new ArgumentNullException("decimalProperty is a required property for FormatTest and cannot be null.");
-
-            if (stringProperty == null)
-                throw new ArgumentNullException("stringProperty is a required property for FormatTest and cannot be null.");
-
-            if (byteProperty == null)
-                throw new ArgumentNullException("byteProperty is a required property for FormatTest and cannot be null.");
-
-            if (binary == null)
-                throw new ArgumentNullException("binary is a required property for FormatTest and cannot be null.");
-
-            if (date == null)
-                throw new ArgumentNullException("date is a required property for FormatTest and cannot be null.");
-
-            if (dateTime == null)
-                throw new ArgumentNullException("dateTime is a required property for FormatTest and cannot be null.");
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for FormatTest and cannot be null.");
-
-            if (password == null)
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null.");
-
-            if (patternWithDigits == null)
-                throw new ArgumentNullException("patternWithDigits is a required property for FormatTest and cannot be null.");
-
-            if (patternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException("patternWithDigitsAndDelimiter is a required property for FormatTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Binary = binary;
             ByteProperty = byteProperty;
             Date = date;
@@ -538,6 +478,66 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (integer == null)
+                throw new ArgumentNullException(nameof(integer), "Property is required for class FormatTest.");
+
+            if (int32 == null)
+                throw new ArgumentNullException(nameof(int32), "Property is required for class FormatTest.");
+
+            if (unsignedInteger == null)
+                throw new ArgumentNullException(nameof(unsignedInteger), "Property is required for class FormatTest.");
+
+            if (int64 == null)
+                throw new ArgumentNullException(nameof(int64), "Property is required for class FormatTest.");
+
+            if (unsignedLong == null)
+                throw new ArgumentNullException(nameof(unsignedLong), "Property is required for class FormatTest.");
+
+            if (number == null)
+                throw new ArgumentNullException(nameof(number), "Property is required for class FormatTest.");
+
+            if (floatProperty == null)
+                throw new ArgumentNullException(nameof(floatProperty), "Property is required for class FormatTest.");
+
+            if (doubleProperty == null)
+                throw new ArgumentNullException(nameof(doubleProperty), "Property is required for class FormatTest.");
+
+            if (decimalProperty == null)
+                throw new ArgumentNullException(nameof(decimalProperty), "Property is required for class FormatTest.");
+
+            if (stringProperty == null)
+                throw new ArgumentNullException(nameof(stringProperty), "Property is required for class FormatTest.");
+
+            if (byteProperty == null)
+                throw new ArgumentNullException(nameof(byteProperty), "Property is required for class FormatTest.");
+
+            if (binary == null)
+                throw new ArgumentNullException(nameof(binary), "Property is required for class FormatTest.");
+
+            if (date == null)
+                throw new ArgumentNullException(nameof(date), "Property is required for class FormatTest.");
+
+            if (dateTime == null)
+                throw new ArgumentNullException(nameof(dateTime), "Property is required for class FormatTest.");
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class FormatTest.");
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password), "Property is required for class FormatTest.");
+
+            if (patternWithDigits == null)
+                throw new ArgumentNullException(nameof(patternWithDigits), "Property is required for class FormatTest.");
+
+            if (patternWithDigitsAndDelimiter == null)
+                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FormatTest(binary, byteProperty, date, dateTime, decimalProperty, doubleProperty, floatProperty, int32, int64, integer, number, password, patternWithDigits, patternWithDigitsAndDelimiter, stringProperty, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Fruit.cs
@@ -38,15 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Apple? apple, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = apple;
             Color = color;
         }
@@ -59,15 +50,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Banana = banana;
             Color = color;
         }
@@ -164,6 +146,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Fruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (appleDeserialized)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -39,15 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public GmFruit(Apple? apple, Banana banana, string color)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for GmFruit and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = Apple;
             Banana = Banana;
             Color = color;
@@ -145,6 +136,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class GmFruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new GmFruit(apple, banana, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public GrandparentAnimal(string petType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (petType == null)
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             PetType = petType;
         }
 
@@ -142,6 +133,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (petType == null)
+                throw new ArgumentNullException(nameof(petType), "Property is required for class GrandparentAnimal.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new GrandparentAnimal(petType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         internal HasOnlyReadOnly(string bar, string foo)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for HasOnlyReadOnly and cannot be null.");
-
-            if (foo == null)
-                throw new ArgumentNullException("foo is a required property for HasOnlyReadOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
             Foo = foo;
         }
@@ -185,6 +173,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class HasOnlyReadOnly.");
+
+            if (foo == null)
+                throw new ArgumentNullException(nameof(foo), "Property is required for class HasOnlyReadOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/List.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public List(string _123list)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (_123list == null)
-                throw new ArgumentNullException("_123list is a required property for List and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             _123List = _123list;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (_123list == null)
+                throw new ArgumentNullException(nameof(_123list), "Property is required for class List.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new List(_123list);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MapTest.cs
@@ -40,24 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public MapTest(Dictionary<string, bool> directMap, Dictionary<string, bool> indirectMap, Dictionary<string, Dictionary<string, string>> mapMapOfString, Dictionary<string, MapTest.InnerEnum> mapOfEnumString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mapMapOfString == null)
-                throw new ArgumentNullException("mapMapOfString is a required property for MapTest and cannot be null.");
-
-            if (mapOfEnumString == null)
-                throw new ArgumentNullException("mapOfEnumString is a required property for MapTest and cannot be null.");
-
-            if (directMap == null)
-                throw new ArgumentNullException("directMap is a required property for MapTest and cannot be null.");
-
-            if (indirectMap == null)
-                throw new ArgumentNullException("indirectMap is a required property for MapTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DirectMap = directMap;
             IndirectMap = indirectMap;
             MapMapOfString = mapMapOfString;
@@ -234,6 +216,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mapMapOfString == null)
+                throw new ArgumentNullException(nameof(mapMapOfString), "Property is required for class MapTest.");
+
+            if (mapOfEnumString == null)
+                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is required for class MapTest.");
+
+            if (directMap == null)
+                throw new ArgumentNullException(nameof(directMap), "Property is required for class MapTest.");
+
+            if (indirectMap == null)
+                throw new ArgumentNullException(nameof(indirectMap), "Property is required for class MapTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -40,24 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public MixedPropertiesAndAdditionalPropertiesClass(DateTime dateTime, Dictionary<string, Animal> map, Guid uuid, Guid uuidWithPattern)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (uuidWithPattern == null)
-                throw new ArgumentNullException("uuidWithPattern is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (dateTime == null)
-                throw new ArgumentNullException("dateTime is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (map == null)
-                throw new ArgumentNullException("map is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DateTime = dateTime;
             Map = map;
             Uuid = uuid;
@@ -196,6 +178,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (uuidWithPattern == null)
+                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (dateTime == null)
+                throw new ArgumentNullException(nameof(dateTime), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (map == null)
+                throw new ArgumentNullException(nameof(map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Model200Response(string classProperty, int name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Model200Response and cannot be null.");
-
-            if (classProperty == null)
-                throw new ArgumentNullException("classProperty is a required property for Model200Response and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassProperty = classProperty;
             Name = name;
         }
@@ -149,6 +137,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Model200Response.");
+
+            if (classProperty == null)
+                throw new ArgumentNullException(nameof(classProperty), "Property is required for class Model200Response.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Model200Response(classProperty, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ModelClient(string clientProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (clientProperty == null)
-                throw new ArgumentNullException("clientProperty is a required property for ModelClient and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             _ClientProperty = clientProperty;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (clientProperty == null)
+                throw new ArgumentNullException(nameof(clientProperty), "Property is required for class ModelClient.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ModelClient(clientProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
@@ -40,24 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Name(int nameProperty, string property, int snakeCase, int _123number)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (nameProperty == null)
-                throw new ArgumentNullException("nameProperty is a required property for Name and cannot be null.");
-
-            if (snakeCase == null)
-                throw new ArgumentNullException("snakeCase is a required property for Name and cannot be null.");
-
-            if (property == null)
-                throw new ArgumentNullException("property is a required property for Name and cannot be null.");
-
-            if (_123number == null)
-                throw new ArgumentNullException("_123number is a required property for Name and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             NameProperty = nameProperty;
             Property = property;
             SnakeCase = snakeCase;
@@ -220,6 +202,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (nameProperty == null)
+                throw new ArgumentNullException(nameof(nameProperty), "Property is required for class Name.");
+
+            if (snakeCase == null)
+                throw new ArgumentNullException(nameof(snakeCase), "Property is required for class Name.");
+
+            if (property == null)
+                throw new ArgumentNullException(nameof(property), "Property is required for class Name.");
+
+            if (_123number == null)
+                throw new ArgumentNullException(nameof(_123number), "Property is required for class Name.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Name(nameProperty, property, snakeCase, _123number);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -48,18 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public NullableClass(List<Object> arrayItemsNullable, Dictionary<string, Object> objectItemsNullable, List<Object>? arrayAndItemsNullableProp = default, List<Object>? arrayNullableProp = default, bool? booleanProp = default, DateTime? dateProp = default, DateTime? datetimeProp = default, int? integerProp = default, decimal? numberProp = default, Dictionary<string, Object>? objectAndItemsNullableProp = default, Dictionary<string, Object>? objectNullableProp = default, string? stringProp = default) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayItemsNullable == null)
-                throw new ArgumentNullException("arrayItemsNullable is a required property for NullableClass and cannot be null.");
-
-            if (objectItemsNullable == null)
-                throw new ArgumentNullException("objectItemsNullable is a required property for NullableClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayItemsNullable = arrayItemsNullable;
             ObjectItemsNullable = objectItemsNullable;
             ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
@@ -293,6 +281,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayItemsNullable == null)
+                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is required for class NullableClass.");
+
+            if (objectItemsNullable == null)
+                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is required for class NullableClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new NullableClass(arrayItemsNullable, objectItemsNullable, arrayAndItemsNullableProp, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public NumberOnly(decimal justNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (justNumber == null)
-                throw new ArgumentNullException("justNumber is a required property for NumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             JustNumber = justNumber;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (justNumber == null)
+                throw new ArgumentNullException(nameof(justNumber), "Property is required for class NumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -40,24 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ObjectWithDeprecatedFields(List<string> bars, DeprecatedObject deprecatedRef, decimal id, string uuid)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (deprecatedRef == null)
-                throw new ArgumentNullException("deprecatedRef is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (bars == null)
-                throw new ArgumentNullException("bars is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bars = bars;
             DeprecatedRef = deprecatedRef;
             Id = id;
@@ -186,6 +168,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (deprecatedRef == null)
+                throw new ArgumentNullException(nameof(deprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (bars == null)
+                throw new ArgumentNullException(nameof(bars), "Property is required for class ObjectWithDeprecatedFields.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
@@ -42,30 +42,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Order(long id, long petId, int quantity, DateTime shipDate, StatusEnum status, bool complete = false)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Order and cannot be null.");
-
-            if (petId == null)
-                throw new ArgumentNullException("petId is a required property for Order and cannot be null.");
-
-            if (quantity == null)
-                throw new ArgumentNullException("quantity is a required property for Order and cannot be null.");
-
-            if (shipDate == null)
-                throw new ArgumentNullException("shipDate is a required property for Order and cannot be null.");
-
-            if (status == null)
-                throw new ArgumentNullException("status is a required property for Order and cannot be null.");
-
-            if (complete == null)
-                throw new ArgumentNullException("complete is a required property for Order and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             PetId = petId;
             Quantity = quantity;
@@ -287,6 +263,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Order.");
+
+            if (petId == null)
+                throw new ArgumentNullException(nameof(petId), "Property is required for class Order.");
+
+            if (quantity == null)
+                throw new ArgumentNullException(nameof(quantity), "Property is required for class Order.");
+
+            if (shipDate == null)
+                throw new ArgumentNullException(nameof(shipDate), "Property is required for class Order.");
+
+            if (status == null)
+                throw new ArgumentNullException(nameof(status), "Property is required for class Order.");
+
+            if (complete == null)
+                throw new ArgumentNullException(nameof(complete), "Property is required for class Order.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Order(id, petId, quantity, shipDate, status, complete);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -39,21 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public OuterComposite(bool myBoolean, decimal myNumber, string myString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (myNumber == null)
-                throw new ArgumentNullException("myNumber is a required property for OuterComposite and cannot be null.");
-
-            if (myString == null)
-                throw new ArgumentNullException("myString is a required property for OuterComposite and cannot be null.");
-
-            if (myBoolean == null)
-                throw new ArgumentNullException("myBoolean is a required property for OuterComposite and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             MyBoolean = myBoolean;
             MyNumber = myNumber;
             MyString = myString;
@@ -166,6 +151,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (myNumber == null)
+                throw new ArgumentNullException(nameof(myNumber), "Property is required for class OuterComposite.");
+
+            if (myString == null)
+                throw new ArgumentNullException(nameof(myString), "Property is required for class OuterComposite.");
+
+            if (myBoolean == null)
+                throw new ArgumentNullException(nameof(myBoolean), "Property is required for class OuterComposite.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
@@ -42,30 +42,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Pet(Category category, long id, string name, List<string> photoUrls, StatusEnum status, List<Tag> tags)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Pet and cannot be null.");
-
-            if (category == null)
-                throw new ArgumentNullException("category is a required property for Pet and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null.");
-
-            if (photoUrls == null)
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null.");
-
-            if (tags == null)
-                throw new ArgumentNullException("tags is a required property for Pet and cannot be null.");
-
-            if (status == null)
-                throw new ArgumentNullException("status is a required property for Pet and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Category = category;
             Id = id;
             Name = name;
@@ -281,6 +257,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Pet.");
+
+            if (category == null)
+                throw new ArgumentNullException(nameof(category), "Property is required for class Pet.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Pet.");
+
+            if (photoUrls == null)
+                throw new ArgumentNullException(nameof(photoUrls), "Property is required for class Pet.");
+
+            if (tags == null)
+                throw new ArgumentNullException(nameof(tags), "Property is required for class Pet.");
+
+            if (status == null)
+                throw new ArgumentNullException(nameof(status), "Property is required for class Pet.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Pet(category, id, name, photoUrls, status, tags);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public QuadrilateralInterface(string quadrilateralType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             QuadrilateralType = quadrilateralType;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class QuadrilateralInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new QuadrilateralInterface(quadrilateralType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ReadOnlyFirst(string bar, string baz)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for ReadOnlyFirst and cannot be null.");
-
-            if (baz == null)
-                throw new ArgumentNullException("baz is a required property for ReadOnlyFirst and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
             Baz = baz;
         }
@@ -184,6 +172,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class ReadOnlyFirst.");
+
+            if (baz == null)
+                throw new ArgumentNullException(nameof(baz), "Property is required for class ReadOnlyFirst.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Return(int returnProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (returnProperty == null)
-                throw new ArgumentNullException("returnProperty is a required property for Return and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ReturnProperty = returnProperty;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (returnProperty == null)
+                throw new ArgumentNullException(nameof(returnProperty), "Property is required for class Return.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Return(returnProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Shape.cs
@@ -38,15 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Shape(Triangle triangle, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Triangle = triangle;
             QuadrilateralType = quadrilateralType;
         }
@@ -59,15 +50,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Shape(Quadrilateral quadrilateral, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Quadrilateral = quadrilateral;
             QuadrilateralType = quadrilateralType;
         }
@@ -181,6 +163,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class Shape.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (triangleDeserialized)
                 return new Shape(triangle, quadrilateralType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeInterface(string shapeType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ShapeType = shapeType;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (shapeType == null)
+                throw new ArgumentNullException(nameof(shapeType), "Property is required for class ShapeInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ShapeInterface(shapeType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -38,15 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeOrNull(Triangle triangle, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Triangle = triangle;
             QuadrilateralType = quadrilateralType;
         }
@@ -59,15 +50,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeOrNull(Quadrilateral quadrilateral, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Quadrilateral = quadrilateral;
             QuadrilateralType = quadrilateralType;
         }
@@ -181,6 +163,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class ShapeOrNull.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (triangleDeserialized)
                 return new ShapeOrNull(triangle, quadrilateralType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public SpecialModelName(string specialModelNameProperty, long specialPropertyName)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (specialPropertyName == null)
-                throw new ArgumentNullException("specialPropertyName is a required property for SpecialModelName and cannot be null.");
-
-            if (specialModelNameProperty == null)
-                throw new ArgumentNullException("specialModelNameProperty is a required property for SpecialModelName and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             SpecialModelNameProperty = specialModelNameProperty;
             SpecialPropertyName = specialPropertyName;
         }
@@ -149,6 +137,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (specialPropertyName == null)
+                throw new ArgumentNullException(nameof(specialPropertyName), "Property is required for class SpecialModelName.");
+
+            if (specialModelNameProperty == null)
+                throw new ArgumentNullException(nameof(specialModelNameProperty), "Property is required for class SpecialModelName.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new SpecialModelName(specialModelNameProperty, specialPropertyName);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Tag(long id, string name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Tag and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Tag and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             Name = name;
         }
@@ -149,6 +137,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Tag.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Tag.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Triangle.cs
@@ -39,18 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(EquilateralTriangle equilateralTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EquilateralTriangle = equilateralTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -65,18 +53,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(IsoscelesTriangle isoscelesTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             IsoscelesTriangle = isoscelesTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -91,18 +67,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(ScaleneTriangle scaleneTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ScaleneTriangle = scaleneTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -236,6 +200,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (shapeType == null)
+                throw new ArgumentNullException(nameof(shapeType), "Property is required for class Triangle.");
+
+            if (triangleType == null)
+                throw new ArgumentNullException(nameof(triangleType), "Property is required for class Triangle.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (equilateralTriangleDeserialized)
                 return new Triangle(equilateralTriangle, shapeType, triangleType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public TriangleInterface(string triangleType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (triangleType == null)
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             TriangleType = triangleType;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (triangleType == null)
+                throw new ArgumentNullException(nameof(triangleType), "Property is required for class TriangleInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new TriangleInterface(triangleType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
@@ -48,39 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public User(string email, string firstName, long id, string lastName, Object objectWithNoDeclaredProps, string password, string phone, int userStatus, string username, Object? anyTypeProp = default, Object? anyTypePropNullable = default, Object? objectWithNoDeclaredPropsNullable = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for User and cannot be null.");
-
-            if (username == null)
-                throw new ArgumentNullException("username is a required property for User and cannot be null.");
-
-            if (firstName == null)
-                throw new ArgumentNullException("firstName is a required property for User and cannot be null.");
-
-            if (lastName == null)
-                throw new ArgumentNullException("lastName is a required property for User and cannot be null.");
-
-            if (email == null)
-                throw new ArgumentNullException("email is a required property for User and cannot be null.");
-
-            if (password == null)
-                throw new ArgumentNullException("password is a required property for User and cannot be null.");
-
-            if (phone == null)
-                throw new ArgumentNullException("phone is a required property for User and cannot be null.");
-
-            if (userStatus == null)
-                throw new ArgumentNullException("userStatus is a required property for User and cannot be null.");
-
-            if (objectWithNoDeclaredProps == null)
-                throw new ArgumentNullException("objectWithNoDeclaredProps is a required property for User and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Email = email;
             FirstName = firstName;
             Id = id;
@@ -310,6 +277,39 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class User.");
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username), "Property is required for class User.");
+
+            if (firstName == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is required for class User.");
+
+            if (lastName == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is required for class User.");
+
+            if (email == null)
+                throw new ArgumentNullException(nameof(email), "Property is required for class User.");
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password), "Property is required for class User.");
+
+            if (phone == null)
+                throw new ArgumentNullException(nameof(phone), "Property is required for class User.");
+
+            if (userStatus == null)
+                throw new ArgumentNullException(nameof(userStatus), "Property is required for class User.");
+
+            if (objectWithNoDeclaredProps == null)
+                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is required for class User.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new User(email, firstName, id, lastName, objectWithNoDeclaredProps, password, phone, userStatus, username, anyTypeProp, anyTypePropNullable, objectWithNoDeclaredPropsNullable);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Whale.cs
@@ -39,21 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Whale(string className, bool hasBaleen, bool hasTeeth)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (hasBaleen == null)
-                throw new ArgumentNullException("hasBaleen is a required property for Whale and cannot be null.");
-
-            if (hasTeeth == null)
-                throw new ArgumentNullException("hasTeeth is a required property for Whale and cannot be null.");
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             HasBaleen = hasBaleen;
             HasTeeth = hasTeeth;
@@ -166,6 +151,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (hasBaleen == null)
+                throw new ArgumentNullException(nameof(hasBaleen), "Property is required for class Whale.");
+
+            if (hasTeeth == null)
+                throw new ArgumentNullException(nameof(hasTeeth), "Property is required for class Whale.");
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Whale.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Whale(className, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Zebra.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Zebra(string className, TypeEnum type) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for Zebra and cannot be null.");
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             Type = type;
         }
@@ -211,6 +199,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class Zebra.");
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Zebra.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Zebra(className, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (activityOutputs == null)
-                throw new ArgumentNullException("activityOutputs is a required property for Activity and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ActivityOutputs = activityOutputs;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (activityOutputs == null)
+                throw new ArgumentNullException(nameof(activityOutputs), "Property is required for class Activity.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ActivityOutputElementRepresentation(string prop1, Object prop2)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (prop1 == null)
-                throw new ArgumentNullException("prop1 is a required property for ActivityOutputElementRepresentation and cannot be null.");
-
-            if (prop2 == null)
-                throw new ArgumentNullException("prop2 is a required property for ActivityOutputElementRepresentation and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Prop1 = prop1;
             Prop2 = prop2;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (prop1 == null)
+                throw new ArgumentNullException(nameof(prop1), "Property is required for class ActivityOutputElementRepresentation.");
+
+            if (prop2 == null)
+                throw new ArgumentNullException(nameof(prop2), "Property is required for class ActivityOutputElementRepresentation.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -42,33 +42,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AdditionalPropertiesClass(Object emptyMap, Dictionary<string, Dictionary<string, string>> mapOfMapProperty, Dictionary<string, string> mapProperty, Object mapWithUndeclaredPropertiesAnytype1, Object mapWithUndeclaredPropertiesAnytype2, Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3, Dictionary<string, string> mapWithUndeclaredPropertiesString, Object anytype1 = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mapProperty == null)
-                throw new ArgumentNullException("mapProperty is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapOfMapProperty == null)
-                throw new ArgumentNullException("mapOfMapProperty is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype1 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype2 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype3 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (emptyMap == null)
-                throw new ArgumentNullException("emptyMap is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesString is a required property for AdditionalPropertiesClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EmptyMap = emptyMap;
             MapOfMapProperty = mapOfMapProperty;
             MapProperty = mapProperty;
@@ -248,6 +221,33 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mapProperty == null)
+                throw new ArgumentNullException(nameof(mapProperty), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapOfMapProperty == null)
+                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype1 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype2 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype3 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+
+            if (emptyMap == null)
+                throw new ArgumentNullException(nameof(emptyMap), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesString == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AdditionalPropertiesClass(emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString, anytype1);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Animal(string className, string color = "red")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null.");
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for Animal and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             Color = color;
         }
@@ -156,6 +144,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Animal.");
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Animal.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Animal(className, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ApiResponse(int code, string message, string type)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (code == null)
-                throw new ArgumentNullException("code is a required property for ApiResponse and cannot be null.");
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for ApiResponse and cannot be null.");
-
-            if (message == null)
-                throw new ArgumentNullException("message is a required property for ApiResponse and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Code = code;
             Message = message;
             Type = type;
@@ -163,6 +148,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (code == null)
+                throw new ArgumentNullException(nameof(code), "Property is required for class ApiResponse.");
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class ApiResponse.");
+
+            if (message == null)
+                throw new ArgumentNullException(nameof(message), "Property is required for class ApiResponse.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Apple(string cultivar, string origin)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (cultivar == null)
-                throw new ArgumentNullException("cultivar is a required property for Apple and cannot be null.");
-
-            if (origin == null)
-                throw new ArgumentNullException("origin is a required property for Apple and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Cultivar = cultivar;
             Origin = origin;
         }
@@ -160,6 +148,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (cultivar == null)
+                throw new ArgumentNullException(nameof(cultivar), "Property is required for class Apple.");
+
+            if (origin == null)
+                throw new ArgumentNullException(nameof(origin), "Property is required for class Apple.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Apple(cultivar, origin);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AppleReq(string cultivar, bool mealy)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (cultivar == null)
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null.");
-
-            if (mealy == null)
-                throw new ArgumentNullException("mealy is a required property for AppleReq and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Cultivar = cultivar;
             Mealy = mealy;
         }
@@ -140,6 +128,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (cultivar == null)
+                throw new ArgumentNullException(nameof(cultivar), "Property is required for class AppleReq.");
+
+            if (mealy == null)
+                throw new ArgumentNullException(nameof(mealy), "Property is required for class AppleReq.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AppleReq(cultivar, mealy);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayArrayNumber == null)
-                throw new ArgumentNullException("arrayArrayNumber is a required property for ArrayOfArrayOfNumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayArrayNumber = arrayArrayNumber;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayArrayNumber == null)
+                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayOfNumberOnly(List<decimal> arrayNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayNumber == null)
-                throw new ArgumentNullException("arrayNumber is a required property for ArrayOfNumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayNumber = arrayNumber;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayNumber == null)
+                throw new ArgumentNullException(nameof(arrayNumber), "Property is required for class ArrayOfNumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayTest(List<List<long>> arrayArrayOfInteger, List<List<ReadOnlyFirst>> arrayArrayOfModel, List<string> arrayOfString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayOfString == null)
-                throw new ArgumentNullException("arrayOfString is a required property for ArrayTest and cannot be null.");
-
-            if (arrayArrayOfInteger == null)
-                throw new ArgumentNullException("arrayArrayOfInteger is a required property for ArrayTest and cannot be null.");
-
-            if (arrayArrayOfModel == null)
-                throw new ArgumentNullException("arrayArrayOfModel is a required property for ArrayTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayArrayOfInteger = arrayArrayOfInteger;
             ArrayArrayOfModel = arrayArrayOfModel;
             ArrayOfString = arrayOfString;
@@ -165,6 +150,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayOfString == null)
+                throw new ArgumentNullException(nameof(arrayOfString), "Property is required for class ArrayTest.");
+
+            if (arrayArrayOfInteger == null)
+                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is required for class ArrayTest.");
+
+            if (arrayArrayOfModel == null)
+                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is required for class ArrayTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Banana(decimal lengthCm)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (lengthCm == null)
-                throw new ArgumentNullException("lengthCm is a required property for Banana and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             LengthCm = lengthCm;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (lengthCm == null)
+                throw new ArgumentNullException(nameof(lengthCm), "Property is required for class Banana.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public BananaReq(decimal lengthCm, bool sweet)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (lengthCm == null)
-                throw new ArgumentNullException("lengthCm is a required property for BananaReq and cannot be null.");
-
-            if (sweet == null)
-                throw new ArgumentNullException("sweet is a required property for BananaReq and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             LengthCm = lengthCm;
             Sweet = sweet;
         }
@@ -141,6 +129,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (lengthCm == null)
+                throw new ArgumentNullException(nameof(lengthCm), "Property is required for class BananaReq.");
+
+            if (sweet == null)
+                throw new ArgumentNullException(nameof(sweet), "Property is required for class BananaReq.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new BananaReq(lengthCm, sweet);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public BasquePig(string className)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class BasquePig.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new BasquePig(className);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -40,30 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Capitalization(string aTTNAME, string capitalCamel, string capitalSnake, string sCAETHFlowPoints, string smallCamel, string smallSnake)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (smallCamel == null)
-                throw new ArgumentNullException("smallCamel is a required property for Capitalization and cannot be null.");
-
-            if (capitalCamel == null)
-                throw new ArgumentNullException("capitalCamel is a required property for Capitalization and cannot be null.");
-
-            if (smallSnake == null)
-                throw new ArgumentNullException("smallSnake is a required property for Capitalization and cannot be null.");
-
-            if (capitalSnake == null)
-                throw new ArgumentNullException("capitalSnake is a required property for Capitalization and cannot be null.");
-
-            if (sCAETHFlowPoints == null)
-                throw new ArgumentNullException("sCAETHFlowPoints is a required property for Capitalization and cannot be null.");
-
-            if (aTTNAME == null)
-                throw new ArgumentNullException("aTTNAME is a required property for Capitalization and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ATT_NAME = aTTNAME;
             CapitalCamel = capitalCamel;
             CapitalSnake = capitalSnake;
@@ -211,6 +187,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (smallCamel == null)
+                throw new ArgumentNullException(nameof(smallCamel), "Property is required for class Capitalization.");
+
+            if (capitalCamel == null)
+                throw new ArgumentNullException(nameof(capitalCamel), "Property is required for class Capitalization.");
+
+            if (smallSnake == null)
+                throw new ArgumentNullException(nameof(smallSnake), "Property is required for class Capitalization.");
+
+            if (capitalSnake == null)
+                throw new ArgumentNullException(nameof(capitalSnake), "Property is required for class Capitalization.");
+
+            if (sCAETHFlowPoints == null)
+                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is required for class Capitalization.");
+
+            if (aTTNAME == null)
+                throw new ArgumentNullException(nameof(aTTNAME), "Property is required for class Capitalization.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public CatAllOf(bool declawed)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (declawed == null)
-                throw new ArgumentNullException("declawed is a required property for CatAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Declawed = declawed;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (declawed == null)
+                throw new ArgumentNullException(nameof(declawed), "Property is required for class CatAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new CatAllOf(declawed);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Category(long id, string name = "default-name")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Category and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Category and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             Name = name;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Category.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Category.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Category(id, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCatAllOf(string name, PetTypeEnum petType = PetTypeEnum.ChildCat)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for ChildCatAllOf and cannot be null.");
-
-            if (petType == null)
-                throw new ArgumentNullException("petType is a required property for ChildCatAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Name = name;
             PetType = petType;
         }
@@ -186,6 +174,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class ChildCatAllOf.");
+
+            if (petType == null)
+                throw new ArgumentNullException(nameof(petType), "Property is required for class ChildCatAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ChildCatAllOf(name, petType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ClassModel(string classProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (classProperty == null)
-                throw new ArgumentNullException("classProperty is a required property for ClassModel and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassProperty = classProperty;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (classProperty == null)
+                throw new ArgumentNullException(nameof(classProperty), "Property is required for class ClassModel.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ClassModel(classProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DanishPig(string className)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class DanishPig.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DanishPig(className);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DateOnlyClass(DateTime dateOnlyProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (dateOnlyProperty == null)
-                throw new ArgumentNullException("dateOnlyProperty is a required property for DateOnlyClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DateOnlyProperty = dateOnlyProperty;
         }
 
@@ -137,6 +128,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (dateOnlyProperty == null)
+                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is required for class DateOnlyClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DeprecatedObject(string name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for DeprecatedObject and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Name = name;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class DeprecatedObject.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DogAllOf(string breed)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (breed == null)
-                throw new ArgumentNullException("breed is a required property for DogAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Breed = breed;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (breed == null)
+                throw new ArgumentNullException(nameof(breed), "Property is required for class DogAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DogAllOf(breed);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -38,21 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Drawing(Shape mainShape, ShapeOrNull shapeOrNull, List<Shape> shapes, NullableShape nullableShape = default) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mainShape == null)
-                throw new ArgumentNullException("mainShape is a required property for Drawing and cannot be null.");
-
-            if (shapeOrNull == null)
-                throw new ArgumentNullException("shapeOrNull is a required property for Drawing and cannot be null.");
-
-            if (shapes == null)
-                throw new ArgumentNullException("shapes is a required property for Drawing and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             MainShape = mainShape;
             ShapeOrNull = shapeOrNull;
             Shapes = shapes;
@@ -173,6 +158,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mainShape == null)
+                throw new ArgumentNullException(nameof(mainShape), "Property is required for class Drawing.");
+
+            if (shapeOrNull == null)
+                throw new ArgumentNullException(nameof(shapeOrNull), "Property is required for class Drawing.");
+
+            if (shapes == null)
+                throw new ArgumentNullException(nameof(shapes), "Property is required for class Drawing.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Drawing(mainShape, shapeOrNull, shapes, nullableShape);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public EnumArrays(List<EnumArrays.ArrayEnumEnum> arrayEnum, JustSymbolEnum justSymbol)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (justSymbol == null)
-                throw new ArgumentNullException("justSymbol is a required property for EnumArrays and cannot be null.");
-
-            if (arrayEnum == null)
-                throw new ArgumentNullException("arrayEnum is a required property for EnumArrays and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayEnum = arrayEnum;
             JustSymbol = justSymbol;
         }
@@ -248,6 +236,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (justSymbol == null)
+                throw new ArgumentNullException(nameof(justSymbol), "Property is required for class EnumArrays.");
+
+            if (arrayEnum == null)
+                throw new ArgumentNullException(nameof(arrayEnum), "Property is required for class EnumArrays.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -43,36 +43,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public EnumTest(EnumIntegerEnum enumInteger, EnumIntegerOnlyEnum enumIntegerOnly, EnumNumberEnum enumNumber, EnumStringEnum enumString, EnumStringRequiredEnum enumStringRequired, OuterEnumDefaultValue outerEnumDefaultValue, OuterEnumInteger outerEnumInteger, OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue, OuterEnum? outerEnum = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (enumString == null)
-                throw new ArgumentNullException("enumString is a required property for EnumTest and cannot be null.");
-
-            if (enumStringRequired == null)
-                throw new ArgumentNullException("enumStringRequired is a required property for EnumTest and cannot be null.");
-
-            if (enumInteger == null)
-                throw new ArgumentNullException("enumInteger is a required property for EnumTest and cannot be null.");
-
-            if (enumIntegerOnly == null)
-                throw new ArgumentNullException("enumIntegerOnly is a required property for EnumTest and cannot be null.");
-
-            if (enumNumber == null)
-                throw new ArgumentNullException("enumNumber is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumInteger == null)
-                throw new ArgumentNullException("outerEnumInteger is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumDefaultValue == null)
-                throw new ArgumentNullException("outerEnumDefaultValue is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumIntegerDefaultValue == null)
-                throw new ArgumentNullException("outerEnumIntegerDefaultValue is a required property for EnumTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EnumInteger = enumInteger;
             EnumIntegerOnly = enumIntegerOnly;
             EnumNumber = enumNumber;
@@ -524,6 +494,36 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (enumString == null)
+                throw new ArgumentNullException(nameof(enumString), "Property is required for class EnumTest.");
+
+            if (enumStringRequired == null)
+                throw new ArgumentNullException(nameof(enumStringRequired), "Property is required for class EnumTest.");
+
+            if (enumInteger == null)
+                throw new ArgumentNullException(nameof(enumInteger), "Property is required for class EnumTest.");
+
+            if (enumIntegerOnly == null)
+                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is required for class EnumTest.");
+
+            if (enumNumber == null)
+                throw new ArgumentNullException(nameof(enumNumber), "Property is required for class EnumTest.");
+
+            if (outerEnumInteger == null)
+                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is required for class EnumTest.");
+
+            if (outerEnumDefaultValue == null)
+                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is required for class EnumTest.");
+
+            if (outerEnumIntegerDefaultValue == null)
+                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is required for class EnumTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new EnumTest(enumInteger, enumIntegerOnly, enumNumber, enumString, enumStringRequired, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue, outerEnum);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/File.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public File(string sourceURI)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (sourceURI == null)
-                throw new ArgumentNullException("sourceURI is a required property for File and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             SourceURI = sourceURI;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (sourceURI == null)
+                throw new ArgumentNullException(nameof(sourceURI), "Property is required for class File.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FileSchemaTestClass(File file, List<File> files)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (file == null)
-                throw new ArgumentNullException("file is a required property for FileSchemaTestClass and cannot be null.");
-
-            if (files == null)
-                throw new ArgumentNullException("files is a required property for FileSchemaTestClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             File = file;
             Files = files;
         }
@@ -148,6 +136,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (file == null)
+                throw new ArgumentNullException(nameof(file), "Property is required for class FileSchemaTestClass.");
+
+            if (files == null)
+                throw new ArgumentNullException(nameof(files), "Property is required for class FileSchemaTestClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Foo(string bar = "bar")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for Foo and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class Foo.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FooGetDefaultResponse(Foo stringProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (stringProperty == null)
-                throw new ArgumentNullException("stringProperty is a required property for FooGetDefaultResponse and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             StringProperty = stringProperty;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (stringProperty == null)
+                throw new ArgumentNullException(nameof(stringProperty), "Property is required for class FooGetDefaultResponse.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FooGetDefaultResponse(stringProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -52,66 +52,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FormatTest(System.IO.Stream binary, byte[] byteProperty, DateTime date, DateTime dateTime, decimal decimalProperty, double doubleProperty, float floatProperty, int int32, long int64, int integer, decimal number, string password, string patternWithDigits, string patternWithDigitsAndDelimiter, string stringProperty, uint unsignedInteger, ulong unsignedLong, Guid uuid)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (integer == null)
-                throw new ArgumentNullException("integer is a required property for FormatTest and cannot be null.");
-
-            if (int32 == null)
-                throw new ArgumentNullException("int32 is a required property for FormatTest and cannot be null.");
-
-            if (unsignedInteger == null)
-                throw new ArgumentNullException("unsignedInteger is a required property for FormatTest and cannot be null.");
-
-            if (int64 == null)
-                throw new ArgumentNullException("int64 is a required property for FormatTest and cannot be null.");
-
-            if (unsignedLong == null)
-                throw new ArgumentNullException("unsignedLong is a required property for FormatTest and cannot be null.");
-
-            if (number == null)
-                throw new ArgumentNullException("number is a required property for FormatTest and cannot be null.");
-
-            if (floatProperty == null)
-                throw new ArgumentNullException("floatProperty is a required property for FormatTest and cannot be null.");
-
-            if (doubleProperty == null)
-                throw new ArgumentNullException("doubleProperty is a required property for FormatTest and cannot be null.");
-
-            if (decimalProperty == null)
-                throw new ArgumentNullException("decimalProperty is a required property for FormatTest and cannot be null.");
-
-            if (stringProperty == null)
-                throw new ArgumentNullException("stringProperty is a required property for FormatTest and cannot be null.");
-
-            if (byteProperty == null)
-                throw new ArgumentNullException("byteProperty is a required property for FormatTest and cannot be null.");
-
-            if (binary == null)
-                throw new ArgumentNullException("binary is a required property for FormatTest and cannot be null.");
-
-            if (date == null)
-                throw new ArgumentNullException("date is a required property for FormatTest and cannot be null.");
-
-            if (dateTime == null)
-                throw new ArgumentNullException("dateTime is a required property for FormatTest and cannot be null.");
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for FormatTest and cannot be null.");
-
-            if (password == null)
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null.");
-
-            if (patternWithDigits == null)
-                throw new ArgumentNullException("patternWithDigits is a required property for FormatTest and cannot be null.");
-
-            if (patternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException("patternWithDigitsAndDelimiter is a required property for FormatTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Binary = binary;
             ByteProperty = byteProperty;
             Date = date;
@@ -536,6 +476,66 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (integer == null)
+                throw new ArgumentNullException(nameof(integer), "Property is required for class FormatTest.");
+
+            if (int32 == null)
+                throw new ArgumentNullException(nameof(int32), "Property is required for class FormatTest.");
+
+            if (unsignedInteger == null)
+                throw new ArgumentNullException(nameof(unsignedInteger), "Property is required for class FormatTest.");
+
+            if (int64 == null)
+                throw new ArgumentNullException(nameof(int64), "Property is required for class FormatTest.");
+
+            if (unsignedLong == null)
+                throw new ArgumentNullException(nameof(unsignedLong), "Property is required for class FormatTest.");
+
+            if (number == null)
+                throw new ArgumentNullException(nameof(number), "Property is required for class FormatTest.");
+
+            if (floatProperty == null)
+                throw new ArgumentNullException(nameof(floatProperty), "Property is required for class FormatTest.");
+
+            if (doubleProperty == null)
+                throw new ArgumentNullException(nameof(doubleProperty), "Property is required for class FormatTest.");
+
+            if (decimalProperty == null)
+                throw new ArgumentNullException(nameof(decimalProperty), "Property is required for class FormatTest.");
+
+            if (stringProperty == null)
+                throw new ArgumentNullException(nameof(stringProperty), "Property is required for class FormatTest.");
+
+            if (byteProperty == null)
+                throw new ArgumentNullException(nameof(byteProperty), "Property is required for class FormatTest.");
+
+            if (binary == null)
+                throw new ArgumentNullException(nameof(binary), "Property is required for class FormatTest.");
+
+            if (date == null)
+                throw new ArgumentNullException(nameof(date), "Property is required for class FormatTest.");
+
+            if (dateTime == null)
+                throw new ArgumentNullException(nameof(dateTime), "Property is required for class FormatTest.");
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class FormatTest.");
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password), "Property is required for class FormatTest.");
+
+            if (patternWithDigits == null)
+                throw new ArgumentNullException(nameof(patternWithDigits), "Property is required for class FormatTest.");
+
+            if (patternWithDigitsAndDelimiter == null)
+                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FormatTest(binary, byteProperty, date, dateTime, decimalProperty, doubleProperty, floatProperty, int32, int64, integer, number, password, patternWithDigits, patternWithDigitsAndDelimiter, stringProperty, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Fruit.cs
@@ -36,15 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = apple;
             Color = color;
         }
@@ -57,15 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Banana = banana;
             Color = color;
         }
@@ -162,6 +144,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Fruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (appleDeserialized)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public GmFruit(Apple apple, Banana banana, string color)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for GmFruit and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = Apple;
             Banana = Banana;
             Color = color;
@@ -143,6 +134,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class GmFruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new GmFruit(apple, banana, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public GrandparentAnimal(string petType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (petType == null)
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             PetType = petType;
         }
 
@@ -140,6 +131,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (petType == null)
+                throw new ArgumentNullException(nameof(petType), "Property is required for class GrandparentAnimal.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new GrandparentAnimal(petType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         internal HasOnlyReadOnly(string bar, string foo)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for HasOnlyReadOnly and cannot be null.");
-
-            if (foo == null)
-                throw new ArgumentNullException("foo is a required property for HasOnlyReadOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
             Foo = foo;
         }
@@ -183,6 +171,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class HasOnlyReadOnly.");
+
+            if (foo == null)
+                throw new ArgumentNullException(nameof(foo), "Property is required for class HasOnlyReadOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/List.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public List(string _123list)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (_123list == null)
-                throw new ArgumentNullException("_123list is a required property for List and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             _123List = _123list;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (_123list == null)
+                throw new ArgumentNullException(nameof(_123list), "Property is required for class List.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new List(_123list);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public MapTest(Dictionary<string, bool> directMap, Dictionary<string, bool> indirectMap, Dictionary<string, Dictionary<string, string>> mapMapOfString, Dictionary<string, MapTest.InnerEnum> mapOfEnumString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mapMapOfString == null)
-                throw new ArgumentNullException("mapMapOfString is a required property for MapTest and cannot be null.");
-
-            if (mapOfEnumString == null)
-                throw new ArgumentNullException("mapOfEnumString is a required property for MapTest and cannot be null.");
-
-            if (directMap == null)
-                throw new ArgumentNullException("directMap is a required property for MapTest and cannot be null.");
-
-            if (indirectMap == null)
-                throw new ArgumentNullException("indirectMap is a required property for MapTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DirectMap = directMap;
             IndirectMap = indirectMap;
             MapMapOfString = mapMapOfString;
@@ -232,6 +214,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mapMapOfString == null)
+                throw new ArgumentNullException(nameof(mapMapOfString), "Property is required for class MapTest.");
+
+            if (mapOfEnumString == null)
+                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is required for class MapTest.");
+
+            if (directMap == null)
+                throw new ArgumentNullException(nameof(directMap), "Property is required for class MapTest.");
+
+            if (indirectMap == null)
+                throw new ArgumentNullException(nameof(indirectMap), "Property is required for class MapTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public MixedPropertiesAndAdditionalPropertiesClass(DateTime dateTime, Dictionary<string, Animal> map, Guid uuid, Guid uuidWithPattern)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (uuidWithPattern == null)
-                throw new ArgumentNullException("uuidWithPattern is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (dateTime == null)
-                throw new ArgumentNullException("dateTime is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (map == null)
-                throw new ArgumentNullException("map is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DateTime = dateTime;
             Map = map;
             Uuid = uuid;
@@ -194,6 +176,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (uuidWithPattern == null)
+                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (dateTime == null)
+                throw new ArgumentNullException(nameof(dateTime), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (map == null)
+                throw new ArgumentNullException(nameof(map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Model200Response(string classProperty, int name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Model200Response and cannot be null.");
-
-            if (classProperty == null)
-                throw new ArgumentNullException("classProperty is a required property for Model200Response and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassProperty = classProperty;
             Name = name;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Model200Response.");
+
+            if (classProperty == null)
+                throw new ArgumentNullException(nameof(classProperty), "Property is required for class Model200Response.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Model200Response(classProperty, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ModelClient(string clientProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (clientProperty == null)
-                throw new ArgumentNullException("clientProperty is a required property for ModelClient and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             _ClientProperty = clientProperty;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (clientProperty == null)
+                throw new ArgumentNullException(nameof(clientProperty), "Property is required for class ModelClient.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ModelClient(clientProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Name(int nameProperty, string property, int snakeCase, int _123number)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (nameProperty == null)
-                throw new ArgumentNullException("nameProperty is a required property for Name and cannot be null.");
-
-            if (snakeCase == null)
-                throw new ArgumentNullException("snakeCase is a required property for Name and cannot be null.");
-
-            if (property == null)
-                throw new ArgumentNullException("property is a required property for Name and cannot be null.");
-
-            if (_123number == null)
-                throw new ArgumentNullException("_123number is a required property for Name and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             NameProperty = nameProperty;
             Property = property;
             SnakeCase = snakeCase;
@@ -218,6 +200,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (nameProperty == null)
+                throw new ArgumentNullException(nameof(nameProperty), "Property is required for class Name.");
+
+            if (snakeCase == null)
+                throw new ArgumentNullException(nameof(snakeCase), "Property is required for class Name.");
+
+            if (property == null)
+                throw new ArgumentNullException(nameof(property), "Property is required for class Name.");
+
+            if (_123number == null)
+                throw new ArgumentNullException(nameof(_123number), "Property is required for class Name.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Name(nameProperty, property, snakeCase, _123number);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -46,18 +46,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public NullableClass(List<Object> arrayItemsNullable, Dictionary<string, Object> objectItemsNullable, List<Object> arrayAndItemsNullableProp = default, List<Object> arrayNullableProp = default, bool? booleanProp = default, DateTime? dateProp = default, DateTime? datetimeProp = default, int? integerProp = default, decimal? numberProp = default, Dictionary<string, Object> objectAndItemsNullableProp = default, Dictionary<string, Object> objectNullableProp = default, string stringProp = default) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayItemsNullable == null)
-                throw new ArgumentNullException("arrayItemsNullable is a required property for NullableClass and cannot be null.");
-
-            if (objectItemsNullable == null)
-                throw new ArgumentNullException("objectItemsNullable is a required property for NullableClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayItemsNullable = arrayItemsNullable;
             ObjectItemsNullable = objectItemsNullable;
             ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
@@ -291,6 +279,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayItemsNullable == null)
+                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is required for class NullableClass.");
+
+            if (objectItemsNullable == null)
+                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is required for class NullableClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new NullableClass(arrayItemsNullable, objectItemsNullable, arrayAndItemsNullableProp, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public NumberOnly(decimal justNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (justNumber == null)
-                throw new ArgumentNullException("justNumber is a required property for NumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             JustNumber = justNumber;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (justNumber == null)
+                throw new ArgumentNullException(nameof(justNumber), "Property is required for class NumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ObjectWithDeprecatedFields(List<string> bars, DeprecatedObject deprecatedRef, decimal id, string uuid)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (deprecatedRef == null)
-                throw new ArgumentNullException("deprecatedRef is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (bars == null)
-                throw new ArgumentNullException("bars is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bars = bars;
             DeprecatedRef = deprecatedRef;
             Id = id;
@@ -184,6 +166,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (deprecatedRef == null)
+                throw new ArgumentNullException(nameof(deprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (bars == null)
+                throw new ArgumentNullException(nameof(bars), "Property is required for class ObjectWithDeprecatedFields.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
@@ -40,30 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Order(long id, long petId, int quantity, DateTime shipDate, StatusEnum status, bool complete = false)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Order and cannot be null.");
-
-            if (petId == null)
-                throw new ArgumentNullException("petId is a required property for Order and cannot be null.");
-
-            if (quantity == null)
-                throw new ArgumentNullException("quantity is a required property for Order and cannot be null.");
-
-            if (shipDate == null)
-                throw new ArgumentNullException("shipDate is a required property for Order and cannot be null.");
-
-            if (status == null)
-                throw new ArgumentNullException("status is a required property for Order and cannot be null.");
-
-            if (complete == null)
-                throw new ArgumentNullException("complete is a required property for Order and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             PetId = petId;
             Quantity = quantity;
@@ -285,6 +261,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Order.");
+
+            if (petId == null)
+                throw new ArgumentNullException(nameof(petId), "Property is required for class Order.");
+
+            if (quantity == null)
+                throw new ArgumentNullException(nameof(quantity), "Property is required for class Order.");
+
+            if (shipDate == null)
+                throw new ArgumentNullException(nameof(shipDate), "Property is required for class Order.");
+
+            if (status == null)
+                throw new ArgumentNullException(nameof(status), "Property is required for class Order.");
+
+            if (complete == null)
+                throw new ArgumentNullException(nameof(complete), "Property is required for class Order.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Order(id, petId, quantity, shipDate, status, complete);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public OuterComposite(bool myBoolean, decimal myNumber, string myString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (myNumber == null)
-                throw new ArgumentNullException("myNumber is a required property for OuterComposite and cannot be null.");
-
-            if (myString == null)
-                throw new ArgumentNullException("myString is a required property for OuterComposite and cannot be null.");
-
-            if (myBoolean == null)
-                throw new ArgumentNullException("myBoolean is a required property for OuterComposite and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             MyBoolean = myBoolean;
             MyNumber = myNumber;
             MyString = myString;
@@ -164,6 +149,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (myNumber == null)
+                throw new ArgumentNullException(nameof(myNumber), "Property is required for class OuterComposite.");
+
+            if (myString == null)
+                throw new ArgumentNullException(nameof(myString), "Property is required for class OuterComposite.");
+
+            if (myBoolean == null)
+                throw new ArgumentNullException(nameof(myBoolean), "Property is required for class OuterComposite.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -40,30 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Pet(Category category, long id, string name, List<string> photoUrls, StatusEnum status, List<Tag> tags)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Pet and cannot be null.");
-
-            if (category == null)
-                throw new ArgumentNullException("category is a required property for Pet and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null.");
-
-            if (photoUrls == null)
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null.");
-
-            if (tags == null)
-                throw new ArgumentNullException("tags is a required property for Pet and cannot be null.");
-
-            if (status == null)
-                throw new ArgumentNullException("status is a required property for Pet and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Category = category;
             Id = id;
             Name = name;
@@ -279,6 +255,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Pet.");
+
+            if (category == null)
+                throw new ArgumentNullException(nameof(category), "Property is required for class Pet.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Pet.");
+
+            if (photoUrls == null)
+                throw new ArgumentNullException(nameof(photoUrls), "Property is required for class Pet.");
+
+            if (tags == null)
+                throw new ArgumentNullException(nameof(tags), "Property is required for class Pet.");
+
+            if (status == null)
+                throw new ArgumentNullException(nameof(status), "Property is required for class Pet.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Pet(category, id, name, photoUrls, status, tags);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public QuadrilateralInterface(string quadrilateralType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             QuadrilateralType = quadrilateralType;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class QuadrilateralInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new QuadrilateralInterface(quadrilateralType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ReadOnlyFirst(string bar, string baz)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for ReadOnlyFirst and cannot be null.");
-
-            if (baz == null)
-                throw new ArgumentNullException("baz is a required property for ReadOnlyFirst and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
             Baz = baz;
         }
@@ -182,6 +170,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class ReadOnlyFirst.");
+
+            if (baz == null)
+                throw new ArgumentNullException(nameof(baz), "Property is required for class ReadOnlyFirst.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Return(int returnProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (returnProperty == null)
-                throw new ArgumentNullException("returnProperty is a required property for Return and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ReturnProperty = returnProperty;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (returnProperty == null)
+                throw new ArgumentNullException(nameof(returnProperty), "Property is required for class Return.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Return(returnProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -36,15 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Shape(Triangle triangle, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Triangle = triangle;
             QuadrilateralType = quadrilateralType;
         }
@@ -57,15 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Shape(Quadrilateral quadrilateral, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Quadrilateral = quadrilateral;
             QuadrilateralType = quadrilateralType;
         }
@@ -179,6 +161,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class Shape.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (triangleDeserialized)
                 return new Shape(triangle, quadrilateralType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeInterface(string shapeType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ShapeType = shapeType;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (shapeType == null)
+                throw new ArgumentNullException(nameof(shapeType), "Property is required for class ShapeInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ShapeInterface(shapeType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -36,15 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeOrNull(Triangle triangle, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Triangle = triangle;
             QuadrilateralType = quadrilateralType;
         }
@@ -57,15 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeOrNull(Quadrilateral quadrilateral, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Quadrilateral = quadrilateral;
             QuadrilateralType = quadrilateralType;
         }
@@ -179,6 +161,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class ShapeOrNull.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (triangleDeserialized)
                 return new ShapeOrNull(triangle, quadrilateralType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public SpecialModelName(string specialModelNameProperty, long specialPropertyName)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (specialPropertyName == null)
-                throw new ArgumentNullException("specialPropertyName is a required property for SpecialModelName and cannot be null.");
-
-            if (specialModelNameProperty == null)
-                throw new ArgumentNullException("specialModelNameProperty is a required property for SpecialModelName and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             SpecialModelNameProperty = specialModelNameProperty;
             SpecialPropertyName = specialPropertyName;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (specialPropertyName == null)
+                throw new ArgumentNullException(nameof(specialPropertyName), "Property is required for class SpecialModelName.");
+
+            if (specialModelNameProperty == null)
+                throw new ArgumentNullException(nameof(specialModelNameProperty), "Property is required for class SpecialModelName.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new SpecialModelName(specialModelNameProperty, specialPropertyName);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Tag(long id, string name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Tag and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Tag and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             Name = name;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Tag.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Tag.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Triangle.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(EquilateralTriangle equilateralTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EquilateralTriangle = equilateralTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -63,18 +51,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(IsoscelesTriangle isoscelesTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             IsoscelesTriangle = isoscelesTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -89,18 +65,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(ScaleneTriangle scaleneTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ScaleneTriangle = scaleneTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -234,6 +198,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (shapeType == null)
+                throw new ArgumentNullException(nameof(shapeType), "Property is required for class Triangle.");
+
+            if (triangleType == null)
+                throw new ArgumentNullException(nameof(triangleType), "Property is required for class Triangle.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (equilateralTriangleDeserialized)
                 return new Triangle(equilateralTriangle, shapeType, triangleType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public TriangleInterface(string triangleType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (triangleType == null)
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             TriangleType = triangleType;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (triangleType == null)
+                throw new ArgumentNullException(nameof(triangleType), "Property is required for class TriangleInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new TriangleInterface(triangleType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
@@ -46,39 +46,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public User(string email, string firstName, long id, string lastName, Object objectWithNoDeclaredProps, string password, string phone, int userStatus, string username, Object anyTypeProp = default, Object anyTypePropNullable = default, Object objectWithNoDeclaredPropsNullable = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for User and cannot be null.");
-
-            if (username == null)
-                throw new ArgumentNullException("username is a required property for User and cannot be null.");
-
-            if (firstName == null)
-                throw new ArgumentNullException("firstName is a required property for User and cannot be null.");
-
-            if (lastName == null)
-                throw new ArgumentNullException("lastName is a required property for User and cannot be null.");
-
-            if (email == null)
-                throw new ArgumentNullException("email is a required property for User and cannot be null.");
-
-            if (password == null)
-                throw new ArgumentNullException("password is a required property for User and cannot be null.");
-
-            if (phone == null)
-                throw new ArgumentNullException("phone is a required property for User and cannot be null.");
-
-            if (userStatus == null)
-                throw new ArgumentNullException("userStatus is a required property for User and cannot be null.");
-
-            if (objectWithNoDeclaredProps == null)
-                throw new ArgumentNullException("objectWithNoDeclaredProps is a required property for User and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Email = email;
             FirstName = firstName;
             Id = id;
@@ -308,6 +275,39 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class User.");
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username), "Property is required for class User.");
+
+            if (firstName == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is required for class User.");
+
+            if (lastName == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is required for class User.");
+
+            if (email == null)
+                throw new ArgumentNullException(nameof(email), "Property is required for class User.");
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password), "Property is required for class User.");
+
+            if (phone == null)
+                throw new ArgumentNullException(nameof(phone), "Property is required for class User.");
+
+            if (userStatus == null)
+                throw new ArgumentNullException(nameof(userStatus), "Property is required for class User.");
+
+            if (objectWithNoDeclaredProps == null)
+                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is required for class User.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new User(email, firstName, id, lastName, objectWithNoDeclaredProps, password, phone, userStatus, username, anyTypeProp, anyTypePropNullable, objectWithNoDeclaredPropsNullable);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Whale(string className, bool hasBaleen, bool hasTeeth)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (hasBaleen == null)
-                throw new ArgumentNullException("hasBaleen is a required property for Whale and cannot be null.");
-
-            if (hasTeeth == null)
-                throw new ArgumentNullException("hasTeeth is a required property for Whale and cannot be null.");
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             HasBaleen = hasBaleen;
             HasTeeth = hasTeeth;
@@ -164,6 +149,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (hasBaleen == null)
+                throw new ArgumentNullException(nameof(hasBaleen), "Property is required for class Whale.");
+
+            if (hasTeeth == null)
+                throw new ArgumentNullException(nameof(hasTeeth), "Property is required for class Whale.");
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Whale.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Whale(className, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Zebra(string className, TypeEnum type) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for Zebra and cannot be null.");
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             Type = type;
         }
@@ -209,6 +197,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class Zebra.");
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Zebra.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Zebra(className, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/AdultAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/AdultAllOf.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AdultAllOf(List<Child> children)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (children == null)
-                throw new ArgumentNullException("children is a required property for AdultAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Children = children;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (children == null)
+                throw new ArgumentNullException(nameof(children), "Property is required for class AdultAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AdultAllOf(children);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Child.cs
@@ -41,15 +41,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Child(ChildAllOf childAllOf, bool boosterSeat, string firstName, string lastName, string type) : base(firstName, lastName, type)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (boosterSeat == null)
-                throw new ArgumentNullException("boosterSeat is a required property for Child and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ChildAllOf = childAllOf;
             BoosterSeat = boosterSeat;
         }
@@ -143,6 +134,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (boosterSeat == null)
+                throw new ArgumentNullException(nameof(boosterSeat), "Property is required for class Child.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Child(childAllOf, boosterSeat, firstName, lastName, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/ChildAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/ChildAllOf.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildAllOf(int age)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (age == null)
-                throw new ArgumentNullException("age is a required property for ChildAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Age = age;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (age == null)
+                throw new ArgumentNullException(nameof(age), "Property is required for class ChildAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ChildAllOf(age);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Person.cs
@@ -39,21 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Person(string firstName, string lastName, string type)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for Person and cannot be null.");
-
-            if (lastName == null)
-                throw new ArgumentNullException("lastName is a required property for Person and cannot be null.");
-
-            if (firstName == null)
-                throw new ArgumentNullException("firstName is a required property for Person and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             FirstName = firstName;
             LastName = lastName;
             Type = type;
@@ -174,6 +159,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class Person.");
+
+            if (lastName == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is required for class Person.");
+
+            if (firstName == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is required for class Person.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Person(firstName, lastName, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Apple(string kind)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (kind == null)
-                throw new ArgumentNullException("kind is a required property for Apple and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Kind = kind;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (kind == null)
+                throw new ArgumentNullException(nameof(kind), "Property is required for class Apple.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Banana(decimal count)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (count == null)
-                throw new ArgumentNullException("count is a required property for Banana and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Count = count;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (count == null)
+                throw new ArgumentNullException(nameof(count), "Property is required for class Banana.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -39,15 +39,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Apple apple, Banana banana, string color)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for Fruit and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = Apple;
             Banana = Banana;
             Color = color;
@@ -152,6 +143,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Fruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Fruit(apple, banana, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Apple(string kind)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (kind == null)
-                throw new ArgumentNullException("kind is a required property for Apple and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Kind = kind;
         }
 
@@ -132,6 +123,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (kind == null)
+                throw new ArgumentNullException(nameof(kind), "Property is required for class Apple.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Apple(kind);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Banana(decimal count)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (count == null)
-                throw new ArgumentNullException("count is a required property for Banana and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Count = count;
         }
 
@@ -133,6 +124,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (count == null)
+                throw new ArgumentNullException(nameof(count), "Property is required for class Banana.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Banana(count);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -38,15 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = apple;
             Color = color;
         }
@@ -59,15 +50,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Banana = banana;
             Color = color;
         }
@@ -171,6 +153,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Fruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (appleDeserialized)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Activity.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (activityOutputs == null)
-                throw new ArgumentNullException("activityOutputs is a required property for Activity and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ActivityOutputs = activityOutputs;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (activityOutputs == null)
+                throw new ArgumentNullException(nameof(activityOutputs), "Property is required for class Activity.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Activity(activityOutputs);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ActivityOutputElementRepresentation(string prop1, Object prop2)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (prop1 == null)
-                throw new ArgumentNullException("prop1 is a required property for ActivityOutputElementRepresentation and cannot be null.");
-
-            if (prop2 == null)
-                throw new ArgumentNullException("prop2 is a required property for ActivityOutputElementRepresentation and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Prop1 = prop1;
             Prop2 = prop2;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (prop1 == null)
+                throw new ArgumentNullException(nameof(prop1), "Property is required for class ActivityOutputElementRepresentation.");
+
+            if (prop2 == null)
+                throw new ArgumentNullException(nameof(prop2), "Property is required for class ActivityOutputElementRepresentation.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ActivityOutputElementRepresentation(prop1, prop2);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -42,33 +42,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AdditionalPropertiesClass(Object emptyMap, Dictionary<string, Dictionary<string, string>> mapOfMapProperty, Dictionary<string, string> mapProperty, Object mapWithUndeclaredPropertiesAnytype1, Object mapWithUndeclaredPropertiesAnytype2, Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3, Dictionary<string, string> mapWithUndeclaredPropertiesString, Object anytype1 = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mapProperty == null)
-                throw new ArgumentNullException("mapProperty is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapOfMapProperty == null)
-                throw new ArgumentNullException("mapOfMapProperty is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype1 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype1 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype2 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype2 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesAnytype3 == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesAnytype3 is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (emptyMap == null)
-                throw new ArgumentNullException("emptyMap is a required property for AdditionalPropertiesClass and cannot be null.");
-
-            if (mapWithUndeclaredPropertiesString == null)
-                throw new ArgumentNullException("mapWithUndeclaredPropertiesString is a required property for AdditionalPropertiesClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EmptyMap = emptyMap;
             MapOfMapProperty = mapOfMapProperty;
             MapProperty = mapProperty;
@@ -248,6 +221,33 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mapProperty == null)
+                throw new ArgumentNullException(nameof(mapProperty), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapOfMapProperty == null)
+                throw new ArgumentNullException(nameof(mapOfMapProperty), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype1 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype1), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype2 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype2), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesAnytype3 == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesAnytype3), "Property is required for class AdditionalPropertiesClass.");
+
+            if (emptyMap == null)
+                throw new ArgumentNullException(nameof(emptyMap), "Property is required for class AdditionalPropertiesClass.");
+
+            if (mapWithUndeclaredPropertiesString == null)
+                throw new ArgumentNullException(nameof(mapWithUndeclaredPropertiesString), "Property is required for class AdditionalPropertiesClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AdditionalPropertiesClass(emptyMap, mapOfMapProperty, mapProperty, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, mapWithUndeclaredPropertiesString, anytype1);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Animal(string className, string color = "red")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Animal and cannot be null.");
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for Animal and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             Color = color;
         }
@@ -156,6 +144,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Animal.");
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Animal.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Animal(className, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ApiResponse(int code, string message, string type)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (code == null)
-                throw new ArgumentNullException("code is a required property for ApiResponse and cannot be null.");
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for ApiResponse and cannot be null.");
-
-            if (message == null)
-                throw new ArgumentNullException("message is a required property for ApiResponse and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Code = code;
             Message = message;
             Type = type;
@@ -163,6 +148,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (code == null)
+                throw new ArgumentNullException(nameof(code), "Property is required for class ApiResponse.");
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class ApiResponse.");
+
+            if (message == null)
+                throw new ArgumentNullException(nameof(message), "Property is required for class ApiResponse.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ApiResponse(code, message, type);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Apple(string cultivar, string origin)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (cultivar == null)
-                throw new ArgumentNullException("cultivar is a required property for Apple and cannot be null.");
-
-            if (origin == null)
-                throw new ArgumentNullException("origin is a required property for Apple and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Cultivar = cultivar;
             Origin = origin;
         }
@@ -160,6 +148,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (cultivar == null)
+                throw new ArgumentNullException(nameof(cultivar), "Property is required for class Apple.");
+
+            if (origin == null)
+                throw new ArgumentNullException(nameof(origin), "Property is required for class Apple.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Apple(cultivar, origin);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public AppleReq(string cultivar, bool mealy)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (cultivar == null)
-                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null.");
-
-            if (mealy == null)
-                throw new ArgumentNullException("mealy is a required property for AppleReq and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Cultivar = cultivar;
             Mealy = mealy;
         }
@@ -140,6 +128,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (cultivar == null)
+                throw new ArgumentNullException(nameof(cultivar), "Property is required for class AppleReq.");
+
+            if (mealy == null)
+                throw new ArgumentNullException(nameof(mealy), "Property is required for class AppleReq.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new AppleReq(cultivar, mealy);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayArrayNumber == null)
-                throw new ArgumentNullException("arrayArrayNumber is a required property for ArrayOfArrayOfNumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayArrayNumber = arrayArrayNumber;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayArrayNumber == null)
+                throw new ArgumentNullException(nameof(arrayArrayNumber), "Property is required for class ArrayOfArrayOfNumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayOfArrayOfNumberOnly(arrayArrayNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayOfNumberOnly(List<decimal> arrayNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayNumber == null)
-                throw new ArgumentNullException("arrayNumber is a required property for ArrayOfNumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayNumber = arrayNumber;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayNumber == null)
+                throw new ArgumentNullException(nameof(arrayNumber), "Property is required for class ArrayOfNumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayOfNumberOnly(arrayNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ArrayTest(List<List<long>> arrayArrayOfInteger, List<List<ReadOnlyFirst>> arrayArrayOfModel, List<string> arrayOfString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayOfString == null)
-                throw new ArgumentNullException("arrayOfString is a required property for ArrayTest and cannot be null.");
-
-            if (arrayArrayOfInteger == null)
-                throw new ArgumentNullException("arrayArrayOfInteger is a required property for ArrayTest and cannot be null.");
-
-            if (arrayArrayOfModel == null)
-                throw new ArgumentNullException("arrayArrayOfModel is a required property for ArrayTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayArrayOfInteger = arrayArrayOfInteger;
             ArrayArrayOfModel = arrayArrayOfModel;
             ArrayOfString = arrayOfString;
@@ -165,6 +150,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayOfString == null)
+                throw new ArgumentNullException(nameof(arrayOfString), "Property is required for class ArrayTest.");
+
+            if (arrayArrayOfInteger == null)
+                throw new ArgumentNullException(nameof(arrayArrayOfInteger), "Property is required for class ArrayTest.");
+
+            if (arrayArrayOfModel == null)
+                throw new ArgumentNullException(nameof(arrayArrayOfModel), "Property is required for class ArrayTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ArrayTest(arrayArrayOfInteger, arrayArrayOfModel, arrayOfString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Banana(decimal lengthCm)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (lengthCm == null)
-                throw new ArgumentNullException("lengthCm is a required property for Banana and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             LengthCm = lengthCm;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (lengthCm == null)
+                throw new ArgumentNullException(nameof(lengthCm), "Property is required for class Banana.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Banana(lengthCm);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public BananaReq(decimal lengthCm, bool sweet)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (lengthCm == null)
-                throw new ArgumentNullException("lengthCm is a required property for BananaReq and cannot be null.");
-
-            if (sweet == null)
-                throw new ArgumentNullException("sweet is a required property for BananaReq and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             LengthCm = lengthCm;
             Sweet = sweet;
         }
@@ -141,6 +129,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (lengthCm == null)
+                throw new ArgumentNullException(nameof(lengthCm), "Property is required for class BananaReq.");
+
+            if (sweet == null)
+                throw new ArgumentNullException(nameof(sweet), "Property is required for class BananaReq.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new BananaReq(lengthCm, sweet);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public BasquePig(string className)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class BasquePig.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new BasquePig(className);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -40,30 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Capitalization(string aTTNAME, string capitalCamel, string capitalSnake, string sCAETHFlowPoints, string smallCamel, string smallSnake)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (smallCamel == null)
-                throw new ArgumentNullException("smallCamel is a required property for Capitalization and cannot be null.");
-
-            if (capitalCamel == null)
-                throw new ArgumentNullException("capitalCamel is a required property for Capitalization and cannot be null.");
-
-            if (smallSnake == null)
-                throw new ArgumentNullException("smallSnake is a required property for Capitalization and cannot be null.");
-
-            if (capitalSnake == null)
-                throw new ArgumentNullException("capitalSnake is a required property for Capitalization and cannot be null.");
-
-            if (sCAETHFlowPoints == null)
-                throw new ArgumentNullException("sCAETHFlowPoints is a required property for Capitalization and cannot be null.");
-
-            if (aTTNAME == null)
-                throw new ArgumentNullException("aTTNAME is a required property for Capitalization and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ATT_NAME = aTTNAME;
             CapitalCamel = capitalCamel;
             CapitalSnake = capitalSnake;
@@ -211,6 +187,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (smallCamel == null)
+                throw new ArgumentNullException(nameof(smallCamel), "Property is required for class Capitalization.");
+
+            if (capitalCamel == null)
+                throw new ArgumentNullException(nameof(capitalCamel), "Property is required for class Capitalization.");
+
+            if (smallSnake == null)
+                throw new ArgumentNullException(nameof(smallSnake), "Property is required for class Capitalization.");
+
+            if (capitalSnake == null)
+                throw new ArgumentNullException(nameof(capitalSnake), "Property is required for class Capitalization.");
+
+            if (sCAETHFlowPoints == null)
+                throw new ArgumentNullException(nameof(sCAETHFlowPoints), "Property is required for class Capitalization.");
+
+            if (aTTNAME == null)
+                throw new ArgumentNullException(nameof(aTTNAME), "Property is required for class Capitalization.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Capitalization(aTTNAME, capitalCamel, capitalSnake, sCAETHFlowPoints, smallCamel, smallSnake);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public CatAllOf(bool declawed)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (declawed == null)
-                throw new ArgumentNullException("declawed is a required property for CatAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Declawed = declawed;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (declawed == null)
+                throw new ArgumentNullException(nameof(declawed), "Property is required for class CatAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new CatAllOf(declawed);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Category(long id, string name = "default-name")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Category and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Category and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             Name = name;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Category.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Category.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Category(id, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ChildCatAllOf(string name, PetTypeEnum petType = PetTypeEnum.ChildCat)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for ChildCatAllOf and cannot be null.");
-
-            if (petType == null)
-                throw new ArgumentNullException("petType is a required property for ChildCatAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Name = name;
             PetType = petType;
         }
@@ -186,6 +174,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class ChildCatAllOf.");
+
+            if (petType == null)
+                throw new ArgumentNullException(nameof(petType), "Property is required for class ChildCatAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ChildCatAllOf(name, petType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ClassModel(string classProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (classProperty == null)
-                throw new ArgumentNullException("classProperty is a required property for ClassModel and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassProperty = classProperty;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (classProperty == null)
+                throw new ArgumentNullException(nameof(classProperty), "Property is required for class ClassModel.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ClassModel(classProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DanishPig(string className)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class DanishPig.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DanishPig(className);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DateOnlyClass(DateTime dateOnlyProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (dateOnlyProperty == null)
-                throw new ArgumentNullException("dateOnlyProperty is a required property for DateOnlyClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DateOnlyProperty = dateOnlyProperty;
         }
 
@@ -137,6 +128,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (dateOnlyProperty == null)
+                throw new ArgumentNullException(nameof(dateOnlyProperty), "Property is required for class DateOnlyClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DateOnlyClass(dateOnlyProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DeprecatedObject(string name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for DeprecatedObject and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Name = name;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class DeprecatedObject.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DeprecatedObject(name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public DogAllOf(string breed)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (breed == null)
-                throw new ArgumentNullException("breed is a required property for DogAllOf and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Breed = breed;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (breed == null)
+                throw new ArgumentNullException(nameof(breed), "Property is required for class DogAllOf.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new DogAllOf(breed);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -38,21 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Drawing(Shape mainShape, ShapeOrNull shapeOrNull, List<Shape> shapes, NullableShape nullableShape = default) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mainShape == null)
-                throw new ArgumentNullException("mainShape is a required property for Drawing and cannot be null.");
-
-            if (shapeOrNull == null)
-                throw new ArgumentNullException("shapeOrNull is a required property for Drawing and cannot be null.");
-
-            if (shapes == null)
-                throw new ArgumentNullException("shapes is a required property for Drawing and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             MainShape = mainShape;
             ShapeOrNull = shapeOrNull;
             Shapes = shapes;
@@ -173,6 +158,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mainShape == null)
+                throw new ArgumentNullException(nameof(mainShape), "Property is required for class Drawing.");
+
+            if (shapeOrNull == null)
+                throw new ArgumentNullException(nameof(shapeOrNull), "Property is required for class Drawing.");
+
+            if (shapes == null)
+                throw new ArgumentNullException(nameof(shapes), "Property is required for class Drawing.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Drawing(mainShape, shapeOrNull, shapes, nullableShape);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public EnumArrays(List<EnumArrays.ArrayEnumEnum> arrayEnum, JustSymbolEnum justSymbol)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (justSymbol == null)
-                throw new ArgumentNullException("justSymbol is a required property for EnumArrays and cannot be null.");
-
-            if (arrayEnum == null)
-                throw new ArgumentNullException("arrayEnum is a required property for EnumArrays and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayEnum = arrayEnum;
             JustSymbol = justSymbol;
         }
@@ -248,6 +236,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (justSymbol == null)
+                throw new ArgumentNullException(nameof(justSymbol), "Property is required for class EnumArrays.");
+
+            if (arrayEnum == null)
+                throw new ArgumentNullException(nameof(arrayEnum), "Property is required for class EnumArrays.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new EnumArrays(arrayEnum, justSymbol);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -43,36 +43,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public EnumTest(EnumIntegerEnum enumInteger, EnumIntegerOnlyEnum enumIntegerOnly, EnumNumberEnum enumNumber, EnumStringEnum enumString, EnumStringRequiredEnum enumStringRequired, OuterEnumDefaultValue outerEnumDefaultValue, OuterEnumInteger outerEnumInteger, OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue, OuterEnum? outerEnum = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (enumString == null)
-                throw new ArgumentNullException("enumString is a required property for EnumTest and cannot be null.");
-
-            if (enumStringRequired == null)
-                throw new ArgumentNullException("enumStringRequired is a required property for EnumTest and cannot be null.");
-
-            if (enumInteger == null)
-                throw new ArgumentNullException("enumInteger is a required property for EnumTest and cannot be null.");
-
-            if (enumIntegerOnly == null)
-                throw new ArgumentNullException("enumIntegerOnly is a required property for EnumTest and cannot be null.");
-
-            if (enumNumber == null)
-                throw new ArgumentNullException("enumNumber is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumInteger == null)
-                throw new ArgumentNullException("outerEnumInteger is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumDefaultValue == null)
-                throw new ArgumentNullException("outerEnumDefaultValue is a required property for EnumTest and cannot be null.");
-
-            if (outerEnumIntegerDefaultValue == null)
-                throw new ArgumentNullException("outerEnumIntegerDefaultValue is a required property for EnumTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EnumInteger = enumInteger;
             EnumIntegerOnly = enumIntegerOnly;
             EnumNumber = enumNumber;
@@ -524,6 +494,36 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (enumString == null)
+                throw new ArgumentNullException(nameof(enumString), "Property is required for class EnumTest.");
+
+            if (enumStringRequired == null)
+                throw new ArgumentNullException(nameof(enumStringRequired), "Property is required for class EnumTest.");
+
+            if (enumInteger == null)
+                throw new ArgumentNullException(nameof(enumInteger), "Property is required for class EnumTest.");
+
+            if (enumIntegerOnly == null)
+                throw new ArgumentNullException(nameof(enumIntegerOnly), "Property is required for class EnumTest.");
+
+            if (enumNumber == null)
+                throw new ArgumentNullException(nameof(enumNumber), "Property is required for class EnumTest.");
+
+            if (outerEnumInteger == null)
+                throw new ArgumentNullException(nameof(outerEnumInteger), "Property is required for class EnumTest.");
+
+            if (outerEnumDefaultValue == null)
+                throw new ArgumentNullException(nameof(outerEnumDefaultValue), "Property is required for class EnumTest.");
+
+            if (outerEnumIntegerDefaultValue == null)
+                throw new ArgumentNullException(nameof(outerEnumIntegerDefaultValue), "Property is required for class EnumTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new EnumTest(enumInteger, enumIntegerOnly, enumNumber, enumString, enumStringRequired, outerEnumDefaultValue, outerEnumInteger, outerEnumIntegerDefaultValue, outerEnum);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/File.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public File(string sourceURI)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (sourceURI == null)
-                throw new ArgumentNullException("sourceURI is a required property for File and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             SourceURI = sourceURI;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (sourceURI == null)
+                throw new ArgumentNullException(nameof(sourceURI), "Property is required for class File.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new File(sourceURI);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FileSchemaTestClass(File file, List<File> files)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (file == null)
-                throw new ArgumentNullException("file is a required property for FileSchemaTestClass and cannot be null.");
-
-            if (files == null)
-                throw new ArgumentNullException("files is a required property for FileSchemaTestClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             File = file;
             Files = files;
         }
@@ -148,6 +136,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (file == null)
+                throw new ArgumentNullException(nameof(file), "Property is required for class FileSchemaTestClass.");
+
+            if (files == null)
+                throw new ArgumentNullException(nameof(files), "Property is required for class FileSchemaTestClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FileSchemaTestClass(file, files);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Foo.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Foo(string bar = "bar")
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for Foo and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class Foo.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Foo(bar);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FooGetDefaultResponse(Foo stringProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (stringProperty == null)
-                throw new ArgumentNullException("stringProperty is a required property for FooGetDefaultResponse and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             StringProperty = stringProperty;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (stringProperty == null)
+                throw new ArgumentNullException(nameof(stringProperty), "Property is required for class FooGetDefaultResponse.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FooGetDefaultResponse(stringProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -52,66 +52,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public FormatTest(System.IO.Stream binary, byte[] byteProperty, DateTime date, DateTime dateTime, decimal decimalProperty, double doubleProperty, float floatProperty, int int32, long int64, int integer, decimal number, string password, string patternWithDigits, string patternWithDigitsAndDelimiter, string stringProperty, uint unsignedInteger, ulong unsignedLong, Guid uuid)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (integer == null)
-                throw new ArgumentNullException("integer is a required property for FormatTest and cannot be null.");
-
-            if (int32 == null)
-                throw new ArgumentNullException("int32 is a required property for FormatTest and cannot be null.");
-
-            if (unsignedInteger == null)
-                throw new ArgumentNullException("unsignedInteger is a required property for FormatTest and cannot be null.");
-
-            if (int64 == null)
-                throw new ArgumentNullException("int64 is a required property for FormatTest and cannot be null.");
-
-            if (unsignedLong == null)
-                throw new ArgumentNullException("unsignedLong is a required property for FormatTest and cannot be null.");
-
-            if (number == null)
-                throw new ArgumentNullException("number is a required property for FormatTest and cannot be null.");
-
-            if (floatProperty == null)
-                throw new ArgumentNullException("floatProperty is a required property for FormatTest and cannot be null.");
-
-            if (doubleProperty == null)
-                throw new ArgumentNullException("doubleProperty is a required property for FormatTest and cannot be null.");
-
-            if (decimalProperty == null)
-                throw new ArgumentNullException("decimalProperty is a required property for FormatTest and cannot be null.");
-
-            if (stringProperty == null)
-                throw new ArgumentNullException("stringProperty is a required property for FormatTest and cannot be null.");
-
-            if (byteProperty == null)
-                throw new ArgumentNullException("byteProperty is a required property for FormatTest and cannot be null.");
-
-            if (binary == null)
-                throw new ArgumentNullException("binary is a required property for FormatTest and cannot be null.");
-
-            if (date == null)
-                throw new ArgumentNullException("date is a required property for FormatTest and cannot be null.");
-
-            if (dateTime == null)
-                throw new ArgumentNullException("dateTime is a required property for FormatTest and cannot be null.");
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for FormatTest and cannot be null.");
-
-            if (password == null)
-                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null.");
-
-            if (patternWithDigits == null)
-                throw new ArgumentNullException("patternWithDigits is a required property for FormatTest and cannot be null.");
-
-            if (patternWithDigitsAndDelimiter == null)
-                throw new ArgumentNullException("patternWithDigitsAndDelimiter is a required property for FormatTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Binary = binary;
             ByteProperty = byteProperty;
             Date = date;
@@ -536,6 +476,66 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (integer == null)
+                throw new ArgumentNullException(nameof(integer), "Property is required for class FormatTest.");
+
+            if (int32 == null)
+                throw new ArgumentNullException(nameof(int32), "Property is required for class FormatTest.");
+
+            if (unsignedInteger == null)
+                throw new ArgumentNullException(nameof(unsignedInteger), "Property is required for class FormatTest.");
+
+            if (int64 == null)
+                throw new ArgumentNullException(nameof(int64), "Property is required for class FormatTest.");
+
+            if (unsignedLong == null)
+                throw new ArgumentNullException(nameof(unsignedLong), "Property is required for class FormatTest.");
+
+            if (number == null)
+                throw new ArgumentNullException(nameof(number), "Property is required for class FormatTest.");
+
+            if (floatProperty == null)
+                throw new ArgumentNullException(nameof(floatProperty), "Property is required for class FormatTest.");
+
+            if (doubleProperty == null)
+                throw new ArgumentNullException(nameof(doubleProperty), "Property is required for class FormatTest.");
+
+            if (decimalProperty == null)
+                throw new ArgumentNullException(nameof(decimalProperty), "Property is required for class FormatTest.");
+
+            if (stringProperty == null)
+                throw new ArgumentNullException(nameof(stringProperty), "Property is required for class FormatTest.");
+
+            if (byteProperty == null)
+                throw new ArgumentNullException(nameof(byteProperty), "Property is required for class FormatTest.");
+
+            if (binary == null)
+                throw new ArgumentNullException(nameof(binary), "Property is required for class FormatTest.");
+
+            if (date == null)
+                throw new ArgumentNullException(nameof(date), "Property is required for class FormatTest.");
+
+            if (dateTime == null)
+                throw new ArgumentNullException(nameof(dateTime), "Property is required for class FormatTest.");
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class FormatTest.");
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password), "Property is required for class FormatTest.");
+
+            if (patternWithDigits == null)
+                throw new ArgumentNullException(nameof(patternWithDigits), "Property is required for class FormatTest.");
+
+            if (patternWithDigitsAndDelimiter == null)
+                throw new ArgumentNullException(nameof(patternWithDigitsAndDelimiter), "Property is required for class FormatTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new FormatTest(binary, byteProperty, date, dateTime, decimalProperty, doubleProperty, floatProperty, int32, int64, integer, number, password, patternWithDigits, patternWithDigitsAndDelimiter, stringProperty, unsignedInteger, unsignedLong, uuid);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Fruit.cs
@@ -36,15 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = apple;
             Color = color;
         }
@@ -57,15 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException(nameof(Color));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Banana = banana;
             Color = color;
         }
@@ -162,6 +144,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class Fruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (appleDeserialized)
                 return new Fruit(apple, color);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -37,15 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public GmFruit(Apple apple, Banana banana, string color)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (color == null)
-                throw new ArgumentNullException("color is a required property for GmFruit and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Apple = Apple;
             Banana = Banana;
             Color = color;
@@ -143,6 +134,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (color == null)
+                throw new ArgumentNullException(nameof(color), "Property is required for class GmFruit.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new GmFruit(apple, banana, color);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public GrandparentAnimal(string petType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (petType == null)
-                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             PetType = petType;
         }
 
@@ -140,6 +131,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (petType == null)
+                throw new ArgumentNullException(nameof(petType), "Property is required for class GrandparentAnimal.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new GrandparentAnimal(petType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         internal HasOnlyReadOnly(string bar, string foo)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for HasOnlyReadOnly and cannot be null.");
-
-            if (foo == null)
-                throw new ArgumentNullException("foo is a required property for HasOnlyReadOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
             Foo = foo;
         }
@@ -183,6 +171,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class HasOnlyReadOnly.");
+
+            if (foo == null)
+                throw new ArgumentNullException(nameof(foo), "Property is required for class HasOnlyReadOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new HasOnlyReadOnly(bar, foo);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/List.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public List(string _123list)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (_123list == null)
-                throw new ArgumentNullException("_123list is a required property for List and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             _123List = _123list;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (_123list == null)
+                throw new ArgumentNullException(nameof(_123list), "Property is required for class List.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new List(_123list);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public MapTest(Dictionary<string, bool> directMap, Dictionary<string, bool> indirectMap, Dictionary<string, Dictionary<string, string>> mapMapOfString, Dictionary<string, MapTest.InnerEnum> mapOfEnumString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (mapMapOfString == null)
-                throw new ArgumentNullException("mapMapOfString is a required property for MapTest and cannot be null.");
-
-            if (mapOfEnumString == null)
-                throw new ArgumentNullException("mapOfEnumString is a required property for MapTest and cannot be null.");
-
-            if (directMap == null)
-                throw new ArgumentNullException("directMap is a required property for MapTest and cannot be null.");
-
-            if (indirectMap == null)
-                throw new ArgumentNullException("indirectMap is a required property for MapTest and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DirectMap = directMap;
             IndirectMap = indirectMap;
             MapMapOfString = mapMapOfString;
@@ -232,6 +214,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (mapMapOfString == null)
+                throw new ArgumentNullException(nameof(mapMapOfString), "Property is required for class MapTest.");
+
+            if (mapOfEnumString == null)
+                throw new ArgumentNullException(nameof(mapOfEnumString), "Property is required for class MapTest.");
+
+            if (directMap == null)
+                throw new ArgumentNullException(nameof(directMap), "Property is required for class MapTest.");
+
+            if (indirectMap == null)
+                throw new ArgumentNullException(nameof(indirectMap), "Property is required for class MapTest.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new MapTest(directMap, indirectMap, mapMapOfString, mapOfEnumString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public MixedPropertiesAndAdditionalPropertiesClass(DateTime dateTime, Dictionary<string, Animal> map, Guid uuid, Guid uuidWithPattern)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (uuidWithPattern == null)
-                throw new ArgumentNullException("uuidWithPattern is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (dateTime == null)
-                throw new ArgumentNullException("dateTime is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-            if (map == null)
-                throw new ArgumentNullException("map is a required property for MixedPropertiesAndAdditionalPropertiesClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             DateTime = dateTime;
             Map = map;
             Uuid = uuid;
@@ -194,6 +176,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (uuidWithPattern == null)
+                throw new ArgumentNullException(nameof(uuidWithPattern), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (dateTime == null)
+                throw new ArgumentNullException(nameof(dateTime), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+            if (map == null)
+                throw new ArgumentNullException(nameof(map), "Property is required for class MixedPropertiesAndAdditionalPropertiesClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new MixedPropertiesAndAdditionalPropertiesClass(dateTime, map, uuid, uuidWithPattern);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Model200Response(string classProperty, int name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Model200Response and cannot be null.");
-
-            if (classProperty == null)
-                throw new ArgumentNullException("classProperty is a required property for Model200Response and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassProperty = classProperty;
             Name = name;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Model200Response.");
+
+            if (classProperty == null)
+                throw new ArgumentNullException(nameof(classProperty), "Property is required for class Model200Response.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Model200Response(classProperty, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ModelClient(string clientProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (clientProperty == null)
-                throw new ArgumentNullException("clientProperty is a required property for ModelClient and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             _ClientProperty = clientProperty;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (clientProperty == null)
+                throw new ArgumentNullException(nameof(clientProperty), "Property is required for class ModelClient.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ModelClient(clientProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Name(int nameProperty, string property, int snakeCase, int _123number)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (nameProperty == null)
-                throw new ArgumentNullException("nameProperty is a required property for Name and cannot be null.");
-
-            if (snakeCase == null)
-                throw new ArgumentNullException("snakeCase is a required property for Name and cannot be null.");
-
-            if (property == null)
-                throw new ArgumentNullException("property is a required property for Name and cannot be null.");
-
-            if (_123number == null)
-                throw new ArgumentNullException("_123number is a required property for Name and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             NameProperty = nameProperty;
             Property = property;
             SnakeCase = snakeCase;
@@ -218,6 +200,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (nameProperty == null)
+                throw new ArgumentNullException(nameof(nameProperty), "Property is required for class Name.");
+
+            if (snakeCase == null)
+                throw new ArgumentNullException(nameof(snakeCase), "Property is required for class Name.");
+
+            if (property == null)
+                throw new ArgumentNullException(nameof(property), "Property is required for class Name.");
+
+            if (_123number == null)
+                throw new ArgumentNullException(nameof(_123number), "Property is required for class Name.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Name(nameProperty, property, snakeCase, _123number);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -46,18 +46,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public NullableClass(List<Object> arrayItemsNullable, Dictionary<string, Object> objectItemsNullable, List<Object> arrayAndItemsNullableProp = default, List<Object> arrayNullableProp = default, bool? booleanProp = default, DateTime? dateProp = default, DateTime? datetimeProp = default, int? integerProp = default, decimal? numberProp = default, Dictionary<string, Object> objectAndItemsNullableProp = default, Dictionary<string, Object> objectNullableProp = default, string stringProp = default) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (arrayItemsNullable == null)
-                throw new ArgumentNullException("arrayItemsNullable is a required property for NullableClass and cannot be null.");
-
-            if (objectItemsNullable == null)
-                throw new ArgumentNullException("objectItemsNullable is a required property for NullableClass and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ArrayItemsNullable = arrayItemsNullable;
             ObjectItemsNullable = objectItemsNullable;
             ArrayAndItemsNullableProp = arrayAndItemsNullableProp;
@@ -291,6 +279,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (arrayItemsNullable == null)
+                throw new ArgumentNullException(nameof(arrayItemsNullable), "Property is required for class NullableClass.");
+
+            if (objectItemsNullable == null)
+                throw new ArgumentNullException(nameof(objectItemsNullable), "Property is required for class NullableClass.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new NullableClass(arrayItemsNullable, objectItemsNullable, arrayAndItemsNullableProp, arrayNullableProp, booleanProp, dateProp, datetimeProp, integerProp, numberProp, objectAndItemsNullableProp, objectNullableProp, stringProp);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public NumberOnly(decimal justNumber)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (justNumber == null)
-                throw new ArgumentNullException("justNumber is a required property for NumberOnly and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             JustNumber = justNumber;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (justNumber == null)
+                throw new ArgumentNullException(nameof(justNumber), "Property is required for class NumberOnly.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new NumberOnly(justNumber);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -38,24 +38,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ObjectWithDeprecatedFields(List<string> bars, DeprecatedObject deprecatedRef, decimal id, string uuid)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (uuid == null)
-                throw new ArgumentNullException("uuid is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (deprecatedRef == null)
-                throw new ArgumentNullException("deprecatedRef is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-            if (bars == null)
-                throw new ArgumentNullException("bars is a required property for ObjectWithDeprecatedFields and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bars = bars;
             DeprecatedRef = deprecatedRef;
             Id = id;
@@ -184,6 +166,24 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (uuid == null)
+                throw new ArgumentNullException(nameof(uuid), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (deprecatedRef == null)
+                throw new ArgumentNullException(nameof(deprecatedRef), "Property is required for class ObjectWithDeprecatedFields.");
+
+            if (bars == null)
+                throw new ArgumentNullException(nameof(bars), "Property is required for class ObjectWithDeprecatedFields.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ObjectWithDeprecatedFields(bars, deprecatedRef, id, uuid);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
@@ -40,30 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Order(long id, long petId, int quantity, DateTime shipDate, StatusEnum status, bool complete = false)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Order and cannot be null.");
-
-            if (petId == null)
-                throw new ArgumentNullException("petId is a required property for Order and cannot be null.");
-
-            if (quantity == null)
-                throw new ArgumentNullException("quantity is a required property for Order and cannot be null.");
-
-            if (shipDate == null)
-                throw new ArgumentNullException("shipDate is a required property for Order and cannot be null.");
-
-            if (status == null)
-                throw new ArgumentNullException("status is a required property for Order and cannot be null.");
-
-            if (complete == null)
-                throw new ArgumentNullException("complete is a required property for Order and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             PetId = petId;
             Quantity = quantity;
@@ -285,6 +261,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Order.");
+
+            if (petId == null)
+                throw new ArgumentNullException(nameof(petId), "Property is required for class Order.");
+
+            if (quantity == null)
+                throw new ArgumentNullException(nameof(quantity), "Property is required for class Order.");
+
+            if (shipDate == null)
+                throw new ArgumentNullException(nameof(shipDate), "Property is required for class Order.");
+
+            if (status == null)
+                throw new ArgumentNullException(nameof(status), "Property is required for class Order.");
+
+            if (complete == null)
+                throw new ArgumentNullException(nameof(complete), "Property is required for class Order.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Order(id, petId, quantity, shipDate, status, complete);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public OuterComposite(bool myBoolean, decimal myNumber, string myString)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (myNumber == null)
-                throw new ArgumentNullException("myNumber is a required property for OuterComposite and cannot be null.");
-
-            if (myString == null)
-                throw new ArgumentNullException("myString is a required property for OuterComposite and cannot be null.");
-
-            if (myBoolean == null)
-                throw new ArgumentNullException("myBoolean is a required property for OuterComposite and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             MyBoolean = myBoolean;
             MyNumber = myNumber;
             MyString = myString;
@@ -164,6 +149,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (myNumber == null)
+                throw new ArgumentNullException(nameof(myNumber), "Property is required for class OuterComposite.");
+
+            if (myString == null)
+                throw new ArgumentNullException(nameof(myString), "Property is required for class OuterComposite.");
+
+            if (myBoolean == null)
+                throw new ArgumentNullException(nameof(myBoolean), "Property is required for class OuterComposite.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new OuterComposite(myBoolean, myNumber, myString);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -40,30 +40,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Pet(Category category, long id, string name, List<string> photoUrls, StatusEnum status, List<Tag> tags)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Pet and cannot be null.");
-
-            if (category == null)
-                throw new ArgumentNullException("category is a required property for Pet and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Pet and cannot be null.");
-
-            if (photoUrls == null)
-                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null.");
-
-            if (tags == null)
-                throw new ArgumentNullException("tags is a required property for Pet and cannot be null.");
-
-            if (status == null)
-                throw new ArgumentNullException("status is a required property for Pet and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Category = category;
             Id = id;
             Name = name;
@@ -279,6 +255,30 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Pet.");
+
+            if (category == null)
+                throw new ArgumentNullException(nameof(category), "Property is required for class Pet.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Pet.");
+
+            if (photoUrls == null)
+                throw new ArgumentNullException(nameof(photoUrls), "Property is required for class Pet.");
+
+            if (tags == null)
+                throw new ArgumentNullException(nameof(tags), "Property is required for class Pet.");
+
+            if (status == null)
+                throw new ArgumentNullException(nameof(status), "Property is required for class Pet.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Pet(category, id, name, photoUrls, status, tags);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public QuadrilateralInterface(string quadrilateralType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             QuadrilateralType = quadrilateralType;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class QuadrilateralInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new QuadrilateralInterface(quadrilateralType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ReadOnlyFirst(string bar, string baz)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (bar == null)
-                throw new ArgumentNullException("bar is a required property for ReadOnlyFirst and cannot be null.");
-
-            if (baz == null)
-                throw new ArgumentNullException("baz is a required property for ReadOnlyFirst and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Bar = bar;
             Baz = baz;
         }
@@ -182,6 +170,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (bar == null)
+                throw new ArgumentNullException(nameof(bar), "Property is required for class ReadOnlyFirst.");
+
+            if (baz == null)
+                throw new ArgumentNullException(nameof(baz), "Property is required for class ReadOnlyFirst.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ReadOnlyFirst(bar, baz);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Return(int returnProperty)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (returnProperty == null)
-                throw new ArgumentNullException("returnProperty is a required property for Return and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ReturnProperty = returnProperty;
         }
 
@@ -131,6 +122,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (returnProperty == null)
+                throw new ArgumentNullException(nameof(returnProperty), "Property is required for class Return.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Return(returnProperty);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -36,15 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Shape(Triangle triangle, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Triangle = triangle;
             QuadrilateralType = quadrilateralType;
         }
@@ -57,15 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Shape(Quadrilateral quadrilateral, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Quadrilateral = quadrilateral;
             QuadrilateralType = quadrilateralType;
         }
@@ -179,6 +161,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class Shape.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (triangleDeserialized)
                 return new Shape(triangle, quadrilateralType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeInterface(string shapeType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ShapeType = shapeType;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (shapeType == null)
+                throw new ArgumentNullException(nameof(shapeType), "Property is required for class ShapeInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new ShapeInterface(shapeType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -36,15 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeOrNull(Triangle triangle, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Triangle = triangle;
             QuadrilateralType = quadrilateralType;
         }
@@ -57,15 +48,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public ShapeOrNull(Quadrilateral quadrilateral, string quadrilateralType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (quadrilateralType == null)
-                throw new ArgumentNullException(nameof(QuadrilateralType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Quadrilateral = quadrilateral;
             QuadrilateralType = quadrilateralType;
         }
@@ -179,6 +161,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (quadrilateralType == null)
+                throw new ArgumentNullException(nameof(quadrilateralType), "Property is required for class ShapeOrNull.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (triangleDeserialized)
                 return new ShapeOrNull(triangle, quadrilateralType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public SpecialModelName(string specialModelNameProperty, long specialPropertyName)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (specialPropertyName == null)
-                throw new ArgumentNullException("specialPropertyName is a required property for SpecialModelName and cannot be null.");
-
-            if (specialModelNameProperty == null)
-                throw new ArgumentNullException("specialModelNameProperty is a required property for SpecialModelName and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             SpecialModelNameProperty = specialModelNameProperty;
             SpecialPropertyName = specialPropertyName;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (specialPropertyName == null)
+                throw new ArgumentNullException(nameof(specialPropertyName), "Property is required for class SpecialModelName.");
+
+            if (specialModelNameProperty == null)
+                throw new ArgumentNullException(nameof(specialModelNameProperty), "Property is required for class SpecialModelName.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new SpecialModelName(specialModelNameProperty, specialPropertyName);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Tag(long id, string name)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for Tag and cannot be null.");
-
-            if (name == null)
-                throw new ArgumentNullException("name is a required property for Tag and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Id = id;
             Name = name;
         }
@@ -147,6 +135,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class Tag.");
+
+            if (name == null)
+                throw new ArgumentNullException(nameof(name), "Property is required for class Tag.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Tag(id, name);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Triangle.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(EquilateralTriangle equilateralTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             EquilateralTriangle = equilateralTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -63,18 +51,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(IsoscelesTriangle isoscelesTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             IsoscelesTriangle = isoscelesTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -89,18 +65,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Triangle(ScaleneTriangle scaleneTriangle, string shapeType, string triangleType)
         {
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (shapeType == null)
-                throw new ArgumentNullException(nameof(ShapeType));
-
-            if (triangleType == null)
-                throw new ArgumentNullException(nameof(TriangleType));
-
-            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ScaleneTriangle = scaleneTriangle;
             ShapeType = shapeType;
             TriangleType = triangleType;
@@ -234,6 +198,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (shapeType == null)
+                throw new ArgumentNullException(nameof(shapeType), "Property is required for class Triangle.");
+
+            if (triangleType == null)
+                throw new ArgumentNullException(nameof(triangleType), "Property is required for class Triangle.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             if (equilateralTriangleDeserialized)
                 return new Triangle(equilateralTriangle, shapeType, triangleType);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -35,15 +35,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public TriangleInterface(string triangleType)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (triangleType == null)
-                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             TriangleType = triangleType;
         }
 
@@ -130,6 +121,15 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (triangleType == null)
+                throw new ArgumentNullException(nameof(triangleType), "Property is required for class TriangleInterface.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new TriangleInterface(triangleType);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
@@ -46,39 +46,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public User(string email, string firstName, long id, string lastName, Object objectWithNoDeclaredProps, string password, string phone, int userStatus, string username, Object anyTypeProp = default, Object anyTypePropNullable = default, Object objectWithNoDeclaredPropsNullable = default)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (id == null)
-                throw new ArgumentNullException("id is a required property for User and cannot be null.");
-
-            if (username == null)
-                throw new ArgumentNullException("username is a required property for User and cannot be null.");
-
-            if (firstName == null)
-                throw new ArgumentNullException("firstName is a required property for User and cannot be null.");
-
-            if (lastName == null)
-                throw new ArgumentNullException("lastName is a required property for User and cannot be null.");
-
-            if (email == null)
-                throw new ArgumentNullException("email is a required property for User and cannot be null.");
-
-            if (password == null)
-                throw new ArgumentNullException("password is a required property for User and cannot be null.");
-
-            if (phone == null)
-                throw new ArgumentNullException("phone is a required property for User and cannot be null.");
-
-            if (userStatus == null)
-                throw new ArgumentNullException("userStatus is a required property for User and cannot be null.");
-
-            if (objectWithNoDeclaredProps == null)
-                throw new ArgumentNullException("objectWithNoDeclaredProps is a required property for User and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             Email = email;
             FirstName = firstName;
             Id = id;
@@ -308,6 +275,39 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id), "Property is required for class User.");
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username), "Property is required for class User.");
+
+            if (firstName == null)
+                throw new ArgumentNullException(nameof(firstName), "Property is required for class User.");
+
+            if (lastName == null)
+                throw new ArgumentNullException(nameof(lastName), "Property is required for class User.");
+
+            if (email == null)
+                throw new ArgumentNullException(nameof(email), "Property is required for class User.");
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password), "Property is required for class User.");
+
+            if (phone == null)
+                throw new ArgumentNullException(nameof(phone), "Property is required for class User.");
+
+            if (userStatus == null)
+                throw new ArgumentNullException(nameof(userStatus), "Property is required for class User.");
+
+            if (objectWithNoDeclaredProps == null)
+                throw new ArgumentNullException(nameof(objectWithNoDeclaredProps), "Property is required for class User.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new User(email, firstName, id, lastName, objectWithNoDeclaredProps, password, phone, userStatus, username, anyTypeProp, anyTypePropNullable, objectWithNoDeclaredPropsNullable);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -37,21 +37,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Whale(string className, bool hasBaleen, bool hasTeeth)
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (hasBaleen == null)
-                throw new ArgumentNullException("hasBaleen is a required property for Whale and cannot be null.");
-
-            if (hasTeeth == null)
-                throw new ArgumentNullException("hasTeeth is a required property for Whale and cannot be null.");
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Whale and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             HasBaleen = hasBaleen;
             HasTeeth = hasTeeth;
@@ -164,6 +149,21 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (hasBaleen == null)
+                throw new ArgumentNullException(nameof(hasBaleen), "Property is required for class Whale.");
+
+            if (hasTeeth == null)
+                throw new ArgumentNullException(nameof(hasTeeth), "Property is required for class Whale.");
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Whale.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Whale(className, hasBaleen, hasTeeth);
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -36,18 +36,6 @@ namespace Org.OpenAPITools.Model
         [JsonConstructor]
         public Zebra(string className, TypeEnum type) : base()
         {
-#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            if (type == null)
-                throw new ArgumentNullException("type is a required property for Zebra and cannot be null.");
-
-            if (className == null)
-                throw new ArgumentNullException("className is a required property for Zebra and cannot be null.");
-
-#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
             ClassName = className;
             Type = type;
         }
@@ -209,6 +197,18 @@ namespace Org.OpenAPITools.Model
                     }
                 }
             }
+
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
+
+            if (type == null)
+                throw new ArgumentNullException(nameof(type), "Property is required for class Zebra.");
+
+            if (className == null)
+                throw new ArgumentNullException(nameof(className), "Property is required for class Zebra.");
+
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+#pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
 
             return new Zebra(className, type);
         }


### PR DESCRIPTION
Moving the null checks to the JsonConverter. Its a bit unusual to have them in the constructor, and not flexible. It is easy for users to replace converters in the event users do not want the null checks. The only reason they are there at all is because System.Text.Json does not have missing members support like Newtonsoft.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
