### PR TITLE
Added converterFactories property to ApiClient in jvm-retrofit2.

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -29,6 +29,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
+import retrofit2.CallAdapter
 import retrofit2.converter.scalars.ScalarsConverterFactory
 {{#useRxJava}}
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory
@@ -60,11 +61,7 @@ import okhttp3.MediaType.Companion.toMediaType
     private val okHttpClientBuilder: OkHttpClient.Builder? = null{{^kotlinx_serialization}},
     private val serializerBuilder: {{#gson}}Gson{{/gson}}{{#moshi}}Moshi.{{/moshi}}Builder = Serializer.{{#gson}}gson{{/gson}}{{#moshi}}moshi{{/moshi}}Builder{{/kotlinx_serialization}},
     private val callFactory : Call.Factory? = null,
-    private val converterFactories: List<Converter.Factory> = listOf(
-        ScalarsConverterFactory.create(),
-        {{#gson}}
-        GsonConverterFactory.create(serializerBuilder.create()),
-        {{/gson}}
+    private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
         {{#useRxJava}}
         RxJavaCallAdapterFactory.create(),
         {{/useRxJava}}
@@ -74,6 +71,12 @@ import okhttp3.MediaType.Companion.toMediaType
         {{#useRxJava3}}
         RxJava3CallAdapterFactory.create(),
         {{/useRxJava3}}
+    ),
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        {{#gson}}
+        GsonConverterFactory.create(serializerBuilder.create()),
+        {{/gson}}
         {{#moshi}}
         MoshiConverterFactory.create(serializerBuilder.build()),
         {{/moshi}}
@@ -88,6 +91,11 @@ import okhttp3.MediaType.Companion.toMediaType
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
+            .apply {
+                callAdapterFactories.forEach {
+                    addCallAdapterFactory(it)
+                }
+            }
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -81,7 +81,11 @@ import okhttp3.MediaType.Companion.toMediaType
         kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
         {{/kotlinx_serialization}}
     ),
-    @Deprecated("this property is deprecated. use converterFactories.")
+    @Deprecated(
+        message = "This property is deprecated. Please use converterFactories",
+        replaceWith = ReplaceWith("converterFactories"),
+        level = DeprecationLevel.ERROR
+    )
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -60,6 +60,28 @@ import okhttp3.MediaType.Companion.toMediaType
     private val okHttpClientBuilder: OkHttpClient.Builder? = null{{^kotlinx_serialization}},
     private val serializerBuilder: {{#gson}}Gson{{/gson}}{{#moshi}}Moshi.{{/moshi}}Builder = Serializer.{{#gson}}gson{{/gson}}{{#moshi}}moshi{{/moshi}}Builder{{/kotlinx_serialization}},
     private val callFactory : Call.Factory? = null,
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        {{#gson}}
+        GsonConverterFactory.create(serializerBuilder.create()),
+        {{/gson}}
+        {{#useRxJava}}
+        RxJavaCallAdapterFactory.create(),
+        {{/useRxJava}}
+        {{#useRxJava2}}
+        RxJava2CallAdapterFactory.create(),
+        {{/useRxJava2}}
+        {{#useRxJava3}}
+        RxJava3CallAdapterFactory.create(),
+        {{/useRxJava3}}
+        {{#moshi}}
+        MoshiConverterFactory.create(serializerBuilder.build()),
+        {{/moshi}}
+        {{#kotlinx_serialization}}
+        kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
+        {{/kotlinx_serialization}}
+    ),
+    @Deprecated("this property is deprecated. use converterFactories.")
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
@@ -68,24 +90,11 @@ import okhttp3.MediaType.Companion.toMediaType
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
-            .addConverterFactory(ScalarsConverterFactory.create())
-            {{#gson}}
-            .addConverterFactory(GsonConverterFactory.create(serializerBuilder.create()))
-            {{/gson}}
-            {{#useRxJava}}
-            .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-            {{/useRxJava}}
-            {{#useRxJava2}}
-            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-            {{/useRxJava2}}{{#useRxJava3}}
-            .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
-            {{/useRxJava3}}
-            {{#moshi}}
-            .addConverterFactory(MoshiConverterFactory.create(serializerBuilder.build()))
-            {{/moshi}}
-            {{#kotlinx_serialization}}
-            .addConverterFactory(kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()))
-            {{/kotlinx_serialization}}
+            .apply {
+                converterFactories.forEach {
+                    addConverterFactory(it)
+                }
+            }
             .apply {
                 if (converterFactory != null) {
                     addConverterFactory(converterFactory)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/infrastructure/ApiClient.kt.mustache
@@ -80,13 +80,7 @@ import okhttp3.MediaType.Companion.toMediaType
         {{#kotlinx_serialization}}
         kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
         {{/kotlinx_serialization}}
-    ),
-    @Deprecated(
-        message = "This property is deprecated. Please use converterFactories",
-        replaceWith = ReplaceWith("converterFactories"),
-        level = DeprecationLevel.ERROR
     )
-    private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
     var logger: ((String) -> Unit)? = null
@@ -97,11 +91,6 @@ import okhttp3.MediaType.Companion.toMediaType
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)
-                }
-            }
-            .apply {
-                if (converterFactory != null) {
-                    addConverterFactory(converterFactory)
                 }
             }
     }

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -21,7 +21,11 @@ class ApiClient(
         ScalarsConverterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
     ),
-    @Deprecated("this property is deprecated. use converterFactories.")
+    @Deprecated(
+        message = "This property is deprecated. Please use converterFactories",
+        replaceWith = ReplaceWith("converterFactories"),
+        level = DeprecationLevel.ERROR
+    )
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -17,6 +17,11 @@ class ApiClient(
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory : Call.Factory? = null,
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        MoshiConverterFactory.create(serializerBuilder.build()),
+    ),
+    @Deprecated("this property is deprecated. use converterFactories.")
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
@@ -25,8 +30,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
-            .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(MoshiConverterFactory.create(serializerBuilder.build()))
+            .apply {
+                converterFactories.forEach {
+                    addConverterFactory(it)
+                }
+            }
             .apply {
                 if (converterFactory != null) {
                     addConverterFactory(converterFactory)

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -20,13 +20,7 @@ class ApiClient(
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
-    ),
-    @Deprecated(
-        message = "This property is deprecated. Please use converterFactories",
-        replaceWith = ReplaceWith("converterFactories"),
-        level = DeprecationLevel.ERROR
     )
-    private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
     var logger: ((String) -> Unit)? = null
@@ -37,11 +31,6 @@ class ApiClient(
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)
-                }
-            }
-            .apply {
-                if (converterFactory != null) {
-                    addConverterFactory(converterFactory)
                 }
             }
     }

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -7,6 +7,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
+import retrofit2.CallAdapter
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import com.squareup.moshi.Moshi
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -17,6 +18,8 @@ class ApiClient(
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory : Call.Factory? = null,
+    private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
+    ),
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
@@ -28,6 +31,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
+            .apply {
+                callAdapterFactories.forEach {
+                    addCallAdapterFactory(it)
+                }
+            }
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
+import retrofit2.CallAdapter
 import retrofit2.converter.scalars.ScalarsConverterFactory
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -23,6 +24,8 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val callFactory : Call.Factory? = null,
+    private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
+    ),
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
         kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
@@ -34,6 +37,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
+            .apply {
+                callAdapterFactories.forEach {
+                    addCallAdapterFactory(it)
+                }
+            }
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -27,7 +27,11 @@ class ApiClient(
         ScalarsConverterFactory.create(),
         kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
     ),
-    @Deprecated("this property is deprecated. use converterFactories.")
+    @Deprecated(
+        message = "This property is deprecated. Please use converterFactories",
+        replaceWith = ReplaceWith("converterFactories"),
+        level = DeprecationLevel.ERROR
+    )
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -26,13 +26,7 @@ class ApiClient(
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
         kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
-    ),
-    @Deprecated(
-        message = "This property is deprecated. Please use converterFactories",
-        replaceWith = ReplaceWith("converterFactories"),
-        level = DeprecationLevel.ERROR
     )
-    private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
     var logger: ((String) -> Unit)? = null
@@ -43,11 +37,6 @@ class ApiClient(
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)
-                }
-            }
-            .apply {
-                if (converterFactory != null) {
-                    addConverterFactory(converterFactory)
                 }
             }
     }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,6 +23,11 @@ class ApiClient(
     private var baseUrl: String = defaultBasePath,
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val callFactory : Call.Factory? = null,
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()),
+    ),
+    @Deprecated("this property is deprecated. use converterFactories.")
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
@@ -31,8 +36,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
-            .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(kotlinxSerializationJson.asConverterFactory("application/json".toMediaType()))
+            .apply {
+                converterFactories.forEach {
+                    addConverterFactory(it)
+                }
+            }
             .apply {
                 if (converterFactory != null) {
                     addConverterFactory(converterFactory)

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
+import retrofit2.CallAdapter
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import com.squareup.moshi.Moshi
@@ -24,9 +25,11 @@ class ApiClient(
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory : Call.Factory? = null,
+    private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
+        RxJava3CallAdapterFactory.create(),
+    ),
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
-        RxJava3CallAdapterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
     )
 ) {
@@ -36,6 +39,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
+            .apply {
+                callAdapterFactories.forEach {
+                    addCallAdapterFactory(it)
+                }
+            }
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -29,7 +29,11 @@ class ApiClient(
         RxJava3CallAdapterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
     ),
-    @Deprecated("this property is deprecated. use converterFactories.")
+    @Deprecated(
+        message = "This property is deprecated. Please use converterFactories",
+        replaceWith = ReplaceWith("converterFactories"),
+        level = DeprecationLevel.ERROR
+    )
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -24,6 +24,12 @@ class ApiClient(
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory : Call.Factory? = null,
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        RxJava3CallAdapterFactory.create(),
+        MoshiConverterFactory.create(serializerBuilder.build()),
+    ),
+    @Deprecated("this property is deprecated. use converterFactories.")
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
@@ -32,10 +38,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
-            .addConverterFactory(ScalarsConverterFactory.create())
-
-            .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
-            .addConverterFactory(MoshiConverterFactory.create(serializerBuilder.build()))
+            .apply {
+                converterFactories.forEach {
+                    addConverterFactory(it)
+                }
+            }
             .apply {
                 if (converterFactory != null) {
                     addConverterFactory(converterFactory)

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -28,13 +28,7 @@ class ApiClient(
         ScalarsConverterFactory.create(),
         RxJava3CallAdapterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
-    ),
-    @Deprecated(
-        message = "This property is deprecated. Please use converterFactories",
-        replaceWith = ReplaceWith("converterFactories"),
-        level = DeprecationLevel.ERROR
     )
-    private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
     var logger: ((String) -> Unit)? = null
@@ -45,11 +39,6 @@ class ApiClient(
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)
-                }
-            }
-            .apply {
-                if (converterFactory != null) {
-                    addConverterFactory(converterFactory)
                 }
             }
     }

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
+import retrofit2.CallAdapter
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import com.squareup.moshi.Moshi
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -23,6 +24,8 @@ class ApiClient(
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory : Call.Factory? = null,
+    private val callAdapterFactories: List<CallAdapter.Factory> = listOf(
+    ),
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
@@ -34,6 +37,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
+            .apply {
+                callAdapterFactories.forEach {
+                    addCallAdapterFactory(it)
+                }
+            }
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -27,7 +27,11 @@ class ApiClient(
         ScalarsConverterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
     ),
-    @Deprecated("this property is deprecated. use converterFactories.")
+    @Deprecated(
+        message = "This property is deprecated. Please use converterFactories",
+        replaceWith = ReplaceWith("converterFactories"),
+        level = DeprecationLevel.ERROR
+    )
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -23,6 +23,11 @@ class ApiClient(
     private val okHttpClientBuilder: OkHttpClient.Builder? = null,
     private val serializerBuilder: Moshi.Builder = Serializer.moshiBuilder,
     private val callFactory : Call.Factory? = null,
+    private val converterFactories: List<Converter.Factory> = listOf(
+        ScalarsConverterFactory.create(),
+        MoshiConverterFactory.create(serializerBuilder.build()),
+    ),
+    @Deprecated("this property is deprecated. use converterFactories.")
     private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
@@ -31,8 +36,11 @@ class ApiClient(
     private val retrofitBuilder: Retrofit.Builder by lazy {
         Retrofit.Builder()
             .baseUrl(baseUrl)
-            .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(MoshiConverterFactory.create(serializerBuilder.build()))
+            .apply {
+                converterFactories.forEach {
+                    addConverterFactory(it)
+                }
+            }
             .apply {
                 if (converterFactory != null) {
                     addConverterFactory(converterFactory)

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -26,13 +26,7 @@ class ApiClient(
     private val converterFactories: List<Converter.Factory> = listOf(
         ScalarsConverterFactory.create(),
         MoshiConverterFactory.create(serializerBuilder.build()),
-    ),
-    @Deprecated(
-        message = "This property is deprecated. Please use converterFactories",
-        replaceWith = ReplaceWith("converterFactories"),
-        level = DeprecationLevel.ERROR
     )
-    private val converterFactory: Converter.Factory? = null,
 ) {
     private val apiAuthorizations = mutableMapOf<String, Interceptor>()
     var logger: ((String) -> Unit)? = null
@@ -43,11 +37,6 @@ class ApiClient(
             .apply {
                 converterFactories.forEach {
                     addConverterFactory(it)
-                }
-            }
-            .apply {
-                if (converterFactory != null) {
-                    addConverterFactory(converterFactory)
                 }
             }
     }

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/APIs.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/APIs.swift
@@ -5,14 +5,6 @@
 //
 
 import Foundation
-
-// We reverted the change of PetstoreClientAPI to PetstoreClient introduced in https://github.com/OpenAPITools/openapi-generator/pull/9624
-// Because it was causing the following issue https://github.com/OpenAPITools/openapi-generator/issues/9953
-// If you are affected by this issue, please consider removing the following two lines,
-// By setting the option removeMigrationProjectNameClass to true in the generator
-@available(*, deprecated, renamed: "PetstoreClientAPI")
-public typealias PetstoreClient = PetstoreClientAPI
-
 open class PetstoreClientAPI {
     public static var basePath = "http://localhost"
     public static var customHeaders: [String: String] = [:]
@@ -31,8 +23,6 @@ open class RequestBuilder<T> {
     public let requiresAuthentication: Bool
 
     /// Optional block to obtain a reference to the request's progress instance when available.
-    /// With the URLSession http client the request's progress only works on iOS 11.0, macOS 10.13, macCatalyst 13.0, tvOS 11.0, watchOS 4.0.
-    /// If you need to get the request's progress in older OS versions, please use Alamofire http client.
     public var onProgressReady: ((Progress) -> Void)?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool) {

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -8,10 +8,6 @@ import Foundation
 
 open class Configuration {
     
-    // This value is used to configure the date formatter that is used to serialize dates into JSON format.
-    // You must set it prior to encoding any dates, and it will only be read once.
-    @available(*, unavailable, message: "To set a different date format, use CodableHelper.dateFormatter instead.")
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
     /// Configures the range of HTTP status codes that will result in a successful response
     ///
     /// If a HTTP status code is outside of this range the response will be interpreted as failed.

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -52,7 +52,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
      - intercept and handle errors like authorization
      - retry the request.
      */
-    @available(*, deprecated, message: "Please override execute() method to intercept and handle errors like authorization or retry the request. Check the Wiki for more info. https://github.com/OpenAPITools/openapi-generator/wiki/FAQ#how-do-i-implement-bearer-token-authentication-with-urlsession-on-the-swift-api-client")
+    @available(*, unavailable, message: "Please override execute() method to intercept and handle errors like authorization or retry the request. Check the Wiki for more info. https://github.com/OpenAPITools/openapi-generator/wiki/FAQ#how-do-i-implement-bearer-token-authentication-with-urlsession-on-the-swift-api-client")
     public var taskCompletionShouldRetry: ((Data?, URLResponse?, Error?, @escaping (Bool) -> Void) -> Void)?
 
     required public init(method: String, URLString: String, parameters: [String: Any]?, headers: [String: String] = [:], requiresAuthentication: Bool) {
@@ -91,10 +91,6 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
         var originalRequest = URLRequest(url: url)
 
         originalRequest.httpMethod = method.rawValue
-
-        headers.forEach { key, value in
-            originalRequest.setValue(value, forHTTPHeaderField: key)
-        }
 
         buildHeaders().forEach { key, value in
             originalRequest.setValue(value, forHTTPHeaderField: key)
@@ -145,32 +141,13 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
              }
 
             let dataTask = urlSession.dataTask(with: request) { data, response, error in
-
-                if let taskCompletionShouldRetry = self.taskCompletionShouldRetry {
-
-                    taskCompletionShouldRetry(data, response, error) { shouldRetry in
-
-                        if shouldRetry {
-                            cleanupRequest()
-                            self.execute(apiResponseQueue, completion)
-                        } else {
-                            apiResponseQueue.async {
-                                self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                                cleanupRequest()
-                            }
-                        }
-                    }
-                } else {
-                    apiResponseQueue.async {
-                        self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
-                        cleanupRequest()
-                    }
+                apiResponseQueue.async {
+                    self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
+                    cleanupRequest()
                 }
             }
 
-            if #available(iOS 11.0, macOS 10.13, macCatalyst 13.0, tvOS 11.0, watchOS 4.0, *) {
-                onProgressReady?(dataTask.progress)
-            }
+            onProgressReady?(dataTask.progress)
 
             taskIdentifier = dataTask.taskIdentifier
             challengeHandlerStore[dataTask.taskIdentifier] = taskDidReceiveChallenge
@@ -218,10 +195,10 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
 
     open func buildHeaders() -> [String: String] {
         var httpHeaders: [String: String] = [:]
-        for (key, value) in headers {
+        for (key, value) in PetstoreClientAPI.customHeaders {
             httpHeaders[key] = value
         }
-        for (key, value) in PetstoreClientAPI.customHeaders {
+        for (key, value) in headers {
             httpHeaders[key] = value
         }
         return httpHeaders


### PR DESCRIPTION
The existing `converterFactory` property worked fine, but was not available in certain cases.

I think there are these problems.
1. You can add only one `converterFactory`.
2. `converterFactory` can only be added at the very end.

In my case, I had to add my custom Converter.Factory first, because JsonParser doesn't handle empty strings and throws an exception. (#14982)

At first, I planned to add a `preConverterFactory` property, but changed `converterFactory` to an array to make it more customizable.

For backwards compatibility, `converterFactory` has not been removed from the code, it has been left using the @Deprecated annotation.

I think this PR of mine will help you meet more requirements.
 
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert, @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @wing328 
