### PR TITLE
Update modelbase-header.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
@@ -233,7 +233,7 @@ bool ModelBase::fromJson( const web::json::value& val, std::vector<T> &outVal )
     bool ok = true;
     if (val.is_array())
     {
-        for (const auto jitem : val.as_array())
+        for (const web::json::value & jitem : val.as_array())
         {
             T item;
             ok &= fromJson(jitem, item);


### PR DESCRIPTION
Fixes warning in ModelBase.h

warning: loop variable 'jitem' creates a copy from type 'const web::json::value' [-Wrange-loop-construct]


