### PR TITLE
[java] For microprofile generator use rootJavaEEPackage instead of javaxPackage for specifiying JavaEE Base package

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -20,8 +20,8 @@ import io.smallrye.mutiny.Uni;
 {{/microprofileMutiny}}
 
 {{#useBeanValidation}}
-import {{javaxPackage}}.validation.constraints.*;
-import {{javaxPackage}}.validation.Valid;
+import {{rootJavaEEPackage}}.validation.constraints.*;
+import {{rootJavaEEPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;


### PR DESCRIPTION
In order to properly use jakarta packages instead of javax packages when beanValidation is turned on in addition to useJakartaEE being set to true. 

Settings from the configOptions. 
useBeanValidation: "true",
microprofileRestClientVersion: "3.0",
useJakartaEE: "true",

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 

  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
FYI @bbdouglas @sreeshas @jfiala  @lukoyanov  @cbornet  @jeff9finger  @karismann  @Zomzog @lwlee2608 