### PR TITLE
[openapi-normalizer] Fix nullable boolean check in oneOf schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -691,6 +691,7 @@ public class OpenAPINormalizer {
 
             // if only one element left, simplify to just the element (schema)
             if (schema.getOneOf().size() == 1) {
+                if (Boolean.TRUE.equals(schema.getNullable())) { // retain nullable setting
                 if (schema.getNullable()) { // retain nullable setting
                     ((Schema) schema.getOneOf().get(0)).setNullable(true);
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -692,7 +692,6 @@ public class OpenAPINormalizer {
             // if only one element left, simplify to just the element (schema)
             if (schema.getOneOf().size() == 1) {
                 if (Boolean.TRUE.equals(schema.getNullable())) { // retain nullable setting
-                if (schema.getNullable()) { // retain nullable setting
                     ((Schema) schema.getOneOf().get(0)).setNullable(true);
                 }
                 return (Schema) schema.getOneOf().get(0);

--- a/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
@@ -55,9 +55,27 @@ components:
         number:
           anyOf:
             - $ref: '#/components/schemas/Number'
+    ParentWithOneOfProperty:
+      type: object
+      properties:
+        number:
+          oneOf:
+            - $ref: '#/components/schemas/Number'
+    ParentWithPluralOneOfProperty:
+      type: object
+      properties:
+        number:
+          oneOf:
+            - $ref: '#/components/schemas/Number'
+            - $ref: '#/components/schemas/Number2'
     Number:
       enum:
         - one
         - two
         - three
+      type: string
+    Number2:
+       enum:
+         - one
+         - two
       type: string

--- a/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
@@ -75,7 +75,7 @@ components:
         - three
       type: string
     Number2:
-       enum:
-         - one
-         - two
+      enum:
+        - one
+        - two
       type: string


### PR DESCRIPTION
- Fix nullable boolean check in oneOf schema as getNulalble can return null
- add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @OpenAPITools/generator-core-team 