### PR TITLE
[python-nextgen] use Field(...) for required properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -1289,6 +1289,12 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
                     fieldCustomization = String.format(Locale.ROOT, "Field(%s)", StringUtils.join(fields, ", "));
                 }
 
+                if ("...".equals(fieldCustomization)) {
+                    // use Field() to avoid pylint warnings
+                    pydanticImports.add("Field");
+                    fieldCustomization = "Field(...)";
+                }
+
                 cp.vendorExtensions.put("x-py-typing", typing + " = " + fieldCustomization);
 
                 // setup x-py-name for each oneOf/anyOf schema

--- a/samples/client/echo_api/python-nextgen/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/models/pet.py
@@ -30,7 +30,7 @@ class Pet(BaseModel):
     Pet
     """
     id: Optional[StrictInt] = None
-    name: StrictStr = ...
+    name: StrictStr = Field(...)
     category: Optional[Category] = None
     photo_urls: conlist(StrictStr) = Field(..., alias="photoUrls")
     tags: Optional[conlist(Tag)] = None

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/basque_pig.py
@@ -27,7 +27,7 @@ class BasquePig(BaseModel):
     BasquePig
     """
     class_name: StrictStr = Field(..., alias="className")
-    color: StrictStr = ...
+    color: StrictStr = Field(...)
     __properties = ["className", "color"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/category.py
@@ -20,14 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictInt, StrictStr
+from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 class Category(BaseModel):
     """
     Category
     """
     id: Optional[StrictInt] = None
-    name: StrictStr = ...
+    name: StrictStr = Field(...)
     __properties = ["id", "name"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/danish_pig.py
@@ -27,7 +27,7 @@ class DanishPig(BaseModel):
     DanishPig
     """
     class_name: StrictStr = Field(..., alias="className")
-    size: StrictInt = ...
+    size: StrictInt = Field(...)
     __properties = ["className", "size"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/enum_test.py
@@ -31,7 +31,7 @@ class EnumTest(BaseModel):
     EnumTest
     """
     enum_string: Optional[StrictStr] = None
-    enum_string_required: StrictStr = ...
+    enum_string_required: StrictStr = Field(...)
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[float] = None

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/format_test.py
@@ -29,7 +29,7 @@ class FormatTest(BaseModel):
     integer: Optional[conint(strict=True, le=100, ge=10)] = None
     int32: Optional[conint(strict=True, le=200, ge=20)] = None
     int64: Optional[StrictInt] = None
-    number: confloat(le=543.2, ge=32.1) = ...
+    number: confloat(le=543.2, ge=32.1) = Field(...)
     float: Optional[confloat(le=987.6, ge=54.3)] = None
     double: Optional[confloat(le=123.4, ge=67.8)] = None
     decimal: Optional[condecimal()] = None
@@ -40,7 +40,7 @@ class FormatTest(BaseModel):
     var_date: date = Field(..., alias="date")
     date_time: Optional[datetime] = Field(None, alias="dateTime")
     uuid: Optional[StrictStr] = None
-    password: constr(strict=True, max_length=64, min_length=10) = ...
+    password: constr(strict=True, max_length=64, min_length=10) = Field(...)
     pattern_with_digits: Optional[constr(strict=True)] = Field(None, description="A string that is a 10 digit number. Can have leading zeros.")
     pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/name.py
@@ -26,7 +26,7 @@ class Name(BaseModel):
     """
     Model for testing model name same as property name
     """
-    name: StrictInt = ...
+    name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None
     var_property: Optional[StrictStr] = Field(None, alias="property")
     var_123_number: Optional[StrictInt] = Field(None, alias="123Number")

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/nullable_class.py
@@ -20,13 +20,13 @@ import json
 
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, StrictBool, StrictInt, StrictStr, conlist
+from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr, conlist
 
 class NullableClass(BaseModel):
     """
     NullableClass
     """
-    required_integer_prop: Optional[StrictInt] = ...
+    required_integer_prop: Optional[StrictInt] = Field(...)
     integer_prop: Optional[StrictInt] = None
     number_prop: Optional[float] = None
     boolean_prop: Optional[StrictBool] = None

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_integer import OuterEnumInteger
 
@@ -29,7 +29,7 @@ class OuterObjectWithEnumProperty(BaseModel):
     OuterObjectWithEnumProperty
     """
     str_value: Optional[OuterEnum] = None
-    value: OuterEnumInteger = ...
+    value: OuterEnumInteger = Field(...)
     __properties = ["str_value", "value"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/pet.py
@@ -30,7 +30,7 @@ class Pet(BaseModel):
     """
     id: Optional[StrictInt] = None
     category: Optional[Category] = None
-    name: StrictStr = ...
+    name: StrictStr = Field(...)
     photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(..., alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
     status: Optional[StrictStr] = Field(None, description="pet status in the store")

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/basque_pig.py
@@ -27,7 +27,7 @@ class BasquePig(BaseModel):
     BasquePig
     """
     class_name: StrictStr = Field(..., alias="className")
-    color: StrictStr = ...
+    color: StrictStr = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/category.py
@@ -20,14 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictInt, StrictStr
+from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 class Category(BaseModel):
     """
     Category
     """
     id: Optional[StrictInt] = None
-    name: StrictStr = ...
+    name: StrictStr = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "name"]
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/danish_pig.py
@@ -27,7 +27,7 @@ class DanishPig(BaseModel):
     DanishPig
     """
     class_name: StrictStr = Field(..., alias="className")
-    size: StrictInt = ...
+    size: StrictInt = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "size"]
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/enum_test.py
@@ -31,7 +31,7 @@ class EnumTest(BaseModel):
     EnumTest
     """
     enum_string: Optional[StrictStr] = None
-    enum_string_required: StrictStr = ...
+    enum_string_required: StrictStr = Field(...)
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[StrictFloat] = None

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/format_test.py
@@ -29,7 +29,7 @@ class FormatTest(BaseModel):
     integer: Optional[conint(strict=True, le=100, ge=10)] = None
     int32: Optional[conint(strict=True, le=200, ge=20)] = None
     int64: Optional[StrictInt] = None
-    number: confloat(le=543.2, ge=32.1, strict=True) = ...
+    number: confloat(le=543.2, ge=32.1, strict=True) = Field(...)
     float: Optional[confloat(le=987.6, ge=54.3, strict=True)] = None
     double: Optional[confloat(le=123.4, ge=67.8, strict=True)] = None
     decimal: Optional[condecimal()] = None
@@ -40,7 +40,7 @@ class FormatTest(BaseModel):
     var_date: date = Field(..., alias="date")
     date_time: Optional[datetime] = Field(None, alias="dateTime")
     uuid: Optional[StrictStr] = None
-    password: constr(strict=True, max_length=64, min_length=10) = ...
+    password: constr(strict=True, max_length=64, min_length=10) = Field(...)
     pattern_with_digits: Optional[constr(strict=True)] = Field(None, description="A string that is a 10 digit number. Can have leading zeros.")
     pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/name.py
@@ -26,7 +26,7 @@ class Name(BaseModel):
     """
     Model for testing model name same as property name
     """
-    name: StrictInt = ...
+    name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None
     var_property: Optional[StrictStr] = Field(None, alias="property")
     var_123_number: Optional[StrictInt] = Field(None, alias="123Number")

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/nullable_class.py
@@ -20,13 +20,13 @@ import json
 
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, conlist
+from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, conlist
 
 class NullableClass(BaseModel):
     """
     NullableClass
     """
-    required_integer_prop: Optional[StrictInt] = ...
+    required_integer_prop: Optional[StrictInt] = Field(...)
     integer_prop: Optional[StrictInt] = None
     number_prop: Optional[StrictFloat] = None
     boolean_prop: Optional[StrictBool] = None

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/outer_object_with_enum_property.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_integer import OuterEnumInteger
 
@@ -29,7 +29,7 @@ class OuterObjectWithEnumProperty(BaseModel):
     OuterObjectWithEnumProperty
     """
     str_value: Optional[OuterEnum] = None
-    value: OuterEnumInteger = ...
+    value: OuterEnumInteger = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["str_value", "value"]
 

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/pet.py
@@ -30,7 +30,7 @@ class Pet(BaseModel):
     """
     id: Optional[StrictInt] = None
     category: Optional[Category] = None
-    name: StrictStr = ...
+    name: StrictStr = Field(...)
     photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(..., alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
     status: Optional[StrictStr] = Field(None, description="pet status in the store")


### PR DESCRIPTION
Use Field(...) for required properties

To fix https://github.com/OpenAPITools/openapi-generator/issues/15137

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

