### PR TITLE
[openapi-normalizer] Fix NPE in simplifyOneOfAnyOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -728,7 +728,7 @@ public class OpenAPINormalizer {
 
             // if only one element left, simplify to just the element (schema)
             if (schema.getAnyOf().size() == 1) {
-                if (schema.getNullable()) { // retain nullable setting
+                if (Boolean.TRUE.equals(schema.getNullable())) { // retain nullable setting
                     ((Schema) schema.getAnyOf().get(0)).setNullable(true);
                 }
                 return (Schema) schema.getAnyOf().get(0);

--- a/modules/openapi-generator/src/test/resources/3_0/simplifyAnyOfStringAndEnumString_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/simplifyAnyOfStringAndEnumString_test.yaml
@@ -36,4 +36,11 @@ components:
       enum:
         - A
         - B
+    SingleAnyOfTest:
+      description: to test anyOf (enum string only)
+      anyOf:
+        - type: string
+          enum:
+            - A
+            - B
 

--- a/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
@@ -42,4 +42,10 @@ components:
         - type: integer
         - type: string
         - $ref: null
-
+    SingleAnyOfTest:
+      description: to test anyOf (enum string only)
+      anyOf:
+        - type: string
+          enum:
+            - A
+            - B


### PR DESCRIPTION
Fix NPE in simplifyOneOfAnyOf as getNullable can return null instead of true/false

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
