### PR TITLE
[php-nextgen] Exclude composer.lock from codebase

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/gitignore
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/gitignore
@@ -5,7 +5,8 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+# makes sense since it's a library(client SDK) and not a project
+composer.lock
 
 # php-cs-fixer cache
 .php_cs.cache

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/.gitignore
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/.gitignore
@@ -5,7 +5,8 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+# makes sense since it's a library(client SDK) and not a project
+composer.lock
 
 # php-cs-fixer cache
 .php_cs.cache


### PR DESCRIPTION
Since client generator is library and not a project it makes sense to exclude composer.lock from codebase by default.

Ref: http://getcomposer.org/doc/02-libraries.md#lock-file

cc @Articus @jebentier @dkarlovi @mandrean @jfastnacht @renepardon

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
