### PR TITLE
[go-server] Update dependencies and use generics

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/go.mod.mustache
@@ -1,18 +1,18 @@
 module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}
 
-go 1.13
+go 1.18
 
 {{#routers}}
 	{{#mux}}
-require github.com/gorilla/mux v1.7.3
+require github.com/gorilla/mux v1.8.0
 		{{#featureCORS}}
 require github.com/gorilla/handlers v1.5.1
 		{{/featureCORS}}
 	{{/mux}}
 	{{#chi}}
-require github.com/go-chi/chi/v5 v5.0.3
+require github.com/go-chi/chi/v5 v5.0.8
 		{{#featureCORS}}
-require github.com/go-chi/cors v1.2.0
+require github.com/go-chi/cors v1.2.1
 		{{/featureCORS}}
 	{{/chi}}
 {{/routers}}

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -34,7 +34,7 @@ func IsZeroValue(val interface{}) bool {
 
 // AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
-func AssertRecurseInterfaceRequired[S [][]any, T any](obj S, callback func(T) error) error {
+func AssertRecurseInterfaceRequired[T any](obj interface{}, callback func(T) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -34,17 +34,23 @@ func IsZeroValue(val interface{}) bool {
 
 // AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
-func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
+func AssertRecurseInterfaceRequired[S [][]any, T any](obj S, callback func(T) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
 // AssertRecurseValueRequired checks each struct in the nested slice against the callback.
-// This method traverse nested slices in a preorder fashion.
-func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
+// This method traverse nested slices in a preorder fashion. ErrTypeAssertionError is thrown if
+// the underlying struct does not match type T.
+func AssertRecurseValueRequired[T any](value reflect.Value, callback func(T) error) error {
 	switch value.Kind() {
 	// If it is a struct we check using callback
 	case reflect.Struct:
-		if err := callback(value.Interface()); err != nil {
+		obj, ok := value.Interface().(T)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+
+		if err := callback(obj); err != nil {
 			return err
 		}
 

--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -93,7 +93,7 @@ func Assert{{classname}}Required(obj {{classname}}) error {
 		{{^items.isModel}}
 			{{#mostInnerItems.isModel}}
 				{{^mostInnerItems.isPrimitiveType}}
-{{#isNullable}}	{{/isNullable}}	if err := AssertRecurse{{mostInnerItems.dataType}}Required({{#isNullable}}*{{/isNullable}}obj.{{name}}); err != nil {
+{{#isNullable}}	{{/isNullable}}	if err := AssertRecurseInterfaceRequired({{#isNullable}}*{{/isNullable}}obj.{{name}}, Assert{{mostInnerItems.dataType}}Required); err != nil {
 {{#isNullable}}	{{/isNullable}}		return err
 {{#isNullable}}	{{/isNullable}}	}
 				{{/mostInnerItems.isPrimitiveType}}
@@ -119,16 +119,4 @@ func Assert{{classname}}Required(obj {{classname}}) error {
 	{{/isNullable}}
 {{/Vars}}
 	return nil
-}
-
-// AssertRecurse{{classname}}Required recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of {{classname}} (e.g. [][]{{classname}}), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurse{{classname}}Required(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		a{{classname}}, ok := obj.({{classname}})
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return Assert{{classname}}Required(a{{classname}})
-	})
 }{{/model}}{{/models}}

--- a/samples/server/petstore/go-api-server/go.mod
+++ b/samples/server/petstore/go-api-server/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.13
+go 1.18
 
-require github.com/gorilla/mux v1.7.3
+require github.com/gorilla/mux v1.8.0

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -38,17 +38,23 @@ func IsZeroValue(val interface{}) bool {
 
 // AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
-func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
+func AssertRecurseInterfaceRequired[T any](obj interface{}, callback func(T) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
 // AssertRecurseValueRequired checks each struct in the nested slice against the callback.
-// This method traverse nested slices in a preorder fashion.
-func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
+// This method traverse nested slices in a preorder fashion. ErrTypeAssertionError is thrown if
+// the underlying struct does not match type T.
+func AssertRecurseValueRequired[T any](value reflect.Value, callback func(T) error) error {
 	switch value.Kind() {
 	// If it is a struct we check using callback
 	case reflect.Struct:
-		if err := callback(value.Interface()); err != nil {
+		obj, ok := value.Interface().(T)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+
+		if err := callback(obj); err != nil {
 			return err
 		}
 

--- a/samples/server/petstore/go-api-server/go/model_api_response.go
+++ b/samples/server/petstore/go-api-server/go/model_api_response.go
@@ -23,15 +23,3 @@ type ApiResponse struct {
 func AssertApiResponseRequired(obj ApiResponse) error {
 	return nil
 }
-
-// AssertRecurseApiResponseRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of ApiResponse (e.g. [][]ApiResponse), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseApiResponseRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aApiResponse, ok := obj.(ApiResponse)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertApiResponseRequired(aApiResponse)
-	})
-}

--- a/samples/server/petstore/go-api-server/go/model_category.go
+++ b/samples/server/petstore/go-api-server/go/model_category.go
@@ -21,15 +21,3 @@ type Category struct {
 func AssertCategoryRequired(obj Category) error {
 	return nil
 }
-
-// AssertRecurseCategoryRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Category (e.g. [][]Category), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseCategoryRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aCategory, ok := obj.(Category)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertCategoryRequired(aCategory)
-	})
-}

--- a/samples/server/petstore/go-api-server/go/model_order.go
+++ b/samples/server/petstore/go-api-server/go/model_order.go
@@ -34,15 +34,3 @@ type Order struct {
 func AssertOrderRequired(obj Order) error {
 	return nil
 }
-
-// AssertRecurseOrderRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Order (e.g. [][]Order), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseOrderRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aOrder, ok := obj.(Order)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertOrderRequired(aOrder)
-	})
-}

--- a/samples/server/petstore/go-api-server/go/model_pet.go
+++ b/samples/server/petstore/go-api-server/go/model_pet.go
@@ -49,15 +49,3 @@ func AssertPetRequired(obj Pet) error {
 	}
 	return nil
 }
-
-// AssertRecursePetRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Pet (e.g. [][]Pet), otherwise ErrTypeAssertionError is thrown.
-func AssertRecursePetRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aPet, ok := obj.(Pet)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertPetRequired(aPet)
-	})
-}

--- a/samples/server/petstore/go-api-server/go/model_tag.go
+++ b/samples/server/petstore/go-api-server/go/model_tag.go
@@ -21,15 +21,3 @@ type Tag struct {
 func AssertTagRequired(obj Tag) error {
 	return nil
 }
-
-// AssertRecurseTagRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Tag (e.g. [][]Tag), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseTagRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aTag, ok := obj.(Tag)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertTagRequired(aTag)
-	})
-}

--- a/samples/server/petstore/go-api-server/go/model_user.go
+++ b/samples/server/petstore/go-api-server/go/model_user.go
@@ -34,15 +34,3 @@ type User struct {
 func AssertUserRequired(obj User) error {
 	return nil
 }
-
-// AssertRecurseUserRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of User (e.g. [][]User), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseUserRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aUser, ok := obj.(User)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertUserRequired(aUser)
-	})
-}

--- a/samples/server/petstore/go-chi-server/go.mod
+++ b/samples/server/petstore/go-chi-server/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.13
+go 1.18
 
-require github.com/go-chi/chi/v5 v5.0.3
+require github.com/go-chi/chi/v5 v5.0.8

--- a/samples/server/petstore/go-chi-server/go/helpers.go
+++ b/samples/server/petstore/go-chi-server/go/helpers.go
@@ -38,17 +38,23 @@ func IsZeroValue(val interface{}) bool {
 
 // AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
-func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
+func AssertRecurseInterfaceRequired[T any](obj interface{}, callback func(T) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
 // AssertRecurseValueRequired checks each struct in the nested slice against the callback.
-// This method traverse nested slices in a preorder fashion.
-func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
+// This method traverse nested slices in a preorder fashion. ErrTypeAssertionError is thrown if
+// the underlying struct does not match type T.
+func AssertRecurseValueRequired[T any](value reflect.Value, callback func(T) error) error {
 	switch value.Kind() {
 	// If it is a struct we check using callback
 	case reflect.Struct:
-		if err := callback(value.Interface()); err != nil {
+		obj, ok := value.Interface().(T)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+
+		if err := callback(obj); err != nil {
 			return err
 		}
 

--- a/samples/server/petstore/go-chi-server/go/model_api_response.go
+++ b/samples/server/petstore/go-chi-server/go/model_api_response.go
@@ -23,15 +23,3 @@ type ApiResponse struct {
 func AssertApiResponseRequired(obj ApiResponse) error {
 	return nil
 }
-
-// AssertRecurseApiResponseRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of ApiResponse (e.g. [][]ApiResponse), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseApiResponseRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aApiResponse, ok := obj.(ApiResponse)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertApiResponseRequired(aApiResponse)
-	})
-}

--- a/samples/server/petstore/go-chi-server/go/model_category.go
+++ b/samples/server/petstore/go-chi-server/go/model_category.go
@@ -21,15 +21,3 @@ type Category struct {
 func AssertCategoryRequired(obj Category) error {
 	return nil
 }
-
-// AssertRecurseCategoryRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Category (e.g. [][]Category), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseCategoryRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aCategory, ok := obj.(Category)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertCategoryRequired(aCategory)
-	})
-}

--- a/samples/server/petstore/go-chi-server/go/model_order.go
+++ b/samples/server/petstore/go-chi-server/go/model_order.go
@@ -34,15 +34,3 @@ type Order struct {
 func AssertOrderRequired(obj Order) error {
 	return nil
 }
-
-// AssertRecurseOrderRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Order (e.g. [][]Order), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseOrderRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aOrder, ok := obj.(Order)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertOrderRequired(aOrder)
-	})
-}

--- a/samples/server/petstore/go-chi-server/go/model_pet.go
+++ b/samples/server/petstore/go-chi-server/go/model_pet.go
@@ -49,15 +49,3 @@ func AssertPetRequired(obj Pet) error {
 	}
 	return nil
 }
-
-// AssertRecursePetRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Pet (e.g. [][]Pet), otherwise ErrTypeAssertionError is thrown.
-func AssertRecursePetRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aPet, ok := obj.(Pet)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertPetRequired(aPet)
-	})
-}

--- a/samples/server/petstore/go-chi-server/go/model_tag.go
+++ b/samples/server/petstore/go-chi-server/go/model_tag.go
@@ -21,15 +21,3 @@ type Tag struct {
 func AssertTagRequired(obj Tag) error {
 	return nil
 }
-
-// AssertRecurseTagRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Tag (e.g. [][]Tag), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseTagRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aTag, ok := obj.(Tag)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertTagRequired(aTag)
-	})
-}

--- a/samples/server/petstore/go-chi-server/go/model_user.go
+++ b/samples/server/petstore/go-chi-server/go/model_user.go
@@ -34,15 +34,3 @@ type User struct {
 func AssertUserRequired(obj User) error {
 	return nil
 }
-
-// AssertRecurseUserRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of User (e.g. [][]User), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseUserRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aUser, ok := obj.(User)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertUserRequired(aUser)
-	})
-}

--- a/samples/server/petstore/go-server-required/go.mod
+++ b/samples/server/petstore/go-server-required/go.mod
@@ -1,5 +1,5 @@
 module github.com/GIT_USER_ID/GIT_REPO_ID
 
-go 1.13
+go 1.18
 
-require github.com/go-chi/chi/v5 v5.0.3
+require github.com/go-chi/chi/v5 v5.0.8

--- a/samples/server/petstore/go-server-required/go/helpers.go
+++ b/samples/server/petstore/go-server-required/go/helpers.go
@@ -38,17 +38,23 @@ func IsZeroValue(val interface{}) bool {
 
 // AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
-func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
+func AssertRecurseInterfaceRequired[T any](obj interface{}, callback func(T) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
 // AssertRecurseValueRequired checks each struct in the nested slice against the callback.
-// This method traverse nested slices in a preorder fashion.
-func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
+// This method traverse nested slices in a preorder fashion. ErrTypeAssertionError is thrown if
+// the underlying struct does not match type T.
+func AssertRecurseValueRequired[T any](value reflect.Value, callback func(T) error) error {
 	switch value.Kind() {
 	// If it is a struct we check using callback
 	case reflect.Struct:
-		if err := callback(value.Interface()); err != nil {
+		obj, ok := value.Interface().(T)
+		if !ok {
+			return ErrTypeAssertionError
+		}
+
+		if err := callback(obj); err != nil {
 			return err
 		}
 

--- a/samples/server/petstore/go-server-required/go/model_an_object.go
+++ b/samples/server/petstore/go-server-required/go/model_an_object.go
@@ -30,15 +30,3 @@ func AssertAnObjectRequired(obj AnObject) error {
 	}
 	return nil
 }
-
-// AssertRecurseAnObjectRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of AnObject (e.g. [][]AnObject), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseAnObjectRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aAnObject, ok := obj.(AnObject)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertAnObjectRequired(aAnObject)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_api_response.go
+++ b/samples/server/petstore/go-server-required/go/model_api_response.go
@@ -23,15 +23,3 @@ type ApiResponse struct {
 func AssertApiResponseRequired(obj ApiResponse) error {
 	return nil
 }
-
-// AssertRecurseApiResponseRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of ApiResponse (e.g. [][]ApiResponse), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseApiResponseRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aApiResponse, ok := obj.(ApiResponse)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertApiResponseRequired(aApiResponse)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_category.go
+++ b/samples/server/petstore/go-server-required/go/model_category.go
@@ -21,15 +21,3 @@ type Category struct {
 func AssertCategoryRequired(obj Category) error {
 	return nil
 }
-
-// AssertRecurseCategoryRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Category (e.g. [][]Category), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseCategoryRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aCategory, ok := obj.(Category)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertCategoryRequired(aCategory)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_order.go
+++ b/samples/server/petstore/go-server-required/go/model_order.go
@@ -50,15 +50,3 @@ func AssertOrderRequired(obj Order) error {
 
 	return nil
 }
-
-// AssertRecurseOrderRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Order (e.g. [][]Order), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseOrderRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aOrder, ok := obj.(Order)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertOrderRequired(aOrder)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_order_info.go
+++ b/samples/server/petstore/go-server-required/go/model_order_info.go
@@ -27,15 +27,3 @@ type OrderInfo struct {
 func AssertOrderInfoRequired(obj OrderInfo) error {
 	return nil
 }
-
-// AssertRecurseOrderInfoRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of OrderInfo (e.g. [][]OrderInfo), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseOrderInfoRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aOrderInfo, ok := obj.(OrderInfo)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertOrderInfoRequired(aOrderInfo)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_pet.go
+++ b/samples/server/petstore/go-server-required/go/model_pet.go
@@ -52,15 +52,3 @@ func AssertPetRequired(obj Pet) error {
 	}
 	return nil
 }
-
-// AssertRecursePetRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Pet (e.g. [][]Pet), otherwise ErrTypeAssertionError is thrown.
-func AssertRecursePetRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aPet, ok := obj.(Pet)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertPetRequired(aPet)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_special_info.go
+++ b/samples/server/petstore/go-server-required/go/model_special_info.go
@@ -21,15 +21,3 @@ type SpecialInfo struct {
 func AssertSpecialInfoRequired(obj SpecialInfo) error {
 	return nil
 }
-
-// AssertRecurseSpecialInfoRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of SpecialInfo (e.g. [][]SpecialInfo), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseSpecialInfoRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aSpecialInfo, ok := obj.(SpecialInfo)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertSpecialInfoRequired(aSpecialInfo)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_tag.go
+++ b/samples/server/petstore/go-server-required/go/model_tag.go
@@ -21,15 +21,3 @@ type Tag struct {
 func AssertTagRequired(obj Tag) error {
 	return nil
 }
-
-// AssertRecurseTagRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of Tag (e.g. [][]Tag), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseTagRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aTag, ok := obj.(Tag)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertTagRequired(aTag)
-	})
-}

--- a/samples/server/petstore/go-server-required/go/model_user.go
+++ b/samples/server/petstore/go-server-required/go/model_user.go
@@ -48,24 +48,12 @@ func AssertUserRequired(obj User) error {
 	}
 
 	if obj.DeepSliceModel != nil {
-		if err := AssertRecurseTagRequired(*obj.DeepSliceModel); err != nil {
+		if err := AssertRecurseInterfaceRequired(*obj.DeepSliceModel, AssertTagRequired); err != nil {
 			return err
 		}
 	}
-	if err := AssertRecurseAnObjectRequired(obj.DeepSliceMap); err != nil {
+	if err := AssertRecurseInterfaceRequired(obj.DeepSliceMap, AssertAnObjectRequired); err != nil {
 		return err
 	}
 	return nil
-}
-
-// AssertRecurseUserRequired recursively checks if required fields are not zero-ed in a nested slice.
-// Accepts only nested slice of User (e.g. [][]User), otherwise ErrTypeAssertionError is thrown.
-func AssertRecurseUserRequired(objSlice interface{}) error {
-	return AssertRecurseInterfaceRequired(objSlice, func(obj interface{}) error {
-		aUser, ok := obj.(User)
-		if !ok {
-			return ErrTypeAssertionError
-		}
-		return AssertUserRequired(aUser)
-	})
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The required Go version in go.mod is 1.13. Since Chi requires 1.14, this is not suitable.
Since Go versions <1.18 has been long end-of-life, and >=1.18 is required for generics 1.18 is used.

Other updates include

- bump Chi and Mux dependencies
- Change recurse to use generics

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
