### PR TITLE
[dart][dart-dio] Fix property deprecation and add parameter deprecation

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
@@ -39,11 +39,11 @@ class {{classname}} {
   @Deprecated('This operation has been deprecated')
   {{/isDeprecated}}
   Future<Response<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {{nickname}}({ {{#allParams}}{{#isPathParam}}
-    required {{{dataType}}} {{paramName}},{{/isPathParam}}{{#isQueryParam}}
-    {{#required}}{{^isNullable}}{{^defaultValue}}required {{/defaultValue}}{{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}}{{^isContainer}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isContainer}},{{/isQueryParam}}{{#isHeaderParam}}
-    {{#required}}{{^isNullable}}{{^defaultValue}}required {{/defaultValue}}{{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}}{{^isContainer}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isContainer}},{{/isHeaderParam}}{{#isBodyParam}}
-    {{#required}}{{^isNullable}}required {{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}},{{/isBodyParam}}{{#isFormParam}}
-    {{#required}}{{^isNullable}}required {{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}},{{/isFormParam}}{{/allParams}}
+    {{#isDeprecated}}@Deprecated('{{paramName}} is deprecated') {{/isDeprecated}}required {{{dataType}}} {{paramName}},{{/isPathParam}}{{#isQueryParam}}
+    {{#isDeprecated}}@Deprecated('{{paramName}} is deprecated') {{/isDeprecated}}{{#required}}{{^isNullable}}{{^defaultValue}}required {{/defaultValue}}{{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}}{{^isContainer}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isContainer}},{{/isQueryParam}}{{#isHeaderParam}}
+    {{#isDeprecated}}@Deprecated('{{paramName}} is deprecated') {{/isDeprecated}}{{#required}}{{^isNullable}}{{^defaultValue}}required {{/defaultValue}}{{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}}{{^isContainer}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isContainer}},{{/isHeaderParam}}{{#isBodyParam}}
+    {{#isDeprecated}}@Deprecated('{{paramName}} is deprecated') {{/isDeprecated}}{{#required}}{{^isNullable}}required {{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}},{{/isBodyParam}}{{#isFormParam}}
+    {{#isDeprecated}}@Deprecated('{{paramName}} is deprecated') {{/isDeprecated}}{{#required}}{{^isNullable}}required {{/isNullable}}{{/required}}{{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}} {{paramName}},{{/isFormParam}}{{/allParams}}
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_members.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_members.mustache
@@ -3,9 +3,9 @@
   {{#description}}
   /// {{{.}}}
   {{/description}}
-  {{#isDeprecated}}
+  {{#deprecated}}
   @Deprecated('{{{name}}} has been deprecated')
-  {{/isDeprecated}}
+  {{/deprecated}}
   @BuiltValueField(wireName: r'{{baseName}}')
   {{>serialization/built_value/variable_type}}{{^isNullable}}{{^required}}?{{/required}}{{/isNullable}} get {{name}};
   {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
@@ -35,9 +35,9 @@ class {{{classname}}} {
           // maximum: {{{maximum}}}
       {{/maximum}}
   {{/isEnum}}
-  {{#isDeprecated}}
+  {{#deprecated}}
   @Deprecated('{{{name}}} has been deprecated')
-  {{/isDeprecated}}
+  {{/deprecated}}
   {{^isBinary}}
   @JsonKey(
     {{#defaultValue}}defaultValue: {{{defaultValue}}},{{/defaultValue}}

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
@@ -158,7 +158,7 @@ _bodyData=jsonEncode(pet);
   /// Returns a [Future] containing a [Response] with a [List<Pet>] as data
   /// Throws [DioError] if API call or serialization fails
   Future<Response<List<Pet>>> findPetsByStatus({ 
-    required List<String> status,
+    @Deprecated('status is deprecated') required List<String> status,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/deprecated_object.dart
@@ -22,7 +22,6 @@ class DeprecatedObject {
      this.name,
   });
 
-  @Deprecated('name has been deprecated')
   @JsonKey(
     
     name: r'name',

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/object_with_deprecated_fields.dart
@@ -40,6 +40,7 @@ class ObjectWithDeprecatedFields {
 
 
 
+  @Deprecated('id has been deprecated')
   @JsonKey(
     
     name: r'id',
@@ -52,6 +53,7 @@ class ObjectWithDeprecatedFields {
 
 
 
+  @Deprecated('deprecatedRef has been deprecated')
   @JsonKey(
     
     name: r'deprecatedRef',
@@ -64,6 +66,7 @@ class ObjectWithDeprecatedFields {
 
 
 
+  @Deprecated('bars has been deprecated')
   @JsonKey(
     
     name: r'bars',

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
@@ -162,7 +162,7 @@ class PetApi {
   /// Returns a [Future] containing a [Response] with a [BuiltList<Pet>] as data
   /// Throws [DioError] if API call or serialization fails
   Future<Response<BuiltList<Pet>>> findPetsByStatus({ 
-    required BuiltList<String> status,
+    @Deprecated('status is deprecated') required BuiltList<String> status,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/deprecated_object.dart
@@ -15,7 +15,6 @@ part 'deprecated_object.g.dart';
 @Deprecated('DeprecatedObject has been deprecated')
 @BuiltValue()
 abstract class DeprecatedObject implements Built<DeprecatedObject, DeprecatedObjectBuilder> {
-  @Deprecated('name has been deprecated')
   @BuiltValueField(wireName: r'name')
   String? get name;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/object_with_deprecated_fields.dart
@@ -22,12 +22,15 @@ abstract class ObjectWithDeprecatedFields implements Built<ObjectWithDeprecatedF
   @BuiltValueField(wireName: r'uuid')
   String? get uuid;
 
+  @Deprecated('id has been deprecated')
   @BuiltValueField(wireName: r'id')
   num? get id;
 
+  @Deprecated('deprecatedRef has been deprecated')
   @BuiltValueField(wireName: r'deprecatedRef')
   DeprecatedObject? get deprecatedRef;
 
+  @Deprecated('bars has been deprecated')
   @BuiltValueField(wireName: r'bars')
   BuiltList<String>? get bars;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/test/api/pet_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/test/api/pet_api_test.dart
@@ -198,6 +198,7 @@ void main() {
         );
 
         final response = await client.getPetApi().findPetsByStatus(
+              // ignore: deprecated_member_use
               status: ListBuilder<String>(<String>[
                 PetStatusEnum.available.name,
                 PetStatusEnum.sold.name,


### PR DESCRIPTION
Addresses problems in #13818

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)