### PR TITLE
[python] Allow clients to define TLS Server name (SNI)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-legacy/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/configuration.mustache
@@ -273,6 +273,10 @@ conf = {{{packageName}}}.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         {{#asyncio}}
         self.connection_pool_maxsize = 100

--- a/modules/openapi-generator/src/main/resources/python-legacy/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/rest.mustache
@@ -60,6 +60,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/modules/openapi-generator/src/main/resources/python-nextgen/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/configuration.mustache
@@ -243,6 +243,10 @@ conf = {{{packageName}}}.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         {{#asyncio}}
         self.connection_pool_maxsize = 100

--- a/modules/openapi-generator/src/main/resources/python-nextgen/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/rest.mustache
@@ -56,6 +56,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/modules/openapi-generator/src/main/resources/python-prior/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-prior/configuration.mustache
@@ -258,6 +258,10 @@ conf = {{{packageName}}}.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         {{#asyncio}}
         self.connection_pool_maxsize = 100

--- a/modules/openapi-generator/src/main/resources/python-prior/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-prior/rest.mustache
@@ -56,6 +56,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/modules/openapi-generator/src/main/resources/python/configuration.handlebars
+++ b/modules/openapi-generator/src/main/resources/python/configuration.handlebars
@@ -278,6 +278,10 @@ conf = {{{packageName}}}.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         {{#if asyncio}}
         self.connection_pool_maxsize = 100

--- a/modules/openapi-generator/src/main/resources/python/rest.handlebars
+++ b/modules/openapi-generator/src/main/resources/python/rest.handlebars
@@ -46,6 +46,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/configuration.py
@@ -143,6 +143,10 @@ class Configuration(object):
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/client/echo_api/python-nextgen/openapi_client/rest.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/rest.py
@@ -67,6 +67,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -208,6 +208,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = 100
         """This value is passed to the aiohttp to limit simultaneous connections.

--- a/samples/client/petstore/python-legacy/petstore_api/configuration.py
+++ b/samples/client/petstore/python-legacy/petstore_api/configuration.py
@@ -209,6 +209,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/client/petstore/python-legacy/petstore_api/rest.py
+++ b/samples/client/petstore/python-legacy/petstore_api/rest.py
@@ -68,6 +68,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/client/petstore/python-prior/petstore_api/configuration.py
+++ b/samples/client/petstore/python-prior/petstore_api/configuration.py
@@ -203,6 +203,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/client/petstore/python-prior/petstore_api/rest.py
+++ b/samples/client/petstore/python-prior/petstore_api/rest.py
@@ -64,6 +64,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/client/petstore/python-prior_disallowAdditionalPropertiesIfNotPresent/petstore_api/configuration.py
+++ b/samples/client/petstore/python-prior_disallowAdditionalPropertiesIfNotPresent/petstore_api/configuration.py
@@ -203,6 +203,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/client/petstore/python-prior_disallowAdditionalPropertiesIfNotPresent/petstore_api/rest.py
+++ b/samples/client/petstore/python-prior_disallowAdditionalPropertiesIfNotPresent/petstore_api/rest.py
@@ -64,6 +64,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -209,6 +209,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/configuration.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/configuration.py
@@ -146,6 +146,10 @@ class Configuration(object):
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/rest.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/rest.py
@@ -53,6 +53,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-prior/x_auth_id_alias/configuration.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-prior/x_auth_id_alias/configuration.py
@@ -187,6 +187,10 @@ conf = x_auth_id_alias.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-prior/x_auth_id_alias/rest.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-prior/x_auth_id_alias/rest.py
@@ -64,6 +64,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/configuration.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/configuration.py
@@ -146,6 +146,10 @@ class Configuration(object):
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
@@ -53,6 +53,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/configuration.py
@@ -256,6 +256,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/rest.py
@@ -68,6 +68,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/configuration.py
@@ -227,6 +227,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = 100
         """This value is passed to the aiohttp to limit simultaneous connections.

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/configuration.py
@@ -228,6 +228,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/rest.py
@@ -66,6 +66,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/openapi3/client/petstore/python-prior/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-prior/petstore_api/configuration.py
@@ -250,6 +250,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/petstore/python-prior/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-prior/petstore_api/rest.py
@@ -64,6 +64,10 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -257,6 +257,10 @@ conf = petstore_api.Configuration(
         self.assert_hostname = None
         """Set this to True/False to enable/disable SSL hostname verification.
         """
+        self.tls_server_name = None
+        """SSL/TLS Server Name Indication (SNI)
+           Set this to the SNI value expected by the server.
+        """
 
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -53,6 +53,9 @@ class RESTClientObject(object):
         if configuration.retries is not None:
             addition_pool_args['retries'] = configuration.retries
 
+        if configuration.tls_server_name:
+            addition_pool_args['server_hostname'] = configuration.tls_server_name
+
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 


### PR DESCRIPTION
This PR allows users to define custom SNI when using the python clients

Fixes https://github.com/OpenAPITools/openapi-generator/issues/15282


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]

cc @spacether (2019/11)  @krjakbrjak (2023/02)
