### PR TITLE
[python-nextgen] Add bytearray, none_type as primitive type

### DIFF
--- a/docs/generators/python-nextgen.md
+++ b/docs/generators/python-nextgen.md
@@ -50,6 +50,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>Dict</li>
 <li>List</li>
 <li>bool</li>
+<li>bytearray</li>
 <li>bytes</li>
 <li>date</li>
 <li>datetime</li>
@@ -58,6 +59,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>float</li>
 <li>int</li>
 <li>list</li>
+<li>none_type</li>
 <li>object</li>
 <li>str</li>
 </ul>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -120,6 +120,8 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
 
         languageSpecificPrimitives.remove("file");
         languageSpecificPrimitives.add("decimal.Decimal");
+        languageSpecificPrimitives.add("bytearray");
+        languageSpecificPrimitives.add("none_type");
 
         supportsInheritance = true;
         modelPackage = "models";

--- a/samples/client/echo_api/python-nextgen/docs/BodyApi.md
+++ b/samples/client/echo_api/python-nextgen/docs/BodyApi.md
@@ -51,7 +51,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**bytearray**](bytearray.md)
+**bytearray**
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FakeApi.md
@@ -612,7 +612,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    body = petstore_api.bytearray() # bytearray | image to upload
+    body = None # bytearray | image to upload
 
     try:
         await api_instance.test_body_with_binary(body)
@@ -934,13 +934,13 @@ async with petstore_api.ApiClient(configuration) as api_client:
     number = 3.4 # float | None
     double = 3.4 # float | None
     pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-    byte = petstore_api.bytearray() # bytearray | None
+    byte = None # bytearray | None
     integer = 56 # int | None (optional)
     int32 = 56 # int | None (optional)
     int64 = 56 # int | None (optional)
     float = 3.4 # float | None (optional)
     string = 'string_example' # str | None (optional)
-    binary = petstore_api.bytearray() # bytearray | None (optional)
+    binary = None # bytearray | None (optional)
     var_date = '2013-10-20' # date | None (optional)
     date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
     password = 'password_example' # str | None (optional)

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/FormatTest.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **decimal** | **decimal.Decimal** |  | [optional] 
 **string** | **str** |  | [optional] 
 **string_with_double_quote_pattern** | **str** |  | [optional] 
-**byte** | [**bytearray**](bytearray.md) |  | [optional] 
-**binary** | [**bytearray**](bytearray.md) |  | [optional] 
+**byte** | **bytearray** |  | [optional] 
+**binary** | **bytearray** |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/docs/PetApi.md
@@ -1176,7 +1176,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
-    file = petstore_api.bytearray() # bytearray | file to upload (optional)
+    file = None # bytearray | file to upload (optional)
 
     try:
         # uploads an image
@@ -1250,7 +1250,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
-    required_file = petstore_api.bytearray() # bytearray | file to upload
+    required_file = None # bytearray | file to upload
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
     try:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
@@ -92,12 +92,6 @@ class FormatTest(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of byte
-        if self.byte:
-            _dict['byte'] = self.byte.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of binary
-        if self.binary:
-            _dict['binary'] = self.binary.to_dict()
         return _dict
 
     @classmethod
@@ -119,8 +113,8 @@ class FormatTest(BaseModel):
             "decimal": obj.get("decimal"),
             "string": obj.get("string"),
             "string_with_double_quote_pattern": obj.get("string_with_double_quote_pattern"),
-            "byte": bytearray.from_dict(obj.get("byte")) if obj.get("byte") is not None else None,
-            "binary": bytearray.from_dict(obj.get("binary")) if obj.get("binary") is not None else None,
+            "byte": obj.get("byte"),
+            "binary": obj.get("binary"),
             "var_date": obj.get("date"),
             "date_time": obj.get("dateTime"),
             "uuid": obj.get("uuid"),

--- a/samples/openapi3/client/petstore/python-nextgen/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/FakeApi.md
@@ -612,7 +612,7 @@ configuration = petstore_api.Configuration(
 with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    body = petstore_api.bytearray() # bytearray | image to upload
+    body = None # bytearray | image to upload
 
     try:
         api_instance.test_body_with_binary(body)
@@ -934,13 +934,13 @@ with petstore_api.ApiClient(configuration) as api_client:
     number = 3.4 # float | None
     double = 3.4 # float | None
     pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-    byte = petstore_api.bytearray() # bytearray | None
+    byte = None # bytearray | None
     integer = 56 # int | None (optional)
     int32 = 56 # int | None (optional)
     int64 = 56 # int | None (optional)
     float = 3.4 # float | None (optional)
     string = 'string_example' # str | None (optional)
-    binary = petstore_api.bytearray() # bytearray | None (optional)
+    binary = None # bytearray | None (optional)
     var_date = '2013-10-20' # date | None (optional)
     date_time = '2013-10-20T19:20:30+01:00' # datetime | None (optional)
     password = 'password_example' # str | None (optional)

--- a/samples/openapi3/client/petstore/python-nextgen/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/FormatTest.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **decimal** | **decimal.Decimal** |  | [optional] 
 **string** | **str** |  | [optional] 
 **string_with_double_quote_pattern** | **str** |  | [optional] 
-**byte** | [**bytearray**](bytearray.md) |  | [optional] 
-**binary** | [**bytearray**](bytearray.md) |  | [optional] 
+**byte** | **bytearray** |  | [optional] 
+**binary** | **bytearray** |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 

--- a/samples/openapi3/client/petstore/python-nextgen/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python-nextgen/docs/PetApi.md
@@ -1176,7 +1176,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
-    file = petstore_api.bytearray() # bytearray | file to upload (optional)
+    file = None # bytearray | file to upload (optional)
 
     try:
         # uploads an image
@@ -1250,7 +1250,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.PetApi(api_client)
     pet_id = 56 # int | ID of pet to update
-    required_file = petstore_api.bytearray() # bytearray | file to upload
+    required_file = None # bytearray | file to upload
     additional_metadata = 'additional_metadata_example' # str | Additional data to pass to server (optional)
 
     try:

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
@@ -94,12 +94,6 @@ class FormatTest(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of byte
-        if self.byte:
-            _dict['byte'] = self.byte.to_dict()
-        # override the default output from pydantic by calling `to_dict()` of binary
-        if self.binary:
-            _dict['binary'] = self.binary.to_dict()
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():
@@ -126,8 +120,8 @@ class FormatTest(BaseModel):
             "decimal": obj.get("decimal"),
             "string": obj.get("string"),
             "string_with_double_quote_pattern": obj.get("string_with_double_quote_pattern"),
-            "byte": bytearray.from_dict(obj.get("byte")) if obj.get("byte") is not None else None,
-            "binary": bytearray.from_dict(obj.get("binary")) if obj.get("binary") is not None else None,
+            "byte": obj.get("byte"),
+            "binary": obj.get("binary"),
             "var_date": obj.get("date"),
             "date_time": obj.get("dateTime"),
             "uuid": obj.get("uuid"),


### PR DESCRIPTION
Add bytearray, none_type as primitive type. Otherwise, bytearray, none_type will be treated as model.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)
