### PR TITLE
[python-nextgen] fix optional dict of object

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
@@ -220,7 +220,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             {{#isMap}}
             {{^items.isPrimitiveType}}
             {{^items.isEnumOrRef}}
-            "{{{name}}}": dict((_k, {{{dataType}}}.from_dict(_v)) for _k, _v in obj.get("{{{baseName}}}").items()) if obj.get("{{{baseName}}}") is not None else None{{^-last}},{{/-last}}
+            "{{{name}}}": dict((_k, {{{items.dataType}}}.from_dict(_v)) for _k, _v in obj.get("{{{baseName}}}").items()) if obj.get("{{{baseName}}}") is not None else None{{^-last}},{{/-last}}
             {{/items.isEnumOrRef}}
             {{#items.isEnumOrRef}}
             "{{{name}}}": dict((_k, _v) for _k, _v in obj.get("{{{baseName}}}").items()){{^-last}},{{/-last}}

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -76,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _obj = MixedPropertiesAndAdditionalPropertiesClass.parse_obj({
             "uuid": obj.get("uuid"),
             "date_time": obj.get("dateTime"),
-            "map": dict((_k, Dict[str, Animal].from_dict(_v)) for _k, _v in obj.get("map").items()) if obj.get("map") is not None else None
+            "map": dict((_k, Animal.from_dict(_v)) for _k, _v in obj.get("map").items()) if obj.get("map") is not None else None
         })
         return _obj
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -72,7 +72,7 @@ class ParentWithOptionalDict(BaseModel):
             return ParentWithOptionalDict.parse_obj(obj)
 
         _obj = ParentWithOptionalDict.parse_obj({
-            "optional_dict": dict((_k, Dict[str, InnerDictWithProperty].from_dict(_v)) for _k, _v in obj.get("optionalDict").items()) if obj.get("optionalDict") is not None else None
+            "optional_dict": dict((_k, InnerDictWithProperty.from_dict(_v)) for _k, _v in obj.get("optionalDict").items()) if obj.get("optionalDict") is not None else None
         })
         return _obj
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -83,7 +83,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         _obj = MixedPropertiesAndAdditionalPropertiesClass.parse_obj({
             "uuid": obj.get("uuid"),
             "date_time": obj.get("dateTime"),
-            "map": dict((_k, Dict[str, Animal].from_dict(_v)) for _k, _v in obj.get("map").items()) if obj.get("map") is not None else None
+            "map": dict((_k, Animal.from_dict(_v)) for _k, _v in obj.get("map").items()) if obj.get("map") is not None else None
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/parent_with_optional_dict.py
@@ -79,7 +79,7 @@ class ParentWithOptionalDict(BaseModel):
             return ParentWithOptionalDict.parse_obj(obj)
 
         _obj = ParentWithOptionalDict.parse_obj({
-            "optional_dict": dict((_k, Dict[str, InnerDictWithProperty].from_dict(_v)) for _k, _v in obj.get("optionalDict").items()) if obj.get("optionalDict") is not None else None
+            "optional_dict": dict((_k, InnerDictWithProperty.from_dict(_v)) for _k, _v in obj.get("optionalDict").items()) if obj.get("optionalDict") is not None else None
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
@@ -393,3 +393,6 @@ class ModelTests(unittest.TestCase):
         a = petstore_api.ParentWithOptionalDict.from_dict({})
         self.assertFalse(a is None)
 
+        b = petstore_api.ParentWithOptionalDict.from_dict({"optionalDict": {"key": {"aProperty": {"a": "b"}}}})
+        self.assertFalse(b is None)
+        self.assertEqual(b.optional_dict["key"].a_property["a"], "b")


### PR DESCRIPTION
- fix optional dict of object
- add test

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)
