### PR TITLE
fix JsonNullable issue

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -235,7 +235,6 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
                 supportingFiles.add(new SupportingFile("RFC3339DateFormat.mustache", invokerFolder.toString(), "RFC3339DateFormat.java"));
                 break;
             case SERIALIZATION_LIBRARY_JSONB:
-                openApiNullable = false;        // for Jackson only
                 additionalProperties.put(SERIALIZATION_LIBRARY_JSONB, "true");
                 additionalProperties.remove(SERIALIZATION_LIBRARY_JACKSON);
                 break;
@@ -245,6 +244,10 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
                 LOGGER.error("Unknown serialization library option");
                 break;
         }
+
+        // JsonNullable is not implemented
+        openApiNullable = false;
+        additionalProperties.put(OPENAPI_NULLABLE, openApiNullable);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
@@ -263,6 +263,10 @@ public class JavaHelidonServerCodegen extends JavaHelidonCommonCodegen {
                 LOGGER.error("Unknown serialization library option");
                 break;
         }
+
+        // JsonNullable is not implemented
+        openApiNullable = false;
+        additionalProperties.put(OPENAPI_NULLABLE, openApiNullable);
     }
 
     private void addApiTemplateFiles() {

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -16,6 +16,12 @@
     <description>{{artifactDescription}}</description>
     <packaging>jar</packaging>
 
+    <properties>
+        {{#openApiNullable}}
+            <version.jackson.databind.nullable>0.2.6</version.jackson.databind.nullable>
+        {{/openApiNullable}}
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.rest-client</groupId>
@@ -37,15 +43,17 @@
             <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json</groupId>
             <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json-api</artifactId>
         </dependency>
+{{#openApiNullable}}
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${version.jackson.databind.nullable}</version>
+        </dependency>
+{{/openApiNullable}}
 {{#jackson}}
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openapitools</groupId>
-            <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.6</version>
         </dependency>
 {{/jackson}}
 {{#jsonb}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
@@ -17,6 +17,12 @@
     <version>{{artifactVersion}}</version>
     <packaging>jar</packaging>
 
+    <properties>
+{{#openApiNullable}}
+        <version.jackson.databind.nullable>0.2.6</version.jackson.databind.nullable>
+{{/openApiNullable}}
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
@@ -30,6 +36,13 @@
             <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json</groupId>
             <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json-api</artifactId>
         </dependency>
+{{#openApiNullable}}
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${version.jackson.databind.nullable}</version>
+        </dependency>
+{{/openApiNullable}}
 {{#jackson}}
         <dependency>
             <groupId>io.helidon.media</groupId>
@@ -38,11 +51,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openapitools</groupId>
-            <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.6</version>
         </dependency>
 {{/jackson}}
 {{#jsonb}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pom.mustache
@@ -17,11 +17,11 @@
     <version>{{artifactVersion}}</version>
     <packaging>jar</packaging>
 
-{{#openApiNullable}}
     <properties>
-        <version.jackson.databind.nullable>0.2.3</version.jackson.databind.nullable>
-    </properties>
+{{#openApiNullable}}
+        <version.jackson.databind.nullable>0.2.6</version.jackson.databind.nullable>
 {{/openApiNullable}}
+    </properties>
 
     <dependencies>
         <dependency>

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/pom.mustache
@@ -19,7 +19,9 @@
 
     <properties>
         <mainClass>{{{invokerPackage}}}.Main</mainClass>
-        <version.jackson.databind.nullable>0.2.3</version.jackson.databind.nullable>
+{{#openApiNullable}}
+        <version.jackson.databind.nullable>0.2.6</version.jackson.databind.nullable>
+{{/openApiNullable}}
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fixes [#6660](https://github.com/helidon-io/helidon/issues/6660)

I turned off using of `org.openapitools.jackson.nullable.JsonNullable` to fix issue with duplicated imports and unused dependencies as Helidon generators do not support this feature at the moment.