### PR TITLE
[JS] Update optional parameters in jsdoc

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/libraries/apollo/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/libraries/apollo/api.mustache
@@ -29,7 +29,7 @@ export default class <&classname> extends ApiClient {
      * <&notes></notes><#allParams><#required>
      * @param {<&vendorExtensions.x-jsdoc-type>} <&paramName> <&description></required></allParams><#hasOptionalParams>
      * @param {Object} opts Optional parameters<#allParams><^required>
-     * @param {<&vendorExtensions.x-jsdoc-type>} opts.<&paramName> <&description><#defaultValue> (default to <&.>)</defaultValue></required></allParams></hasOptionalParams>
+     * @param {<&vendorExtensions.x-jsdoc-type>} [<&paramName><#defaultValue> = <&.></defaultValue>] <&description></required></allParams></hasOptionalParams>
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      <=| |=>* @return {Promise|#returnType|<|&vendorExtensions.x-jsdoc-type|>|/returnType|}|=< >=|
      */

--- a/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/api.mustache
@@ -38,7 +38,7 @@ export default class <&classname> {
      * <&notes></notes><#allParams><#required>
      * @param {<&vendorExtensions.x-jsdoc-type>} <&paramName> <&description></required></allParams><#hasOptionalParams>
      * @param {Object} opts Optional parameters<#allParams><^required>
-     * @param {<&vendorExtensions.x-jsdoc-type>} opts.<&paramName> <&description><#defaultValue> (default to <&.>)</defaultValue></required></allParams></hasOptionalParams><^usePromises>
+     * @param {<&vendorExtensions.x-jsdoc-type>} [<&paramName><#defaultValue> = <&.>)</defaultValue>] <&description></required></allParams></hasOptionalParams><^usePromises>
      * @param {module:<#invokerPackage><&invokerPackage>/</invokerPackage><#apiPackage><&apiPackage>/</apiPackage><&classname>~<&operationId>Callback} callback The callback function, accepting three arguments: error, data, response<#returnType>
      * data is of type: {@link <&vendorExtensions.x-jsdoc-type>}</returnType></usePromises><#usePromises>
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}<#returnType>, with an object containing data of type {@link <&vendorExtensions.x-jsdoc-type>} and HTTP response</returnType><^returnType>, with an object containing HTTP response</returnType></usePromises>

--- a/samples/client/petstore/javascript-apollo/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-apollo/src/api/FakeApi.js
@@ -74,8 +74,8 @@ export default class FakeApi extends ApiClient {
      * test http signature authentication
      * @param {module:model/Pet} pet Pet object that needs to be added to the store
      * @param {Object} opts Optional parameters
-     * @param {String} opts.query1 query parameter
-     * @param {String} opts.header1 header parameter
+     * @param {String} [query1] query parameter
+     * @param {String} [header1] header parameter
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */
@@ -114,7 +114,7 @@ export default class FakeApi extends ApiClient {
     /**
      * Test serialization of outer boolean types
      * @param {Object} opts Optional parameters
-     * @param {Boolean} opts.body Input boolean as post body
+     * @param {Boolean} [body] Input boolean as post body
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise<Boolean>}
      */
@@ -147,7 +147,7 @@ export default class FakeApi extends ApiClient {
     /**
      * Test serialization of object with outer number type
      * @param {Object} opts Optional parameters
-     * @param {module:model/OuterComposite} opts.outerComposite Input composite as post body
+     * @param {module:model/OuterComposite} [outerComposite] Input composite as post body
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise<module:model/OuterComposite>}
      */
@@ -180,7 +180,7 @@ export default class FakeApi extends ApiClient {
     /**
      * Test serialization of outer number types
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.body Input number as post body
+     * @param {Number} [body] Input number as post body
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise<Number>}
      */
@@ -213,7 +213,7 @@ export default class FakeApi extends ApiClient {
     /**
      * Test serialization of outer string types
      * @param {Object} opts Optional parameters
-     * @param {String} opts.body Input string as post body
+     * @param {String} [body] Input string as post body
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise<String>}
      */
@@ -432,16 +432,16 @@ export default class FakeApi extends ApiClient {
      * @param {String} patternWithoutDelimiter None
      * @param {Blob} _byte None
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.integer None
-     * @param {Number} opts.int32 None
-     * @param {Number} opts.int64 None
-     * @param {Number} opts._float None
-     * @param {String} opts.string None
-     * @param {File} opts.binary None
-     * @param {Date} opts.date None
-     * @param {Date} opts.dateTime None
-     * @param {String} opts.password None
-     * @param {String} opts.callback None
+     * @param {Number} [integer] None
+     * @param {Number} [int32] None
+     * @param {Number} [int64] None
+     * @param {Number} [_float] None
+     * @param {String} [string] None
+     * @param {File} [binary] None
+     * @param {Date} [date] None
+     * @param {Date} [dateTime] None
+     * @param {String} [password] None
+     * @param {String} [callback] None
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */
@@ -505,15 +505,15 @@ export default class FakeApi extends ApiClient {
      * To test enum parameters
      * To test enum parameters
      * @param {Object} opts Optional parameters
-     * @param {Array.<module:model/String>} opts.enumHeaderStringArray Header parameter enum test (string array)
-     * @param {module:model/String} opts.enumHeaderString Header parameter enum test (string) (default to '-efg')
-     * @param {Array.<module:model/String>} opts.enumQueryStringArray Query parameter enum test (string array)
-     * @param {module:model/String} opts.enumQueryString Query parameter enum test (string) (default to '-efg')
-     * @param {module:model/Number} opts.enumQueryInteger Query parameter enum test (double)
-     * @param {module:model/Number} opts.enumQueryDouble Query parameter enum test (double)
-     * @param {Array.<module:model/EnumClass>} opts.enumQueryModelArray 
-     * @param {Array.<module:model/String>} opts.enumFormStringArray Form parameter enum test (string array) (default to '$')
-     * @param {module:model/String} opts.enumFormString Form parameter enum test (string) (default to '-efg')
+     * @param {Array.<module:model/String>} [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param {module:model/String} [enumHeaderString = '-efg'] Header parameter enum test (string)
+     * @param {Array.<module:model/String>} [enumQueryStringArray] Query parameter enum test (string array)
+     * @param {module:model/String} [enumQueryString = '-efg'] Query parameter enum test (string)
+     * @param {module:model/Number} [enumQueryInteger] Query parameter enum test (double)
+     * @param {module:model/Number} [enumQueryDouble] Query parameter enum test (double)
+     * @param {Array.<module:model/EnumClass>} [enumQueryModelArray] 
+     * @param {Array.<module:model/String>} [enumFormStringArray = '$'] Form parameter enum test (string array)
+     * @param {module:model/String} [enumFormString = '-efg'] Form parameter enum test (string)
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */
@@ -559,9 +559,9 @@ export default class FakeApi extends ApiClient {
      * @param {Boolean} requiredBooleanGroup Required Boolean in group parameters
      * @param {Number} requiredInt64Group Required Integer in group parameters
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.stringGroup String in group parameters
-     * @param {Boolean} opts.booleanGroup Boolean in group parameters
-     * @param {Number} opts.int64Group Integer in group parameters
+     * @param {Number} [stringGroup] String in group parameters
+     * @param {Boolean} [booleanGroup] Boolean in group parameters
+     * @param {Number} [int64Group] Integer in group parameters
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */
@@ -697,7 +697,7 @@ export default class FakeApi extends ApiClient {
      * @param {Array.<String>} context 
      * @param {String} allowEmpty 
      * @param {Object} opts Optional parameters
-     * @param {Object.<String, {String: String}>} opts.language 
+     * @param {Object.<String, {String: String}>} [language] 
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */

--- a/samples/client/petstore/javascript-apollo/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-apollo/src/api/PetApi.js
@@ -85,7 +85,7 @@ export default class PetApi extends ApiClient {
      * 
      * @param {Number} petId Pet id to delete
      * @param {Object} opts Optional parameters
-     * @param {String} opts.apiKey 
+     * @param {String} [apiKey] 
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */
@@ -283,8 +283,8 @@ export default class PetApi extends ApiClient {
      * 
      * @param {Number} petId ID of pet that needs to be updated
      * @param {Object} opts Optional parameters
-     * @param {String} opts.name Updated name of the pet
-     * @param {String} opts.status Updated status of the pet
+     * @param {String} [name] Updated name of the pet
+     * @param {String} [status] Updated status of the pet
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise}
      */
@@ -326,8 +326,8 @@ export default class PetApi extends ApiClient {
      * 
      * @param {Number} petId ID of pet to update
      * @param {Object} opts Optional parameters
-     * @param {String} opts.additionalMetadata Additional data to pass to server
-     * @param {File} opts.file file to upload
+     * @param {String} [additionalMetadata] Additional data to pass to server
+     * @param {File} [file] file to upload
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise<module:model/ApiResponse>}
      */
@@ -370,7 +370,7 @@ export default class PetApi extends ApiClient {
      * @param {Number} petId ID of pet to update
      * @param {File} requiredFile file to upload
      * @param {Object} opts Optional parameters
-     * @param {String} opts.additionalMetadata Additional data to pass to server
+     * @param {String} [additionalMetadata] Additional data to pass to server
      * @param requestInit Dynamic configuration. @see {@link https://github.com/apollographql/apollo-server/pull/1277}
      * @return {Promise<module:model/ApiResponse>}
      */

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -89,8 +89,8 @@ export default class FakeApi {
      * test http signature authentication
      * @param {module:model/Pet} pet Pet object that needs to be added to the store
      * @param {Object} opts Optional parameters
-     * @param {String} opts.query1 query parameter
-     * @param {String} opts.header1 header parameter
+     * @param {String} [query1] query parameter
+     * @param {String} [header1] header parameter
      * @param {module:api/FakeApi~fakeHttpSignatureTestCallback} callback The callback function, accepting three arguments: error, data, response
      */
     fakeHttpSignatureTest(pet, opts, callback) {
@@ -134,7 +134,7 @@ export default class FakeApi {
     /**
      * Test serialization of outer boolean types
      * @param {Object} opts Optional parameters
-     * @param {Boolean} opts.body Input boolean as post body
+     * @param {Boolean} [body] Input boolean as post body
      * @param {module:api/FakeApi~fakeOuterBooleanSerializeCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link Boolean}
      */
@@ -173,7 +173,7 @@ export default class FakeApi {
     /**
      * Test serialization of object with outer number type
      * @param {Object} opts Optional parameters
-     * @param {module:model/OuterComposite} opts.outerComposite Input composite as post body
+     * @param {module:model/OuterComposite} [outerComposite] Input composite as post body
      * @param {module:api/FakeApi~fakeOuterCompositeSerializeCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link module:model/OuterComposite}
      */
@@ -212,7 +212,7 @@ export default class FakeApi {
     /**
      * Test serialization of outer number types
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.body Input number as post body
+     * @param {Number} [body] Input number as post body
      * @param {module:api/FakeApi~fakeOuterNumberSerializeCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link Number}
      */
@@ -251,7 +251,7 @@ export default class FakeApi {
     /**
      * Test serialization of outer string types
      * @param {Object} opts Optional parameters
-     * @param {String} opts.body Input string as post body
+     * @param {String} [body] Input string as post body
      * @param {module:api/FakeApi~fakeOuterStringSerializeCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link String}
      */
@@ -503,16 +503,16 @@ export default class FakeApi {
      * @param {String} patternWithoutDelimiter None
      * @param {Blob} _byte None
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.integer None
-     * @param {Number} opts.int32 None
-     * @param {Number} opts.int64 None
-     * @param {Number} opts._float None
-     * @param {String} opts.string None
-     * @param {File} opts.binary None
-     * @param {Date} opts.date None
-     * @param {Date} opts.dateTime None
-     * @param {String} opts.password None
-     * @param {String} opts.callback None
+     * @param {Number} [integer] None
+     * @param {Number} [int32] None
+     * @param {Number} [int64] None
+     * @param {Number} [_float] None
+     * @param {String} [string] None
+     * @param {File} [binary] None
+     * @param {Date} [date] None
+     * @param {Date} [dateTime] None
+     * @param {String} [password] None
+     * @param {String} [callback] None
      * @param {module:api/FakeApi~testEndpointParametersCallback} callback The callback function, accepting three arguments: error, data, response
      */
     testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, opts, callback) {
@@ -581,15 +581,15 @@ export default class FakeApi {
      * To test enum parameters
      * To test enum parameters
      * @param {Object} opts Optional parameters
-     * @param {Array.<module:model/String>} opts.enumHeaderStringArray Header parameter enum test (string array)
-     * @param {module:model/String} opts.enumHeaderString Header parameter enum test (string) (default to '-efg')
-     * @param {Array.<module:model/String>} opts.enumQueryStringArray Query parameter enum test (string array)
-     * @param {module:model/String} opts.enumQueryString Query parameter enum test (string) (default to '-efg')
-     * @param {module:model/Number} opts.enumQueryInteger Query parameter enum test (double)
-     * @param {module:model/Number} opts.enumQueryDouble Query parameter enum test (double)
-     * @param {Array.<module:model/EnumClass>} opts.enumQueryModelArray 
-     * @param {Array.<module:model/String>} opts.enumFormStringArray Form parameter enum test (string array) (default to '$')
-     * @param {module:model/String} opts.enumFormString Form parameter enum test (string) (default to '-efg')
+     * @param {Array.<module:model/String>} [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param {module:model/String} [enumHeaderString = '-efg')] Header parameter enum test (string)
+     * @param {Array.<module:model/String>} [enumQueryStringArray] Query parameter enum test (string array)
+     * @param {module:model/String} [enumQueryString = '-efg')] Query parameter enum test (string)
+     * @param {module:model/Number} [enumQueryInteger] Query parameter enum test (double)
+     * @param {module:model/Number} [enumQueryDouble] Query parameter enum test (double)
+     * @param {Array.<module:model/EnumClass>} [enumQueryModelArray] 
+     * @param {Array.<module:model/String>} [enumFormStringArray = '$')] Form parameter enum test (string array)
+     * @param {module:model/String} [enumFormString = '-efg')] Form parameter enum test (string)
      * @param {module:api/FakeApi~testEnumParametersCallback} callback The callback function, accepting three arguments: error, data, response
      */
     testEnumParameters(opts, callback) {
@@ -640,9 +640,9 @@ export default class FakeApi {
      * @param {Boolean} requiredBooleanGroup Required Boolean in group parameters
      * @param {Number} requiredInt64Group Required Integer in group parameters
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.stringGroup String in group parameters
-     * @param {Boolean} opts.booleanGroup Boolean in group parameters
-     * @param {Number} opts.int64Group Integer in group parameters
+     * @param {Number} [stringGroup] String in group parameters
+     * @param {Boolean} [booleanGroup] Boolean in group parameters
+     * @param {Number} [int64Group] Integer in group parameters
      * @param {module:api/FakeApi~testGroupParametersCallback} callback The callback function, accepting three arguments: error, data, response
      */
     testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, opts, callback) {
@@ -793,7 +793,7 @@ export default class FakeApi {
      * @param {Array.<String>} context 
      * @param {String} allowEmpty 
      * @param {Object} opts Optional parameters
-     * @param {Object.<String, {String: String}>} opts.language 
+     * @param {Object.<String, {String: String}>} [language] 
      * @param {module:api/FakeApi~testQueryParameterCollectionFormatCallback} callback The callback function, accepting three arguments: error, data, response
      */
     testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts, callback) {

--- a/samples/client/petstore/javascript-es6/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/PetApi.js
@@ -99,7 +99,7 @@ export default class PetApi {
      * 
      * @param {Number} petId Pet id to delete
      * @param {Object} opts Optional parameters
-     * @param {String} opts.apiKey 
+     * @param {String} [apiKey] 
      * @param {module:api/PetApi~deletePetCallback} callback The callback function, accepting three arguments: error, data, response
      */
     deletePet(petId, opts, callback) {
@@ -325,8 +325,8 @@ export default class PetApi {
      * 
      * @param {Number} petId ID of pet that needs to be updated
      * @param {Object} opts Optional parameters
-     * @param {String} opts.name Updated name of the pet
-     * @param {String} opts.status Updated status of the pet
+     * @param {String} [name] Updated name of the pet
+     * @param {String} [status] Updated status of the pet
      * @param {module:api/PetApi~updatePetWithFormCallback} callback The callback function, accepting three arguments: error, data, response
      */
     updatePetWithForm(petId, opts, callback) {
@@ -373,8 +373,8 @@ export default class PetApi {
      * 
      * @param {Number} petId ID of pet to update
      * @param {Object} opts Optional parameters
-     * @param {String} opts.additionalMetadata Additional data to pass to server
-     * @param {File} opts.file file to upload
+     * @param {String} [additionalMetadata] Additional data to pass to server
+     * @param {File} [file] file to upload
      * @param {module:api/PetApi~uploadFileCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link module:model/ApiResponse}
      */
@@ -423,7 +423,7 @@ export default class PetApi {
      * @param {Number} petId ID of pet to update
      * @param {File} requiredFile file to upload
      * @param {Object} opts Optional parameters
-     * @param {String} opts.additionalMetadata Additional data to pass to server
+     * @param {String} [additionalMetadata] Additional data to pass to server
      * @param {module:api/PetApi~uploadFileWithRequiredFileCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link module:model/ApiResponse}
      */

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
@@ -85,8 +85,8 @@ export default class FakeApi {
      * test http signature authentication
      * @param {module:model/Pet} pet Pet object that needs to be added to the store
      * @param {Object} opts Optional parameters
-     * @param {String} opts.query1 query parameter
-     * @param {String} opts.header1 header parameter
+     * @param {String} [query1] query parameter
+     * @param {String} [header1] header parameter
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     fakeHttpSignatureTestWithHttpInfo(pet, opts) {
@@ -138,7 +138,7 @@ export default class FakeApi {
     /**
      * Test serialization of outer boolean types
      * @param {Object} opts Optional parameters
-     * @param {Boolean} opts.body Input boolean as post body
+     * @param {Boolean} [body] Input boolean as post body
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link Boolean} and HTTP response
      */
     fakeOuterBooleanSerializeWithHttpInfo(opts) {
@@ -182,7 +182,7 @@ export default class FakeApi {
     /**
      * Test serialization of object with outer number type
      * @param {Object} opts Optional parameters
-     * @param {module:model/OuterComposite} opts.outerComposite Input composite as post body
+     * @param {module:model/OuterComposite} [outerComposite] Input composite as post body
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OuterComposite} and HTTP response
      */
     fakeOuterCompositeSerializeWithHttpInfo(opts) {
@@ -226,7 +226,7 @@ export default class FakeApi {
     /**
      * Test serialization of outer number types
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.body Input number as post body
+     * @param {Number} [body] Input number as post body
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link Number} and HTTP response
      */
     fakeOuterNumberSerializeWithHttpInfo(opts) {
@@ -270,7 +270,7 @@ export default class FakeApi {
     /**
      * Test serialization of outer string types
      * @param {Object} opts Optional parameters
-     * @param {String} opts.body Input string as post body
+     * @param {String} [body] Input string as post body
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link String} and HTTP response
      */
     fakeOuterStringSerializeWithHttpInfo(opts) {
@@ -551,16 +551,16 @@ export default class FakeApi {
      * @param {String} patternWithoutDelimiter None
      * @param {Blob} _byte None
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.integer None
-     * @param {Number} opts.int32 None
-     * @param {Number} opts.int64 None
-     * @param {Number} opts._float None
-     * @param {String} opts.string None
-     * @param {File} opts.binary None
-     * @param {Date} opts.date None
-     * @param {Date} opts.dateTime None
-     * @param {String} opts.password None
-     * @param {String} opts.callback None
+     * @param {Number} [integer] None
+     * @param {Number} [int32] None
+     * @param {Number} [int64] None
+     * @param {Number} [_float] None
+     * @param {String} [string] None
+     * @param {File} [binary] None
+     * @param {Date} [date] None
+     * @param {Date} [dateTime] None
+     * @param {String} [password] None
+     * @param {String} [callback] None
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, opts) {
@@ -649,15 +649,15 @@ export default class FakeApi {
      * To test enum parameters
      * To test enum parameters
      * @param {Object} opts Optional parameters
-     * @param {Array.<module:model/String>} opts.enumHeaderStringArray Header parameter enum test (string array)
-     * @param {module:model/String} opts.enumHeaderString Header parameter enum test (string) (default to '-efg')
-     * @param {Array.<module:model/String>} opts.enumQueryStringArray Query parameter enum test (string array)
-     * @param {module:model/String} opts.enumQueryString Query parameter enum test (string) (default to '-efg')
-     * @param {module:model/Number} opts.enumQueryInteger Query parameter enum test (double)
-     * @param {module:model/Number} opts.enumQueryDouble Query parameter enum test (double)
-     * @param {Array.<module:model/EnumClass>} opts.enumQueryModelArray 
-     * @param {Array.<module:model/String>} opts.enumFormStringArray Form parameter enum test (string array) (default to '$')
-     * @param {module:model/String} opts.enumFormString Form parameter enum test (string) (default to '-efg')
+     * @param {Array.<module:model/String>} [enumHeaderStringArray] Header parameter enum test (string array)
+     * @param {module:model/String} [enumHeaderString = '-efg')] Header parameter enum test (string)
+     * @param {Array.<module:model/String>} [enumQueryStringArray] Query parameter enum test (string array)
+     * @param {module:model/String} [enumQueryString = '-efg')] Query parameter enum test (string)
+     * @param {module:model/Number} [enumQueryInteger] Query parameter enum test (double)
+     * @param {module:model/Number} [enumQueryDouble] Query parameter enum test (double)
+     * @param {Array.<module:model/EnumClass>} [enumQueryModelArray] 
+     * @param {Array.<module:model/String>} [enumFormStringArray = '$')] Form parameter enum test (string array)
+     * @param {module:model/String} [enumFormString = '-efg')] Form parameter enum test (string)
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     testEnumParametersWithHttpInfo(opts) {
@@ -723,9 +723,9 @@ export default class FakeApi {
      * @param {Boolean} requiredBooleanGroup Required Boolean in group parameters
      * @param {Number} requiredInt64Group Required Integer in group parameters
      * @param {Object} opts Optional parameters
-     * @param {Number} opts.stringGroup String in group parameters
-     * @param {Boolean} opts.booleanGroup Boolean in group parameters
-     * @param {Number} opts.int64Group Integer in group parameters
+     * @param {Number} [stringGroup] String in group parameters
+     * @param {Boolean} [booleanGroup] Boolean in group parameters
+     * @param {Number} [int64Group] Integer in group parameters
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, opts) {
@@ -901,7 +901,7 @@ export default class FakeApi {
      * @param {Array.<String>} context 
      * @param {String} allowEmpty 
      * @param {Object} opts Optional parameters
-     * @param {Object.<String, {String: String}>} opts.language 
+     * @param {Object.<String, {String: String}>} [language] 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, opts) {

--- a/samples/client/petstore/javascript-promise-es6/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/PetApi.js
@@ -98,7 +98,7 @@ export default class PetApi {
      * 
      * @param {Number} petId Pet id to delete
      * @param {Object} opts Optional parameters
-     * @param {String} opts.apiKey 
+     * @param {String} [apiKey] 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     deletePetWithHttpInfo(petId, opts) {
@@ -353,8 +353,8 @@ export default class PetApi {
      * 
      * @param {Number} petId ID of pet that needs to be updated
      * @param {Object} opts Optional parameters
-     * @param {String} opts.name Updated name of the pet
-     * @param {String} opts.status Updated status of the pet
+     * @param {String} [name] Updated name of the pet
+     * @param {String} [status] Updated status of the pet
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
     updatePetWithFormWithHttpInfo(petId, opts) {
@@ -410,8 +410,8 @@ export default class PetApi {
      * 
      * @param {Number} petId ID of pet to update
      * @param {Object} opts Optional parameters
-     * @param {String} opts.additionalMetadata Additional data to pass to server
-     * @param {File} opts.file file to upload
+     * @param {String} [additionalMetadata] Additional data to pass to server
+     * @param {File} [file] file to upload
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ApiResponse} and HTTP response
      */
     uploadFileWithHttpInfo(petId, opts) {
@@ -468,7 +468,7 @@ export default class PetApi {
      * @param {Number} petId ID of pet to update
      * @param {File} requiredFile file to upload
      * @param {Object} opts Optional parameters
-     * @param {String} opts.additionalMetadata Additional data to pass to server
+     * @param {String} [additionalMetadata] Additional data to pass to server
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ApiResponse} and HTTP response
      */
     uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, opts) {


### PR DESCRIPTION
Update optional parameters in jsdoc

To close https://github.com/OpenAPITools/openapi-generator/issues/15014


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)
