### PR TITLE
fix: issue 14770: add option to exclude fluent setters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -137,6 +137,7 @@ public class CodegenConstants {
 
     public static final String SERIALIZE_BIG_DECIMAL_AS_STRING = "bigDecimalAsString";
     public static final String SERIALIZE_BIG_DECIMAL_AS_STRING_DESC = "Treat BigDecimal values as Strings to avoid precision loss.";
+    public static final String SKIP_FLUENT_SETTERS = "skipFluentSetters";
 
     public static final String LIBRARY = "library";
     public static final String LIBRARY_DESC = "library template (sub-template)";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -137,7 +137,6 @@ public class CodegenConstants {
 
     public static final String SERIALIZE_BIG_DECIMAL_AS_STRING = "bigDecimalAsString";
     public static final String SERIALIZE_BIG_DECIMAL_AS_STRING_DESC = "Treat BigDecimal values as Strings to avoid precision loss.";
-    public static final String SKIP_FLUENT_SETTERS = "skipFluentSetters";
 
     public static final String LIBRARY = "library";
     public static final String LIBRARY_DESC = "library template (sub-template)";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -63,6 +62,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     public static final String ASYNC_NATIVE = "asyncNative";
     public static final String CONFIG_KEY = "configKey";
     public static final String PARCELABLE_MODEL = "parcelableModel";
+    public static final String SKIP_FLUENT_SETTERS = "skipFluentSetters";
     public static final String USE_RUNTIME_EXCEPTION = "useRuntimeException";
     public static final String USE_REFLECTION_EQUALS_HASHCODE = "useReflectionEqualsHashCode";
     public static final String CASE_INSENSITIVE_RESPONSE_HEADERS = "caseInsensitiveResponseHeaders";

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -116,6 +116,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   ));
 
   {{/vendorExtensions.x-enum-as-string}}
+  {{^skipFluentSetters}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
@@ -131,6 +132,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/vendorExtensions.x-is-jackson-optional-nullable}}
     return this;
   }
+  {{/skipFluentSetters}}
   {{#isArray}}
 
   public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
@@ -153,11 +153,13 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{#deprecated}}
   @Deprecated
   {{/deprecated}}
+  {{^skipFluentSetters}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.x-is-jackson-optional-nullable}}
     {{^vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = {{name}};{{/vendorExtensions.x-is-jackson-optional-nullable}}
     return this;
   }
+  {{/skipFluentSetters}}
   {{#isArray}}
 
   public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -131,11 +131,13 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{#vars}}
 
   {{^isReadOnly}}
+  {{^skipFluentSetters}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.x-is-jackson-optional-nullable}}
     {{^vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = {{name}};{{/vendorExtensions.x-is-jackson-optional-nullable}}
     return this;
   }
+  {{/skipFluentSetters}}
   {{#isArray}}
 
   public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {

--- a/modules/openapi-generator/src/main/resources/JavaInflector/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/pojo.mustache
@@ -27,6 +27,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
 
   {{/vars}}
   {{#vars}}
+  {{^skipFluentSetters}}
   /**{{#description}}
    * {{{.}}}{{/description}}{{#minimum}}
    * minimum: {{.}}{{/minimum}}{{#maximum}}
@@ -36,6 +37,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
     this.{{name}} = {{name}};
     return this;
   }
+  {{/skipFluentSetters}}
 
   {{#vendorExtensions.x-extra-annotation}}{{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}
   @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -40,10 +40,12 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
 
   {{/vars}}
   {{#vars}}
+  {{^skipFluentSetters}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;
   }
+  {{/skipFluentSetters}}
   {{#isArray}}
 
   public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
@@ -46,10 +46,12 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
 
   {{/vars}}
   {{#vars}}
+  {{^skipFluentSetters}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;
   }
+  {{/skipFluentSetters}}
   {{#isArray}}
 
   public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -1381,7 +1381,7 @@ public class JavaModelTest {
                 .setGeneratorName("java")
                 .setLibrary("rest-assured")
                 .addAdditionalProperty("java8", "true")
-                .addAdditionalProperty(CodegenConstants.SKIP_FLUENT_SETTERS, "Type")
+                .addAdditionalProperty(JavaClientCodegen.SKIP_FLUENT_SETTERS, "Type")
                 .addAdditionalProperty(CodegenConstants.SERIALIZABLE_MODEL, true)
                 .setInputSpec(inputSpec)
                 .setOutputDir(output.getAbsolutePath());
@@ -1416,7 +1416,7 @@ public class JavaModelTest {
                 .setGeneratorName("java")
                 .setLibrary("rest-assured")
                 .addAdditionalProperty("java8", "true")
-                .addAdditionalProperty(CodegenConstants.SKIP_FLUENT_SETTERS, "true")
+                .addAdditionalProperty(JavaClientCodegen.SKIP_FLUENT_SETTERS, "true")
                 .addAdditionalProperty(CodegenConstants.SERIALIZABLE_MODEL, true)
                 .setInputSpec(inputSpec)
                 .setOutputDir(output.getAbsolutePath());
@@ -1483,7 +1483,7 @@ public class JavaModelTest {
                 .setGeneratorName("java")
                 .setLibrary("rest-assured")
                 .addAdditionalProperty("java8", "true")
-                .addAdditionalProperty(CodegenConstants.SKIP_FLUENT_SETTERS, "Type,Type1")
+                .addAdditionalProperty(JavaClientCodegen.SKIP_FLUENT_SETTERS, "Type,Type1")
                 .addAdditionalProperty(CodegenConstants.SERIALIZABLE_MODEL, true)
                 .setInputSpec(inputSpec)
                 .setOutputDir(output.getAbsolutePath());

--- a/modules/openapi-generator/src/test/resources/3_0/conflictingFluentSetter.json
+++ b/modules/openapi-generator/src/test/resources/3_0/conflictingFluentSetter.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Api",
+    "description": "Issue 14770. An api with 2 models with conflicting setters and fluent setters.",
+    "version": "1"
+  },
+  "paths": {
+  },
+  "components": {
+    "schemas": {
+      "Type": {
+        "type": "object",
+        "properties": {
+          "constraints": {
+            "type": "string"
+          },
+          "setConstraints": {
+            "type": "string"
+          }
+        }
+      },
+      "Type1": {
+        "type": "object",
+        "properties": {
+          "constraints": {
+            "type": "string"
+          },
+          "setConstraints": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fluent setters may conflict with ordinary setter, if model has 2 properties name '${X}' and 'set${X}'.
Add skipFluentSetters additional property used to skip fluent setters. Set it to "true" to skip fluent setters in all models, or provide a comma separated list of models to exclude fluent setters.

Add tests for new option.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
