### PR TITLE
[dart-dio] fix endpoints returning null

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
@@ -116,7 +116,7 @@ class {{classname}} {
     );
     {{#returnType}}
 
-    {{{returnType}}} _responseData;
+    {{{.}}}? _responseData;
 
     try {
 {{#includeLibraryTemplate}}api/deserialize{{/includeLibraryTemplate}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/api/deserialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/api/deserialize.mustache
@@ -10,14 +10,14 @@
       {{^returnTypeIsPrimitive}}      
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType({{{returnType}}}),
+        specifiedType: const FullType({{{returnType}}}),
       ) as {{{returnType}}};
       {{/returnTypeIsPrimitive}}
       {{/returnSimpleType}}
       {{^returnSimpleType}}      
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Built{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Map{{/isMap}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]),
+        specifiedType: const FullType(Built{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Map{{/isMap}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]),
       ) as {{{returnType}}};
       {{/returnSimpleType}}
       {{/isResponseFile}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/api/deserialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/api/deserialize.mustache
@@ -1,24 +1,23 @@
+      final rawResponse = _response.data;
       {{#isResponseFile}}
-      _responseData = _response.data as {{{returnType}}};
+      _responseData = rawResponse == null ? null : rawResponse as {{{returnType}}};
       {{/isResponseFile}}
       {{^isResponseFile}}
       {{#returnSimpleType}}
       {{#returnTypeIsPrimitive}}
-      _responseData = _response.data as {{{returnType}}};
+      _responseData = rawResponse == null ? null : rawResponse as {{{returnType}}};
       {{/returnTypeIsPrimitive}}
-      {{^returnTypeIsPrimitive}}
-      const _responseType = FullType({{{returnType}}});
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      {{^returnTypeIsPrimitive}}      
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType({{{returnType}}}),
       ) as {{{returnType}}};
       {{/returnTypeIsPrimitive}}
       {{/returnSimpleType}}
-      {{^returnSimpleType}}
-      const _responseType = FullType(Built{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Map{{/isMap}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      {{^returnSimpleType}}      
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Built{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Map{{/isMap}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]),
       ) as {{{returnType}}};
       {{/returnSimpleType}}
       {{/isResponseFile}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/deserialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/api/deserialize.mustache
@@ -1,1 +1,2 @@
-_responseData = deserialize<{{{returnType}}}, {{{returnBaseType}}}>(_response.data!, '{{{returnType}}}', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<{{{returnType}}}, {{{returnBaseType}}}>(rawData, '{{{returnType}}}', growable: true);

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/api/default_api.dart
@@ -65,7 +65,7 @@ class DefaultApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Fruit),
+        specifiedType: const FullType(Fruit),
       ) as Fruit;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/src/api/default_api.dart
@@ -59,13 +59,13 @@ class DefaultApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Fruit _responseData;
+    Fruit? _responseData;
 
     try {
-      const _responseType = FullType(Fruit);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Fruit),
       ) as Fruit;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/bar_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/bar_api.dart
@@ -82,13 +82,13 @@ class BarApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Bar _responseData;
+    Bar? _responseData;
 
     try {
-      const _responseType = FullType(Bar);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Bar),
       ) as Bar;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/bar_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/bar_api.dart
@@ -88,7 +88,7 @@ class BarApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Bar),
+        specifiedType: const FullType(Bar),
       ) as Bar;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/foo_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/foo_api.dart
@@ -89,7 +89,7 @@ class FooApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(FooRefOrValue),
+        specifiedType: const FullType(FooRefOrValue),
       ) as FooRefOrValue;
 
     } catch (error, stackTrace) {
@@ -162,7 +162,7 @@ class FooApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(BuiltList, [FullType(FooRefOrValue)]),
+        specifiedType: const FullType(BuiltList, [FullType(FooRefOrValue)]),
       ) as BuiltList<FooRefOrValue>;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/foo_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/api/foo_api.dart
@@ -83,13 +83,13 @@ class FooApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    FooRefOrValue _responseData;
+    FooRefOrValue? _responseData;
 
     try {
-      const _responseType = FullType(FooRefOrValue);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(FooRefOrValue),
       ) as FooRefOrValue;
 
     } catch (error, stackTrace) {
@@ -156,13 +156,13 @@ class FooApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    BuiltList<FooRefOrValue> _responseData;
+    BuiltList<FooRefOrValue>? _responseData;
 
     try {
-      const _responseType = FullType(BuiltList, [FullType(FooRefOrValue)]);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(BuiltList, [FullType(FooRefOrValue)]),
       ) as BuiltList<FooRefOrValue>;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/api/default_api.dart
@@ -65,7 +65,7 @@ class DefaultApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Example),
+        specifiedType: const FullType(Example),
       ) as Example;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/src/api/default_api.dart
@@ -59,13 +59,13 @@ class DefaultApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Example _responseData;
+    Example? _responseData;
 
     try {
-      const _responseType = FullType(Example);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Example),
       ) as Example;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/another_fake_api.dart
@@ -79,10 +79,11 @@ _bodyData=jsonEncode(modelClient);
       onReceiveProgress: onReceiveProgress,
     );
 
-    ModelClient _responseData;
+    ModelClient? _responseData;
 
     try {
-_responseData = deserialize<ModelClient, ModelClient>(_response.data!, 'ModelClient', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(rawData, 'ModelClient', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/default_api.dart
@@ -59,10 +59,11 @@ class DefaultApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    FooGetDefaultResponse _responseData;
+    FooGetDefaultResponse? _responseData;
 
     try {
-_responseData = deserialize<FooGetDefaultResponse, FooGetDefaultResponse>(_response.data!, 'FooGetDefaultResponse', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<FooGetDefaultResponse, FooGetDefaultResponse>(rawData, 'FooGetDefaultResponse', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_api.dart
@@ -66,10 +66,11 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    HealthCheckResult _responseData;
+    HealthCheckResult? _responseData;
 
     try {
-_responseData = deserialize<HealthCheckResult, HealthCheckResult>(_response.data!, 'HealthCheckResult', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<HealthCheckResult, HealthCheckResult>(rawData, 'HealthCheckResult', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -236,10 +237,11 @@ _bodyData=jsonEncode(body);
       onReceiveProgress: onReceiveProgress,
     );
 
-    bool _responseData;
+    bool? _responseData;
 
     try {
-_responseData = deserialize<bool, bool>(_response.data!, 'bool', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<bool, bool>(rawData, 'bool', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -324,10 +326,11 @@ _bodyData=jsonEncode(outerComposite);
       onReceiveProgress: onReceiveProgress,
     );
 
-    OuterComposite _responseData;
+    OuterComposite? _responseData;
 
     try {
-_responseData = deserialize<OuterComposite, OuterComposite>(_response.data!, 'OuterComposite', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<OuterComposite, OuterComposite>(rawData, 'OuterComposite', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -412,10 +415,11 @@ _bodyData=jsonEncode(body);
       onReceiveProgress: onReceiveProgress,
     );
 
-    num _responseData;
+    num? _responseData;
 
     try {
-_responseData = deserialize<num, num>(_response.data!, 'num', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<num, num>(rawData, 'num', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -500,10 +504,11 @@ _bodyData=jsonEncode(body);
       onReceiveProgress: onReceiveProgress,
     );
 
-    String _responseData;
+    String? _responseData;
 
     try {
-_responseData = deserialize<String, String>(_response.data!, 'String', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<String, String>(rawData, 'String', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -588,10 +593,11 @@ _bodyData=jsonEncode(outerObjectWithEnumProperty);
       onReceiveProgress: onReceiveProgress,
     );
 
-    OuterObjectWithEnumProperty _responseData;
+    OuterObjectWithEnumProperty? _responseData;
 
     try {
-_responseData = deserialize<OuterObjectWithEnumProperty, OuterObjectWithEnumProperty>(_response.data!, 'OuterObjectWithEnumProperty', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<OuterObjectWithEnumProperty, OuterObjectWithEnumProperty>(rawData, 'OuterObjectWithEnumProperty', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -879,10 +885,11 @@ _bodyData=jsonEncode(modelClient);
       onReceiveProgress: onReceiveProgress,
     );
 
-    ModelClient _responseData;
+    ModelClient? _responseData;
 
     try {
-_responseData = deserialize<ModelClient, ModelClient>(_response.data!, 'ModelClient', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(rawData, 'ModelClient', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/fake_classname_tags123_api.dart
@@ -86,10 +86,11 @@ _bodyData=jsonEncode(modelClient);
       onReceiveProgress: onReceiveProgress,
     );
 
-    ModelClient _responseData;
+    ModelClient? _responseData;
 
     try {
-_responseData = deserialize<ModelClient, ModelClient>(_response.data!, 'ModelClient', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<ModelClient, ModelClient>(rawData, 'ModelClient', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/pet_api.dart
@@ -197,10 +197,11 @@ _bodyData=jsonEncode(pet);
       onReceiveProgress: onReceiveProgress,
     );
 
-    List<Pet> _responseData;
+    List<Pet>? _responseData;
 
     try {
-_responseData = deserialize<List<Pet>, Pet>(_response.data!, 'List<Pet>', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<List<Pet>, Pet>(rawData, 'List<Pet>', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -278,10 +279,11 @@ _responseData = deserialize<List<Pet>, Pet>(_response.data!, 'List<Pet>', growab
       onReceiveProgress: onReceiveProgress,
     );
 
-    Set<Pet> _responseData;
+    Set<Pet>? _responseData;
 
     try {
-_responseData = deserialize<Set<Pet>, Pet>(_response.data!, 'Set<Pet>', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<Set<Pet>, Pet>(rawData, 'Set<Pet>', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -355,10 +357,11 @@ _responseData = deserialize<Set<Pet>, Pet>(_response.data!, 'Set<Pet>', growable
       onReceiveProgress: onReceiveProgress,
     );
 
-    Pet _responseData;
+    Pet? _responseData;
 
     try {
-_responseData = deserialize<Pet, Pet>(_response.data!, 'Pet', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<Pet, Pet>(rawData, 'Pet', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -596,10 +599,11 @@ _bodyData=jsonEncode(pet);
       onReceiveProgress: onReceiveProgress,
     );
 
-    ApiResponse _responseData;
+    ApiResponse? _responseData;
 
     try {
-_responseData = deserialize<ApiResponse, ApiResponse>(_response.data!, 'ApiResponse', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<ApiResponse, ApiResponse>(rawData, 'ApiResponse', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -693,10 +697,11 @@ _responseData = deserialize<ApiResponse, ApiResponse>(_response.data!, 'ApiRespo
       onReceiveProgress: onReceiveProgress,
     );
 
-    ApiResponse _responseData;
+    ApiResponse? _responseData;
 
     try {
-_responseData = deserialize<ApiResponse, ApiResponse>(_response.data!, 'ApiResponse', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<ApiResponse, ApiResponse>(rawData, 'ApiResponse', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/store_api.dart
@@ -113,10 +113,11 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Map<String, int> _responseData;
+    Map<String, int>? _responseData;
 
     try {
-_responseData = deserialize<Map<String, int>, int>(_response.data!, 'Map<String, int>', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<Map<String, int>, int>(rawData, 'Map<String, int>', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -183,10 +184,11 @@ _responseData = deserialize<Map<String, int>, int>(_response.data!, 'Map<String,
       onReceiveProgress: onReceiveProgress,
     );
 
-    Order _responseData;
+    Order? _responseData;
 
     try {
-_responseData = deserialize<Order, Order>(_response.data!, 'Order', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<Order, Order>(rawData, 'Order', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -271,10 +273,11 @@ _bodyData=jsonEncode(order);
       onReceiveProgress: onReceiveProgress,
     );
 
-    Order _responseData;
+    Order? _responseData;
 
     try {
-_responseData = deserialize<Order, Order>(_response.data!, 'Order', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<Order, Order>(rawData, 'Order', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/api/user_api.dart
@@ -303,10 +303,11 @@ _bodyData=jsonEncode(user);
       onReceiveProgress: onReceiveProgress,
     );
 
-    User _responseData;
+    User? _responseData;
 
     try {
-_responseData = deserialize<User, User>(_response.data!, 'User', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<User, User>(rawData, 'User', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,
@@ -381,10 +382,11 @@ _responseData = deserialize<User, User>(_response.data!, 'User', growable: true)
       onReceiveProgress: onReceiveProgress,
     );
 
-    String _responseData;
+    String? _responseData;
 
     try {
-_responseData = deserialize<String, String>(_response.data!, 'String', growable: true);
+final rawData = _response.data;
+_responseData = rawData == null ? null : deserialize<String, String>(rawData, 'String', growable: true);
     } catch (error, stackTrace) {
       throw DioError(
         requestOptions: _response.requestOptions,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/another_fake_api.dart
@@ -87,7 +87,7 @@ class AnotherFakeApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(ModelClient),
+        specifiedType: const FullType(ModelClient),
       ) as ModelClient;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/another_fake_api.dart
@@ -81,13 +81,13 @@ class AnotherFakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    ModelClient _responseData;
+    ModelClient? _responseData;
 
     try {
-      const _responseType = FullType(ModelClient);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(ModelClient),
       ) as ModelClient;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/default_api.dart
@@ -59,13 +59,13 @@ class DefaultApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    FooGetDefaultResponse _responseData;
+    FooGetDefaultResponse? _responseData;
 
     try {
-      const _responseType = FullType(FooGetDefaultResponse);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(FooGetDefaultResponse),
       ) as FooGetDefaultResponse;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/default_api.dart
@@ -65,7 +65,7 @@ class DefaultApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(FooGetDefaultResponse),
+        specifiedType: const FullType(FooGetDefaultResponse),
       ) as FooGetDefaultResponse;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_api.dart
@@ -76,7 +76,7 @@ class FakeApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(HealthCheckResult),
+        specifiedType: const FullType(HealthCheckResult),
       ) as HealthCheckResult;
 
     } catch (error, stackTrace) {
@@ -346,7 +346,7 @@ class FakeApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(OuterComposite),
+        specifiedType: const FullType(OuterComposite),
       ) as OuterComposite;
 
     } catch (error, stackTrace) {
@@ -623,7 +623,7 @@ class FakeApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(OuterObjectWithEnumProperty),
+        specifiedType: const FullType(OuterObjectWithEnumProperty),
       ) as OuterObjectWithEnumProperty;
 
     } catch (error, stackTrace) {
@@ -926,7 +926,7 @@ class FakeApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(ModelClient),
+        specifiedType: const FullType(ModelClient),
       ) as ModelClient;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_api.dart
@@ -70,13 +70,13 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    HealthCheckResult _responseData;
+    HealthCheckResult? _responseData;
 
     try {
-      const _responseType = FullType(HealthCheckResult);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(HealthCheckResult),
       ) as HealthCheckResult;
 
     } catch (error, stackTrace) {
@@ -248,10 +248,11 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    bool _responseData;
+    bool? _responseData;
 
     try {
-      _responseData = _response.data as bool;
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : rawResponse as bool;
 
     } catch (error, stackTrace) {
       throw DioError(
@@ -339,13 +340,13 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    OuterComposite _responseData;
+    OuterComposite? _responseData;
 
     try {
-      const _responseType = FullType(OuterComposite);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(OuterComposite),
       ) as OuterComposite;
 
     } catch (error, stackTrace) {
@@ -433,10 +434,11 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    num _responseData;
+    num? _responseData;
 
     try {
-      _responseData = _response.data as num;
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : rawResponse as num;
 
     } catch (error, stackTrace) {
       throw DioError(
@@ -523,10 +525,11 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    String _responseData;
+    String? _responseData;
 
     try {
-      _responseData = _response.data as String;
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : rawResponse as String;
 
     } catch (error, stackTrace) {
       throw DioError(
@@ -614,13 +617,13 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    OuterObjectWithEnumProperty _responseData;
+    OuterObjectWithEnumProperty? _responseData;
 
     try {
-      const _responseType = FullType(OuterObjectWithEnumProperty);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(OuterObjectWithEnumProperty),
       ) as OuterObjectWithEnumProperty;
 
     } catch (error, stackTrace) {
@@ -917,13 +920,13 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    ModelClient _responseData;
+    ModelClient? _responseData;
 
     try {
-      const _responseType = FullType(ModelClient);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(ModelClient),
       ) as ModelClient;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_classname_tags123_api.dart
@@ -88,13 +88,13 @@ class FakeClassnameTags123Api {
       onReceiveProgress: onReceiveProgress,
     );
 
-    ModelClient _responseData;
+    ModelClient? _responseData;
 
     try {
-      const _responseType = FullType(ModelClient);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(ModelClient),
       ) as ModelClient;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/fake_classname_tags123_api.dart
@@ -94,7 +94,7 @@ class FakeClassnameTags123Api {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(ModelClient),
+        specifiedType: const FullType(ModelClient),
       ) as ModelClient;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
@@ -201,13 +201,13 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    BuiltList<Pet> _responseData;
+    BuiltList<Pet>? _responseData;
 
     try {
-      const _responseType = FullType(BuiltList, [FullType(Pet)]);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(BuiltList, [FullType(Pet)]),
       ) as BuiltList<Pet>;
 
     } catch (error, stackTrace) {
@@ -287,13 +287,13 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    BuiltSet<Pet> _responseData;
+    BuiltSet<Pet>? _responseData;
 
     try {
-      const _responseType = FullType(BuiltSet, [FullType(Pet)]);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(BuiltSet, [FullType(Pet)]),
       ) as BuiltSet<Pet>;
 
     } catch (error, stackTrace) {
@@ -369,13 +369,13 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Pet _responseData;
+    Pet? _responseData;
 
     try {
-      const _responseType = FullType(Pet);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Pet),
       ) as Pet;
 
     } catch (error, stackTrace) {
@@ -625,13 +625,13 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    ApiResponse _responseData;
+    ApiResponse? _responseData;
 
     try {
-      const _responseType = FullType(ApiResponse);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(ApiResponse),
       ) as ApiResponse;
 
     } catch (error, stackTrace) {
@@ -731,13 +731,13 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    ApiResponse _responseData;
+    ApiResponse? _responseData;
 
     try {
-      const _responseType = FullType(ApiResponse);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(ApiResponse),
       ) as ApiResponse;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/pet_api.dart
@@ -207,7 +207,7 @@ class PetApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(BuiltList, [FullType(Pet)]),
+        specifiedType: const FullType(BuiltList, [FullType(Pet)]),
       ) as BuiltList<Pet>;
 
     } catch (error, stackTrace) {
@@ -293,7 +293,7 @@ class PetApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(BuiltSet, [FullType(Pet)]),
+        specifiedType: const FullType(BuiltSet, [FullType(Pet)]),
       ) as BuiltSet<Pet>;
 
     } catch (error, stackTrace) {
@@ -375,7 +375,7 @@ class PetApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Pet),
+        specifiedType: const FullType(Pet),
       ) as Pet;
 
     } catch (error, stackTrace) {
@@ -631,7 +631,7 @@ class PetApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(ApiResponse),
+        specifiedType: const FullType(ApiResponse),
       ) as ApiResponse;
 
     } catch (error, stackTrace) {
@@ -737,7 +737,7 @@ class PetApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(ApiResponse),
+        specifiedType: const FullType(ApiResponse),
       ) as ApiResponse;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/store_api.dart
@@ -114,13 +114,13 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    BuiltMap<String, int> _responseData;
+    BuiltMap<String, int>? _responseData;
 
     try {
-      const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(BuiltMap, [FullType(String), FullType(int)]),
       ) as BuiltMap<String, int>;
 
     } catch (error, stackTrace) {
@@ -189,13 +189,13 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Order _responseData;
+    Order? _responseData;
 
     try {
-      const _responseType = FullType(Order);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Order),
       ) as Order;
 
     } catch (error, stackTrace) {
@@ -284,13 +284,13 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    Order _responseData;
+    Order? _responseData;
 
     try {
-      const _responseType = FullType(Order);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(Order),
       ) as Order;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/store_api.dart
@@ -120,7 +120,7 @@ class StoreApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(BuiltMap, [FullType(String), FullType(int)]),
+        specifiedType: const FullType(BuiltMap, [FullType(String), FullType(int)]),
       ) as BuiltMap<String, int>;
 
     } catch (error, stackTrace) {
@@ -195,7 +195,7 @@ class StoreApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Order),
+        specifiedType: const FullType(Order),
       ) as Order;
 
     } catch (error, stackTrace) {
@@ -290,7 +290,7 @@ class StoreApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(Order),
+        specifiedType: const FullType(Order),
       ) as Order;
 
     } catch (error, stackTrace) {

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/user_api.dart
@@ -311,13 +311,13 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    User _responseData;
+    User? _responseData;
 
     try {
-      const _responseType = FullType(User);
-      _responseData = _serializers.deserialize(
-        _response.data!,
-        specifiedType: _responseType,
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : _serializers.deserialize(
+        rawResponse,
+        specifiedType: FullType(User),
       ) as User;
 
     } catch (error, stackTrace) {
@@ -394,10 +394,11 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    String _responseData;
+    String? _responseData;
 
     try {
-      _responseData = _response.data as String;
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null ? null : rawResponse as String;
 
     } catch (error, stackTrace) {
       throw DioError(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api/user_api.dart
@@ -317,7 +317,7 @@ class UserApi {
       final rawResponse = _response.data;
       _responseData = rawResponse == null ? null : _serializers.deserialize(
         rawResponse,
-        specifiedType: FullType(User),
+        specifiedType: const FullType(User),
       ) as User;
 
     } catch (error, stackTrace) {


### PR DESCRIPTION
Modify mustache files to handle cases where the response data is null (e.g. status code 204) instead of throwing an exception
fixes https://github.com/OpenAPITools/openapi-generator/issues/15426

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)