### PR TITLE
[python-nextgen] use __fields_set__ to determine if the field is needed in to_dict

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
@@ -162,7 +162,8 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{#allVars}}
         {{#isNullable}}
         # set to None if {{{name}}} (nullable) is None
-        if self.{{name}} is None:
+        # and __fields_set__ contains the field
+        if self.{{name}} is None and "{{{name}}}" in self.__fields_set__:
             _dict['{{{baseName}}}'] = None
 
         {{/isNullable}}

--- a/samples/client/echo_api/python-nextgen/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/models/default_value.py
@@ -71,15 +71,18 @@ class DefaultValue(BaseModel):
                           },
                           exclude_none=True)
         # set to None if array_string_nullable (nullable) is None
-        if self.array_string_nullable is None:
+        # and __fields_set__ contains the field
+        if self.array_string_nullable is None and "array_string_nullable" in self.__fields_set__:
             _dict['array_string_nullable'] = None
 
         # set to None if array_string_extension_nullable (nullable) is None
-        if self.array_string_extension_nullable is None:
+        # and __fields_set__ contains the field
+        if self.array_string_extension_nullable is None and "array_string_extension_nullable" in self.__fields_set__:
             _dict['array_string_extension_nullable'] = None
 
         # set to None if string_nullable (nullable) is None
-        if self.string_nullable is None:
+        # and __fields_set__ contains the field
+        if self.string_nullable is None and "string_nullable" in self.__fields_set__:
             _dict['string_nullable'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
@@ -103,7 +103,8 @@ class EnumTest(BaseModel):
                           },
                           exclude_none=True)
         # set to None if outer_enum (nullable) is None
-        if self.outer_enum is None:
+        # and __fields_set__ contains the field
+        if self.outer_enum is None and "outer_enum" in self.__fields_set__:
             _dict['outerEnum'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/health_check_result.py
@@ -53,7 +53,8 @@ class HealthCheckResult(BaseModel):
                           },
                           exclude_none=True)
         # set to None if nullable_message (nullable) is None
-        if self.nullable_message is None:
+        # and __fields_set__ contains the field
+        if self.nullable_message is None and "nullable_message" in self.__fields_set__:
             _dict['NullableMessage'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/nullable_class.py
@@ -65,47 +65,58 @@ class NullableClass(BaseModel):
                           },
                           exclude_none=True)
         # set to None if required_integer_prop (nullable) is None
-        if self.required_integer_prop is None:
+        # and __fields_set__ contains the field
+        if self.required_integer_prop is None and "required_integer_prop" in self.__fields_set__:
             _dict['required_integer_prop'] = None
 
         # set to None if integer_prop (nullable) is None
-        if self.integer_prop is None:
+        # and __fields_set__ contains the field
+        if self.integer_prop is None and "integer_prop" in self.__fields_set__:
             _dict['integer_prop'] = None
 
         # set to None if number_prop (nullable) is None
-        if self.number_prop is None:
+        # and __fields_set__ contains the field
+        if self.number_prop is None and "number_prop" in self.__fields_set__:
             _dict['number_prop'] = None
 
         # set to None if boolean_prop (nullable) is None
-        if self.boolean_prop is None:
+        # and __fields_set__ contains the field
+        if self.boolean_prop is None and "boolean_prop" in self.__fields_set__:
             _dict['boolean_prop'] = None
 
         # set to None if string_prop (nullable) is None
-        if self.string_prop is None:
+        # and __fields_set__ contains the field
+        if self.string_prop is None and "string_prop" in self.__fields_set__:
             _dict['string_prop'] = None
 
         # set to None if date_prop (nullable) is None
-        if self.date_prop is None:
+        # and __fields_set__ contains the field
+        if self.date_prop is None and "date_prop" in self.__fields_set__:
             _dict['date_prop'] = None
 
         # set to None if datetime_prop (nullable) is None
-        if self.datetime_prop is None:
+        # and __fields_set__ contains the field
+        if self.datetime_prop is None and "datetime_prop" in self.__fields_set__:
             _dict['datetime_prop'] = None
 
         # set to None if array_nullable_prop (nullable) is None
-        if self.array_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.array_nullable_prop is None and "array_nullable_prop" in self.__fields_set__:
             _dict['array_nullable_prop'] = None
 
         # set to None if array_and_items_nullable_prop (nullable) is None
-        if self.array_and_items_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.array_and_items_nullable_prop is None and "array_and_items_nullable_prop" in self.__fields_set__:
             _dict['array_and_items_nullable_prop'] = None
 
         # set to None if object_nullable_prop (nullable) is None
-        if self.object_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.object_nullable_prop is None and "object_nullable_prop" in self.__fields_set__:
             _dict['object_nullable_prop'] = None
 
         # set to None if object_and_items_nullable_prop (nullable) is None
-        if self.object_and_items_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.object_and_items_nullable_prop is None and "object_and_items_nullable_prop" in self.__fields_set__:
             _dict['object_and_items_nullable_prop'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -56,7 +56,8 @@ class OuterObjectWithEnumProperty(BaseModel):
                           },
                           exclude_none=True)
         # set to None if str_value (nullable) is None
-        if self.str_value is None:
+        # and __fields_set__ contains the field
+        if self.str_value is None and "str_value" in self.__fields_set__:
             _dict['str_value'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/tests/test_model.py
@@ -195,7 +195,7 @@ class ModelTests(unittest.TestCase):
         # test enum ref property
         # test to_json
         d = petstore_api.OuterObjectWithEnumProperty(value=petstore_api.OuterEnumInteger.NUMBER_1)
-        self.assertEqual(d.to_json(), '{"value": 1, "str_value": null}')
+        self.assertEqual(d.to_json(), '{"value": 1}')
         d2 = petstore_api.OuterObjectWithEnumProperty(value=petstore_api.OuterEnumInteger.NUMBER_1, str_value=petstore_api.OuterEnum.DELIVERED)
         self.assertEqual(d2.to_json(), '{"str_value": "delivered", "value": 1}')
         # test from_json (round trip)

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
@@ -110,7 +110,8 @@ class EnumTest(BaseModel):
                 _dict[_key] = _value
 
         # set to None if outer_enum (nullable) is None
-        if self.outer_enum is None:
+        # and __fields_set__ contains the field
+        if self.outer_enum is None and "outer_enum" in self.__fields_set__:
             _dict['outerEnum'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/health_check_result.py
@@ -60,7 +60,8 @@ class HealthCheckResult(BaseModel):
                 _dict[_key] = _value
 
         # set to None if nullable_message (nullable) is None
-        if self.nullable_message is None:
+        # and __fields_set__ contains the field
+        if self.nullable_message is None and "nullable_message" in self.__fields_set__:
             _dict['NullableMessage'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/nullable_class.py
@@ -65,47 +65,58 @@ class NullableClass(BaseModel):
                           },
                           exclude_none=True)
         # set to None if required_integer_prop (nullable) is None
-        if self.required_integer_prop is None:
+        # and __fields_set__ contains the field
+        if self.required_integer_prop is None and "required_integer_prop" in self.__fields_set__:
             _dict['required_integer_prop'] = None
 
         # set to None if integer_prop (nullable) is None
-        if self.integer_prop is None:
+        # and __fields_set__ contains the field
+        if self.integer_prop is None and "integer_prop" in self.__fields_set__:
             _dict['integer_prop'] = None
 
         # set to None if number_prop (nullable) is None
-        if self.number_prop is None:
+        # and __fields_set__ contains the field
+        if self.number_prop is None and "number_prop" in self.__fields_set__:
             _dict['number_prop'] = None
 
         # set to None if boolean_prop (nullable) is None
-        if self.boolean_prop is None:
+        # and __fields_set__ contains the field
+        if self.boolean_prop is None and "boolean_prop" in self.__fields_set__:
             _dict['boolean_prop'] = None
 
         # set to None if string_prop (nullable) is None
-        if self.string_prop is None:
+        # and __fields_set__ contains the field
+        if self.string_prop is None and "string_prop" in self.__fields_set__:
             _dict['string_prop'] = None
 
         # set to None if date_prop (nullable) is None
-        if self.date_prop is None:
+        # and __fields_set__ contains the field
+        if self.date_prop is None and "date_prop" in self.__fields_set__:
             _dict['date_prop'] = None
 
         # set to None if datetime_prop (nullable) is None
-        if self.datetime_prop is None:
+        # and __fields_set__ contains the field
+        if self.datetime_prop is None and "datetime_prop" in self.__fields_set__:
             _dict['datetime_prop'] = None
 
         # set to None if array_nullable_prop (nullable) is None
-        if self.array_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.array_nullable_prop is None and "array_nullable_prop" in self.__fields_set__:
             _dict['array_nullable_prop'] = None
 
         # set to None if array_and_items_nullable_prop (nullable) is None
-        if self.array_and_items_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.array_and_items_nullable_prop is None and "array_and_items_nullable_prop" in self.__fields_set__:
             _dict['array_and_items_nullable_prop'] = None
 
         # set to None if object_nullable_prop (nullable) is None
-        if self.object_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.object_nullable_prop is None and "object_nullable_prop" in self.__fields_set__:
             _dict['object_nullable_prop'] = None
 
         # set to None if object_and_items_nullable_prop (nullable) is None
-        if self.object_and_items_nullable_prop is None:
+        # and __fields_set__ contains the field
+        if self.object_and_items_nullable_prop is None and "object_and_items_nullable_prop" in self.__fields_set__:
             _dict['object_and_items_nullable_prop'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/outer_object_with_enum_property.py
@@ -63,7 +63,8 @@ class OuterObjectWithEnumProperty(BaseModel):
                 _dict[_key] = _value
 
         # set to None if str_value (nullable) is None
-        if self.str_value is None:
+        # and __fields_set__ contains the field
+        if self.str_value is None and "str_value" in self.__fields_set__:
             _dict['str_value'] = None
 
         return _dict

--- a/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
@@ -289,7 +289,7 @@ class ModelTests(unittest.TestCase):
         # test enum ref property
         # test to_json
         d = petstore_api.OuterObjectWithEnumProperty(value=petstore_api.OuterEnumInteger.NUMBER_1)
-        self.assertEqual(d.to_json(), '{"value": 1, "str_value": null}')
+        self.assertEqual(d.to_json(), '{"value": 1}')
         d2 = petstore_api.OuterObjectWithEnumProperty(value=petstore_api.OuterEnumInteger.NUMBER_1, str_value=petstore_api.OuterEnum.DELIVERED)
         self.assertEqual(d2.to_json(), '{"str_value": "delivered", "value": 1}')
         # test from_json (round trip)
@@ -297,6 +297,13 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(d3.str_value, petstore_api.OuterEnum.DELIVERED)
         self.assertEqual(d3.value, petstore_api.OuterEnumInteger.NUMBER_1)
         self.assertEqual(d3.to_json(), '{"str_value": "delivered", "value": 1}')
+        d4 = petstore_api.OuterObjectWithEnumProperty(value=petstore_api.OuterEnumInteger.NUMBER_1, str_value=None)
+        self.assertEqual(d4.to_json(), '{"value": 1, "str_value": null}')
+        d5 = petstore_api.OuterObjectWithEnumProperty(value=petstore_api.OuterEnumInteger.NUMBER_1)
+        self.assertEqual(d5.__fields_set__, {'value'})
+        d5.str_value = None # set None explicitly
+        self.assertEqual(d5.__fields_set__, {'value', 'str_value'})
+        self.assertEqual(d5.to_json(), '{"value": 1, "str_value": null}')
 
     def test_valdiator(self):
         # test regular expression


### PR DESCRIPTION
- use `__fields_set__` to determine if the nullable field is needed (set explicitly to None) in to_dict
- add tests
- to fix https://github.com/OpenAPITools/openapi-generator/issues/15056

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)
