### PR TITLE
Respect api visibility for oneof enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelOneOf.mustache
@@ -1,4 +1,4 @@
-public enum {{classname}}: {{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable, JSONEncodable{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}}{{/useVapor}} {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{classname}}: {{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable, JSONEncodable{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}}{{/useVapor}} {
     {{#oneOf}}
     case type{{.}}({{.}})
     {{/oneOf}}


### PR DESCRIPTION
Swift5 generator does not take into account of the `--additional-properties=nonPublicApi=true` param when generating oneOf models (enums).  @4brunu @jaz-ah @Edubits

This PR adds the same check present in other templates to add `public` or `internal` keyword