### PR TITLE
[python-nextgen] Fix binary response

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -113,8 +113,10 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
         typeMapping.put("array", "List");
         typeMapping.put("set", "List");
         typeMapping.put("map", "Dict");
-        typeMapping.put("file", "str");
         typeMapping.put("decimal", "decimal.Decimal");
+        typeMapping.put("file", "bytearray");
+        typeMapping.put("binary", "bytearray");
+        typeMapping.put("ByteArray", "bytearray");
 
         languageSpecificPrimitives.remove("file");
         languageSpecificPrimitives.add("decimal.Decimal");

--- a/modules/openapi-generator/src/main/resources/python-nextgen/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/api_client.mustache
@@ -241,7 +241,9 @@ class ApiClient(object):
 
         response_type = response_types_map.get(str(response_data.status), None)
 
-        if response_type not in ["file", "bytes"]:
+        if response_type == "bytearray":
+            response_data.data = response_data.data
+        else:
             match = None
             content_type = response_data.getheader('content-type')
             if content_type is not None:
@@ -250,8 +252,9 @@ class ApiClient(object):
             response_data.data = response_data.data.decode(encoding)
 
         # deserialize response data
-
-        if response_type:
+        if response_type == "bytearray":
+            return_data = response_data.data
+        elif response_type:
             return_data = self.deserialize(response_data, response_type)
         else:
             return_data = None

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -330,6 +330,21 @@ paths:
             text/plain:
               schema:
                 type: string
+  /binary/gif:
+    post:
+      tags:
+        - body
+      summary: Test binary (gif) response body
+      description: Test binary (gif) response body
+      operationId: test/binary/gif
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            image/gif:
+              schema:
+                type: string
+                format: binary
 
 components:
   requestBodies:

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -84,12 +84,11 @@ public class BodyApiExample {
         defaultClient.setBasePath("http://localhost:3000");
         
         BodyApi apiInstance = new BodyApi(defaultClient);
-        Pet pet = new Pet(); // Pet | Pet object that needs to be added to the store
         try {
-            Pet result = apiInstance.testEchoBodyPet(pet);
+            File result = apiInstance.testBinaryGif();
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling BodyApi#testEchoBodyPet");
+            System.err.println("Exception when calling BodyApi#testBinaryGif");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -106,6 +105,7 @@ All URIs are relative to *http://localhost:3000*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -326,6 +326,22 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /binary/gif:
+    post:
+      description: Test binary (gif) response body
+      operationId: test/binary/gif
+      responses:
+        "200":
+          content:
+            image/gif:
+              schema:
+                format: binary
+                type: string
+          description: Successful operation
+      summary: Test binary (gif) response body
+      tags:
+      - body
+      x-accepts: image/gif
 components:
   requestBodies:
     Pet:

--- a/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
@@ -4,9 +4,72 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 
+
+
+## testBinaryGif
+
+> File testBinaryGif()
+
+Test binary (gif) response body
+
+Test binary (gif) response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        try {
+            File result = apiInstance.testBinaryGif();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testBinaryGif");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+[**File**](File.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: image/gif
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
 
 
 ## testEchoBodyPet

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -20,6 +20,7 @@ import org.openapitools.client.Configuration;
 import org.openapitools.client.model.*;
 import org.openapitools.client.Pair;
 
+import java.io.File;
 import org.openapitools.client.model.Pet;
 
 
@@ -50,6 +51,73 @@ public class BodyApi {
 
   public void setApiClient(ApiClient apiClient) {
     this.apiClient = apiClient;
+  }
+
+  /**
+   * Test binary (gif) response body
+   * Test binary (gif) response body
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File testBinaryGif() throws ApiException {
+    return this.testBinaryGif(Collections.emptyMap());
+  }
+
+
+  /**
+   * Test binary (gif) response body
+   * Test binary (gif) response body
+   * @param additionalHeaders additionalHeaders for this call
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File testBinaryGif(Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/binary/gif";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "image/gif"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    TypeReference<File> localVarReturnType = new TypeReference<File>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
   }
 
   /**

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -326,6 +326,22 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /binary/gif:
+    post:
+      description: Test binary (gif) response body
+      operationId: test/binary/gif
+      responses:
+        "200":
+          content:
+            image/gif:
+              schema:
+                format: binary
+                type: string
+          description: Successful operation
+      summary: Test binary (gif) response body
+      tags:
+      - body
+      x-accepts: image/gif
 components:
   requestBodies:
     Pet:

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -4,6 +4,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.EncodingUtils;
 import org.openapitools.client.model.ApiResponse;
 
+import java.io.File;
 import org.openapitools.client.model.Pet;
 
 import java.util.ArrayList;
@@ -14,6 +15,31 @@ import feign.*;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public interface BodyApi extends ApiClient.Api {
+
+
+  /**
+   * Test binary (gif) response body
+   * Test binary (gif) response body
+   * @return File
+   */
+  @RequestLine("POST /binary/gif")
+  @Headers({
+    "Accept: image/gif",
+  })
+  File testBinaryGif();
+
+  /**
+   * Test binary (gif) response body
+   * Similar to <code>testBinaryGif</code> but it also returns the http response headers .
+   * Test binary (gif) response body
+   * @return A ApiResponse that wraps the response boyd and the http headers.
+   */
+  @RequestLine("POST /binary/gif")
+  @Headers({
+    "Accept: image/gif",
+  })
+  ApiResponse<File> testBinaryGifWithHttpInfo();
+
 
 
   /**

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -83,12 +83,11 @@ public class BodyApiExample {
         // Configure clients using the `defaultClient` object, such as
         // overriding the host and port, timeout, etc.
         BodyApi apiInstance = new BodyApi(defaultClient);
-        Pet pet = new Pet(); // Pet | Pet object that needs to be added to the store
         try {
-            Pet result = apiInstance.testEchoBodyPet(pet);
+            File result = apiInstance.testBinaryGif();
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling BodyApi#testEchoBodyPet");
+            System.err.println("Exception when calling BodyApi#testBinaryGif");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -105,6 +104,8 @@ All URIs are relative to *http://localhost:3000*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
+*BodyApi* | [**testBinaryGifWithHttpInfo**](docs/BodyApi.md#testBinaryGifWithHttpInfo) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetWithHttpInfo**](docs/BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -326,6 +326,22 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /binary/gif:
+    post:
+      description: Test binary (gif) response body
+      operationId: test/binary/gif
+      responses:
+        "200":
+          content:
+            image/gif:
+              schema:
+                format: binary
+                type: string
+          description: Successful operation
+      summary: Test binary (gif) response body
+      tags:
+      - body
+      x-accepts: image/gif
 components:
   requestBodies:
     Pet:

--- a/samples/client/echo_api/java/native/docs/BodyApi.md
+++ b/samples/client/echo_api/java/native/docs/BodyApi.md
@@ -4,11 +4,139 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
+| [**testBinaryGifWithHttpInfo**](BodyApi.md#testBinaryGifWithHttpInfo) | **POST** /binary/gif | Test binary (gif) response body |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetWithHttpInfo**](BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 | [**testEchoBodyPetResponseStringWithHttpInfo**](BodyApi.md#testEchoBodyPetResponseStringWithHttpInfo) | **POST** /echo/body/Pet/response_string | Test empty response body |
 
+
+
+## testBinaryGif
+
+> File testBinaryGif()
+
+Test binary (gif) response body
+
+Test binary (gif) response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        try {
+            File result = apiInstance.testBinaryGif();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testBinaryGif");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+[**File**](File.md)
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testBinaryGifWithHttpInfo
+
+> ApiResponse<File> testBinaryGif testBinaryGifWithHttpInfo()
+
+Test binary (gif) response body
+
+Test binary (gif) response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        try {
+            ApiResponse<File> response = apiInstance.testBinaryGifWithHttpInfo();
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testBinaryGif");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+ApiResponse<[**File**](File.md)>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
 
 
 ## testEchoBodyPet

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -17,6 +17,7 @@ import org.openapitools.client.ApiException;
 import org.openapitools.client.ApiResponse;
 import org.openapitools.client.Pair;
 
+import java.io.File;
 import org.openapitools.client.model.Pet;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -81,6 +82,71 @@ public class BodyApi {
     return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
+  /**
+   * Test binary (gif) response body
+   * Test binary (gif) response body
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File testBinaryGif() throws ApiException {
+    ApiResponse<File> localVarResponse = testBinaryGifWithHttpInfo();
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test binary (gif) response body
+   * Test binary (gif) response body
+   * @return ApiResponse&lt;File&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<File> testBinaryGifWithHttpInfo() throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testBinaryGifRequestBuilder();
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testBinaryGif", localVarResponse);
+        }
+        return new ApiResponse<File>(
+          localVarResponse.statusCode(),
+          localVarResponse.headers().map(),
+          localVarResponse.body() == null ? null : memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<File>() {}) // closes the InputStream
+        );
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testBinaryGifRequestBuilder() throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/binary/gif";
+
+    localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+
+    localVarRequestBuilder.header("Accept", "image/gif");
+
+    localVarRequestBuilder.method("POST", HttpRequest.BodyPublishers.noBody());
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
   /**
    * Test body parameter(s)
    * Test body parameter(s)

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -91,12 +91,11 @@ public class Example {
     defaultClient.setBasePath("http://localhost:3000");
 
     BodyApi apiInstance = new BodyApi(defaultClient);
-    Pet pet = new Pet(); // Pet | Pet object that needs to be added to the store
     try {
-      Pet result = apiInstance.testEchoBodyPet(pet);
+      File result = apiInstance.testBinaryGif();
       System.out.println(result);
     } catch (ApiException e) {
-      System.err.println("Exception when calling BodyApi#testEchoBodyPet");
+      System.err.println("Exception when calling BodyApi#testBinaryGif");
       System.err.println("Status code: " + e.getCode());
       System.err.println("Reason: " + e.getResponseBody());
       System.err.println("Response headers: " + e.getResponseHeaders());
@@ -113,6 +112,7 @@ All URIs are relative to *http://localhost:3000*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -326,6 +326,22 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /binary/gif:
+    post:
+      description: Test binary (gif) response body
+      operationId: test/binary/gif
+      responses:
+        "200":
+          content:
+            image/gif:
+              schema:
+                format: binary
+                type: string
+          description: Successful operation
+      summary: Test binary (gif) response body
+      tags:
+      - body
+      x-accepts: image/gif
 components:
   requestBodies:
     Pet:

--- a/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
@@ -4,9 +4,68 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 
+
+<a name="testBinaryGif"></a>
+# **testBinaryGif**
+> File testBinaryGif()
+
+Test binary (gif) response body
+
+Test binary (gif) response body
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:3000");
+
+    BodyApi apiInstance = new BodyApi(defaultClient);
+    try {
+      File result = apiInstance.testBinaryGif();
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling BodyApi#testBinaryGif");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**File**](File.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
 
 <a name="testEchoBodyPet"></a>
 # **testEchoBodyPet**

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import java.io.File;
 import org.openapitools.client.model.Pet;
 
 import java.lang.reflect.Type;
@@ -73,6 +74,119 @@ public class BodyApi {
         this.localCustomBaseUrl = customBaseUrl;
     }
 
+    /**
+     * Build call for testBinaryGif
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testBinaryGifCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/binary/gif";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "image/gif"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testBinaryGifValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        return testBinaryGifCall(_callback);
+
+    }
+
+    /**
+     * Test binary (gif) response body
+     * Test binary (gif) response body
+     * @return File
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public File testBinaryGif() throws ApiException {
+        ApiResponse<File> localVarResp = testBinaryGifWithHttpInfo();
+        return localVarResp.getData();
+    }
+
+    /**
+     * Test binary (gif) response body
+     * Test binary (gif) response body
+     * @return ApiResponse&lt;File&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<File> testBinaryGifWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = testBinaryGifValidateBeforeCall(null);
+        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Test binary (gif) response body (asynchronously)
+     * Test binary (gif) response body
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testBinaryGifAsync(final ApiCallback<File> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testBinaryGifValidateBeforeCall(_callback);
+        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
     /**
      * Build call for testEchoBodyPet
      * @param pet Pet object that needs to be added to the store (optional)

--- a/samples/client/echo_api/python-nextgen/README.md
+++ b/samples/client/echo_api/python-nextgen/README.md
@@ -68,15 +68,14 @@ configuration = openapi_client.Configuration(
 with openapi_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = openapi_client.BodyApi(api_client)
-    pet = openapi_client.Pet() # Pet | Pet object that needs to be added to the store (optional)
 
     try:
-        # Test body parameter(s)
-        api_response = api_instance.test_echo_body_pet(pet=pet)
-        print("The response of BodyApi->test_echo_body_pet:\n")
+        # Test binary (gif) response body
+        api_response = api_instance.test_binary_gif()
+        print("The response of BodyApi->test_binary_gif:\n")
         pprint(api_response)
     except ApiException as e:
-        print("Exception when calling BodyApi->test_echo_body_pet: %s\n" % e)
+        print("Exception when calling BodyApi->test_binary_gif: %s\n" % e)
 
 ```
 
@@ -86,6 +85,7 @@ All URIs are relative to *http://localhost:3000*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*BodyApi* | [**test_binary_gif**](docs/BodyApi.md#test_binary_gif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)

--- a/samples/client/echo_api/python-nextgen/docs/BodyApi.md
+++ b/samples/client/echo_api/python-nextgen/docs/BodyApi.md
@@ -4,9 +4,70 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**test_binary_gif**](BodyApi.md#test_binary_gif) | **POST** /binary/gif | Test binary (gif) response body
 [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
 
+
+# **test_binary_gif**
+> bytearray test_binary_gif()
+
+Test binary (gif) response body
+
+Test binary (gif) response body
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import os
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.BodyApi(api_client)
+
+    try:
+        # Test binary (gif) response body
+        api_response = api_instance.test_binary_gif()
+        print("The response of BodyApi->test_binary_gif:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling BodyApi->test_binary_gif: %s\n" % e)
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**bytearray**](bytearray.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_echo_body_pet**
 > Pet test_echo_body_pet(pet=pet)

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
@@ -44,6 +44,138 @@ class BodyApi(object):
         self.api_client = api_client
 
     @validate_arguments
+    def test_binary_gif(self, **kwargs) -> bytearray:  # noqa: E501
+        """Test binary (gif) response body  # noqa: E501
+
+        Test binary (gif) response body  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_binary_gif(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :type _preload_content: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: bytearray
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_binary_gif_with_http_info(**kwargs)  # noqa: E501
+
+    @validate_arguments
+    def test_binary_gif_with_http_info(self, **kwargs):  # noqa: E501
+        """Test binary (gif) response body  # noqa: E501
+
+        Test binary (gif) response body  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_binary_gif_with_http_info(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :type _return_http_data_only: bool, optional
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :type _preload_content: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(bytearray, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_binary_gif" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['image/gif'])  # noqa: E501
+
+        # authentication setting
+        _auth_settings = []  # noqa: E501
+
+        _response_types_map = {
+            '200': "bytearray",
+        }
+
+        return self.api_client.call_api(
+            '/binary/gif', 'POST',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
     def test_echo_body_pet(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> Pet:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 

--- a/samples/client/echo_api/python-nextgen/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api_client.py
@@ -229,7 +229,9 @@ class ApiClient(object):
 
         response_type = response_types_map.get(str(response_data.status), None)
 
-        if response_type not in ["file", "bytes"]:
+        if response_type == "bytearray":
+            response_data.data = response_data.data
+        else:
             match = None
             content_type = response_data.getheader('content-type')
             if content_type is not None:
@@ -238,8 +240,9 @@ class ApiClient(object):
             response_data.data = response_data.data.decode(encoding)
 
         # deserialize response data
-
-        if response_type:
+        if response_type == "bytearray":
+            return_data = response_data.data
+        elif response_type:
             return_data = self.deserialize(response_data, response_type)
         else:
             return_data = None

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import unittest
 import datetime
+import base64
 
 import openapi_client
 from openapi_client.api.query_api import QueryApi # noqa: E501
@@ -50,6 +51,13 @@ class TestManual(unittest.TestCase):
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
         self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19%3A20%3A30.000000-0500&date_query=2013-10-20&string_query=string_query_example")
+
+    def testBinaryGif(self):
+        api_instance = openapi_client.BodyApi()
+
+        # Test binary response
+        api_response = api_instance.test_binary_gif()
+        self.assertEqual((base64.b64encode(api_response)).decode("utf-8"), "R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==")
 
 class EchoServerResponseParser():
     def __init__(self, http_response):

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FakeApi.md
@@ -612,7 +612,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    body = 'body_example' # str | image to upload
+    body = petstore_api.bytearray() # bytearray | image to upload
 
     try:
         await api_instance.test_body_with_binary(body)
@@ -624,7 +624,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **str**| image to upload | 
+ **body** | **bytearray**| image to upload | 
 
 ### Return type
 
@@ -934,13 +934,13 @@ async with petstore_api.ApiClient(configuration) as api_client:
     number = 3.4 # float | None
     double = 3.4 # float | None
     pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-    byte = 'byte_example' # str | None
+    byte = petstore_api.bytearray() # bytearray | None
     integer = 56 # int | None (optional)
     int32 = 56 # int | None (optional)
     int64 = 56 # int | None (optional)
     float = 3.4 # float | None (optional)
     string = 'string_example' # str | None (optional)
-    binary = 'binary_example' # str | None (optional)
+    binary = petstore_api.bytearray() # bytearray | None (optional)
     var_date = '2013-10-20' # date | None (optional)
     date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
     password = 'password_example' # str | None (optional)
@@ -960,13 +960,13 @@ Name | Type | Description  | Notes
  **number** | **float**| None | 
  **double** | **float**| None | 
  **pattern_without_delimiter** | **str**| None | 
- **byte** | **str**| None | 
+ **byte** | **bytearray**| None | 
  **integer** | **int**| None | [optional] 
  **int32** | **int**| None | [optional] 
  **int64** | **int**| None | [optional] 
  **float** | **float**| None | [optional] 
  **string** | **str**| None | [optional] 
- **binary** | **str**| None | [optional] 
+ **binary** | **bytearray**| None | [optional] 
  **var_date** | **date**| None | [optional] 
  **date_time** | **datetime**| None | [optional] 
  **password** | **str**| None | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FormatTest.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **decimal** | **decimal.Decimal** |  | [optional] 
 **string** | **str** |  | [optional] 
 **string_with_double_quote_pattern** | **str** |  | [optional] 
-**byte** | **str** |  | [optional] 
-**binary** | **str** |  | [optional] 
+**byte** | [**bytearray**](bytearray.md) |  | [optional] 
+**binary** | [**bytearray**](bytearray.md) |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/PetApi.md
@@ -1176,7 +1176,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
-    file = 'file_example' # str | file to upload (optional)
+    file = petstore_api.bytearray() # bytearray | file to upload (optional)
 
     try:
         # uploads an image
@@ -1193,7 +1193,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet_id** | **int**| ID of pet to update | 
  **additional_metadata** | **str**| Additional data to pass to server | [optional] 
- **file** | **str**| file to upload | [optional] 
+ **file** | **bytearray**| file to upload | [optional] 
 
 ### Return type
 
@@ -1250,7 +1250,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
-    required_file = 'required_file_example' # str | file to upload
+    required_file = petstore_api.bytearray() # bytearray | file to upload
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
     try:
@@ -1267,7 +1267,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet_id** | **int**| ID of pet to update | 
- **required_file** | **str**| file to upload | 
+ **required_file** | **bytearray**| file to upload | 
  **additional_metadata** | **str**| Additional data to pass to server | [optional] 
 
 ### Return type

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
@@ -1310,7 +1310,7 @@ class FakeApi(object):
         >>> result = thread.get()
 
         :param body: image to upload (required)
-        :type body: str
+        :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -1343,7 +1343,7 @@ class FakeApi(object):
         >>> result = thread.get()
 
         :param body: image to upload (required)
-        :type body: str
+        :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -2085,7 +2085,7 @@ class FakeApi(object):
         :param pattern_without_delimiter: None (required)
         :type pattern_without_delimiter: str
         :param byte: None (required)
-        :type byte: str
+        :type byte: bytearray
         :param integer: None
         :type integer: int
         :param int32: None
@@ -2097,7 +2097,7 @@ class FakeApi(object):
         :param string: None
         :type string: str
         :param binary: None
-        :type binary: str
+        :type binary: bytearray
         :param var_date: None
         :type var_date: date
         :param date_time: None
@@ -2144,7 +2144,7 @@ class FakeApi(object):
         :param pattern_without_delimiter: None (required)
         :type pattern_without_delimiter: str
         :param byte: None (required)
-        :type byte: str
+        :type byte: bytearray
         :param integer: None
         :type integer: int
         :param int32: None
@@ -2156,7 +2156,7 @@ class FakeApi(object):
         :param string: None
         :type string: str
         :param binary: None
-        :type binary: str
+        :type binary: bytearray
         :param var_date: None
         :type var_date: date
         :param date_time: None

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
@@ -1145,7 +1145,7 @@ class PetApi(object):
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param file: file to upload
-        :type file: str
+        :type file: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -1182,7 +1182,7 @@ class PetApi(object):
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param file: file to upload
-        :type file: str
+        :type file: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -1316,7 +1316,7 @@ class PetApi(object):
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
         :param required_file: file to upload (required)
-        :type required_file: str
+        :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param async_req: Whether to execute the request asynchronously.
@@ -1353,7 +1353,7 @@ class PetApi(object):
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
         :param required_file: file to upload (required)
-        :type required_file: str
+        :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param async_req: Whether to execute the request asynchronously.

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api_client.py
@@ -229,7 +229,9 @@ class ApiClient(object):
 
         response_type = response_types_map.get(str(response_data.status), None)
 
-        if response_type not in ["file", "bytes"]:
+        if response_type == "bytearray":
+            response_data.data = response_data.data
+        else:
             match = None
             content_type = response_data.getheader('content-type')
             if content_type is not None:
@@ -238,8 +240,9 @@ class ApiClient(object):
             response_data.data = response_data.data.decode(encoding)
 
         # deserialize response data
-
-        if response_type:
+        if response_type == "bytearray":
+            return_data = response_data.data
+        elif response_type:
             return_data = self.deserialize(response_data, response_type)
         else:
             return_data = None

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
@@ -92,6 +92,12 @@ class FormatTest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
+        # override the default output from pydantic by calling `to_dict()` of byte
+        if self.byte:
+            _dict['byte'] = self.byte.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of binary
+        if self.binary:
+            _dict['binary'] = self.binary.to_dict()
         return _dict
 
     @classmethod
@@ -113,8 +119,8 @@ class FormatTest(BaseModel):
             "decimal": obj.get("decimal"),
             "string": obj.get("string"),
             "string_with_double_quote_pattern": obj.get("string_with_double_quote_pattern"),
-            "byte": obj.get("byte"),
-            "binary": obj.get("binary"),
+            "byte": bytearray.from_dict(obj.get("byte")) if obj.get("byte") is not None else None,
+            "binary": bytearray.from_dict(obj.get("binary")) if obj.get("binary") is not None else None,
             "var_date": obj.get("date"),
             "date_time": obj.get("dateTime"),
             "uuid": obj.get("uuid"),

--- a/samples/openapi3/client/petstore/python-nextgen/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/FakeApi.md
@@ -612,7 +612,7 @@ configuration = petstore_api.Configuration(
 with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    body = 'body_example' # str | image to upload
+    body = petstore_api.bytearray() # bytearray | image to upload
 
     try:
         api_instance.test_body_with_binary(body)
@@ -624,7 +624,7 @@ with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **str**| image to upload | 
+ **body** | **bytearray**| image to upload | 
 
 ### Return type
 
@@ -934,13 +934,13 @@ with petstore_api.ApiClient(configuration) as api_client:
     number = 3.4 # float | None
     double = 3.4 # float | None
     pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-    byte = 'byte_example' # str | None
+    byte = petstore_api.bytearray() # bytearray | None
     integer = 56 # int | None (optional)
     int32 = 56 # int | None (optional)
     int64 = 56 # int | None (optional)
     float = 3.4 # float | None (optional)
     string = 'string_example' # str | None (optional)
-    binary = 'binary_example' # str | None (optional)
+    binary = petstore_api.bytearray() # bytearray | None (optional)
     var_date = '2013-10-20' # date | None (optional)
     date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
     password = 'password_example' # str | None (optional)
@@ -960,13 +960,13 @@ Name | Type | Description  | Notes
  **number** | **float**| None | 
  **double** | **float**| None | 
  **pattern_without_delimiter** | **str**| None | 
- **byte** | **str**| None | 
+ **byte** | **bytearray**| None | 
  **integer** | **int**| None | [optional] 
  **int32** | **int**| None | [optional] 
  **int64** | **int**| None | [optional] 
  **float** | **float**| None | [optional] 
  **string** | **str**| None | [optional] 
- **binary** | **str**| None | [optional] 
+ **binary** | **bytearray**| None | [optional] 
  **var_date** | **date**| None | [optional] 
  **date_time** | **datetime**| None | [optional] 
  **password** | **str**| None | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/FormatTest.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **decimal** | **decimal.Decimal** |  | [optional] 
 **string** | **str** |  | [optional] 
 **string_with_double_quote_pattern** | **str** |  | [optional] 
-**byte** | **str** |  | [optional] 
-**binary** | **str** |  | [optional] 
+**byte** | [**bytearray**](bytearray.md) |  | [optional] 
+**binary** | [**bytearray**](bytearray.md) |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/PetApi.md
@@ -1176,7 +1176,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
-    file = 'file_example' # str | file to upload (optional)
+    file = petstore_api.bytearray() # bytearray | file to upload (optional)
 
     try:
         # uploads an image
@@ -1193,7 +1193,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet_id** | **int**| ID of pet to update | 
  **additional_metadata** | **str**| Additional data to pass to server | [optional] 
- **file** | **str**| file to upload | [optional] 
+ **file** | **bytearray**| file to upload | [optional] 
 
 ### Return type
 
@@ -1250,7 +1250,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
-    required_file = 'required_file_example' # str | file to upload
+    required_file = petstore_api.bytearray() # bytearray | file to upload
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
     try:
@@ -1267,7 +1267,7 @@ with petstore_api.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet_id** | **int**| ID of pet to update | 
- **required_file** | **str**| file to upload | 
+ **required_file** | **bytearray**| file to upload | 
  **additional_metadata** | **str**| Additional data to pass to server | [optional] 
 
 ### Return type

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_api.py
@@ -1221,7 +1221,7 @@ class FakeApi(object):
         >>> result = thread.get()
 
         :param body: image to upload (required)
-        :type body: str
+        :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -1252,7 +1252,7 @@ class FakeApi(object):
         >>> result = thread.get()
 
         :param body: image to upload (required)
-        :type body: str
+        :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -1946,7 +1946,7 @@ class FakeApi(object):
         :param pattern_without_delimiter: None (required)
         :type pattern_without_delimiter: str
         :param byte: None (required)
-        :type byte: str
+        :type byte: bytearray
         :param integer: None
         :type integer: int
         :param int32: None
@@ -1958,7 +1958,7 @@ class FakeApi(object):
         :param string: None
         :type string: str
         :param binary: None
-        :type binary: str
+        :type binary: bytearray
         :param var_date: None
         :type var_date: date
         :param date_time: None
@@ -2003,7 +2003,7 @@ class FakeApi(object):
         :param pattern_without_delimiter: None (required)
         :type pattern_without_delimiter: str
         :param byte: None (required)
-        :type byte: str
+        :type byte: bytearray
         :param integer: None
         :type integer: int
         :param int32: None
@@ -2015,7 +2015,7 @@ class FakeApi(object):
         :param string: None
         :type string: str
         :param binary: None
-        :type binary: str
+        :type binary: bytearray
         :param var_date: None
         :type var_date: date
         :param date_time: None

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/pet_api.py
@@ -1066,7 +1066,7 @@ class PetApi(object):
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param file: file to upload
-        :type file: str
+        :type file: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -1101,7 +1101,7 @@ class PetApi(object):
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param file: file to upload
-        :type file: str
+        :type file: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -1227,7 +1227,7 @@ class PetApi(object):
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
         :param required_file: file to upload (required)
-        :type required_file: str
+        :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param async_req: Whether to execute the request asynchronously.
@@ -1262,7 +1262,7 @@ class PetApi(object):
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
         :param required_file: file to upload (required)
-        :type required_file: str
+        :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
         :param async_req: Whether to execute the request asynchronously.

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api_client.py
@@ -228,7 +228,9 @@ class ApiClient(object):
 
         response_type = response_types_map.get(str(response_data.status), None)
 
-        if response_type not in ["file", "bytes"]:
+        if response_type == "bytearray":
+            response_data.data = response_data.data
+        else:
             match = None
             content_type = response_data.getheader('content-type')
             if content_type is not None:
@@ -237,8 +239,9 @@ class ApiClient(object):
             response_data.data = response_data.data.decode(encoding)
 
         # deserialize response data
-
-        if response_type:
+        if response_type == "bytearray":
+            return_data = response_data.data
+        elif response_type:
             return_data = self.deserialize(response_data, response_type)
         else:
             return_data = None

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
@@ -94,6 +94,12 @@ class FormatTest(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
+        # override the default output from pydantic by calling `to_dict()` of byte
+        if self.byte:
+            _dict['byte'] = self.byte.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of binary
+        if self.binary:
+            _dict['binary'] = self.binary.to_dict()
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():
@@ -120,8 +126,8 @@ class FormatTest(BaseModel):
             "decimal": obj.get("decimal"),
             "string": obj.get("string"),
             "string_with_double_quote_pattern": obj.get("string_with_double_quote_pattern"),
-            "byte": obj.get("byte"),
-            "binary": obj.get("binary"),
+            "byte": bytearray.from_dict(obj.get("byte")) if obj.get("byte") is not None else None,
+            "binary": bytearray.from_dict(obj.get("binary")) if obj.get("binary") is not None else None,
             "var_date": obj.get("date"),
             "date_time": obj.get("dateTime"),
             "uuid": obj.get("uuid"),


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/15057

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)
