### PR TITLE
[python-nextgen] Better null check for regular expression validator

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/model_generic.mustache
@@ -32,6 +32,18 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     @validator('{{{name}}}')
     def {{{name}}}_validate_regular_expression(cls, v):
+        {{^required}}
+        if v is None:
+            return v
+
+        {{/required}}
+        {{#required}}
+        {{#isNullable}}
+        if v is None:
+            return v
+
+        {{/isNullable}}
+        {{/required}}
         if not re.match(r"{{{.}}}", v{{#vendorExtensions.x-modifiers}} ,re.{{{.}}}{{/vendorExtensions.x-modifiers}}):
             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
         return v
@@ -43,6 +55,14 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{^required}}
         if v is None:
             return v
+
+        {{/required}}
+        {{#required}}
+        {{#isNullable}}
+        if v is None:
+            return v
+
+        {{/isNullable}}
         {{/required}}
         {{#isArray}}
         for i in v:

--- a/samples/client/echo_api/python-nextgen/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/models/default_value.py
@@ -42,6 +42,7 @@ class DefaultValue(BaseModel):
     def array_string_enum_default_validate_enum(cls, v):
         if v is None:
             return v
+
         for i in v:
             if i not in ('success', 'failure', 'unclassified'):
                 raise ValueError("each list item must be one of ('success', 'failure', 'unclassified')")

--- a/samples/client/echo_api/python-nextgen/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/models/pet.py
@@ -41,6 +41,7 @@ class Pet(BaseModel):
     def status_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('available', 'pending', 'sold'):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return v

--- a/samples/client/echo_api/python-nextgen/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/models/query.py
@@ -35,6 +35,7 @@ class Query(BaseModel):
     def outcomes_validate_enum(cls, v):
         if v is None:
             return v
+
         for i in v:
             if i not in ('SUCCESS', 'FAILURE', 'SKIPPED'):
                 raise ValueError("each list item must be one of ('SUCCESS', 'FAILURE', 'SKIPPED')")

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_arrays.py
@@ -34,6 +34,7 @@ class EnumArrays(BaseModel):
     def just_symbol_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('>=', '$'):
             raise ValueError("must be one of enum values ('>=', '$')")
         return v
@@ -42,6 +43,7 @@ class EnumArrays(BaseModel):
     def array_enum_validate_enum(cls, v):
         if v is None:
             return v
+
         for i in v:
             if i not in ('fish', 'crab'):
                 raise ValueError("each list item must be one of ('fish', 'crab')")

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
@@ -45,6 +45,7 @@ class EnumTest(BaseModel):
     def enum_string_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('UPPER', 'lower', ''):
             raise ValueError("must be one of enum values ('UPPER', 'lower', '')")
         return v
@@ -59,6 +60,7 @@ class EnumTest(BaseModel):
     def enum_integer_default_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in (1, 5, 14):
             raise ValueError("must be one of enum values (1, 5, 14)")
         return v
@@ -67,6 +69,7 @@ class EnumTest(BaseModel):
     def enum_integer_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in (1, -1):
             raise ValueError("must be one of enum values (1, -1)")
         return v
@@ -75,6 +78,7 @@ class EnumTest(BaseModel):
     def enum_number_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in (1.1, -1.2):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
@@ -47,24 +47,36 @@ class FormatTest(BaseModel):
 
     @validator('string')
     def string_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"[a-z]", v ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return v
 
     @validator('string_with_double_quote_pattern')
     def string_with_double_quote_pattern_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"this is \"something\"", v):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return v
 
     @validator('pattern_with_digits')
     def pattern_with_digits_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"^\d{10}$", v):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return v
 
     @validator('pattern_with_digits_and_delimiter')
     def pattern_with_digits_and_delimiter_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"^image_\d{1,3}$", v ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/map_test.py
@@ -36,6 +36,7 @@ class MapTest(BaseModel):
     def map_of_enum_string_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('UPPER', 'lower'):
             raise ValueError("must be one of enum values ('UPPER', 'lower')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/order.py
@@ -38,6 +38,7 @@ class Order(BaseModel):
     def status_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('placed', 'approved', 'delivered'):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/pet.py
@@ -40,6 +40,7 @@ class Pet(BaseModel):
     def status_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('available', 'pending', 'sold'):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/special_name.py
@@ -36,6 +36,7 @@ class SpecialName(BaseModel):
     def var_schema_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('available', 'pending', 'sold'):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_arrays.py
@@ -35,6 +35,7 @@ class EnumArrays(BaseModel):
     def just_symbol_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('>=', '$'):
             raise ValueError("must be one of enum values ('>=', '$')")
         return v
@@ -43,6 +44,7 @@ class EnumArrays(BaseModel):
     def array_enum_validate_enum(cls, v):
         if v is None:
             return v
+
         for i in v:
             if i not in ('fish', 'crab'):
                 raise ValueError("each list item must be one of ('fish', 'crab')")

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
@@ -46,6 +46,7 @@ class EnumTest(BaseModel):
     def enum_string_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('UPPER', 'lower', ''):
             raise ValueError("must be one of enum values ('UPPER', 'lower', '')")
         return v
@@ -60,6 +61,7 @@ class EnumTest(BaseModel):
     def enum_integer_default_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in (1, 5, 14):
             raise ValueError("must be one of enum values (1, 5, 14)")
         return v
@@ -68,6 +70,7 @@ class EnumTest(BaseModel):
     def enum_integer_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in (1, -1):
             raise ValueError("must be one of enum values (1, -1)")
         return v
@@ -76,6 +79,7 @@ class EnumTest(BaseModel):
     def enum_number_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in (1.1, -1.2):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
@@ -48,24 +48,36 @@ class FormatTest(BaseModel):
 
     @validator('string')
     def string_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"[a-z]", v ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /[a-z]/i")
         return v
 
     @validator('string_with_double_quote_pattern')
     def string_with_double_quote_pattern_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"this is \"something\"", v):
             raise ValueError(r"must validate the regular expression /this is \"something\"/")
         return v
 
     @validator('pattern_with_digits')
     def pattern_with_digits_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"^\d{10}$", v):
             raise ValueError(r"must validate the regular expression /^\d{10}$/")
         return v
 
     @validator('pattern_with_digits_and_delimiter')
     def pattern_with_digits_and_delimiter_validate_regular_expression(cls, v):
+        if v is None:
+            return v
+
         if not re.match(r"^image_\d{1,3}$", v ,re.IGNORECASE):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/map_test.py
@@ -37,6 +37,7 @@ class MapTest(BaseModel):
     def map_of_enum_string_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('UPPER', 'lower'):
             raise ValueError("must be one of enum values ('UPPER', 'lower')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/order.py
@@ -39,6 +39,7 @@ class Order(BaseModel):
     def status_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('placed', 'approved', 'delivered'):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/pet.py
@@ -41,6 +41,7 @@ class Pet(BaseModel):
     def status_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('available', 'pending', 'sold'):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/special_name.py
@@ -37,6 +37,7 @@ class SpecialName(BaseModel):
     def var_schema_validate_enum(cls, v):
         if v is None:
             return v
+
         if v not in ('available', 'pending', 'sold'):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return v

--- a/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-nextgen/tests/test_model.py
@@ -314,6 +314,10 @@ class ModelTests(unittest.TestCase):
         except ValueError as e:
             self.assertTrue(r"must validate the regular expression /^image_\d{1,3}$/i" in str(e))
 
+        # test None with optional string (with regualr expression)
+        a = petstore_api.FormatTest(number=123.45, byte=bytes("string", 'utf-8'), date="2013-09-17", password="testing09876")
+        a.string = None # shouldn't throw an exception
+
         a.pattern_with_digits_and_delimiter = "IMAGE_123"
         self.assertEqual(a.pattern_with_digits_and_delimiter, "IMAGE_123")
         a.pattern_with_digits_and_delimiter = "image_123"


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/15134


Add null check when the optional/nullable type is defined with regular expression

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)