### PR TITLE
Mark python-nextgen client generator as stable

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -53,7 +53,7 @@ The following generators are available:
 * [powershell (beta)](generators/powershell.md)  
 * [python](generators/python.md)  
 * [python-legacy](generators/python-legacy.md)  
-* [python-nextgen (beta)](generators/python-nextgen.md)  
+* [python-nextgen](generators/python-nextgen.md)  
 * [python-prior](generators/python-prior.md)  
 * [r](generators/r.md)  
 * [ruby](generators/ruby.md)  

--- a/docs/generators/python-nextgen.md
+++ b/docs/generators/python-nextgen.md
@@ -7,7 +7,7 @@ title: Documentation for the python-nextgen Generator
 | Property | Value | Notes |
 | -------- | ----- | ----- |
 | generator name | python-nextgen | pass this to the generate command after -g |
-| generator stability | BETA | |
+| generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Python | |
 | generator language version | 3.7+ | |

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonNextgenClientCodegen.java
@@ -102,7 +102,7 @@ public class PythonNextgenClientCodegen extends AbstractPythonCodegen implements
         );
 
         generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
-                .stability(Stability.BETA)
+                .stability(Stability.STABLE)
                 .build();
 
         // clear import mapping (from default generator) as python does not use it


### PR DESCRIPTION
Mark python-nextgen client generator as stable

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)