### PR TITLE
[cpp-ue4] Fix multi collection format has duplicated prefix

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -99,7 +99,12 @@ FString {{classname}}::{{operationIdCamelCase}}Request::ComputePath() const
 	QueryParams.Add(FString(TEXT("{{baseName}}=")) + ToUrlString({{paramName}}));
 	{{/collectionFormat}}
 	{{#collectionFormat}}
+	{{#isCollectionFormatMulti}}
+	QueryParams.Add(CollectionToUrlString_{{collectionFormat}}({{paramName}}, TEXT("{{baseName}}")));
+	{{/isCollectionFormatMulti}}
+	{{^isCollectionFormatMulti}}
 	QueryParams.Add(FString(TEXT("{{baseName}}=")) + CollectionToUrlString_{{collectionFormat}}({{paramName}}, TEXT("{{baseName}}")));
+	{{/isCollectionFormatMulti}}
 	{{/collectionFormat}}
 	{{/required}}
 	{{^required}}
@@ -112,7 +117,12 @@ FString {{classname}}::{{operationIdCamelCase}}Request::ComputePath() const
 	{{#collectionFormat}}
 	if({{paramName}}.IsSet())
 	{
+		{{#isCollectionFormatMulti}}
+		QueryParams.Add(CollectionToUrlString_{{collectionFormat}}({{paramName}}.GetValue(), TEXT("{{baseName}}")));
+		{{/isCollectionFormatMulti}}
+		{{^isCollectionFormatMulti}}
 		QueryParams.Add(FString(TEXT("{{baseName}}=")) + CollectionToUrlString_{{collectionFormat}}({{paramName}}.GetValue(), TEXT("{{baseName}}")));
+		{{/isCollectionFormatMulti}}
 	}
 	{{/collectionFormat}}
 	{{/required}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Hello, I made another pull request that addresses different issue. Query parameter generation works very well except "multi" collection format. `CollectionToUrlString_multi` generates "key=value1&key=value2&..." like string and if used with query string, duplicated key string is appended like:

`key=key=value1&key=value2`

This commit separates "multi" type collection query string generation from other types.

@Kahncode 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
