### PR TITLE
[Typescript-Angular] always generate package.json

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -184,9 +184,10 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             throw new IllegalArgumentException("Invalid ngVersion: " + ngVersion + ". Only Angular v9+ is supported.");
         }
 
-        if (additionalProperties.containsKey(NPM_NAME)) {
-            addNpmPackageGeneration(ngVersion);
+        if (!additionalProperties.containsKey(NPM_NAME)) {
+            additionalProperties.put(NPM_NAME, "<PLACEHOLDER_NPM_NAME>");
         }
+        addNpmPackageGeneration(ngVersion);
 
         if (additionalProperties.containsKey(STRING_ENUMS)) {
             setStringEnums(Boolean.parseBoolean(additionalProperties.get(STRING_ENUMS).toString()));

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/.openapi-generator/FILES
@@ -11,5 +11,8 @@ model/apple.ts
 model/fruit.ts
 model/grape.ts
 model/models.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@0.0.1
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@0.0.1 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "0.0.1",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^12.2.0",
+    "rxjs": "^6.6.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^12.2.0",
+    "@angular/compiler": "^12.2.0",
+    "@angular/compiler-cli": "^12.2.0",
+    "@angular/core": "^12.2.0",
+    "@angular/platform-browser": "^12.2.0",
+    "ng-packagr": "^12.2.1",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^6.6.0",
+    "tsickle": "^0.43.0",
+    "typescript": ">=4.3.0 <4.4.0",
+    "zone.js": "^0.11.4"
+  }}

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es5",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^12.2.0",
+    "rxjs": "^6.6.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^12.2.0",
+    "@angular/compiler": "^12.2.0",
+    "@angular/compiler-cli": "^12.2.0",
+    "@angular/core": "^12.2.0",
+    "@angular/platform-browser": "^12.2.0",
+    "ng-packagr": "^12.2.1",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^6.6.0",
+    "tsickle": "^0.43.0",
+    "typescript": ">=4.3.0 <4.4.0",
+    "zone.js": "^0.11.4"
+  }}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es5",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^12.2.0",
+    "rxjs": "^6.6.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^12.2.0",
+    "@angular/compiler": "^12.2.0",
+    "@angular/compiler-cli": "^12.2.0",
+    "@angular/core": "^12.2.0",
+    "@angular/platform-browser": "^12.2.0",
+    "ng-packagr": "^12.2.1",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^6.6.0",
+    "tsickle": "^0.43.0",
+    "typescript": ">=4.3.0 <4.4.0",
+    "zone.js": "^0.11.4"
+  }}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es5",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/.openapi-generator/FILES
@@ -11,5 +11,8 @@ model/apple.ts
 model/fruit.ts
 model/grape.ts
 model/models.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@0.0.1
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@0.0.1 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "0.0.1",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^13.0.1",
+    "rxjs": "^7.4.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^13.0.1",
+    "@angular/compiler": "^13.0.1",
+    "@angular/compiler-cli": "^13.0.1",
+    "@angular/core": "^13.0.1",
+    "@angular/platform-browser": "^13.0.1",
+    "ng-packagr": "^13.0.3",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^7.4.0",
+    "tsickle": "^0.43.0",
+    "typescript": ">=4.4.2 <4.5.0",
+    "zone.js": "^0.11.4"
+  }}

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es5",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^13.0.1",
+    "rxjs": "^7.4.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^13.0.1",
+    "@angular/compiler": "^13.0.1",
+    "@angular/compiler-cli": "^13.0.1",
+    "@angular/core": "^13.0.1",
+    "@angular/platform-browser": "^13.0.1",
+    "ng-packagr": "^13.0.3",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^7.4.0",
+    "tsickle": "^0.43.0",
+    "typescript": ">=4.4.2 <4.5.0",
+    "zone.js": "^0.11.4"
+  }}

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es5",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^13.0.1",
+    "rxjs": "^7.4.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^13.0.1",
+    "@angular/compiler": "^13.0.1",
+    "@angular/compiler-cli": "^13.0.1",
+    "@angular/core": "^13.0.1",
+    "@angular/platform-browser": "^13.0.1",
+    "ng-packagr": "^13.0.3",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^7.4.0",
+    "tsickle": "^0.43.0",
+    "typescript": ">=4.4.2 <4.5.0",
+    "zone.js": "^0.11.4"
+  }}

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es6",
+        "module": "es6",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^14.0.5",
+    "rxjs": "^7.5.5"
+  },
+  "devDependencies": {
+    "@angular/common": "^14.0.5",
+    "@angular/compiler": "^14.0.5",
+    "@angular/compiler-cli": "^14.0.5",
+    "@angular/core": "^14.0.5",
+    "@angular/platform-browser": "^14.0.5",
+    "ng-packagr": "^14.0.2",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^7.5.5",
+    "tsickle": "^0.46.3",
+    "typescript": ">=4.6.0 <=4.8.0",
+    "zone.js": "^0.11.5"
+  }}

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es6",
+        "module": "es6",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/README.md
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/package.json
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^14.0.5",
+    "rxjs": "^7.5.5"
+  },
+  "devDependencies": {
+    "@angular/common": "^14.0.5",
+    "@angular/compiler": "^14.0.5",
+    "@angular/compiler-cli": "^14.0.5",
+    "@angular/core": "^14.0.5",
+    "@angular/platform-browser": "^14.0.5",
+    "ng-packagr": "^14.0.2",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^7.5.5",
+    "tsickle": "^0.46.3",
+    "typescript": ">=4.6.0 <=4.8.0",
+    "zone.js": "^0.11.5"
+  }}

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es6",
+        "module": "es6",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/.openapi-generator/FILES
@@ -16,5 +16,8 @@ model/order.ts
 model/pet.ts
 model/tag.ts
 model/user.ts
+ng-package.json
+package.json
 param.ts
+tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/README.md
@@ -1,4 +1,4 @@
-## @
+## &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @ --save
+npm install &lt;PLACEHOLDER_NPM_NAME&gt;@1.0.0 --save
 ```
 
 _without publishing (not recommended):_
@@ -39,7 +39,7 @@ npm link
 
 In your project:
 ```
-npm link 
+npm link &lt;PLACEHOLDER_NPM_NAME&gt;
 ```
 
 __Note for Windows users:__ The Angular CLI has troubles to use linked npm packages.
@@ -54,7 +54,7 @@ In your Angular project:
 
 ```
 // without configuring providers
-import { ApiModule } from '';
+import { ApiModule } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
@@ -73,7 +73,7 @@ export class AppModule {}
 
 ```
 // configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '';
+import { ApiModule, Configuration, ConfigurationParameters } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export function apiConfigFactory (): Configuration {
   const params: ConfigurationParameters = {
@@ -93,7 +93,7 @@ export class AppModule {}
 
 ```
 // configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '';
+import { ApiModule, Configuration } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [ ApiModule ],
@@ -117,7 +117,7 @@ export class AppModule {}
 ```
 
 ```
-import { DefaultApi } from '';
+import { DefaultApi } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 export class AppComponent {
     constructor(private apiGateway: DefaultApi) { }
@@ -155,7 +155,7 @@ export class AppModule {
 If different than the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 bootstrap(AppComponent, [
     { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
@@ -164,7 +164,7 @@ bootstrap(AppComponent, [
 or
 
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 
 @NgModule({
     imports: [],
@@ -188,7 +188,7 @@ export const environment = {
 
 In the src/app/app.module.ts:
 ```
-import { BASE_PATH } from '';
+import { BASE_PATH } from '&lt;PLACEHOLDER_NPM_NAME&gt;';
 import { environment } from '../environments/environment';
 
 @NgModule({

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/ng-package.json
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/package.json
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "<PLACEHOLDER_NPM_NAME>",
+  "version": "1.0.0",
+  "description": "OpenAPI client for <PLACEHOLDER_NPM_NAME>",
+  "author": "OpenAPI-Generator Contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
+  },
+  "keywords": [
+    "openapi-client",
+    "openapi-generator"
+  ],
+  "license": "Unlicense",
+  "scripts": {
+    "build": "ng-packagr -p ng-package.json"
+  },
+  "peerDependencies": {
+    "@angular/core": "^15.0.3",
+    "rxjs": "^7.5.5"
+  },
+  "devDependencies": {
+    "@angular/common": "^15.0.3",
+    "@angular/compiler": "^15.0.3",
+    "@angular/compiler-cli": "^15.0.3",
+    "@angular/core": "^15.0.3",
+    "@angular/platform-browser": "^15.0.3",
+    "ng-packagr": "^15.0.2",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "^7.5.5",
+    "typescript": ">=4.8.2 <4.10.0",
+    "zone.js": "^0.11.5"
+  }}

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": false,
+        "suppressImplicitAnyIndexErrors": true,
+        "target": "es6",
+        "module": "es6",
+        "moduleResolution": "node",
+        "removeComments": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "noLib": false,
+        "declaration": true,
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [
+            "node_modules/@types"
+        ]
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "filesGlob": [
+        "./model/*.ts",
+        "./api/*.ts"
+    ]
+}


### PR DESCRIPTION
This fixes the issue described in #14971, namely that when no `npmName` was provided then the instructions in the generate `README` fail because `npm install` complains that it cannot find a `package.json`.

In practice this PR provides a placeholder value for `NPM_NAME` when the user did not provide one.
Consequently, a `package.json` is always generated.

To test this commit I generated a typescript-angular client (from any arbitrary openapi specification file) and ran the first 2 commands mentioned in the README, ie: `npm install` and `npm run build`.
- With this patch: both commands ran successfully
- Without this patch: the first command fails

---
An alternative I considered was to generate an ad hoc README rather than always providing a `package.json`. This could be achieved with a patch like this:

```
diff --cc modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
index 7675df8f18c,7675df8f18c..a32bc3229cb
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@@ -184,7 -184,7 +184,9 @@@ public class TypeScriptAngularClientCod
              throw new IllegalArgumentException("Invalid ngVersion: " + ngVersion + ". Only Angular v9+ is supported.");
          }
  
--        if (additionalProperties.containsKey(NPM_NAME)) {
++                boolean withNpmPackageGeneration = additionalProperties.containsKey(NPM_NAME);
++                additionalProperties.put("withNpmPackageGeneration", withNpmPackageGeneration);
++        if (withNpmPackageGeneration) {
              addNpmPackageGeneration(ngVersion);
          }
  
diff --cc modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
index 3a65b9117ef,3a65b9117ef..b29e146da5b
--- a/modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
@@@ -1,5 -1,5 +1,6 @@@
  ## {{npmName}}@{{npmVersion}}
  
++{{#withNpmPackageGeneration}}
  ### Building
  
  To install the required dependencies and to build the typescript sources run:
@@@ -11,11 -11,11 +12,13 @@@ npm run buil
  ### publishing
  
  First build the package then run ```npm publish dist``` (don't forget to specify the `dist` folder!)
++{{/withNpmPackageGeneration}}
  
  ### consuming
  
--Navigate to the folder of your consuming project and run one of next commands.
++Navigate to the folder of your consuming project and run {{#withNpmPackageGeneration}}one of {{/withNpmPackageGeneration}}the next command{{#withNpmPackageGeneration}}s{{/withNpmPackageGeneration}}.
  
++{{#withNpmPackageGeneration}}
  _published:_
  

@@@ -23,6 -23,6 +26,7 @@@ npm install {{npmName}}@{{npmVersion}} 

  
  _without publishing (not recommended):_
++{{/withNpmPackageGeneration}}
  
  npm install PATH_TO_GENERATED_PACKAGE/dist.tgz --save
```
To be honest, I have very little experience in frontend (I'm more a backend dev) so I'm not sure which approach would be best. I'm proposing a PR which always generates `package.json` because it seems more consistent with what the javascript client generator is doing (and also because the generated README has several references to `npmName`)

Since this is related to typescript I guess I should ping @TiFu  @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo  @amakhrov  @davidgamero and @mkusaka

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
