### PR TITLE
[cpp-ue4] Series of fixes for cpp-ue4

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/Build.cs.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/Build.cs.mustache
@@ -11,7 +11,7 @@ public class {{unrealModuleName}} : ModuleRules
             new string[]
             {
                 "Core",
-                "Http",
+                "HTTP",
                 "Json",
             }
         );

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -172,11 +172,15 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 		HttpRequest->SetContentAsString(JsonBody);
 		{{/bodyParams.0}}
 		{{^bodyParams.0}}
-		// Form parameters
+		// Form parameters added to try to generate a json body when no body parameters are specified.
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 		Writer->WriteObjectStart();
 		{{#formParams}}
+		{{#isFile}}
+		UE_LOG(Log{{unrealModuleName}}, Error, TEXT("Form parameter ({{baseName}}) was ignored, Files are not supported in json body"));
+		{{/isFile}}
+		{{^isFile}}
 		{{#required}}
 		Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
 		WriteJsonValue(Writer, {{paramName}});
@@ -187,6 +191,7 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 			WriteJsonValue(Writer, {{paramName}}.GetValue());
 		}
 		{{/required}}
+		{{/isFile}}
 		{{/formParams}}
 		Writer->WriteObjectEnd();
 		Writer->Close();

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -172,6 +172,7 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 		HttpRequest->SetContentAsString(JsonBody);
 		{{/bodyParams.0}}
 		{{^bodyParams.0}}
+		{{#formParams.0}}
 		// Form parameters added to try to generate a json body when no body parameters are specified.
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
@@ -197,6 +198,7 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 		Writer->Close();
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
 		HttpRequest->SetContentAsString(JsonBody);
+		{{/formParams.0}}
 		{{/bodyParams.0}}
 	}
 	else if (Consumes.Contains(TEXT("multipart/form-data")))

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -94,10 +94,16 @@ FString Base64UrlEncode(const T& Value)
 	return Base64String;
 }
 
-template<typename T>
+template<typename T, typename std::enable_if<!std::is_base_of<Model, T>::value, int>::type = 0>
 inline FStringFormatArg ToStringFormatArg(const T& Value)
 {
 	return FStringFormatArg(Value);
+}
+
+template<typename T, typename std::enable_if<std::is_base_of<Model, T>::value, int>::type = 0>
+inline FStringFormatArg ToStringFormatArg(const T& EnumModelValue)
+{
+	return FStringFormatArg(T::EnumToString(EnumModelValue.Value));
 }
 
 inline FStringFormatArg ToStringFormatArg(const FDateTime& Value)


### PR DESCRIPTION
Hello,

After recently updating openapi-generator  for our project I noticed some regressions in past pull requests as well as missing features. 
Additions are detailed in the commits but:

- Fixed compilation warnings
- Fixed compilation error on APIs using files in http forms, which was a big breaking change and honestly i'm surprised nobody reported it before
- Added support for enums as url parameters
- Cosmetic improvements to the generated code

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
