### PR TITLE
fix use of isBasic and isBasicBasic and isBasicBearer and isHttpSignature in documentation

### DIFF
--- a/modules/openapi-generator/src/main/resources/Ada/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Ada/README.mustache
@@ -94,10 +94,18 @@ Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}
+{{#isBasicBasic}}
 
 - **Type**: HTTP basic authentication
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}
+
+- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}
+
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}
 
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/apex/README_ant.mustache
+++ b/modules/openapi-generator/src/main/resources/apex/README_ant.mustache
@@ -104,14 +104,14 @@ Please follow the [installation](#installation) instruction and execute the foll
 {{classname}} api = new {{classname}}();
 {{#hasAuthMethods}}
 {{classPrefix}}Client client = api.getClient();
-{{#authMethods}}{{#isBasic}}
+{{#authMethods}}{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 HttpBasicAuth {{{name}}} = (HttpBasicAuth) client.getAuthentication('{{{name}}}');
 {{{name}}}.setUsername('YOUR USERNAME');
 {{{name}}}.setPassword('YOUR PASSWORD');
 
 // You can also set your username and password in one line
-{{{name}}}.setCredentials('YOUR USERNAME', 'YOUR PASSWORD');{{/isBasic}}{{#isApiKey}}
+{{{name}}}.setCredentials('YOUR USERNAME', 'YOUR PASSWORD');{{/isBasicBasic}}{{#isApiKey}}
 // Configure API key authorization: {{{name}}}
 ApiKeyAuth {{{name}}} = (ApiKeyAuth) client.getAuthentication('{{{name}}}');
 {{{name}}}.setApiKey('YOUR API KEY');{{/isApiKey}}{{#isOAuth}}
@@ -161,14 +161,16 @@ Class | Method | HTTP request | Description
 {{#authMethods}}
 ### {{name}}
 
-{{#isApiKey}}
-
-- **Type**: API key
+{{#isApiKey}}- **Type**: API key
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/apex/README_sfdx.mustache
+++ b/modules/openapi-generator/src/main/resources/apex/README_sfdx.mustache
@@ -93,14 +93,16 @@ Class | Method | HTTP request | Description
 {{#authMethods}}
 ### {{name}}
 
-{{#isApiKey}}
-
-- **Type**: API key
+{{#isApiKey}}- **Type**: API key
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/apex/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/apex/api_doc.mustache
@@ -26,14 +26,14 @@ Method | HTTP request | Description
 {{classname}} api = new {{classname}}();
 {{#hasAuthMethods}}
 {{classPrefix}}Client client = api.getClient();
-{{#authMethods}}{{#isBasic}}
+{{#authMethods}}{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 HttpBasicAuth {{{name}}} = (HttpBasicAuth) client.getAuthentication('{{{name}}}');
 {{{name}}}.setUsername('YOUR USERNAME');
 {{{name}}}.setPassword('YOUR PASSWORD');
 
 // You can also set your username and password in one line
-{{{name}}}.setCredentials('YOUR USERNAME', 'YOUR PASSWORD');{{/isBasic}}{{#isApiKey}}
+{{{name}}}.setCredentials('YOUR USERNAME', 'YOUR PASSWORD');{{/isBasicBasic}}{{#isApiKey}}
 // Configure API key authorization: {{{name}}}
 ApiKeyAuth {{{name}}} = (ApiKeyAuth) client.getAuthentication('{{{name}}}');
 {{{name}}}.setApiKey('YOUR API KEY');{{/isApiKey}}{{#isOAuth}}

--- a/modules/openapi-generator/src/main/resources/asciidoc-documentation/index.mustache
+++ b/modules/openapi-generator/src/main/resources/asciidoc-documentation/index.mustache
@@ -32,6 +32,7 @@
 {{#isBasic}}
 {{#isBasicBasic}}* *HTTP Basic* Authentication _{{{name}}}_{{/isBasicBasic}}
 {{#isBasicBearer}}* *Bearer* Authentication {{/isBasicBearer}}
+{{#isHttpSignature}}* *HTTP signature* Authentication{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}* *OAuth*  AuthorizationUrl: _{{authorizationUrl}}_, TokenUrl:   _{{tokenUrl}}_ {{/isOAuth}}
 {{#isApiKey}}* *APIKey* KeyParamName:     _{{keyParamName}}_,     KeyInQuery: _{{isKeyInQuery}}_, KeyInHeader: _{{isKeyInHeader}}_{{/isApiKey}}

--- a/modules/openapi-generator/src/main/resources/csharp-dotnet2/README.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-dotnet2/README.mustache
@@ -152,6 +152,9 @@ No model defined in this package
 {{#isBasicBearer}}
 - **Type**: HTTP bearer authentication
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/README.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/README.mustache
@@ -253,6 +253,8 @@ No model defined in this package
 {{/isBasicBasic}}
 {{#isBasicBearer}}- **Type**: Bearer Authentication
 {{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/README.client.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/README.client.mustache
@@ -162,6 +162,9 @@ Class | Method | HTTP request | Description
 {{#isBasicBearer}}
 - **Type**: Bearer Authentication
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}
 - **Type**: OAuth
 - **Flow**: {{flow}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unityWebRequest/README.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unityWebRequest/README.mustache
@@ -161,6 +161,8 @@ No model defined in this package
 {{/isBasicBasic}}
 {{#isBasicBearer}}- **Type**: Bearer Authentication
 {{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/csharp/README.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/README.mustache
@@ -212,6 +212,9 @@ No model defined in this package
 {{#isBasicBearer}}
 - **Type**: HTTP bearer authentication
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/graphql-schema/README.mustache
+++ b/modules/openapi-generator/src/main/resources/graphql-schema/README.mustache
@@ -53,7 +53,7 @@ Example
     r, err := client.Service.Operation(auth, args)
 ```
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
 
 Example
 ```
@@ -63,7 +63,11 @@ Example
 	})
     r, err := client.Service.Operation(auth, args)
 ```
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/htmlDocs/index.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs/index.mustache
@@ -19,7 +19,7 @@
   {{#hasAuthMethods}}
     <ol>
     {{#authMethods}}
-      <li>{{#isBasic}}HTTP Basic Authentication{{/isBasic}}{{#isOAuth}}OAuth AuthorizationUrl:{{authorizationUrl}}TokenUrl:{{tokenUrl}}{{/isOAuth}}{{#isApiKey}}APIKey KeyParamName:{{keyParamName}} KeyInQuery:{{isKeyInQuery}} KeyInHeader:{{isKeyInHeader}}{{/isApiKey}}</li>
+      <li>{{#isBasicBasic}}HTTP Basic Authentication{{/isBasicBasic}}{{#isBasicBearer}}HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}{{/isBasicBearer}}{{#isHttpSignature}}HTTP signature authentication{{/isHttpSignature}}{{#isOAuth}}OAuth AuthorizationUrl:{{authorizationUrl}}TokenUrl:{{tokenUrl}}{{/isOAuth}}{{#isApiKey}}APIKey KeyParamName:{{keyParamName}} KeyInQuery:{{isKeyInQuery}} KeyInHeader:{{isKeyInHeader}}{{/isApiKey}}</li>
     {{/authMethods}}
     </ol>
   {{/hasAuthMethods}}

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_csharp.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_csharp.mustache
@@ -12,9 +12,9 @@ namespace Example
         {
             {{#hasAuthMethods}}
             {{#authMethods}}
-            {{^isBasicBearer}}{{#isBasic}}// Configure HTTP basic authorization: {{{name}}}
+            {{#isBasicBasic}}// Configure HTTP basic authorization: {{{name}}}
             Configuration.Default.Username = "YOUR_USERNAME";
-            Configuration.Default.Password = "YOUR_PASSWORD";{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}// Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
+            Configuration.Default.Password = "YOUR_PASSWORD";{{/isBasicBasic}}{{#isBasicBearer}}// Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";{{/isBasicBearer}}{{#isApiKey}}// Configure API key authorization: {{{name}}}
             Configuration.Default.ApiKey.Add("{{{keyParamName}}}", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_curl.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_curl.mustache
@@ -1,5 +1,5 @@
 curl -X {{vendorExtensions.x-codegen-http-method-upper-case}}{{#authMethods}} \
-{{#isApiKey}}{{#isKeyInHeader}}-H "{{keyParamName}}: [[apiKey]]"{{/isKeyInHeader}}{{/isApiKey}}{{^isBasicBearer}}{{#isBasic}} -H "Authorization: Basic [[basicHash]]"{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}} -H "Authorization: Bearer [[accessToken]]"{{/isBasicBearer}}{{/authMethods}}{{#hasProduces}} \
+{{#isApiKey}}{{#isKeyInHeader}}-H "{{keyParamName}}: [[apiKey]]"{{/isKeyInHeader}}{{/isApiKey}}{{#isBasicBasic}} -H "Authorization: Basic [[basicHash]]"{{/isBasicBasic}}{{#isBasicBearer}} -H "Authorization: Bearer [[accessToken]]"{{/isBasicBearer}}{{/authMethods}}{{#hasProduces}} \
  -H "Accept: {{#produces}}{{{mediaType}}}{{^-last}},{{/-last}}{{/produces}}"{{/hasProduces}}{{#hasConsumes}} \
  -H "Content-Type: {{#consumes}}{{{mediaType}}}{{^-last}},{{/-last}}{{/consumes}}"{{/hasConsumes}} \
  "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{baseName}}={{{example}}}{{/queryParams}}{{/hasQueryParams}}"{{#requestBodyExamples}} \

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_java.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_java.mustache
@@ -11,11 +11,11 @@ public class {{{classname}}}Example {
         {{#hasAuthMethods}}
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         {{#authMethods}}
-        {{^isBasicBearer}}{{#isBasic}}
+        {{#isBasicBasic}}
         // Configure HTTP basic authorization: {{{name}}}
         HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setUsername("YOUR USERNAME");
-        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}
+        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
         // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
         HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{#isApiKey}}

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_js.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_js.mustache
@@ -1,11 +1,11 @@
 var {{{jsModuleName}}} = require('{{{jsProjectName}}}');
 {{#hasAuthMethods}}
 var defaultClient = {{{jsModuleName}}}.ApiClient.instance;
-{{#authMethods}}{{^isBasicBearer}}{{#isBasic}}
+{{#authMethods}}{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
 {{{name}}}.username = 'YOUR USERNAME';
-{{{name}}}.password = 'YOUR PASSWORD';{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}
+{{{name}}}.password = 'YOUR PASSWORD';{{/isBasicBasic}}{{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 var {{{name}}} = defaultClient.authentications['{{{name}}}'];
 {{{name}}}.accessToken = "YOUR ACCESS TOKEN";{{/isBasicBearer}}{{#isApiKey}}

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_objc.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_objc.mustache
@@ -1,10 +1,10 @@
 {{#hasAuthMethods}}
 {{classPrefix}}Configuration *apiConfig = [{{classPrefix}}Configuration sharedConfig];
 {{#authMethods}}
-{{^isBasicBearer}}{{#isBasic}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization (authentication scheme: {{{name}}})
 [apiConfig setUsername:@"YOUR_USERNAME"];
-[apiConfig setPassword:@"YOUR_PASSWORD"];{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}
+[apiConfig setPassword:@"YOUR_PASSWORD"];{{/isBasicBasic}}{{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];{{/isBasicBearer}}{{#isApiKey}}
 // Configure API key authorization: (authentication scheme: {{{name}}})

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_perl.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_perl.mustache
@@ -3,10 +3,10 @@ use {{{perlModuleName}}}::Configuration;
 use {{perlModuleName}}::{{classname}};
 {{#hasAuthMethods}}
 {{#authMethods}}
-{{^isBasicBearer}}{{#isBasic}}
+{{#isBasicBasic}}
 # Configure HTTP basic authorization: {{{name}}}
 ${{{perlModuleName}}}::Configuration::username = 'YOUR_USERNAME';
-${{{perlModuleName}}}::Configuration::password = 'YOUR_PASSWORD';{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}
+${{{perlModuleName}}}::Configuration::password = 'YOUR_PASSWORD';{{/isBasicBasic}}{{#isBasicBearer}}
 # Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 ${{{perlModuleName}}}::Configuration::access_token = 'YOUR_ACCESS_TOKEN';{{/isBasicBearer}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_php.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_php.mustache
@@ -2,10 +2,10 @@
 require_once(__DIR__ . '/vendor/autoload.php');
 {{#hasAuthMethods}}
 {{#authMethods}}
-{{^isBasicBearer}}{{#isBasic}}
+{{#isBasicBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 {{phpInvokerPackage}}\Configuration::getDefaultConfiguration()->setUsername('YOUR_USERNAME');
-{{phpInvokerPackage}}\Configuration::getDefaultConfiguration()->setPassword('YOUR_PASSWORD');{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}
+{{phpInvokerPackage}}\Configuration::getDefaultConfiguration()->setPassword('YOUR_PASSWORD');{{/isBasicBasic}}{{#isBasicBearer}}
 // Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 {{phpInvokerPackage}}\Configuration::getDefaultConfiguration()->setAccessToken('{{{keyParamName}}}', 'YOUR_ACCESS_TOKEN');{{/isBasicBearer}}{{#isApiKey}}
 // Configure API key authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_python.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_python.mustache
@@ -5,10 +5,10 @@ from {{{pythonPackageName}}}.rest import ApiException
 from pprint import pprint
 {{#hasAuthMethods}}
 {{#authMethods}}
-{{^isBasicBearer}}{{#isBasic}}
+{{#isBasicBasic}}
 # Configure HTTP basic authorization: {{{name}}}
 {{{pythonPackageName}}}.configuration.username = 'YOUR_USERNAME'
-{{{pythonPackageName}}}.configuration.password = 'YOUR_PASSWORD'{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}}
+{{{pythonPackageName}}}.configuration.password = 'YOUR_PASSWORD'{{/isBasicBasic}}{{#isBasicBearer}}
 # Configure Bearer{{#bearerFormat}} ({{{.}}}){{/bearerFormat}} access token for authorization: {{{name}}}
 {{{pythonPackageName}}}.configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isBasicBearer}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/julia-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/README.mustache
@@ -55,7 +55,7 @@ Example
     result = callApi(api, args...; api_key)
 ```
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
 
 Example
 ```
@@ -67,7 +67,11 @@ Example
     api = MyApi(client)
     result = callApi(api, args...; api_key)
 ```
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
+++ b/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
@@ -44,8 +44,12 @@ All endpoints do not require authorization.
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/objc/README.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/README.mustache
@@ -67,10 +67,10 @@ Please follow the [installation procedure](#installation--usage) and then run th
 {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}
 {{#hasAuthMethods}}
 {{classPrefix}}DefaultConfiguration *apiConfig = [{{classPrefix}}DefaultConfiguration sharedConfig];
-{{#authMethods}}{{#isBasic}}// Configure HTTP basic authorization (authentication scheme: {{{name}}})
+{{#authMethods}}{{#isBasicBasic}}// Configure HTTP basic authorization (authentication scheme: {{{name}}})
 [apiConfig setUsername:@"YOUR_USERNAME"];
 [apiConfig setPassword:@"YOUR_PASSWORD"];
-{{/isBasic}}{{#isApiKey}}
+{{/isBasicBasic}}{{#isApiKey}}
 // Configure API key authorization: (authentication scheme: {{{name}}})
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"{{{keyParamName}}}"];
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -127,8 +127,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/objc/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/api_doc.mustache
@@ -25,10 +25,10 @@ Method | HTTP request | Description
 ```objc
 {{#hasAuthMethods}}
 {{classPrefix}}DefaultConfiguration *apiConfig = [{{classPrefix}}DefaultConfiguration sharedConfig];
-{{#authMethods}}{{#isBasic}}// Configure HTTP basic authorization (authentication scheme: {{{name}}})
+{{#authMethods}}{{#isBasicBasic}}// Configure HTTP basic authorization (authentication scheme: {{{name}}})
 [apiConfig setUsername:@"YOUR_USERNAME"];
 [apiConfig setPassword:@"YOUR_PASSWORD"];
-{{/isBasic}}{{#isApiKey}}
+{{/isBasicBasic}}{{#isApiKey}}
 // Configure API key authorization: (authentication scheme: {{{name}}})
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"{{{keyParamName}}}"];
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed

--- a/modules/openapi-generator/src/main/resources/python/common_README.mustache
+++ b/modules/openapi-generator/src/main/resources/python/common_README.mustache
@@ -64,6 +64,9 @@ Class | Method | HTTP request | Description
 {{#isBasicBearer}}
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
@@ -142,7 +142,8 @@ Class | Method | HTTP request | Description
 {{#isBasic}}
 {{#isBasicBasic}}- **Type**: HTTP basic authentication
 {{/isBasicBasic}}{{#isBasicBearer}}- **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
-{{/isBasicBearer}}
+{{/isBasicBearer}}{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}
 

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/README.mustache
@@ -149,8 +149,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/modules/openapi-generator/src/main/resources/scala-sttp/README.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/README.mustache
@@ -92,8 +92,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}

--- a/samples/client/petstore/apex/README.md
+++ b/samples/client/petstore/apex/README.md
@@ -112,7 +112,6 @@ Authentication schemes defined for the API:
 
 ### api_key
 
-
 - **Type**: API key
 - **API key parameter name**: api_key
 - **Location**: HTTP header

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/README.md
@@ -280,4 +280,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/README.md
@@ -193,6 +193,7 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 
 
 ## Build

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/README.md
@@ -193,6 +193,7 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 
 
 ## Build

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/README.md
@@ -193,6 +193,7 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 
 
 ## Build

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/README.md
@@ -305,4 +305,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/README.md
@@ -292,4 +292,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/README.md
@@ -292,4 +292,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/README.md
@@ -292,4 +292,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-unityWebRequest/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-unityWebRequest/README.md
@@ -266,4 +266,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/README.md
@@ -280,4 +280,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/README.md
@@ -292,4 +292,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/csharp/OpenAPIClient/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/README.md
@@ -242,4 +242,5 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/ruby-autoload/README.md
+++ b/samples/client/petstore/ruby-autoload/README.md
@@ -208,4 +208,5 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/ruby-faraday/README.md
+++ b/samples/client/petstore/ruby-faraday/README.md
@@ -208,4 +208,5 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/ruby/README.md
+++ b/samples/client/petstore/ruby/README.md
@@ -208,4 +208,5 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/openapi3/client/petstore/python-aiohttp/README.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/README.md
@@ -246,6 +246,7 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 
 
 ## Author

--- a/samples/openapi3/client/petstore/python/README.md
+++ b/samples/openapi3/client/petstore/python/README.md
@@ -246,6 +246,7 @@ Authentication schemes defined for the API:
 <a id="http_signature_test"></a>
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 
 
 ## Author


### PR DESCRIPTION
Follow-up of #15220 but for all generators where only the documentation (README, api_doc) is affected

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

