### PR TITLE
[Elm] Fix List of type is missing required import(s)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -375,16 +375,24 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
             });
         });
 
-        final boolean includeTime =
-            anyOperationResponse(ops, response -> response.isDate || response.isDateTime) ||
-            anyOperationParam(ops, param -> param.isDate || param.isDateTime);
-        final boolean includeUuid =
-            anyOperationResponse(ops, response -> response.isUuid) ||
-            anyOperationParam(ops, param -> param.isUuid);
+        final boolean includeTime = anyOperationResponse(ops, response -> response.isDate || response.isDateTime) ||
+                anyOperationParam(ops, param -> (param.isDate || param.isDateTime) || itemsIncludesType(param.items, p -> p.isDate || p.isDateTime));
+        final boolean includeUuid = anyOperationResponse(ops, response -> response.isUuid) ||
+                anyOperationParam(ops, param -> param.isUuid || itemsIncludesType(param.items, p -> p.isUuid));
         operations.put("includeTime", includeTime);
         operations.put("includeUuid", includeUuid);
 
         return operations;
+    }
+
+    private static boolean itemsIncludesType(CodegenProperty p, Predicate<CodegenProperty> condition) {
+        if (p == null)
+            return false;
+
+        if (p.items != null)
+            return itemsIncludesType(p.items, condition);
+
+        return condition.test(p);
     }
 
     static class ParameterSorter implements Comparator<CodegenParameter> {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/elm/ElmClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/elm/ElmClientCodegenTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.elm;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.UUIDSchema;
+import io.swagger.v3.oas.models.parameters.QueryParameter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.languages.ElmClientCodegen;
+import org.openapitools.codegen.model.OperationMap;
+import org.openapitools.codegen.model.OperationsMap;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@SuppressWarnings("static-method")
+public class ElmClientCodegenTest {
+    @DataProvider(name = "recursive-lists-of-uuid")
+    private static Schema[] recursiveListOfUuids() {
+        return recursiveListOfType(new UUIDSchema(), 6);
+    }
+
+    @Test(description = "Operation that takes list of UUID (and recursive lists of UUID) includes import from UUID", dataProvider = "recursive-lists-of-uuid")
+    public void operationThatTakesListOfListOfUuidImportsUuid(Schema p) throws Exception {
+        final ElmClientCodegen codegen = new ElmClientCodegen();
+
+        Operation operation = new Operation()
+                .operationId("opId")
+                .addParametersItem(new QueryParameter().name("listOfUuid").schema(p));
+
+        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
+
+        OperationMap operationMap = new OperationMap();
+        operationMap.setOperation(co);
+
+        OperationsMap operationsMap = new OperationsMap();
+        operationsMap.setOperation(operationMap);
+
+        OperationsMap postProcessed = codegen.postProcessOperationsWithModels(operationsMap, Collections.emptyList());
+
+        Assert.assertEquals(postProcessed.get("includeUuid"), true);
+    }
+
+    @DataProvider(name = "recursive-lists-of-datetime")
+    private static Schema[] recursiveListOfDateTime() {
+        return recursiveListOfType(new DateTimeSchema(), 6);
+    }
+
+    @Test(description = "Operation that takes list of DateTime (and recursive lists of DateTime) includes import from Api.Time", dataProvider = "recursive-lists-of-datetime")
+    public void operationThatTakesListOfListOfDateTimeImportsApiTime(Schema p) throws Exception {
+        final ElmClientCodegen codegen = new ElmClientCodegen();
+
+        Operation operation = new Operation()
+                .operationId("opId")
+                .addParametersItem(new QueryParameter().name("listOfDateTime").schema(p));
+
+        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
+
+        OperationMap operationMap = new OperationMap();
+        operationMap.setOperation(co);
+
+        OperationsMap operationsMap = new OperationsMap();
+        operationsMap.setOperation(operationMap);
+
+        OperationsMap postProcessed = codegen.postProcessOperationsWithModels(operationsMap, Collections.emptyList());
+
+        Assert.assertEquals(postProcessed.get("includeTime"), true);
+    }
+
+    // HELPERS
+    private static <TSchema extends Schema> Schema[] recursiveListOfType(TSchema type, int levelsOfRecursion) {
+        final List<Schema> output = new ArrayList<Schema>();
+
+        for (int levels = 0; levels < levelsOfRecursion; ++levels) {
+            ArraySchema baseSchema = new ArraySchema();
+            ArraySchema current = baseSchema;
+            for (int level = 0; level < levels; ++level) {
+                ArraySchema child = new ArraySchema();
+
+                current.items(child);
+                current = child;
+            }
+            current.items(type);
+            output.add(baseSchema);
+        }
+
+        return output.toArray(new Schema[0]);
+    }
+}


### PR DESCRIPTION
Currently, if you have the type `List Uuid`, the needed import from Uuid won't be included. This is the same for `List Posix` which doesn't include the needed import from Api.Time.

Fixed so function recursively checks if the list's item type is UUID or Posix, and then sets flags (includeUuid/includeTime) accordingly.

Added test cases to validate changes.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@eriktim 
