### PR TITLE
Elixir: Update Poison dependency range

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -60,7 +60,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
     List<String> extraApplications = Arrays.asList(":logger");
     List<String> deps = Arrays.asList(
             "{:tesla, \"~> 1.4\"}",
-            "{:poison, \"~> 3.0\"}",
+            "{:poison, \"~> 3.0 or ~> 4.0 or ~> 5.0\"}",
             "{:ex_doc, \"~> 0.28\", only: :dev, runtime: false}"
     );
 

--- a/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
@@ -10,12 +10,12 @@ defmodule {{moduleName}}.Deserializer do
   @spec deserialize(struct(), :atom, :atom, struct(), keyword()) :: struct()
   def deserialize(model, field, :list, mod, options) do
     model
-    |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: [struct(mod)]]))))
+    |> Map.update!(field, &decode(&1, Keyword.merge(options, [as: [struct(mod)]])))
   end
 
   def deserialize(model, field, :struct, mod, options) do
     model
-    |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: struct(mod)]))))
+    |> Map.update!(field, &decode(&1, Keyword.merge(options, [as: struct(mod)])))
   end
 
   def deserialize(model, field, :map, mod, options) do
@@ -26,7 +26,7 @@ defmodule {{moduleName}}.Deserializer do
       existing_value ->
         Map.new(existing_value, fn
           {key, val} ->
-            {key, Poison.Decode.decode(val, Keyword.merge(options, as: struct(mod)))}
+            {key, decode(val, Keyword.merge(options, as: struct(mod)))}
         end)
     end
 
@@ -44,6 +44,16 @@ defmodule {{moduleName}}.Deserializer do
 
       false ->
         model
+    end
+  end
+
+  if function_exported?(Poison.Decode, :decode, 2) do
+    defp decode(value, options) do
+      Poison.Decode.decode(value, options)
+    end
+  else
+    defp decode(value, options) do
+      Poison.Decode.transform(value, options)
     end
   end
 end

--- a/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
@@ -12,12 +12,12 @@ defmodule OpenapiPetstore.Deserializer do
   @spec deserialize(struct(), :atom, :atom, struct(), keyword()) :: struct()
   def deserialize(model, field, :list, mod, options) do
     model
-    |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: [struct(mod)]]))))
+    |> Map.update!(field, &decode(&1, Keyword.merge(options, [as: [struct(mod)]])))
   end
 
   def deserialize(model, field, :struct, mod, options) do
     model
-    |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: struct(mod)]))))
+    |> Map.update!(field, &decode(&1, Keyword.merge(options, [as: struct(mod)])))
   end
 
   def deserialize(model, field, :map, mod, options) do
@@ -28,7 +28,7 @@ defmodule OpenapiPetstore.Deserializer do
       existing_value ->
         Map.new(existing_value, fn
           {key, val} ->
-            {key, Poison.Decode.decode(val, Keyword.merge(options, as: struct(mod)))}
+            {key, decode(val, Keyword.merge(options, as: struct(mod)))}
         end)
     end
 
@@ -46,6 +46,16 @@ defmodule OpenapiPetstore.Deserializer do
 
       false ->
         model
+    end
+  end
+
+  if function_exported?(Poison.Decode, :decode, 2) do
+    defp decode(value, options) do
+      Poison.Decode.decode(value, options)
+    end
+  else
+    defp decode(value, options) do
+      Poison.Decode.transform(value, options)
     end
   end
 end

--- a/samples/client/petstore/elixir/mix.exs
+++ b/samples/client/petstore/elixir/mix.exs
@@ -34,7 +34,7 @@ defmodule OpenapiPetstore.Mixfile do
   defp deps do
     [
       {:tesla, "~> 1.4"},
-      {:poison, "~> 3.0"},
+      {:poison, "~> 3.0 or ~> 4.0 or ~> 5.0"},
       {:ex_doc, "~> 0.28", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
The locked version of Poison was released in 2017 and there have been two major releases since then, 4.0 and 5.0. This allows for *existing* clients to continue to use 3.0, but opens the range so that newer versions can be used instead.

Between Poison 3.1.0 and Poison 4.0.0, Poison.Decode.decode/2 was renamed to Poison.Decode.transform/2, so rather than using Poison.Decode functions directly, we use a compile-time switch to forward to the old functions if Poison.Decode.decode/2 is exported and to the new function if not.

Note that this is *not* the desired end-state; that will be to allow either Poison or Jason (the latter is much more commonly used in the Elixir community as of now), but there are definitely some compatibility issues. (Jason allows for *optional* deserialization into a struct, but it requires explicit configuration for each such struct.)

I'm not sure of the timing on OpenAPI 7, but I would recommend that Poison be locked to only `~> 5.0` at that release, and if possible, we have also added Jason support as a configuration option (and perhaps even the default).

Tagging @mrmstn and @wing328

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

> Note: There appears to be an issue with surefire when running `./run-in-docker.sh mvn clean package` that does not present itself with `./run-in-docker.sh mvn clean install -U` most of the time. When it does, I can only remove my `~/.m2` directory (which would probably be better as I do not have a Java development environment on my macOS system—the only Java project I have worked with in the last year is this one).
>
> This also leaves me not really able to run the integration tests.