### PR TITLE
fix(typescript-fetch): request body with array

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -267,7 +267,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{#bodyParam}}
             {{#isContainer}}
             {{^withoutRuntimeChecks}}
-            body: requestParameters.{{paramName}}{{#isArray}}{{#items}}{{^isPrimitiveType}}.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isArray}},
+            body: requestParameters.{{paramName}}{{#isArray}}{{#items}}{{^isPrimitiveType}}{{^required}}?{{/required}}.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isArray}},
             {{/withoutRuntimeChecks}}
             {{#withoutRuntimeChecks}}
             body: requestParameters.{{paramName}},


### PR DESCRIPTION
The code generated endpoints with array as body request parameter is not valid.

fix for issue https://github.com/OpenAPITools/openapi-generator/issues/14792
