### PR TITLE
[python-nextgen] fix empty dict in body parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-nextgen/api.mustache
@@ -236,7 +236,7 @@ class {{classname}}(object):
         # process the body parameter
         _body_params = None
 {{#bodyParam}}
-        if _params['{{paramName}}']:
+        if _params['{{paramName}}'] is not None:
             _body_params = _params['{{paramName}}']
 
 {{/bodyParam}}

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -367,6 +367,26 @@ paths:
             text/plain:
               schema:
                 type: string
+  /echo/body/FreeFormObject/response_string:
+    post:
+      tags:
+        - body
+      summary: Test free form object
+      description: Test free form object
+      operationId: test/echo/body/FreeFormObject/response_string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Free form object
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
   /binary/gif:
     post:
       tags:

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -351,6 +351,22 @@ paths:
             text/plain:
               schema:
                 type: string
+  /echo/body/Tag/response_string:
+    post:
+      tags:
+        - body
+      summary: Test empty json (request body)
+      description: Test empty json (request body)
+      operationId: test/echo/body/Tag/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Tag'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
   /binary/gif:
     post:
       tags:
@@ -375,6 +391,12 @@ components:
           schema:
             $ref: '#/components/schemas/Pet'
       description: Pet object that needs to be added to the store
+    Tag:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Tag'
+      description: Tag object
   schemas:
     Category:
       type: object

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -108,6 +108,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -106,6 +106,7 @@ All URIs are relative to *http://localhost:3000*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
+*BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -349,6 +349,24 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/Tag/response_string:
+    post:
+      description: Test empty json (request body)
+      operationId: test/echo/body/Tag/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Tag'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test empty json (request body)
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body
@@ -373,6 +391,12 @@ components:
           schema:
             $ref: '#/components/schemas/Pet'
       description: Pet object that needs to be added to the store
+    Tag:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Tag'
+      description: Tag object
   schemas:
     Category:
       example:

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -367,6 +367,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/FreeFormObject/response_string:
+    post:
+      description: Test free form object
+      operationId: test/echo/body/FreeFormObject/response_string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Free form object
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test free form object
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
 | [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
+| [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
@@ -65,6 +66,72 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: image/gif
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyFreeFormObjectResponseString
+
+> String testEchoBodyFreeFormObjectResponseString(body)
+
+Test free form object
+
+Test free form object
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        Object body = null; // Object | Free form object
+        try {
+            String result = apiInstance.testEchoBodyFreeFormObjectResponseString(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyFreeFormObjectResponseString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **Object**| Free form object | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
 
 
 ### HTTP response details

--- a/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
 
@@ -183,6 +184,72 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyTagResponseString
+
+> String testEchoBodyTagResponseString(tag)
+
+Test empty json (request body)
+
+Test empty json (request body)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        Tag tag = new Tag(); // Tag | Tag object
+        try {
+            String result = apiInstance.testEchoBodyTagResponseString(tag);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyTagResponseString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **tag** | [**Tag**](Tag.md)| Tag object | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -122,6 +122,75 @@ public class BodyApi {
   }
 
   /**
+   * Test free form object
+   * Test free form object
+   * @param body Free form object (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testEchoBodyFreeFormObjectResponseString(Object body) throws ApiException {
+    return this.testEchoBodyFreeFormObjectResponseString(body, Collections.emptyMap());
+  }
+
+
+  /**
+   * Test free form object
+   * Test free form object
+   * @param body Free form object (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testEchoBodyFreeFormObjectResponseString(Object body, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = body;
+    
+    // create path and map variables
+    String localVarPath = "/echo/body/FreeFormObject/response_string";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "text/plain"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    TypeReference<String> localVarReturnType = new TypeReference<String>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
    * Test body parameter(s)
    * Test body parameter(s)
    * @param pet Pet object that needs to be added to the store (optional)

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -22,6 +22,7 @@ import org.openapitools.client.Pair;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.Tag;
 
 
 import java.util.ArrayList;
@@ -214,6 +215,75 @@ public class BodyApi {
     
     // create path and map variables
     String localVarPath = "/echo/body/Pet/response_string";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "text/plain"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    TypeReference<String> localVarReturnType = new TypeReference<String>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * Test empty json (request body)
+   * Test empty json (request body)
+   * @param tag Tag object (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testEchoBodyTagResponseString(Tag tag) throws ApiException {
+    return this.testEchoBodyTagResponseString(tag, Collections.emptyMap());
+  }
+
+
+  /**
+   * Test empty json (request body)
+   * Test empty json (request body)
+   * @param tag Tag object (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testEchoBodyTagResponseString(Tag tag, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = tag;
+    
+    // create path and map variables
+    String localVarPath = "/echo/body/Tag/response_string";
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -349,6 +349,24 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/Tag/response_string:
+    post:
+      description: Test empty json (request body)
+      operationId: test/echo/body/Tag/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Tag'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test empty json (request body)
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body
@@ -373,6 +391,12 @@ components:
           schema:
             $ref: '#/components/schemas/Pet'
       description: Pet object that needs to be added to the store
+    Tag:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Tag'
+      description: Tag object
   schemas:
     Category:
       example:

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -367,6 +367,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/FreeFormObject/response_string:
+    post:
+      description: Test free form object
+      operationId: test/echo/body/FreeFormObject/response_string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Free form object
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test free form object
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -44,6 +44,35 @@ public interface BodyApi extends ApiClient.Api {
 
 
   /**
+   * Test free form object
+   * Test free form object
+   * @param body Free form object (optional)
+   * @return String
+   */
+  @RequestLine("POST /echo/body/FreeFormObject/response_string")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: text/plain",
+  })
+  String testEchoBodyFreeFormObjectResponseString(Object body);
+
+  /**
+   * Test free form object
+   * Similar to <code>testEchoBodyFreeFormObjectResponseString</code> but it also returns the http response headers .
+   * Test free form object
+   * @param body Free form object (optional)
+   * @return A ApiResponse that wraps the response boyd and the http headers.
+   */
+  @RequestLine("POST /echo/body/FreeFormObject/response_string")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: text/plain",
+  })
+  ApiResponse<String> testEchoBodyFreeFormObjectResponseStringWithHttpInfo(Object body);
+
+
+
+  /**
    * Test body parameter(s)
    * Test body parameter(s)
    * @param pet Pet object that needs to be added to the store (optional)

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -6,6 +6,7 @@ import org.openapitools.client.model.ApiResponse;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.Tag;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -97,6 +98,35 @@ public interface BodyApi extends ApiClient.Api {
     "Accept: text/plain",
   })
   ApiResponse<String> testEchoBodyPetResponseStringWithHttpInfo(Pet pet);
+
+
+
+  /**
+   * Test empty json (request body)
+   * Test empty json (request body)
+   * @param tag Tag object (optional)
+   * @return String
+   */
+  @RequestLine("POST /echo/body/Tag/response_string")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: text/plain",
+  })
+  String testEchoBodyTagResponseString(Tag tag);
+
+  /**
+   * Test empty json (request body)
+   * Similar to <code>testEchoBodyTagResponseString</code> but it also returns the http response headers .
+   * Test empty json (request body)
+   * @param tag Tag object (optional)
+   * @return A ApiResponse that wraps the response boyd and the http headers.
+   */
+  @RequestLine("POST /echo/body/Tag/response_string")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: text/plain",
+  })
+  ApiResponse<String> testEchoBodyTagResponseStringWithHttpInfo(Tag tag);
 
 
 }

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -110,6 +110,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyPetWithHttpInfo**](docs/BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**testEchoBodyPetResponseStringWithHttpInfo**](docs/BodyApi.md#testEchoBodyPetResponseStringWithHttpInfo) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
+*BodyApi* | [**testEchoBodyTagResponseStringWithHttpInfo**](docs/BodyApi.md#testEchoBodyTagResponseStringWithHttpInfo) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormIntegerBooleanStringWithHttpInfo**](docs/FormApi.md#testFormIntegerBooleanStringWithHttpInfo) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -106,6 +106,8 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**testBinaryGifWithHttpInfo**](docs/BodyApi.md#testBinaryGifWithHttpInfo) | **POST** /binary/gif | Test binary (gif) response body
+*BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
+*BodyApi* | [**testEchoBodyFreeFormObjectResponseStringWithHttpInfo**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseStringWithHttpInfo) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetWithHttpInfo**](docs/BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -349,6 +349,24 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/Tag/response_string:
+    post:
+      description: Test empty json (request body)
+      operationId: test/echo/body/Tag/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Tag'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test empty json (request body)
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body
@@ -373,6 +391,12 @@ components:
           schema:
             $ref: '#/components/schemas/Pet'
       description: Pet object that needs to be added to the store
+    Tag:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Tag'
+      description: Tag object
   schemas:
     Category:
       example:

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -367,6 +367,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/FreeFormObject/response_string:
+    post:
+      description: Test free form object
+      operationId: test/echo/body/FreeFormObject/response_string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Free form object
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test free form object
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/native/docs/BodyApi.md
+++ b/samples/client/echo_api/java/native/docs/BodyApi.md
@@ -10,6 +10,8 @@ All URIs are relative to *http://localhost:3000*
 | [**testEchoBodyPetWithHttpInfo**](BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 | [**testEchoBodyPetResponseStringWithHttpInfo**](BodyApi.md#testEchoBodyPetResponseStringWithHttpInfo) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
+| [**testEchoBodyTagResponseStringWithHttpInfo**](BodyApi.md#testEchoBodyTagResponseStringWithHttpInfo) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
 
@@ -386,6 +388,140 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | [optional] |
+
+### Return type
+
+ApiResponse<**String**>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyTagResponseString
+
+> String testEchoBodyTagResponseString(tag)
+
+Test empty json (request body)
+
+Test empty json (request body)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        Tag tag = new Tag(); // Tag | Tag object
+        try {
+            String result = apiInstance.testEchoBodyTagResponseString(tag);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyTagResponseString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **tag** | [**Tag**](Tag.md)| Tag object | [optional] |
+
+### Return type
+
+**String**
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testEchoBodyTagResponseStringWithHttpInfo
+
+> ApiResponse<String> testEchoBodyTagResponseString testEchoBodyTagResponseStringWithHttpInfo(tag)
+
+Test empty json (request body)
+
+Test empty json (request body)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        Tag tag = new Tag(); // Tag | Tag object
+        try {
+            ApiResponse<String> response = apiInstance.testEchoBodyTagResponseStringWithHttpInfo(tag);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyTagResponseString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **tag** | [**Tag**](Tag.md)| Tag object | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/native/docs/BodyApi.md
+++ b/samples/client/echo_api/java/native/docs/BodyApi.md
@@ -6,6 +6,8 @@ All URIs are relative to *http://localhost:3000*
 |------------- | ------------- | -------------|
 | [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
 | [**testBinaryGifWithHttpInfo**](BodyApi.md#testBinaryGifWithHttpInfo) | **POST** /binary/gif | Test binary (gif) response body |
+| [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
+| [**testEchoBodyFreeFormObjectResponseStringWithHttpInfo**](BodyApi.md#testEchoBodyFreeFormObjectResponseStringWithHttpInfo) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetWithHttpInfo**](BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
@@ -134,6 +136,140 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyFreeFormObjectResponseString
+
+> String testEchoBodyFreeFormObjectResponseString(body)
+
+Test free form object
+
+Test free form object
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        Object body = null; // Object | Free form object
+        try {
+            String result = apiInstance.testEchoBodyFreeFormObjectResponseString(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyFreeFormObjectResponseString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **Object**| Free form object | [optional] |
+
+### Return type
+
+**String**
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testEchoBodyFreeFormObjectResponseStringWithHttpInfo
+
+> ApiResponse<String> testEchoBodyFreeFormObjectResponseString testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body)
+
+Test free form object
+
+Test free form object
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        Object body = null; // Object | Free form object
+        try {
+            ApiResponse<String> response = apiInstance.testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyFreeFormObjectResponseString");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **Object**| Free form object | [optional] |
+
+### Return type
+
+ApiResponse<**String**>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: text/plain
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -149,6 +149,87 @@ public class BodyApi {
     return localVarRequestBuilder;
   }
   /**
+   * Test free form object
+   * Test free form object
+   * @param body Free form object (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testEchoBodyFreeFormObjectResponseString(Object body) throws ApiException {
+    ApiResponse<String> localVarResponse = testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test free form object
+   * Test free form object
+   * @param body Free form object (optional)
+   * @return ApiResponse&lt;String&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<String> testEchoBodyFreeFormObjectResponseStringWithHttpInfo(Object body) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testEchoBodyFreeFormObjectResponseStringRequestBuilder(body);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testEchoBodyFreeFormObjectResponseString", localVarResponse);
+        }
+        // for plain text response
+        if (localVarResponse.headers().map().containsKey("Content-Type") &&
+                "text/plain".equalsIgnoreCase(localVarResponse.headers().map().get("Content-Type").get(0))) {
+          java.util.Scanner s = new java.util.Scanner(localVarResponse.body()).useDelimiter("\\A");
+          String responseBodyText = s.hasNext() ? s.next() : "";
+          return new ApiResponse<String>(
+                  localVarResponse.statusCode(),
+                  localVarResponse.headers().map(),
+                  responseBodyText
+          );
+        } else {
+            throw new RuntimeException("Error! The response Content-Type is supposed to be `text/plain` but it's not: " + localVarResponse);
+        }
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testEchoBodyFreeFormObjectResponseStringRequestBuilder(Object body) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/echo/body/FreeFormObject/response_string";
+
+    localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+
+    localVarRequestBuilder.header("Content-Type", "application/json");
+    localVarRequestBuilder.header("Accept", "text/plain");
+
+    try {
+      byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(body);
+      localVarRequestBuilder.method("POST", HttpRequest.BodyPublishers.ofByteArray(localVarPostBody));
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
+  /**
    * Test body parameter(s)
    * Test body parameter(s)
    * @param pet Pet object that needs to be added to the store (optional)

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -19,6 +19,7 @@ import org.openapitools.client.Pair;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.Tag;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -289,6 +290,87 @@ public class BodyApi {
 
     try {
       byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(pet);
+      localVarRequestBuilder.method("POST", HttpRequest.BodyPublishers.ofByteArray(localVarPostBody));
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
+  /**
+   * Test empty json (request body)
+   * Test empty json (request body)
+   * @param tag Tag object (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testEchoBodyTagResponseString(Tag tag) throws ApiException {
+    ApiResponse<String> localVarResponse = testEchoBodyTagResponseStringWithHttpInfo(tag);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test empty json (request body)
+   * Test empty json (request body)
+   * @param tag Tag object (optional)
+   * @return ApiResponse&lt;String&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<String> testEchoBodyTagResponseStringWithHttpInfo(Tag tag) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testEchoBodyTagResponseStringRequestBuilder(tag);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testEchoBodyTagResponseString", localVarResponse);
+        }
+        // for plain text response
+        if (localVarResponse.headers().map().containsKey("Content-Type") &&
+                "text/plain".equalsIgnoreCase(localVarResponse.headers().map().get("Content-Type").get(0))) {
+          java.util.Scanner s = new java.util.Scanner(localVarResponse.body()).useDelimiter("\\A");
+          String responseBodyText = s.hasNext() ? s.next() : "";
+          return new ApiResponse<String>(
+                  localVarResponse.statusCode(),
+                  localVarResponse.headers().map(),
+                  responseBodyText
+          );
+        } else {
+            throw new RuntimeException("Error! The response Content-Type is supposed to be `text/plain` but it's not: " + localVarResponse);
+        }
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testEchoBodyTagResponseStringRequestBuilder(Tag tag) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/echo/body/Tag/response_string";
+
+    localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+
+    localVarRequestBuilder.header("Content-Type", "application/json");
+    localVarRequestBuilder.header("Accept", "text/plain");
+
+    try {
+      byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(tag);
       localVarRequestBuilder.method("POST", HttpRequest.BodyPublishers.ofByteArray(localVarPostBody));
     } catch (IOException e) {
       throw new ApiException(e);

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -115,6 +115,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -113,6 +113,7 @@ All URIs are relative to *http://localhost:3000*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *BodyApi* | [**testBinaryGif**](docs/BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body
+*BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -349,6 +349,24 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/Tag/response_string:
+    post:
+      description: Test empty json (request body)
+      operationId: test/echo/body/Tag/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Tag'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test empty json (request body)
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body
@@ -373,6 +391,12 @@ components:
           schema:
             $ref: '#/components/schemas/Pet'
       description: Pet object that needs to be added to the store
+    Tag:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Tag'
+      description: Tag object
   schemas:
     Category:
       example:

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -367,6 +367,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/FreeFormObject/response_string:
+    post:
+      description: Test free form object
+      operationId: test/echo/body/FreeFormObject/response_string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Free form object
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test free form object
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: text/plain
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
 | [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
+| [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
@@ -62,6 +63,68 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+<a name="testEchoBodyFreeFormObjectResponseString"></a>
+# **testEchoBodyFreeFormObjectResponseString**
+> String testEchoBodyFreeFormObjectResponseString(body)
+
+Test free form object
+
+Test free form object
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:3000");
+
+    BodyApi apiInstance = new BodyApi(defaultClient);
+    Object body = null; // Object | Free form object
+    try {
+      String result = apiInstance.testEchoBodyFreeFormObjectResponseString(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling BodyApi#testEchoBodyFreeFormObjectResponseString");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **Object**| Free form object | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: text/plain
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testBinaryGif**](BodyApi.md#testBinaryGif) | **POST** /binary/gif | Test binary (gif) response body |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
 <a name="testBinaryGif"></a>
@@ -172,6 +173,68 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+<a name="testEchoBodyTagResponseString"></a>
+# **testEchoBodyTagResponseString**
+> String testEchoBodyTagResponseString(tag)
+
+Test empty json (request body)
+
+Test empty json (request body)
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:3000");
+
+    BodyApi apiInstance = new BodyApi(defaultClient);
+    Tag tag = new Tag(); // Tag | Tag object
+    try {
+      String result = apiInstance.testEchoBodyTagResponseString(tag);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling BodyApi#testEchoBodyTagResponseString");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **tag** | [**Tag**](Tag.md)| Tag object | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.Tag;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -419,6 +420,124 @@ public class BodyApi {
     public okhttp3.Call testEchoBodyPetResponseStringAsync(Pet pet, final ApiCallback<String> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = testEchoBodyPetResponseStringValidateBeforeCall(pet, _callback);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
+     * Build call for testEchoBodyTagResponseString
+     * @param tag Tag object (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testEchoBodyTagResponseStringCall(Tag tag, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = tag;
+
+        // create path and map variables
+        String localVarPath = "/echo/body/Tag/response_string";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "text/plain"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testEchoBodyTagResponseStringValidateBeforeCall(Tag tag, final ApiCallback _callback) throws ApiException {
+        return testEchoBodyTagResponseStringCall(tag, _callback);
+
+    }
+
+    /**
+     * Test empty json (request body)
+     * Test empty json (request body)
+     * @param tag Tag object (optional)
+     * @return String
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public String testEchoBodyTagResponseString(Tag tag) throws ApiException {
+        ApiResponse<String> localVarResp = testEchoBodyTagResponseStringWithHttpInfo(tag);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Test empty json (request body)
+     * Test empty json (request body)
+     * @param tag Tag object (optional)
+     * @return ApiResponse&lt;String&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<String> testEchoBodyTagResponseStringWithHttpInfo(Tag tag) throws ApiException {
+        okhttp3.Call localVarCall = testEchoBodyTagResponseStringValidateBeforeCall(tag, null);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Test empty json (request body) (asynchronously)
+     * Test empty json (request body)
+     * @param tag Tag object (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testEchoBodyTagResponseStringAsync(Tag tag, final ApiCallback<String> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testEchoBodyTagResponseStringValidateBeforeCall(tag, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -189,6 +189,124 @@ public class BodyApi {
         return localVarCall;
     }
     /**
+     * Build call for testEchoBodyFreeFormObjectResponseString
+     * @param body Free form object (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testEchoBodyFreeFormObjectResponseStringCall(Object body, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = body;
+
+        // create path and map variables
+        String localVarPath = "/echo/body/FreeFormObject/response_string";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "text/plain"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testEchoBodyFreeFormObjectResponseStringValidateBeforeCall(Object body, final ApiCallback _callback) throws ApiException {
+        return testEchoBodyFreeFormObjectResponseStringCall(body, _callback);
+
+    }
+
+    /**
+     * Test free form object
+     * Test free form object
+     * @param body Free form object (optional)
+     * @return String
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public String testEchoBodyFreeFormObjectResponseString(Object body) throws ApiException {
+        ApiResponse<String> localVarResp = testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Test free form object
+     * Test free form object
+     * @param body Free form object (optional)
+     * @return ApiResponse&lt;String&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<String> testEchoBodyFreeFormObjectResponseStringWithHttpInfo(Object body) throws ApiException {
+        okhttp3.Call localVarCall = testEchoBodyFreeFormObjectResponseStringValidateBeforeCall(body, null);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Test free form object (asynchronously)
+     * Test free form object
+     * @param body Free form object (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testEchoBodyFreeFormObjectResponseStringAsync(Object body, final ApiCallback<String> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testEchoBodyFreeFormObjectResponseStringValidateBeforeCall(body, _callback);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
      * Build call for testEchoBodyPet
      * @param pet Pet object that needs to be added to the store (optional)
      * @param _callback Callback for upload/download progress

--- a/samples/client/echo_api/python-nextgen/README.md
+++ b/samples/client/echo_api/python-nextgen/README.md
@@ -88,6 +88,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_binary_gif**](docs/BodyApi.md#test_binary_gif) | **POST** /binary/gif | Test binary (gif) response body
 *BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *HeaderApi* | [**test_header_integer_boolean_string**](docs/HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**tests_path_string_path_string_integer_path_integer**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)

--- a/samples/client/echo_api/python-nextgen/README.md
+++ b/samples/client/echo_api/python-nextgen/README.md
@@ -86,6 +86,7 @@ All URIs are relative to *http://localhost:3000*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *BodyApi* | [**test_binary_gif**](docs/BodyApi.md#test_binary_gif) | **POST** /binary/gif | Test binary (gif) response body
+*BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)

--- a/samples/client/echo_api/python-nextgen/docs/BodyApi.md
+++ b/samples/client/echo_api/python-nextgen/docs/BodyApi.md
@@ -7,6 +7,7 @@ Method | HTTP request | Description
 [**test_binary_gif**](BodyApi.md#test_binary_gif) | **POST** /binary/gif | Test binary (gif) response body
 [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+[**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 
 
 # **test_binary_gif**
@@ -181,6 +182,72 @@ with openapi_client.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_echo_body_tag_response_string**
+> str test_echo_body_tag_response_string(tag=tag)
+
+Test empty json (request body)
+
+Test empty json (request body)
+
+### Example
+
+```python
+import time
+import os
+import openapi_client
+from openapi_client.models.tag import Tag
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.BodyApi(api_client)
+    tag = openapi_client.Tag() # Tag | Tag object (optional)
+
+    try:
+        # Test empty json (request body)
+        api_response = api_instance.test_echo_body_tag_response_string(tag=tag)
+        print("The response of BodyApi->test_echo_body_tag_response_string:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling BodyApi->test_echo_body_tag_response_string: %s\n" % e)
+```
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **tag** | [**Tag**](Tag.md)| Tag object | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python-nextgen/docs/BodyApi.md
+++ b/samples/client/echo_api/python-nextgen/docs/BodyApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**test_binary_gif**](BodyApi.md#test_binary_gif) | **POST** /binary/gif | Test binary (gif) response body
+[**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
 [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
@@ -63,6 +64,71 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: image/gif
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_echo_body_free_form_object_response_string**
+> str test_echo_body_free_form_object_response_string(body=body)
+
+Test free form object
+
+Test free form object
+
+### Example
+
+```python
+import time
+import os
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.BodyApi(api_client)
+    body = None # object | Free form object (optional)
+
+    try:
+        # Test free form object
+        api_response = api_instance.test_echo_body_free_form_object_response_string(body=body)
+        print("The response of BodyApi->test_echo_body_free_form_object_response_string:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling BodyApi->test_echo_body_free_form_object_response_string: %s\n" % e)
+```
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | **object**| Free form object | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: text/plain
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
@@ -23,6 +23,7 @@ from pydantic import Field
 from typing import Optional
 
 from openapi_client.models.pet import Pet
+from openapi_client.models.tag import Tag
 
 from openapi_client.api_client import ApiClient
 from openapi_client.exceptions import (  # noqa: F401
@@ -454,6 +455,153 @@ class BodyApi(object):
 
         return self.api_client.call_api(
             '/echo/body/Pet/response_string', 'POST',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
+    def test_echo_body_tag_response_string(self, tag : Annotated[Optional[Tag], Field(description="Tag object")] = None, **kwargs) -> str:  # noqa: E501
+        """Test empty json (request body)  # noqa: E501
+
+        Test empty json (request body)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_echo_body_tag_response_string(tag, async_req=True)
+        >>> result = thread.get()
+
+        :param tag: Tag object
+        :type tag: Tag
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :type _preload_content: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: str
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_echo_body_tag_response_string_with_http_info(tag, **kwargs)  # noqa: E501
+
+    @validate_arguments
+    def test_echo_body_tag_response_string_with_http_info(self, tag : Annotated[Optional[Tag], Field(description="Tag object")] = None, **kwargs):  # noqa: E501
+        """Test empty json (request body)  # noqa: E501
+
+        Test empty json (request body)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_echo_body_tag_response_string_with_http_info(tag, async_req=True)
+        >>> result = thread.get()
+
+        :param tag: Tag object
+        :type tag: Tag
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :type _return_http_data_only: bool, optional
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :type _preload_content: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+            'tag'
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_echo_body_tag_response_string" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        if _params['tag']:
+            _body_params = _params['tag']
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['text/plain'])  # noqa: E501
+
+        # set the HTTP header `Content-Type`
+        _content_types_list = _params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json']))
+        if _content_types_list:
+                _header_params['Content-Type'] = _content_types_list
+
+        # authentication setting
+        _auth_settings = []  # noqa: E501
+
+        _response_types_map = {
+            '200': "str",
+        }
+
+        return self.api_client.call_api(
+            '/echo/body/Tag/response_string', 'POST',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-nextgen/openapi_client/api/body_api.py
@@ -20,7 +20,7 @@ from typing_extensions import Annotated
 
 from pydantic import Field
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from openapi_client.models.pet import Pet
 from openapi_client.models.tag import Tag
@@ -177,6 +177,153 @@ class BodyApi(object):
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
+    def test_echo_body_free_form_object_response_string(self, body : Annotated[Optional[Dict[str, Any]], Field(description="Free form object")] = None, **kwargs) -> str:  # noqa: E501
+        """Test free form object  # noqa: E501
+
+        Test free form object  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_echo_body_free_form_object_response_string(body, async_req=True)
+        >>> result = thread.get()
+
+        :param body: Free form object
+        :type body: object
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :type _preload_content: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: str
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_echo_body_free_form_object_response_string_with_http_info(body, **kwargs)  # noqa: E501
+
+    @validate_arguments
+    def test_echo_body_free_form_object_response_string_with_http_info(self, body : Annotated[Optional[Dict[str, Any]], Field(description="Free form object")] = None, **kwargs):  # noqa: E501
+        """Test free form object  # noqa: E501
+
+        Test free form object  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_echo_body_free_form_object_response_string_with_http_info(body, async_req=True)
+        >>> result = thread.get()
+
+        :param body: Free form object
+        :type body: object
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :type _return_http_data_only: bool, optional
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :type _preload_content: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+            'body'
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_echo_body_free_form_object_response_string" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        if _params['body'] is not None:
+            _body_params = _params['body']
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['text/plain'])  # noqa: E501
+
+        # set the HTTP header `Content-Type`
+        _content_types_list = _params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json']))
+        if _content_types_list:
+                _header_params['Content-Type'] = _content_types_list
+
+        # authentication setting
+        _auth_settings = []  # noqa: E501
+
+        _response_types_map = {
+            '200': "str",
+        }
+
+        return self.api_client.call_api(
+            '/echo/body/FreeFormObject/response_string', 'POST',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
     def test_echo_body_pet(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> Pet:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
@@ -285,7 +432,7 @@ class BodyApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Accept`
@@ -432,7 +579,7 @@ class BodyApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Accept`
@@ -579,7 +726,7 @@ class BodyApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['tag']:
+        if _params['tag'] is not None:
             _body_params = _params['tag']
 
         # set the HTTP header `Accept`

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -97,6 +97,9 @@ class TestManual(unittest.TestCase):
         api_response = api_instance.test_echo_body_tag_response_string(None)
         self.assertEqual(api_response, "") # assertion to ensure emtpy string is sent in the body
 
+        api_response = api_instance.test_echo_body_free_form_object_response_string({})
+        self.assertEqual(api_response, "{}") # assertion to ensure {} is sent in the body
+
     def echoServerResponseParaserTest(self):
         s = """POST /echo/body/Pet/response_string HTTP/1.1
 Host: localhost:3000

--- a/samples/client/echo_api/python-nextgen/test/test_manual.py
+++ b/samples/client/echo_api/python-nextgen/test/test_manual.py
@@ -84,6 +84,35 @@ class TestManual(unittest.TestCase):
         self.assertEqual(n.float, 456.2)
         self.assertEqual(n.double, 34.3)
 
+    def testBodyParameter(self):
+        n = openapi_client.Pet.from_dict({"name": "testing", "photoUrls": ["http://1", "http://2"]})
+        api_instance = openapi_client.BodyApi()
+        api_response = api_instance.test_echo_body_pet_response_string(n)
+        self.assertEqual(api_response, "{'name': 'testing', 'photoUrls': ['http://1', 'http://2']}")
+
+        t = openapi_client.Tag()
+        api_response = api_instance.test_echo_body_tag_response_string(t)
+        self.assertEqual(api_response, "{}") # assertion to ensure {} is sent in the body
+
+        api_response = api_instance.test_echo_body_tag_response_string(None)
+        self.assertEqual(api_response, "") # assertion to ensure emtpy string is sent in the body
+
+    def echoServerResponseParaserTest(self):
+        s = """POST /echo/body/Pet/response_string HTTP/1.1
+Host: localhost:3000
+Accept-Encoding: identity
+Content-Length: 58
+Accept: text/plain
+Content-Type: application/json
+User-Agent: OpenAPI-Generator/1.0.0/python
+
+{"name": "testing", "photoUrls": ["http://1", "http://2"]}"""
+        e = EchoServerResponseParser(s)
+        self.assertEqual(e.body, '{"name": "testing", "photoUrls": ["http://1", "http://2"]}')
+        self.assertEqual(e.path, '/echo/body/Pet/response_string')
+        self.assertEqual(e.headers["Accept"], 'text/plain')
+        self.assertEqual(e.method, 'POST')
+
 class EchoServerResponseParser():
     def __init__(self, http_response):
         if http_response is None:
@@ -100,6 +129,7 @@ class EchoServerResponseParser():
                 self.protocol = items[2];
             elif lines[x] == "": # blank line
                 self.body = "\n".join(lines[x:])
+                break
             else:
                 key_value = lines[x].split(": ")
                 # store the header key-value pair in headers

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/another_fake_api.py
@@ -160,7 +160,7 @@ class AnotherFakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['client']:
+        if _params['client'] is not None:
             _body_params = _params['client']
 
         # set the HTTP header `Accept`

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_api.py
@@ -169,7 +169,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Content-Type`
@@ -616,7 +616,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Content-Type`
@@ -767,7 +767,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Accept`
@@ -924,7 +924,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['outer_composite']:
+        if _params['outer_composite'] is not None:
             _body_params = _params['outer_composite']
 
         # set the HTTP header `Accept`
@@ -1081,7 +1081,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Accept`
@@ -1238,7 +1238,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Accept`
@@ -1395,7 +1395,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['outer_object_with_enum_property']:
+        if _params['outer_object_with_enum_property'] is not None:
             _body_params = _params['outer_object_with_enum_property']
 
         # set the HTTP header `Accept`
@@ -1552,7 +1552,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Content-Type`
@@ -1703,7 +1703,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['file_schema_test_class']:
+        if _params['file_schema_test_class'] is not None:
             _body_params = _params['file_schema_test_class']
 
         # set the HTTP header `Content-Type`
@@ -1860,7 +1860,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -2011,7 +2011,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['client']:
+        if _params['client'] is not None:
             _body_params = _params['client']
 
         # set the HTTP header `Accept`
@@ -2760,7 +2760,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['request_body']:
+        if _params['request_body'] is not None:
             _body_params = _params['request_body']
 
         # set the HTTP header `Content-Type`

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -160,7 +160,7 @@ class FakeClassnameTags123Api(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['client']:
+        if _params['client'] is not None:
             _body_params = _params['client']
 
         # set the HTTP header `Accept`

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/pet_api.py
@@ -163,7 +163,7 @@ class PetApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Content-Type`
@@ -922,7 +922,7 @@ class PetApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Content-Type`

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/store_api.py
@@ -600,7 +600,7 @@ class StoreApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['order']:
+        if _params['order'] is not None:
             _body_params = _params['order']
 
         # set the HTTP header `Accept`

--- a/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen-aiohttp/petstore_api/api/user_api.py
@@ -174,7 +174,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -326,7 +326,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -477,7 +477,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -1227,7 +1227,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/another_fake_api.py
@@ -149,7 +149,7 @@ class AnotherFakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['client']:
+        if _params['client'] is not None:
             _body_params = _params['client']
 
         # set the HTTP header `Accept`

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_api.py
@@ -158,7 +158,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Content-Type`
@@ -575,7 +575,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Content-Type`
@@ -716,7 +716,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Accept`
@@ -863,7 +863,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['outer_composite']:
+        if _params['outer_composite'] is not None:
             _body_params = _params['outer_composite']
 
         # set the HTTP header `Accept`
@@ -1010,7 +1010,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Accept`
@@ -1157,7 +1157,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Accept`
@@ -1304,7 +1304,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['outer_object_with_enum_property']:
+        if _params['outer_object_with_enum_property'] is not None:
             _body_params = _params['outer_object_with_enum_property']
 
         # set the HTTP header `Accept`
@@ -1451,7 +1451,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['body']:
+        if _params['body'] is not None:
             _body_params = _params['body']
 
         # set the HTTP header `Content-Type`
@@ -1592,7 +1592,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['file_schema_test_class']:
+        if _params['file_schema_test_class'] is not None:
             _body_params = _params['file_schema_test_class']
 
         # set the HTTP header `Content-Type`
@@ -1739,7 +1739,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -1880,7 +1880,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['client']:
+        if _params['client'] is not None:
             _body_params = _params['client']
 
         # set the HTTP header `Accept`
@@ -2589,7 +2589,7 @@ class FakeApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['request_body']:
+        if _params['request_body'] is not None:
             _body_params = _params['request_body']
 
         # set the HTTP header `Content-Type`

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/fake_classname_tags123_api.py
@@ -149,7 +149,7 @@ class FakeClassnameTags123Api(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['client']:
+        if _params['client'] is not None:
             _body_params = _params['client']
 
         # set the HTTP header `Accept`

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/pet_api.py
@@ -152,7 +152,7 @@ class PetApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Content-Type`
@@ -861,7 +861,7 @@ class PetApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['pet']:
+        if _params['pet'] is not None:
             _body_params = _params['pet']
 
         # set the HTTP header `Content-Type`

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/store_api.py
@@ -559,7 +559,7 @@ class StoreApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['order']:
+        if _params['order'] is not None:
             _body_params = _params['order']
 
         # set the HTTP header `Accept`

--- a/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-nextgen/petstore_api/api/user_api.py
@@ -163,7 +163,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -305,7 +305,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -446,7 +446,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`
@@ -1146,7 +1146,7 @@ class UserApi(object):
         _files = {}
         # process the body parameter
         _body_params = None
-        if _params['user']:
+        if _params['user'] is not None:
             _body_params = _params['user']
 
         # set the HTTP header `Content-Type`


### PR DESCRIPTION
- To fix https://github.com/OpenAPITools/openapi-generator/issues/15328
- Add more tests for body parameters

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)