### PR TITLE
Issue 13175 - using @objcMembers to expose all props and funcs to ObjC

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -21,7 +21,7 @@ extension {{projectName}}API {
 
 {{#description}}
 /** {{{.}}} */{{/description}}
-{{#objcCompatible}}@objc {{/objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{classname}}{{#objcCompatible}} : NSObject{{/objcCompatible}} {
+{{#objcCompatible}}@objcMembers {{/objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{classname}}{{#objcCompatible}} : NSObject{{/objcCompatible}} {
 {{#operation}}
     {{#allParams}}
     {{#isEnum}}

--- a/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
@@ -1,5 +1,5 @@
 {{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}} {{{classname}}}: {{#useVapor}}Content{{/useVapor}}{{^useVapor}}Codable{{#useJsonEncodable}}, JSONEncodable{{/useJsonEncodable}}{{/useVapor}}{{#vendorExtensions.x-swift-hashable}}, Hashable{{/vendorExtensions.x-swift-hashable}} {
-{{/objcCompatible}}{{#objcCompatible}}@objc {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} class {{classname}}: NSObject, Codable{{#useJsonEncodable}}, JSONEncodable{{/useJsonEncodable}} {
+{{/objcCompatible}}{{#objcCompatible}}@objcMembers {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} class {{classname}}: NSObject, Codable{{#useJsonEncodable}}, JSONEncodable{{/useJsonEncodable}} {
 {{/objcCompatible}}
 
 {{#allVars}}

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc open class AnotherFakeAPI : NSObject {
+@objcMembers open class AnotherFakeAPI : NSObject {
 
     /**
      To test special tags

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc open class FakeAPI : NSObject {
+@objcMembers open class FakeAPI : NSObject {
 
     /**
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc open class FakeClassnameTags123API : NSObject {
+@objcMembers open class FakeClassnameTags123API : NSObject {
 
     /**
      To test class name in snake case

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc open class PetAPI : NSObject {
+@objcMembers open class PetAPI : NSObject {
 
     /**
      Add a new pet to the store

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc open class StoreAPI : NSObject {
+@objcMembers open class StoreAPI : NSObject {
 
     /**
      Delete purchase order by ID

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc open class UserAPI : NSObject {
+@objcMembers open class UserAPI : NSObject {
 
     /**
      Create user

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class AdditionalPropertiesClass: NSObject, Codable, JSONEncodable {
+@objcMembers public class AdditionalPropertiesClass: NSObject, Codable, JSONEncodable {
 
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Animal: NSObject, Codable, JSONEncodable {
+@objcMembers public class Animal: NSObject, Codable, JSONEncodable {
 
     public var _className: String
     public var color: String? = "red"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class ApiResponse: NSObject, Codable, JSONEncodable {
+@objcMembers public class ApiResponse: NSObject, Codable, JSONEncodable {
 
     public var code: Int?
     public var codeNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class ArrayOfArrayOfNumberOnly: NSObject, Codable, JSONEncodable {
+@objcMembers public class ArrayOfArrayOfNumberOnly: NSObject, Codable, JSONEncodable {
 
     public var arrayArrayNumber: [[Double]]?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class ArrayOfNumberOnly: NSObject, Codable, JSONEncodable {
+@objcMembers public class ArrayOfNumberOnly: NSObject, Codable, JSONEncodable {
 
     public var arrayNumber: [Double]?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class ArrayTest: NSObject, Codable, JSONEncodable {
+@objcMembers public class ArrayTest: NSObject, Codable, JSONEncodable {
 
     public var arrayOfString: [String]?
     public var arrayArrayOfInteger: [[Int64]]?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Capitalization: NSObject, Codable, JSONEncodable {
+@objcMembers public class Capitalization: NSObject, Codable, JSONEncodable {
 
     public var smallCamel: String?
     public var capitalCamel: String?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Cat: NSObject, Codable, JSONEncodable {
+@objcMembers public class Cat: NSObject, Codable, JSONEncodable {
 
     public var _className: String
     public var color: String? = "red"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class CatAllOf: NSObject, Codable, JSONEncodable {
+@objcMembers public class CatAllOf: NSObject, Codable, JSONEncodable {
 
     public var declawed: Bool?
     public var declawedNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Category: NSObject, Codable, JSONEncodable {
+@objcMembers public class Category: NSObject, Codable, JSONEncodable {
 
     public var _id: Int64?
     public var _idNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -11,7 +11,7 @@ import AnyCodable
 #endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
-@objc public class ClassModel: NSObject, Codable, JSONEncodable {
+@objcMembers public class ClassModel: NSObject, Codable, JSONEncodable {
 
     public var _class: String?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Client: NSObject, Codable, JSONEncodable {
+@objcMembers public class Client: NSObject, Codable, JSONEncodable {
 
     public var client: String?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Dog: NSObject, Codable, JSONEncodable {
+@objcMembers public class Dog: NSObject, Codable, JSONEncodable {
 
     public var _className: String
     public var color: String? = "red"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class DogAllOf: NSObject, Codable, JSONEncodable {
+@objcMembers public class DogAllOf: NSObject, Codable, JSONEncodable {
 
     public var breed: String?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class EnumArrays: NSObject, Codable, JSONEncodable {
+@objcMembers public class EnumArrays: NSObject, Codable, JSONEncodable {
 
     public enum JustSymbol: String, Codable, CaseIterable {
         case greaterThanOrEqualTo = ">="

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class EnumTest: NSObject, Codable, JSONEncodable {
+@objcMembers public class EnumTest: NSObject, Codable, JSONEncodable {
 
     public enum EnumString: String, Codable, CaseIterable {
         case upper = "UPPER"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -11,7 +11,7 @@ import AnyCodable
 #endif
 
 /** Must be named &#x60;File&#x60; for test. */
-@objc public class File: NSObject, Codable, JSONEncodable {
+@objcMembers public class File: NSObject, Codable, JSONEncodable {
 
     /** Test capitalization */
     public var sourceURI: String?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class FileSchemaTestClass: NSObject, Codable, JSONEncodable {
+@objcMembers public class FileSchemaTestClass: NSObject, Codable, JSONEncodable {
 
     public var file: File?
     public var files: [File]?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class FormatTest: NSObject, Codable, JSONEncodable {
+@objcMembers public class FormatTest: NSObject, Codable, JSONEncodable {
 
     static let integerRule = NumericRule<Int>(minimum: 10, exclusiveMinimum: false, maximum: 100, exclusiveMaximum: false, multipleOf: nil)
     static let int32Rule = NumericRule<Int>(minimum: 20, exclusiveMinimum: false, maximum: 200, exclusiveMaximum: false, multipleOf: nil)

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class HasOnlyReadOnly: NSObject, Codable, JSONEncodable {
+@objcMembers public class HasOnlyReadOnly: NSObject, Codable, JSONEncodable {
 
     public var bar: String?
     public var foo: String?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class List: NSObject, Codable, JSONEncodable {
+@objcMembers public class List: NSObject, Codable, JSONEncodable {
 
     public var _123list: String?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class MapTest: NSObject, Codable, JSONEncodable {
+@objcMembers public class MapTest: NSObject, Codable, JSONEncodable {
 
     public enum MapOfEnumString: String, Codable, CaseIterable {
         case upper = "UPPER"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class MixedPropertiesAndAdditionalPropertiesClass: NSObject, Codable, JSONEncodable {
+@objcMembers public class MixedPropertiesAndAdditionalPropertiesClass: NSObject, Codable, JSONEncodable {
 
     public var uuid: UUID?
     public var dateTime: Date?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -11,7 +11,7 @@ import AnyCodable
 #endif
 
 /** Model for testing model name starting with number */
-@objc public class Model200Response: NSObject, Codable, JSONEncodable {
+@objcMembers public class Model200Response: NSObject, Codable, JSONEncodable {
 
     public var name: Int?
     public var nameNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -11,7 +11,7 @@ import AnyCodable
 #endif
 
 /** Model for testing model name same as property name */
-@objc public class Name: NSObject, Codable, JSONEncodable {
+@objcMembers public class Name: NSObject, Codable, JSONEncodable {
 
     public var name: Int
     public var snakeCase: NullEncodable<Int> = .encodeValue(11033)

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class NumberOnly: NSObject, Codable, JSONEncodable {
+@objcMembers public class NumberOnly: NSObject, Codable, JSONEncodable {
 
     public var justNumber: Double?
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Order: NSObject, Codable, JSONEncodable {
+@objcMembers public class Order: NSObject, Codable, JSONEncodable {
 
     public enum Status: String, Codable, CaseIterable {
         case placed = "placed"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class OuterComposite: NSObject, Codable, JSONEncodable {
+@objcMembers public class OuterComposite: NSObject, Codable, JSONEncodable {
 
     public var myNumber: Double?
     public var myString: String?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Pet: NSObject, Codable, JSONEncodable {
+@objcMembers public class Pet: NSObject, Codable, JSONEncodable {
 
     public enum Status: String, Codable, CaseIterable {
         case available = "available"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class ReadOnlyFirst: NSObject, Codable, JSONEncodable {
+@objcMembers public class ReadOnlyFirst: NSObject, Codable, JSONEncodable {
 
     public var bar: String?
     public var baz: String?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -11,7 +11,7 @@ import AnyCodable
 #endif
 
 /** Model for testing reserved words */
-@objc public class Return: NSObject, Codable, JSONEncodable {
+@objcMembers public class Return: NSObject, Codable, JSONEncodable {
 
     public var _return: Int?
     public var _returnNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class SpecialModelName: NSObject, Codable, JSONEncodable {
+@objcMembers public class SpecialModelName: NSObject, Codable, JSONEncodable {
 
     public var specialPropertyName: Int64?
     public var specialPropertyNameNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class StringBooleanMap: NSObject, Codable, JSONEncodable {
+@objcMembers public class StringBooleanMap: NSObject, Codable, JSONEncodable {
 
 
     public enum CodingKeys: CodingKey, CaseIterable {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class Tag: NSObject, Codable, JSONEncodable {
+@objcMembers public class Tag: NSObject, Codable, JSONEncodable {
 
     public var _id: Int64?
     public var _idNum: NSNumber? {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class TypeHolderDefault: NSObject, Codable, JSONEncodable {
+@objcMembers public class TypeHolderDefault: NSObject, Codable, JSONEncodable {
 
     public var stringItem: String = "what"
     public var numberItem: Double

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class TypeHolderExample: NSObject, Codable, JSONEncodable {
+@objcMembers public class TypeHolderExample: NSObject, Codable, JSONEncodable {
 
     public var stringItem: String
     public var numberItem: Double

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -10,7 +10,7 @@ import Foundation
 import AnyCodable
 #endif
 
-@objc public class User: NSObject, Codable, JSONEncodable {
+@objcMembers public class User: NSObject, Codable, JSONEncodable {
 
     public var _id: Int64?
     public var _idNum: NSNumber? {


### PR DESCRIPTION
When using the `objcCompatible` option for swift5, this will add `@objcMembers` instead of `@objc` at the generated class level for Models and APIs so that all properties and functions will be visible by Objective-C.  I had suggested this in issue 13175 as an enhancement.
I've re-generated the samples, which now reflect this change, and there are no changes to docs.

Attn: @jgavris @ehyche @Edubits @jaz-ah @4brunu 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
