### PR TITLE
[python-nextgen] fix pattern with double quote

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -1201,7 +1201,8 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
                 }
             }
 
-            vendorExtensions.put("x-regex", regex);
+            vendorExtensions.put("x-regex", regex.replace("\"","\\\""));
+            vendorExtensions.put("x-pattern", pattern.replace("\"","\\\""));
             vendorExtensions.put("x-modifiers", modifiers);
         }
     }

--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
@@ -33,7 +33,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     @validator('{{{name}}}')
     def {{{name}}}_validate_regular_expression(cls, v):
         if not re.match(r"{{{.}}}", v{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
-            raise ValueError(r"must validate the regular expression {{{pattern}}}")
+            raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
         return v
     {{/vendorExtensions.x-regex}}
     {{#isEnum}}

--- a/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1591,6 +1591,9 @@ components:
         string:
           type: string
           pattern: '/[a-z]/i'
+        string_with_double_quote_pattern:
+          type: string
+          pattern: 'this is "something"'
         byte:
           type: string
           format: byte

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FormatTest.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **double** | **float** |  | [optional] 
 **decimal** | **decimal.Decimal** |  | [optional] 
 **string** | **str** |  | [optional] 
+**string_with_double_quote_pattern** | **str** |  | [optional] 
 **byte** | **str** |  | [optional] 
 **binary** | **str** |  | [optional] 
 **var_date** | **date** |  | 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
@@ -34,6 +34,7 @@ class FormatTest(BaseModel):
     double: Optional[confloat(le=123.4, ge=67.8)] = None
     decimal: Optional[condecimal()] = None
     string: Optional[constr(strict=True)] = None
+    string_with_double_quote_pattern: Optional[constr(strict=True)] = None
     byte: Optional[StrictBytes] = None
     binary: Optional[StrictBytes] = None
     var_date: date = Field(..., alias="date")
@@ -42,12 +43,18 @@ class FormatTest(BaseModel):
     password: constr(strict=True, max_length=64, min_length=10) = ...
     pattern_with_digits: Optional[constr(strict=True)] = Field(None, description="A string that is a 10 digit number. Can have leading zeros.")
     pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
-    __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
+    __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
     @validator('string')
     def string_validate_regular_expression(cls, v):
         if not re.match(r"[a-z]", v ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
+        return v
+
+    @validator('string_with_double_quote_pattern')
+    def string_with_double_quote_pattern_validate_regular_expression(cls, v):
+        if not re.match(r"this is \"something\"", v):
+            raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return v
 
     @validator('pattern_with_digits')
@@ -105,6 +112,7 @@ class FormatTest(BaseModel):
             "double": obj.get("double"),
             "decimal": obj.get("decimal"),
             "string": obj.get("string"),
+            "string_with_double_quote_pattern": obj.get("string_with_double_quote_pattern"),
             "byte": obj.get("byte"),
             "binary": obj.get("binary"),
             "var_date": obj.get("date"),

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/tests/test_model.py
@@ -209,7 +209,7 @@ class ModelTests(unittest.TestCase):
         a = petstore_api.FormatTest(number=39.8, float=123, byte=bytes("string", 'utf-8'), date="2013-09-17", password="testing09876")
         self.assertEqual(a.float, 123.0)
 
-        json_str = '{"number": 34.5, "float": "456", "date": "2013-12-08", "password": "empty1234567", "pattern_with_digits": "1234567890", "pattern_with_digits_and_delimiter": "image_123" , "string": "string"}'
+        json_str = "{\"number\": 34.5, \"float\": \"456\", \"date\": \"2013-12-08\", \"password\": \"empty1234567\", \"pattern_with_digits\": \"1234567890\", \"pattern_with_digits_and_delimiter\": \"image_123\", \"string_with_double_quote_pattern\": \"this is \\\"something\\\"\", \"string\": \"string\"}"
         # no exception thrown when assigning 456 (integer) to float type since strict is set to false
         f = petstore_api.FormatTest.from_json(json_str)
         self.assertEqual(f.float, 456.0)

--- a/samples/openapi3/client/petstore/python-nextgen/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/FormatTest.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **double** | **float** |  | [optional] 
 **decimal** | **decimal.Decimal** |  | [optional] 
 **string** | **str** |  | [optional] 
+**string_with_double_quote_pattern** | **str** |  | [optional] 
 **byte** | **str** |  | [optional] 
 **binary** | **str** |  | [optional] 
 **var_date** | **date** |  | 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
@@ -34,6 +34,7 @@ class FormatTest(BaseModel):
     double: Optional[confloat(le=123.4, ge=67.8, strict=True)] = None
     decimal: Optional[condecimal()] = None
     string: Optional[constr(strict=True)] = None
+    string_with_double_quote_pattern: Optional[constr(strict=True)] = None
     byte: Optional[StrictBytes] = None
     binary: Optional[StrictBytes] = None
     var_date: date = Field(..., alias="date")
@@ -43,12 +44,18 @@ class FormatTest(BaseModel):
     pattern_with_digits: Optional[constr(strict=True)] = Field(None, description="A string that is a 10 digit number. Can have leading zeros.")
     pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     additional_properties: Dict[str, Any] = {}
-    __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
+    __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
     @validator('string')
     def string_validate_regular_expression(cls, v):
         if not re.match(r"[a-z]", v ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
+        return v
+
+    @validator('string_with_double_quote_pattern')
+    def string_with_double_quote_pattern_validate_regular_expression(cls, v):
+        if not re.match(r"this is \"something\"", v):
+            raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return v
 
     @validator('pattern_with_digits')
@@ -112,6 +119,7 @@ class FormatTest(BaseModel):
             "double": obj.get("double"),
             "decimal": obj.get("decimal"),
             "string": obj.get("string"),
+            "string_with_double_quote_pattern": obj.get("string_with_double_quote_pattern"),
             "byte": obj.get("byte"),
             "binary": obj.get("binary"),
             "var_date": obj.get("date"),


### PR DESCRIPTION
- fix pattern with double quote
- add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)