### PR TITLE
[JAVA][NATIVE] Fix NPE for form values request builder

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -496,11 +496,15 @@ public class {{classname}} {
     {{#formParams}}
     {{#isArray}}
     for (int i=0; i < {{paramName}}.size(); i++) {
-        formValues.add(new BasicNameValuePair("{{{baseName}}}", {{paramName}}.get(i).toString()));
+        if ({{paramName}}.get(i) != null) {
+            formValues.add(new BasicNameValuePair("{{{baseName}}}", {{paramName}}.get(i).toString()));
+        }
     }
     {{/isArray}}
     {{^isArray}}
-    formValues.add(new BasicNameValuePair("{{{baseName}}}", {{paramName}}.toString()));
+    if ({{paramName}} != null) {
+        formValues.add(new BasicNameValuePair("{{{baseName}}}", {{paramName}}.toString()));
+    }
     {{/isArray}}
     {{/formParams}}
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/FormApi.java
@@ -157,9 +157,15 @@ public class FormApi {
     localVarRequestBuilder.header("Accept", "text/plain");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("integer_form", integerForm.toString()));
-    formValues.add(new BasicNameValuePair("boolean_form", booleanForm.toString()));
-    formValues.add(new BasicNameValuePair("string_form", stringForm.toString()));
+    if (integerForm != null) {
+        formValues.add(new BasicNameValuePair("integer_form", integerForm.toString()));
+    }
+    if (booleanForm != null) {
+        formValues.add(new BasicNameValuePair("boolean_form", booleanForm.toString()));
+    }
+    if (stringForm != null) {
+        formValues.add(new BasicNameValuePair("string_form", stringForm.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1032,20 +1032,48 @@ public class FakeApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("integer", integer.toString()));
-    formValues.add(new BasicNameValuePair("int32", int32.toString()));
-    formValues.add(new BasicNameValuePair("int64", int64.toString()));
-    formValues.add(new BasicNameValuePair("number", number.toString()));
-    formValues.add(new BasicNameValuePair("float", _float.toString()));
-    formValues.add(new BasicNameValuePair("double", _double.toString()));
-    formValues.add(new BasicNameValuePair("string", string.toString()));
-    formValues.add(new BasicNameValuePair("pattern_without_delimiter", patternWithoutDelimiter.toString()));
-    formValues.add(new BasicNameValuePair("byte", _byte.toString()));
-    formValues.add(new BasicNameValuePair("binary", binary.toString()));
-    formValues.add(new BasicNameValuePair("date", date.toString()));
-    formValues.add(new BasicNameValuePair("dateTime", dateTime.toString()));
-    formValues.add(new BasicNameValuePair("password", password.toString()));
-    formValues.add(new BasicNameValuePair("callback", paramCallback.toString()));
+    if (integer != null) {
+        formValues.add(new BasicNameValuePair("integer", integer.toString()));
+    }
+    if (int32 != null) {
+        formValues.add(new BasicNameValuePair("int32", int32.toString()));
+    }
+    if (int64 != null) {
+        formValues.add(new BasicNameValuePair("int64", int64.toString()));
+    }
+    if (number != null) {
+        formValues.add(new BasicNameValuePair("number", number.toString()));
+    }
+    if (_float != null) {
+        formValues.add(new BasicNameValuePair("float", _float.toString()));
+    }
+    if (_double != null) {
+        formValues.add(new BasicNameValuePair("double", _double.toString()));
+    }
+    if (string != null) {
+        formValues.add(new BasicNameValuePair("string", string.toString()));
+    }
+    if (patternWithoutDelimiter != null) {
+        formValues.add(new BasicNameValuePair("pattern_without_delimiter", patternWithoutDelimiter.toString()));
+    }
+    if (_byte != null) {
+        formValues.add(new BasicNameValuePair("byte", _byte.toString()));
+    }
+    if (binary != null) {
+        formValues.add(new BasicNameValuePair("binary", binary.toString()));
+    }
+    if (date != null) {
+        formValues.add(new BasicNameValuePair("date", date.toString()));
+    }
+    if (dateTime != null) {
+        formValues.add(new BasicNameValuePair("dateTime", dateTime.toString()));
+    }
+    if (password != null) {
+        formValues.add(new BasicNameValuePair("password", password.toString()));
+    }
+    if (paramCallback != null) {
+        formValues.add(new BasicNameValuePair("callback", paramCallback.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {
@@ -1172,9 +1200,13 @@ public class FakeApi {
 
     List<NameValuePair> formValues = new ArrayList<>();
     for (int i=0; i < enumFormStringArray.size(); i++) {
-        formValues.add(new BasicNameValuePair("enum_form_string_array", enumFormStringArray.get(i).toString()));
+        if (enumFormStringArray.get(i) != null) {
+            formValues.add(new BasicNameValuePair("enum_form_string_array", enumFormStringArray.get(i).toString()));
+        }
     }
-    formValues.add(new BasicNameValuePair("enum_form_string", enumFormString.toString()));
+    if (enumFormString != null) {
+        formValues.add(new BasicNameValuePair("enum_form_string", enumFormString.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {
@@ -1585,8 +1617,12 @@ public class FakeApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("param", param.toString()));
-    formValues.add(new BasicNameValuePair("param2", param2.toString()));
+    if (param != null) {
+        formValues.add(new BasicNameValuePair("param", param.toString()));
+    }
+    if (param2 != null) {
+        formValues.add(new BasicNameValuePair("param2", param2.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
@@ -724,8 +724,12 @@ public class PetApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("name", name.toString()));
-    formValues.add(new BasicNameValuePair("status", status.toString()));
+    if (name != null) {
+        formValues.add(new BasicNameValuePair("name", name.toString()));
+    }
+    if (status != null) {
+        formValues.add(new BasicNameValuePair("status", status.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
@@ -646,8 +646,12 @@ public class PetApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("name", name.toString()));
-    formValues.add(new BasicNameValuePair("status", status.toString()));
+    if (name != null) {
+        formValues.add(new BasicNameValuePair("name", name.toString()));
+    }
+    if (status != null) {
+        formValues.add(new BasicNameValuePair("status", status.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -875,20 +875,48 @@ public class FakeApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("integer", integer.toString()));
-    formValues.add(new BasicNameValuePair("int32", int32.toString()));
-    formValues.add(new BasicNameValuePair("int64", int64.toString()));
-    formValues.add(new BasicNameValuePair("number", number.toString()));
-    formValues.add(new BasicNameValuePair("float", _float.toString()));
-    formValues.add(new BasicNameValuePair("double", _double.toString()));
-    formValues.add(new BasicNameValuePair("string", string.toString()));
-    formValues.add(new BasicNameValuePair("pattern_without_delimiter", patternWithoutDelimiter.toString()));
-    formValues.add(new BasicNameValuePair("byte", _byte.toString()));
-    formValues.add(new BasicNameValuePair("binary", binary.toString()));
-    formValues.add(new BasicNameValuePair("date", date.toString()));
-    formValues.add(new BasicNameValuePair("dateTime", dateTime.toString()));
-    formValues.add(new BasicNameValuePair("password", password.toString()));
-    formValues.add(new BasicNameValuePair("callback", paramCallback.toString()));
+    if (integer != null) {
+        formValues.add(new BasicNameValuePair("integer", integer.toString()));
+    }
+    if (int32 != null) {
+        formValues.add(new BasicNameValuePair("int32", int32.toString()));
+    }
+    if (int64 != null) {
+        formValues.add(new BasicNameValuePair("int64", int64.toString()));
+    }
+    if (number != null) {
+        formValues.add(new BasicNameValuePair("number", number.toString()));
+    }
+    if (_float != null) {
+        formValues.add(new BasicNameValuePair("float", _float.toString()));
+    }
+    if (_double != null) {
+        formValues.add(new BasicNameValuePair("double", _double.toString()));
+    }
+    if (string != null) {
+        formValues.add(new BasicNameValuePair("string", string.toString()));
+    }
+    if (patternWithoutDelimiter != null) {
+        formValues.add(new BasicNameValuePair("pattern_without_delimiter", patternWithoutDelimiter.toString()));
+    }
+    if (_byte != null) {
+        formValues.add(new BasicNameValuePair("byte", _byte.toString()));
+    }
+    if (binary != null) {
+        formValues.add(new BasicNameValuePair("binary", binary.toString()));
+    }
+    if (date != null) {
+        formValues.add(new BasicNameValuePair("date", date.toString()));
+    }
+    if (dateTime != null) {
+        formValues.add(new BasicNameValuePair("dateTime", dateTime.toString()));
+    }
+    if (password != null) {
+        formValues.add(new BasicNameValuePair("password", password.toString()));
+    }
+    if (paramCallback != null) {
+        formValues.add(new BasicNameValuePair("callback", paramCallback.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {
@@ -1012,9 +1040,13 @@ public class FakeApi {
 
     List<NameValuePair> formValues = new ArrayList<>();
     for (int i=0; i < enumFormStringArray.size(); i++) {
-        formValues.add(new BasicNameValuePair("enum_form_string_array", enumFormStringArray.get(i).toString()));
+        if (enumFormStringArray.get(i) != null) {
+            formValues.add(new BasicNameValuePair("enum_form_string_array", enumFormStringArray.get(i).toString()));
+        }
     }
-    formValues.add(new BasicNameValuePair("enum_form_string", enumFormString.toString()));
+    if (enumFormString != null) {
+        formValues.add(new BasicNameValuePair("enum_form_string", enumFormString.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {
@@ -1415,8 +1447,12 @@ public class FakeApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("param", param.toString()));
-    formValues.add(new BasicNameValuePair("param2", param2.toString()));
+    if (param != null) {
+        formValues.add(new BasicNameValuePair("param", param.toString()));
+    }
+    if (param2 != null) {
+        formValues.add(new BasicNameValuePair("param2", param2.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -648,8 +648,12 @@ public class PetApi {
     localVarRequestBuilder.header("Accept", "application/json");
 
     List<NameValuePair> formValues = new ArrayList<>();
-    formValues.add(new BasicNameValuePair("name", name.toString()));
-    formValues.add(new BasicNameValuePair("status", status.toString()));
+    if (name != null) {
+        formValues.add(new BasicNameValuePair("name", name.toString()));
+    }
+    if (status != null) {
+        formValues.add(new BasicNameValuePair("status", status.toString()));
+    }
     HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
     ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
     try {


### PR DESCRIPTION
Skip null form values, so no empty fields are sent. Before this change, null values were not an option (that would cause an NPE). The best could be an empty string.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608