### PR TITLE
[java][native] add @override to POJO

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -267,6 +267,23 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 
   {{/vars}}
 {{>libraries/native/additional_properties}}
+  {{#parent}}
+  {{#allVars}}
+  {{#isOverridden}}
+  @Override
+  public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{setter}}(JsonNullable.<{{{datatypeWithEnum}}}>of({{name}}));
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{setter}}({{name}});
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    return this;
+  }
+
+  {{/isOverridden}}
+  {{/allVars}}
+  {{/parent}}
   /**
    * Return true if this {{name}} object is equal to o.
    */

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1954,4 +1954,32 @@ public class JavaClientCodegenTest {
                 "  public Pet petType(String petType) {\n");
 
     }
+
+    @Test
+    public void testForJavaNativeClientOverrideSetter() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/allOf_composition_discriminator.yaml", null, new ParseOptions()).getOpenAPI();
+
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        codegen.setLibrary(JavaClientCodegen.NATIVE);
+
+        generator.opts(input).generate();
+
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"), "  @Override\n" +
+                "  public Cat petType(String petType) {");
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"), "  }\n" +
+                "\n" +
+                "  public Pet petType(String petType) {\n");
+
+    }
 }

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/model/DataQuery.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/model/DataQuery.java
@@ -129,6 +129,18 @@ public class DataQuery extends Query {
   }
 
 
+  @Override
+  public DataQuery id(Long id) {
+    this.setId(id);
+    return this;
+  }
+
+  @Override
+  public DataQuery outcomes(List<OutcomesEnum> outcomes) {
+    this.setOutcomes(outcomes);
+    return this;
+  }
+
   /**
    * Return true if this DataQuery object is equal to o.
    */

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Cat.java
@@ -78,6 +78,18 @@ public class Cat extends Animal {
   }
 
 
+  @Override
+  public Cat className(String className) {
+    this.setClassName(className);
+    return this;
+  }
+
+  @Override
+  public Cat color(String color) {
+    this.setColor(color);
+    return this;
+  }
+
   /**
    * Return true if this Cat object is equal to o.
    */

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Dog.java
@@ -78,6 +78,18 @@ public class Dog extends Animal {
   }
 
 
+  @Override
+  public Dog className(String className) {
+    this.setClassName(className);
+    return this;
+  }
+
+  @Override
+  public Dog color(String color) {
+    this.setColor(color);
+    return this;
+  }
+
   /**
    * Return true if this Dog object is equal to o.
    */

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -52,6 +52,12 @@ public class ParentPet extends GrandparentAnimal {
   public ParentPet() { 
   }
 
+  @Override
+  public ParentPet petType(String petType) {
+    this.setPetType(petType);
+    return this;
+  }
+
   /**
    * Return true if this ParentPet object is equal to o.
    */

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
@@ -78,6 +78,18 @@ public class Cat extends Animal {
   }
 
 
+  @Override
+  public Cat className(String className) {
+    this.setClassName(className);
+    return this;
+  }
+
+  @Override
+  public Cat color(String color) {
+    this.setColor(color);
+    return this;
+  }
+
   /**
    * Return true if this Cat object is equal to o.
    */

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
@@ -78,6 +78,18 @@ public class Dog extends Animal {
   }
 
 
+  @Override
+  public Dog className(String className) {
+    this.setClassName(className);
+    return this;
+  }
+
+  @Override
+  public Dog color(String color) {
+    this.setColor(color);
+    return this;
+  }
+
   /**
    * Return true if this Dog object is equal to o.
    */

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ParentPet.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ParentPet.java
@@ -52,6 +52,12 @@ public class ParentPet extends GrandparentAnimal {
   public ParentPet() { 
   }
 
+  @Override
+  public ParentPet petType(String petType) {
+    this.setPetType(petType);
+    return this;
+  }
+
   /**
    * Return true if this ParentPet object is equal to o.
    */


### PR DESCRIPTION
add @override to POJO

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

