### PR TITLE
fix minus sign in enum naming in python-nextgen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -1512,7 +1512,7 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
 
     public String toEnumVariableName(String name, String datatype) {
         if ("int".equals(datatype)) {
-            return "NUMBER_" + name;
+            return "NUMBER_" + name.replace("-", "MINUS_");
         }
 
         // remove quote e.g. 'abc' => abc

--- a/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1864,6 +1864,7 @@ components:
     OuterEnumIntegerDefaultValue:
       type: integer
       enum:
+      - -1
       - 0
       - 1
       - 2

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
@@ -29,6 +29,7 @@ class OuterEnumIntegerDefaultValue(int, Enum):
     """
     allowed enum values
     """
+    NUMBER_MINUS_1 = -1
     NUMBER_0 = 0
     NUMBER_1 = 1
     NUMBER_2 = 2

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/models/outer_enum_integer_default_value.py
@@ -29,6 +29,7 @@ class OuterEnumIntegerDefaultValue(int, Enum):
     """
     allowed enum values
     """
+    NUMBER_MINUS_1 = -1
     NUMBER_0 = 0
     NUMBER_1 = 1
     NUMBER_2 = 2


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/15289


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
