### PR TITLE
[C++][Pistache] Add missing 'override' on virtual methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-header.mustache
@@ -27,8 +27,8 @@ namespace {{apiNamespace}}
 class {{declspec}} {{classname}} : public ApiBase {
 public:
     explicit {{classname}}(const std::shared_ptr<Pistache::Rest::Router>& rtr);
-    virtual ~{{classname}}() = default;
-    void init();
+    ~{{classname}}() override = default;
+    void init() override;
 
     static const std::string base;
 

--- a/samples/server/petstore/cpp-pistache/api/PetApi.h
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.h
@@ -38,8 +38,8 @@ namespace org::openapitools::server::api
 class  PetApi : public ApiBase {
 public:
     explicit PetApi(const std::shared_ptr<Pistache::Rest::Router>& rtr);
-    virtual ~PetApi() = default;
-    void init();
+    ~PetApi() override = default;
+    void init() override;
 
     static const std::string base;
 

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.h
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.h
@@ -38,8 +38,8 @@ namespace org::openapitools::server::api
 class  StoreApi : public ApiBase {
 public:
     explicit StoreApi(const std::shared_ptr<Pistache::Rest::Router>& rtr);
-    virtual ~StoreApi() = default;
-    void init();
+    ~StoreApi() override = default;
+    void init() override;
 
     static const std::string base;
 

--- a/samples/server/petstore/cpp-pistache/api/UserApi.h
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.h
@@ -38,8 +38,8 @@ namespace org::openapitools::server::api
 class  UserApi : public ApiBase {
 public:
     explicit UserApi(const std::shared_ptr<Pistache::Rest::Router>& rtr);
-    virtual ~UserApi() = default;
-    void init();
+    ~UserApi() override = default;
+    void init() override;
 
     static const std::string base;
 


### PR DESCRIPTION
This is following #15279
Marking those methods 'override' should avoid producing `-Winconsistent-missing-override` warnings or similar.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. cc @ravinikam @stkrwork @etherealjoy @MartinDelille @muttleyxd
