### PR TITLE
[GO] Add go.mod in go-gin-server generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoGinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoGinServerCodegen.java
@@ -191,6 +191,7 @@ public class GoGinServerCodegen extends AbstractGoCodegen {
         supportingFiles.add(new SupportingFile("routers.mustache", apiPath, "routers.go"));
         supportingFiles.add(new SupportingFile("README.mustache", apiPath, "README.md")
                 .doNotOverwrite());
+        supportingFiles.add(new SupportingFile("go.mod.mustache", "go.mod"));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/go-gin-server/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/go.mod.mustache
@@ -1,0 +1,6 @@
+module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}
+
+go 1.19
+
+require github.com/gin-gonic/gin v1.9.0
+

--- a/modules/openapi-generator/src/main/resources/go-gin-server/main.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/main.mustache
@@ -5,13 +5,9 @@ import (
 	"log"
 
 	// WARNING!
-	// Change this to a fully-qualified import path
-	// once you place this file into your project.
-	// For example,
+	// Pass --git-repo-id and --git-user-id properties when generating the code
 	//
-	//sw "github.com/{{{gitUserId}}}/{{{gitRepoId}}}/{{{apiPath}}}"
-	//
-	sw "./{{apiPath}}"
+	sw "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/{{apiPath}}"
 )
 
 func main() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/goginserver/GoGinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/goginserver/GoGinServerCodegenTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.goginserver;
+
+import org.openapitools.codegen.*;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.openapitools.codegen.languages.GoClientCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class GoGinServerCodegenTest {
+
+    @Test
+    public void verifyGoMod() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go-gin-server")
+                .setGitUserId("my-user")
+                .setGitRepoId("my-repo")
+                .setPackageName("my-package")
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/go.mod"));
+        TestUtils.assertFileContains(Paths.get(output + "/go.mod"),
+                "module github.com/my-user/my-repo");
+        TestUtils.assertFileContains(Paths.get(output + "/go.mod"),
+                "require github.com/gin-gonic/gin v1.9.0");
+    }
+
+}

--- a/samples/server/petstore/go-gin-api-server/.openapi-generator/FILES
+++ b/samples/server/petstore/go-gin-api-server/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 Dockerfile
 api/openapi.yaml
+go.mod
 go/README.md
 go/api_pet.go
 go/api_store.go

--- a/samples/server/petstore/go-gin-api-server/go.mod
+++ b/samples/server/petstore/go-gin-api-server/go.mod
@@ -1,0 +1,6 @@
+module github.com/GIT_USER_ID/GIT_REPO_ID
+
+go 1.19
+
+require github.com/gin-gonic/gin v1.9.0
+

--- a/samples/server/petstore/go-gin-api-server/main.go
+++ b/samples/server/petstore/go-gin-api-server/main.go
@@ -13,13 +13,9 @@ import (
 	"log"
 
 	// WARNING!
-	// Change this to a fully-qualified import path
-	// once you place this file into your project.
-	// For example,
+	// Pass --git-repo-id and --git-user-id properties when generating the code
 	//
-	//sw "github.com/GIT_USER_ID/GIT_REPO_ID/go"
-	//
-	sw "./go"
+	sw "github.com/GIT_USER_ID/GIT_REPO_ID/go"
 )
 
 func main() {


### PR DESCRIPTION
Add `go.mod` in Go Gin Server generator as it is a required directive (the same approach is taken for the Go client) and it conveniently declares the `gin-gonic` dependency.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)