### PR TITLE
[JAVA][spring] #15186 Fix BeanValidation annotations on qualified types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -1302,7 +1302,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         if (StringUtils.isEmpty( dataType ) || dataType.contains( "@Valid" )) {
             return dataType;
         }
-        return dataType.replace( "<", "<@Valid " );
+        return dataType.replaceFirst("< *(.*\\.)?", "<$1@Valid ");
     }
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -651,6 +651,9 @@ public class SpringCodegenTest {
         SpringCodegen codegen = new SpringCodegen();
         codegen.setLibrary(SPRING_CLOUD_LIBRARY);
         codegen.setOutputDir(output.getAbsolutePath());
+        Map<String, String> schemaMapping = codegen.schemaMapping();
+        schemaMapping.put("ResponseTest3", "example.ResponseTest3DTO");
+        schemaMapping.put("ResponseTest4", "org.example.ResponseTest4DTO");
         codegen.additionalProperties().put(SpringCodegen.USE_BEANVALIDATION, "true");
         codegen.additionalProperties().put(SpringCodegen.PERFORM_BEANVALIDATION, "true");
         codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.model");
@@ -684,6 +687,12 @@ public class SpringCodegenTest {
               .toType()
               .hasProperty("listDtos")
               .withType( "List<@Valid ResponseTest2>" )
+              .toType()
+              .hasProperty("listQualifiedDtos")
+              .withType("List<example.@Valid ResponseTest3DTO>")
+              .toType()
+              .hasProperty("listMultilevelQualifiedDtos")
+              .withType("List<org.example.@Valid ResponseTest4DTO>")
               .toType()
               .hasProperty("nullableStrings")
               .withType( "JsonNullable<Set<String>>" )

--- a/modules/openapi-generator/src/test/resources/bugs/issue_14723.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_14723.yaml
@@ -63,6 +63,16 @@ components:
           items:
             $ref: '#/components/schemas/ResponseTest2'
           maxItems: 10
+        listQualifiedDtos:
+          type: array
+          description: DTOs with a qualified type (schema mapping)
+          items:
+            $ref: '#/components/schemas/ResponseTest3'
+        listMultilevelQualifiedDtos:
+          type: array
+          description: DTOs with a qualified type having more than one level
+          items:
+            $ref: '#/components/schemas/ResponseTest4'
         nullableStrings:
           type: array
           description: dtos
@@ -97,5 +107,17 @@ components:
       type: object
       properties:
         label:
+          type: string
+          nullable: false
+    ResponseTest3:
+      type: object
+      properties:
+        note:
+          type: string
+          nullable: false
+    ResponseTest4:
+      type: object
+      properties:
+        tag:
           type: string
           nullable: false


### PR DESCRIPTION
Fix #15186

Use a regular expression over a simple text replacement to account for the case where a qualified type is present when adding annotations to the type parameter of a collection. The test case is amended to include fields where this situation is present and for which incorrect results are produced on the current master.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
- [ ] In case you are adding a new generator, run the following additional script : 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber @welshm @MelleD @borsch @Zomzog