### PR TITLE
[Java] [Microprofile] Remove unused CXF dependency

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -12,9 +12,6 @@ import java.util.Set;
 import {{rootJavaEEPackage}}.ws.rs.*;
 import {{rootJavaEEPackage}}.ws.rs.core.Response;
 import {{rootJavaEEPackage}}.ws.rs.core.MediaType;
-{{^disableMultipart}}
-import org.apache.cxf.jaxrs.ext.multipart.*;
-{{/disableMultipart}}
 {{#microprofileMutiny}}
 import io.smallrye.mutiny.Uni;
 {{/microprofileMutiny}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pom.mustache
@@ -101,13 +101,6 @@
       <version>${smallrye.config.version}</version>
       <scope>test</scope>
     </dependency>
-    {{^disableMultipart}}
-    <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-rs-extension-providers</artifactId>
-        <version>${cxf.rt.rs.extension.providers.version}</version>
-    </dependency>
-    {{/disableMultipart}}
     <dependency>
       <groupId>jakarta.json.bind</groupId>
       <artifactId>jakarta.json.bind-api</artifactId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pom_3.0.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pom_3.0.mustache
@@ -101,13 +101,6 @@
         <scope>test</scope>
     </dependency>
 
-    {{^disableMultipart}}
-    <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-rs-extension-providers</artifactId>
-        <version>${cxf.rt.rs.extension.providers.version}</version>
-    </dependency>
-    {{/disableMultipart}}
     <dependency>
       <groupId>jakarta.json.bind</groupId>
       <artifactId>jakarta.json.bind-api</artifactId>

--- a/samples/client/petstore/java/microprofile-rest-client-3.0/pom.xml
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0/pom.xml
@@ -91,11 +91,6 @@
     </dependency>
 
     <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-rs-extension-providers</artifactId>
-        <version>${cxf.rt.rs.extension.providers.version}</version>
-    </dependency>
-    <dependency>
       <groupId>jakarta.json.bind</groupId>
       <artifactId>jakarta.json.bind-api</artifactId>
       <version>${jakarta.json.bind.version}</version>

--- a/samples/client/petstore/java/microprofile-rest-client-3.0/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0/src/main/java/org/openapitools/client/api/PetApi.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/samples/client/petstore/java/microprofile-rest-client-3.0/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/samples/client/petstore/java/microprofile-rest-client-3.0/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0/src/main/java/org/openapitools/client/api/UserApi.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/samples/client/petstore/java/microprofile-rest-client/pom.xml
+++ b/samples/client/petstore/java/microprofile-rest-client/pom.xml
@@ -91,11 +91,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-rs-extension-providers</artifactId>
-        <version>${cxf.rt.rs.extension.providers.version}</version>
-    </dependency>
-    <dependency>
       <groupId>jakarta.json.bind</groupId>
       <artifactId>jakarta.json.bind-api</artifactId>
       <version>${jakarta.json.bind.version}</version>

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/PetApi.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/UserApi.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
-import org.apache.cxf.jaxrs.ext.multipart.*;
 
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Follow-up for #6680.
Using the microprofile library requires an additional (unnecessary) dependency in a project. If one uses a different implementation than CXF, e.g. Jersey, the CXF dependency has to be pulled in additionally. But Jersey has an own implementation for multipart handling.

The dependency and the corresponding import aren't used at the moment. Thus, they can be safely deleted.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
