### PR TITLE
fix Jsonb issue for Helidon SE Client generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/ApiClient.mustache
@@ -256,7 +256,7 @@ public class ApiClient {
       {{#jsonb}}
       defaultWebClientBuilder.addMediaSupport(jsonbConfig == null
                 ? JsonbSupport.create()
-                : JsonbSupport.create(jsonbConfig));
+                : JsonbSupport.create(JsonbBuilder.create(jsonbConfig)));
       {{/jsonb}}
       {{#jackson}}
       defaultWebClientBuilder.addMediaSupport(objectMapper == null

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
@@ -54,6 +54,10 @@
             <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind</groupId>
             <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.media</groupId>
+            <artifactId>helidon-media-jsonb</artifactId>
+        </dependency>
 {{/jsonb}}
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalHelidonSEClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalHelidonSEClientTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2022 OpenAPI-Generator Contributors (https://openapi-generator.tech)
- * Copyright (c) 2022 Oracle and/or its affiliates
+ * Copyright 2022, 2023 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ package org.openapitools.codegen.java.helidon.functional;
 
 
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.openapitools.codegen.CodegenConstants.SERIALIZATION_LIBRARY;
 
 public class FunctionalHelidonSEClientTest extends FunctionalHelidonClientBase {
 
@@ -26,5 +29,12 @@ public class FunctionalHelidonSEClientTest extends FunctionalHelidonClientBase {
     public void setup() {
         library("se");
         generatorName("java-helidon-client");
+    }
+
+    @Test
+    void buildJsonbProject() {
+        inputSpec("src/test/resources/3_0/petstore.yaml");
+        generate(createConfigurator().addAdditionalProperty(SERIALIZATION_LIBRARY, "jsonb"));
+        buildAndVerify("target/openapi-java-client.jar");
     }
 }


### PR DESCRIPTION
Changed `ApiCleint.java` and `pom.xml` templates for `java-helidon-client` generator and `se` library.
Added additional tests to check that issue was fixed.

Fixes #15145 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
