### PR TITLE
fix: elixir generator failing to compile + invalid references

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -96,7 +96,7 @@ defmodule {{moduleName}}.Connection do
     of the function call, will be set as a bearer token in the
     `authorization` header.
   {{/hasOAuthMethods}}
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 
@@ -133,7 +133,7 @@ defmodule {{moduleName}}.Connection do
     that returns a bearer token.
   - `scopes_or_password`: a list of Strings represenging OAuth2 scopes, or
     a single string that is the password for the username provided.
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 
@@ -155,7 +155,7 @@ defmodule {{moduleName}}.Connection do
     of the function call, will be set as a bearer token in the
     `authorization` header.
   - `scopes`: a list of Strings represenging OAuth2 scopes.
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 
@@ -179,7 +179,7 @@ defmodule {{moduleName}}.Connection do
 
   Tesla.Env.client
   """
-  @spec new(String.t(), String.t()), options) :: Tesla.Env.client()
+  @spec new(String.t(), String.t(), options) :: Tesla.Env.client()
   {{/hasHttpBasicMethods}}
   {{/hasOAuthMethods}}
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mrmstn, but doubt we'd need their review to merge this.