### PR TITLE
[python-nextgen] remove allowStringInDateTimeParameters option

### DIFF
--- a/bin/configs/python-nextgen-echo-api.yaml
+++ b/bin/configs/python-nextgen-echo-api.yaml
@@ -4,4 +4,3 @@ inputSpec: modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
 templateDir: modules/openapi-generator/src/main/resources/python-nextgen
 additionalProperties:
   hideGenerationTimestamp: "true"
-  allowStringInDateTimeParameters: true

--- a/docs/generators/python-nextgen.md
+++ b/docs/generators/python-nextgen.md
@@ -19,7 +19,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
-|allowStringInDateTimeParameters|Allow string as input to datetime/date parameters for backward compartibility.| |false|
 |dateFormat|date format for query parameters| |%Y-%m-%d|
 |datetimeFormat|datetime format for query parameters| |%Y-%m-%dT%H:%M:%S%z|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -47,7 +47,6 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
     public static final String PACKAGE_URL = "packageUrl";
     public static final String DEFAULT_LIBRARY = "urllib3";
     public static final String RECURSION_LIMIT = "recursionLimit";
-    public static final String ALLOW_STRING_IN_DATETIME_PARAMETERS = "allowStringInDateTimeParameters";
     public static final String FLOAT_STRICT_TYPE = "floatStrictType";
     public static final String DATETIME_FORMAT = "datetimeFormat";
     public static final String DATE_FORMAT = "dateFormat";
@@ -57,7 +56,6 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
     protected String modelDocPath = "docs" + File.separator;
     protected boolean hasModelsToImport = Boolean.FALSE;
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
-    protected boolean allowStringInDateTimeParameters = false; // use StrictStr instead of datetime in parameters
     protected boolean floatStrictType = true;
     protected String datetimeFormat = "%Y-%m-%dT%H:%M:%S.%f%z";
     protected String dateFormat = "%Y-%m-%d";
@@ -172,8 +170,6 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
         cliOptions.add(new CliOption(CodegenConstants.SOURCECODEONLY_GENERATION, CodegenConstants.SOURCECODEONLY_GENERATION_DESC)
                 .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(RECURSION_LIMIT, "Set the recursion limit. If not set, use the system default value."));
-        cliOptions.add(new CliOption(ALLOW_STRING_IN_DATETIME_PARAMETERS, "Allow string as input to datetime/date parameters for backward compartibility.")
-                .defaultValue(Boolean.FALSE.toString()));
         cliOptions.add(new CliOption(FLOAT_STRICT_TYPE, "Use strict type for float, i.e. StrictFloat or confloat(strict=true, ...)")
                 .defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(new CliOption(DATETIME_FORMAT, "datetime format for query parameters")
@@ -276,10 +272,6 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
             setUseOneOfDiscriminatorLookup(convertPropertyToBooleanAndWriteBack(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP));
         } else {
             additionalProperties.put(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, useOneOfDiscriminatorLookup);
-        }
-
-        if (additionalProperties.containsKey(ALLOW_STRING_IN_DATETIME_PARAMETERS)) {
-            setAllowStringInDateTimeParameters(convertPropertyToBooleanAndWriteBack(ALLOW_STRING_IN_DATETIME_PARAMETERS));
         }
 
         if (additionalProperties.containsKey(FLOAT_STRICT_TYPE)) {
@@ -602,13 +594,7 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
                 datetimeImports.add("datetime");
             }
 
-            if (allowStringInDateTimeParameters) {
-                pydanticImports.add("StrictStr");
-                typingImports.add("Union");
-                return String.format(Locale.ROOT, "Union[StrictStr, %s]", cp.dataType);
-            } else {
-                return cp.dataType;
-            }
+            return cp.dataType;
         } else if (cp.isUuid) {
             return cp.dataType;
         } else if (cp.isFreeFormObject) { // type: object
@@ -1407,10 +1393,6 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
             return this.reservedWordsMappings().get(name);
         }
         return "var_" + name;
-    }
-
-    public void setAllowStringInDateTimeParameters(boolean allowStringInDateTimeParameters) {
-        this.allowStringInDateTimeParameters = allowStringInDateTimeParameters;
     }
 
     public void setFloatStrictType(boolean floatStrictType) {

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/query_api.py
@@ -24,7 +24,7 @@ from datetime import date, datetime
 
 from pydantic import StrictBool, StrictInt, StrictStr
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 
 from openapi_client.api_client import ApiClient
@@ -47,7 +47,7 @@ class QueryApi(object):
         self.api_client = api_client
 
     @validate_arguments
-    def test_query_datetime_date_string(self, datetime_query : Optional[Union[StrictStr, datetime]] = None, date_query : Optional[Union[StrictStr, date]] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
+    def test_query_datetime_date_string(self, datetime_query : Optional[datetime] = None, date_query : Optional[date] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -82,7 +82,7 @@ class QueryApi(object):
         return self.test_query_datetime_date_string_with_http_info(datetime_query, date_query, string_query, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[Union[StrictStr, datetime]] = None, date_query : Optional[Union[StrictStr, date]] = None, string_query : Optional[StrictStr] = None, **kwargs):  # noqa: E501
+    def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[datetime] = None, date_query : Optional[date] = None, string_query : Optional[StrictStr] = None, **kwargs):  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -51,17 +51,6 @@ class TestManual(unittest.TestCase):
         e = EchoServerResponseParser(api_response)
         self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19%3A20%3A30.000000-0500&date_query=2013-10-20&string_query=string_query_example")
 
-    def testDateTimeQueryWithString(self):
-        api_instance = openapi_client.QueryApi()
-        datetime_query = '19:20:30 2013-10-20' # datetime |  (optional)
-        date_query = '2013-10-20' # date |  (optional)
-        string_query = 'string_query_example' # str |  (optional)
-    
-        # Test query parameter(s)
-        api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
-        e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=19%3A20%3A30%202013-10-20&date_query=2013-10-20&string_query=string_query_example")
-
 class EchoServerResponseParser():
     def __init__(self, http_response):
         if http_response is None:


### PR DESCRIPTION
 remove allowStringInDateTimeParameters option as confirmed with the user that it's no longer needed.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)