### PR TITLE
[C++][Pistache] Generate empty JSON object instead of a null value

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -86,7 +86,7 @@ bool {{classname}}::operator!=(const {{classname}}& rhs) const
 
 void to_json(nlohmann::json& j, const {{classname}}& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     {{#vars}}
     {{#required}}j["{{baseName}}"] = o.m_{{name}};{{/required}}{{^required}}if(o.{{nameInCamelCase}}IsSet(){{#isContainer}} || !o.m_{{name}}.empty(){{/isContainer}})
         j["{{baseName}}"] = o.m_{{name}};{{/required}}

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -85,6 +85,7 @@ bool {{classname}}::operator!=(const {{classname}}& other) const
 
 void to_json(nlohmann::json& j, const {{classname}}& o)
 {
+    j = nlohmann::json::object();
     {{#vars}}
     {{^required}}if (o.{{name}}.has_value()){{/required}}
         j["{{baseName}}"] = o.{{name}}{{^required}}.value(){{/required}};

--- a/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
+++ b/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
@@ -77,7 +77,7 @@ bool ApiResponse::operator!=(const ApiResponse& rhs) const
 
 void to_json(nlohmann::json& j, const ApiResponse& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     if(o.codeIsSet())
         j["code"] = o.m_Code;
     if(o.typeIsSet())

--- a/samples/server/petstore/cpp-pistache/model/Category.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Category.cpp
@@ -72,7 +72,7 @@ bool Category::operator!=(const Category& rhs) const
 
 void to_json(nlohmann::json& j, const Category& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     if(o.idIsSet())
         j["id"] = o.m_Id;
     if(o.nameIsSet())

--- a/samples/server/petstore/cpp-pistache/model/Order.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Order.cpp
@@ -92,7 +92,7 @@ bool Order::operator!=(const Order& rhs) const
 
 void to_json(nlohmann::json& j, const Order& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     if(o.idIsSet())
         j["id"] = o.m_Id;
     if(o.petIdIsSet())

--- a/samples/server/petstore/cpp-pistache/model/Pet.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Pet.cpp
@@ -129,7 +129,7 @@ bool Pet::operator!=(const Pet& rhs) const
 
 void to_json(nlohmann::json& j, const Pet& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     if(o.idIsSet())
         j["id"] = o.m_Id;
     if(o.categoryIsSet())

--- a/samples/server/petstore/cpp-pistache/model/Tag.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Tag.cpp
@@ -72,7 +72,7 @@ bool Tag::operator!=(const Tag& rhs) const
 
 void to_json(nlohmann::json& j, const Tag& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     if(o.idIsSet())
         j["id"] = o.m_Id;
     if(o.nameIsSet())

--- a/samples/server/petstore/cpp-pistache/model/User.cpp
+++ b/samples/server/petstore/cpp-pistache/model/User.cpp
@@ -102,7 +102,7 @@ bool User::operator!=(const User& rhs) const
 
 void to_json(nlohmann::json& j, const User& o)
 {
-    j = nlohmann::json();
+    j = nlohmann::json::object();
     if(o.idIsSet())
         j["id"] = o.m_Id;
     if(o.usernameIsSet())


### PR DESCRIPTION
The `to_json` utilities produce a `null` JSON value instead of an empty `{}` object when all the object properties are optional and not provided. The json object is default constructed (null value). In case there is at least one property affecting it will turn the null/default json into an object, which is not the case with no properties.

* I found it with and use the class model but I think the issue is the same for the struct model, so I fixed that too.
* I don't really understand all the data modes, but I think the enum case should be correct as the value of `j` will be completely overwritten. However I don't know how the `vendorExtensions.x-is-string-enum-container` case work, hopefully this is also correct?

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. cc @ravinikam @stkrwork @etherealjoy @MartinDelille @muttleyxd
