### PR TITLE
[java] Update vertx to newer version 3.5.2

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -32,7 +32,7 @@ ext {
     swagger_annotations_version = "1.5.21"
     jackson_version = "2.13.4"
     jackson_databind_version = "2.13.4.2"
-    vertx_version = "3.4.2"
+    vertx_version = "3.5.2"
     junit_version = "4.13.2"
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.6"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -292,7 +292,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx-version>3.4.2</vertx-version>
+        <vertx-version>3.5.2</vertx-version>
         <swagger-annotations-version>1.6.6</swagger-annotations-version>
         <jackson-version>2.13.4</jackson-version>
         <jackson-databind>2.13.4.2</jackson-databind>

--- a/samples/client/petstore/java/vertx-no-nullable/build.gradle
+++ b/samples/client/petstore/java/vertx-no-nullable/build.gradle
@@ -32,7 +32,7 @@ ext {
     swagger_annotations_version = "1.5.21"
     jackson_version = "2.13.4"
     jackson_databind_version = "2.13.4.2"
-    vertx_version = "3.4.2"
+    vertx_version = "3.5.2"
     junit_version = "4.13.2"
     jakarta_annotation_version = "1.3.5"
 }

--- a/samples/client/petstore/java/vertx-no-nullable/pom.xml
+++ b/samples/client/petstore/java/vertx-no-nullable/pom.xml
@@ -264,7 +264,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx-version>3.4.2</vertx-version>
+        <vertx-version>3.5.2</vertx-version>
         <swagger-annotations-version>1.6.6</swagger-annotations-version>
         <jackson-version>2.13.4</jackson-version>
         <jackson-databind>2.13.4.2</jackson-databind>

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -32,7 +32,7 @@ ext {
     swagger_annotations_version = "1.5.21"
     jackson_version = "2.13.4"
     jackson_databind_version = "2.13.4.2"
-    vertx_version = "3.4.2"
+    vertx_version = "3.5.2"
     junit_version = "4.13.2"
     jackson_databind_nullable_version = "0.2.6"
     jakarta_annotation_version = "1.3.5"

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -269,7 +269,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx-version>3.4.2</vertx-version>
+        <vertx-version>3.5.2</vertx-version>
         <swagger-annotations-version>1.6.6</swagger-annotations-version>
         <jackson-version>2.13.4</jackson-version>
         <jackson-databind>2.13.4.2</jackson-databind>


### PR DESCRIPTION
Update vertx to newer version 3.5.2

To fix https://github.com/OpenAPITools/openapi-generator/issues/15195

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
