### PR TITLE
Add support for `java.util.Date` serialization in Kotlin generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -622,6 +622,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
             case gson:
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/ByteArrayAdapter.kt.mustache", infrastructureFolder, "ByteArrayAdapter.kt"));
+                supportingFiles.add(new SupportingFile("jvm-common/infrastructure/JavaDateAdapter.kt.mustache", infrastructureFolder, "JavaDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateAdapter.kt.mustache", infrastructureFolder, "LocalDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateTimeAdapter.kt.mustache", infrastructureFolder, "LocalDateTimeAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/OffsetDateTimeAdapter.kt.mustache", infrastructureFolder, "OffsetDateTimeAdapter.kt"));
@@ -638,6 +639,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/URLAdapter.kt.mustache", infrastructureFolder, "URLAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/BigIntegerAdapter.kt.mustache", infrastructureFolder, "BigIntegerAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/BigDecimalAdapter.kt.mustache", infrastructureFolder, "BigDecimalAdapter.kt"));
+                supportingFiles.add(new SupportingFile("jvm-common/infrastructure/JavaDateAdapter.kt.mustache", infrastructureFolder, "JavaDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateAdapter.kt.mustache", infrastructureFolder, "LocalDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateTimeAdapter.kt.mustache", infrastructureFolder, "LocalDateTimeAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/OffsetDateTimeAdapter.kt.mustache", infrastructureFolder, "OffsetDateTimeAdapter.kt"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -611,6 +611,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
                 }
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/ByteArrayAdapter.kt.mustache", infrastructureFolder, "ByteArrayAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/UUIDAdapter.kt.mustache", infrastructureFolder, "UUIDAdapter.kt"));
+                supportingFiles.add(new SupportingFile("jvm-common/infrastructure/JavaDateAdapter.kt.mustache", infrastructureFolder, "JavaDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateAdapter.kt.mustache", infrastructureFolder, "LocalDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateTimeAdapter.kt.mustache", infrastructureFolder, "LocalDateTimeAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/OffsetDateTimeAdapter.kt.mustache", infrastructureFolder, "OffsetDateTimeAdapter.kt"));

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/JavaDateAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/JavaDateAdapter.kt.mustache
@@ -1,0 +1,74 @@
+package {{packageName}}.infrastructure
+
+{{#moshi}}
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+{{/moshi}}
+{{#gson}}
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+{{/gson}}
+{{#kotlinx_serialization}}
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+{{/kotlinx_serialization}}
+import java.util.Date
+
+{{#moshi}}
+{{#nonPublicApi}}internal {{/nonPublicApi}}class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}
+{{/moshi}}
+{{#gson}}
+{{#nonPublicApi}}internal {{/nonPublicApi}}class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}
+{{/gson}}
+{{#kotlinx_serialization}}
+@Serializer(forClass = Date::class)
+{{#nonPublicApi}}internal {{/nonPublicApi}}object JavaDateAdapter : KSerializer<Date> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JavaDate", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        encoder.encodeLong(value.time)
+    }
+
+    override fun deserialize(decoder: Decoder): Date {
+        return Date(decoder.decodeLong())
+    }
+}
+{{/kotlinx_serialization}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -48,6 +48,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -60,6 +61,7 @@ import java.util.concurrent.atomic.AtomicLong
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())
@@ -83,6 +85,7 @@ import java.util.concurrent.atomic.AtomicLong
         .registerTypeAdapter(OffsetDateTime::class.java, OffsetDateTimeAdapter())
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
+        .registerTypeAdapter(Date::class.java, JavaDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
 
     @JvmStatic
@@ -108,6 +111,7 @@ import java.util.concurrent.atomic.AtomicLong
         contextual(BigDecimal::class, BigDecimalAdapter)
         contextual(BigInteger::class, BigIntegerAdapter)
         contextual(LocalDate::class, LocalDateAdapter)
+        contextual(Date::class, JavaDateAdapter)
         contextual(LocalDateTime::class, LocalDateTimeAdapter)
         contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
         contextual(UUID::class, UUIDAdapter)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -48,11 +48,11 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
-import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 {{/kotlinx_serialization}}
+import java.util.Date
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}object Serializer {
 {{#moshi}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -466,7 +466,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 27);
+            Assert.assertEquals(files.size(), 28);
 
             // Generator should report a library templated file as a generated file
             TestUtils.ensureContainsFile(files, output, "src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt");
@@ -508,7 +508,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 27);
+            Assert.assertEquals(files.size(), 28);
 
             // Generator should report README.md as a generated file
             TestUtils.ensureContainsFile(files, output, "README.md");
@@ -573,7 +573,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 27);
+            Assert.assertEquals(files.size(), 28);
 
             // Generator should report a library templated file as a generated file
             TestUtils.ensureContainsFile(files, output, "src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt");
@@ -627,7 +627,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 27);
+            Assert.assertEquals(files.size(), 28);
 
             // Generator should report README.md as a generated file
             TestUtils.ensureContainsFile(files, output, "README.md");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -378,7 +378,7 @@ public class KotlinClientCodegenModelTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-        Assert.assertEquals(files.size(), 28);
+        Assert.assertEquals(files.size(), 29);
         TestUtils.assertFileContains(Paths.get(output + "/src/main/kotlin/xyz/abcdef/api/DefaultApi.kt"),
             "fun getSomeValue(@Query(\"since\") since: kotlin.String? = null, @Query(\"sinceBuild\") sinceBuild: kotlin.String? = null, @Query(\"maxBuilds\") maxBuilds: kotlin.Int? = null, @Query(\"maxWaitSecs\") maxWaitSecs: kotlin.Int? = null)"
         );

--- a/samples/client/petstore/kotlin-allOff-discriminator/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-allOff-discriminator/.openapi-generator/FILES
@@ -17,6 +17,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,6 +10,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -3,6 +3,7 @@ package org.openapitools.client.infrastructure
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.EnumJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/.openapi-generator/FILES
@@ -14,6 +14,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/.openapi-generator/FILES
@@ -14,6 +14,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-volley/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-volley/.openapi-generator/FILES
@@ -12,6 +12,7 @@ src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-volley/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-volley/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,34 @@
+package org.openapitools.client.infrastructure
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+import java.util.Date
+
+class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/.openapi-generator/FILES
@@ -15,6 +15,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/.openapi-generator/FILES
@@ -15,6 +15,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/.openapi-generator/FILES
@@ -15,6 +15,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/.openapi-generator/FILES
@@ -13,6 +13,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-default-values-jvm-volley/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-default-values-jvm-volley/.openapi-generator/FILES
@@ -14,6 +14,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ITransformForStorage.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-default-values-jvm-volley/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-volley/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,34 @@
+package org.openapitools.client.infrastructure
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+import java.util.Date
+
+class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-enum-default-value/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-enum-default-value/.openapi-generator/FILES
@@ -15,6 +15,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,6 +10,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -3,6 +3,7 @@ package org.openapitools.client.infrastructure
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.EnumJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-gson/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-gson/.openapi-generator/FILES
@@ -22,6 +22,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,34 @@
+package org.openapitools.client.infrastructure
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+import java.util.Date
+
+class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,7 @@ object Serializer {
         .registerTypeAdapter(OffsetDateTime::class.java, OffsetDateTimeAdapter())
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
+        .registerTypeAdapter(Date::class.java, JavaDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-json-request-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-json-request-string/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,23 @@
+package org.openapitools.client.infrastructure
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import java.util.Date
+
+@Serializer(forClass = Date::class)
+object JavaDateAdapter : KSerializer<Date> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JavaDate", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        encoder.encodeLong(value.time)
+    }
+
+    override fun deserialize(decoder: Decoder): Date {
+        return Date(decoder.decodeLong())
+    }
+}

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,10 +10,10 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
-import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.Date
 
 object Serializer {
     @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -25,6 +26,7 @@ object Serializer {
         contextual(BigDecimal::class, BigDecimalAdapter)
         contextual(BigInteger::class, BigIntegerAdapter)
         contextual(LocalDate::class, LocalDateAdapter)
+        contextual(Date::class, JavaDateAdapter)
         contextual(LocalDateTime::class, LocalDateTimeAdapter)
         contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
         contextual(UUID::class, UUIDAdapter)

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/.openapi-generator/FILES
@@ -22,6 +22,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,34 @@
+package org.openapitools.client.infrastructure
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+import java.util.Date
+
+class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,7 @@ object Serializer {
         .registerTypeAdapter(OffsetDateTime::class.java, OffsetDateTimeAdapter())
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
+        .registerTypeAdapter(Date::class.java, JavaDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/.openapi-generator/FILES
@@ -22,6 +22,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,34 @@
+package org.openapitools.client.infrastructure
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+import java.util.Date
+
+class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,7 @@ object Serializer {
         .registerTypeAdapter(OffsetDateTime::class.java, OffsetDateTimeAdapter())
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
+        .registerTypeAdapter(Date::class.java, JavaDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-volley/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-jvm-volley/.openapi-generator/FILES
@@ -23,6 +23,7 @@ src/main/java/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/java/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/java/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/java/org/openapitools/client/infrastructure/ITransformForStorage.kt
+src/main/java/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/java/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/java/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/java/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,34 @@
+package org.openapitools.client.infrastructure
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.JsonToken.NULL
+import java.io.IOException
+import java.util.Date
+
+class JavaDateAdapter : TypeAdapter<Date>() {
+    @Throws(IOException::class)
+    override fun write(out: JsonWriter?, value: Date?) {
+        if (value == null) {
+            out?.nullValue()
+        } else {
+            out?.value(value.time)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(out: JsonReader?): Date? {
+        out ?: return null
+
+        when (out.peek()) {
+            NULL -> {
+                out.nextNull()
+                return null
+            }
+            else -> {
+                return Date(out.nextLong())
+            }
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-modelMutable/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-modelMutable/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-moshi-codegen/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-moshi-codegen/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -8,6 +8,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,6 +1,7 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-nonpublic/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-nonpublic/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+internal class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ internal object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 internal object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-nullable/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-nullable/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-okhttp3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-okhttp3/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,6 +10,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -3,6 +3,7 @@ package org.openapitools.client.infrastructure
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.EnumJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/.openapi-generator/FILES
@@ -29,6 +29,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,23 @@
+package org.openapitools.client.infrastructure
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import java.util.Date
+
+@Serializer(forClass = Date::class)
+object JavaDateAdapter : KSerializer<Date> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JavaDate", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        encoder.encodeLong(value.time)
+    }
+
+    override fun deserialize(decoder: Decoder): Date {
+        return Date(decoder.decodeLong())
+    }
+}

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,10 +10,10 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
-import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.Date
 
 object Serializer {
     @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -25,6 +26,7 @@ object Serializer {
         contextual(BigDecimal::class, BigDecimalAdapter)
         contextual(BigInteger::class, BigIntegerAdapter)
         contextual(LocalDate::class, LocalDateAdapter)
+        contextual(Date::class, JavaDateAdapter)
         contextual(LocalDateTime::class, LocalDateTimeAdapter)
         contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
         contextual(UUID::class, UUIDAdapter)

--- a/samples/client/petstore/kotlin-retrofit2-rx3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/.openapi-generator/FILES
@@ -26,6 +26,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-retrofit2/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-retrofit2/.openapi-generator/FILES
@@ -26,6 +26,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-string/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-threetenbp/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-threetenbp/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic

--- a/samples/client/petstore/kotlin-uppercase-enum/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-uppercase-enum/.openapi-generator/FILES
@@ -18,6 +18,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/AtomicLongAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,23 @@
+package org.openapitools.client.infrastructure
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import java.util.Date
+
+@Serializer(forClass = Date::class)
+object JavaDateAdapter : KSerializer<Date> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JavaDate", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        encoder.encodeLong(value.time)
+    }
+
+    override fun deserialize(decoder: Decoder): Date {
+        return Date(decoder.decodeLong())
+    }
+}

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,10 +10,10 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
-import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.Date
 
 object Serializer {
     @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import java.net.URI
 import java.net.URL
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -25,6 +26,7 @@ object Serializer {
         contextual(BigDecimal::class, BigDecimalAdapter)
         contextual(BigInteger::class, BigIntegerAdapter)
         contextual(LocalDate::class, LocalDateAdapter)
+        contextual(Date::class, JavaDateAdapter)
         contextual(LocalDateTime::class, LocalDateTimeAdapter)
         contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
         contextual(UUID::class, UUIDAdapter)

--- a/samples/client/petstore/kotlin/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/JavaDateAdapter.kt
@@ -1,0 +1,13 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.Date
+
+class JavaDateAdapter {
+    @ToJson
+    fun toJson(value: Date): String = value.time.toString()
+
+    @FromJson
+    fun fromJson(value: String): Date = Date(value.toLong())
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -9,6 +9,7 @@ object Serializer {
         .add(OffsetDateTimeAdapter())
         .add(LocalDateTimeAdapter())
         .add(LocalDateAdapter())
+        .add(JavaDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(URIAdapter())

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -2,6 +2,7 @@ package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.util.Date
 
 object Serializer {
     @JvmStatic


### PR DESCRIPTION
This pr add serialization support for `java.util.Date` class in the Kotlin generator. I have no idea why it isn't there in the first place, but I need it and others may too, so... here it is.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert (2017/09), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)