### PR TITLE
[csharp-netcore][generichost] Moved deserialization logic to template

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/ApiResponse`1.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/ApiResponse`1.mustache
@@ -112,9 +112,7 @@ namespace {{packageName}}.{{clientPackage}}
         /// </summary>
         public T{{nrt?}} ToModel(System.Text.Json.JsonSerializerOptions{{nrt?}} options = null)
         {
-            return IsSuccessStatusCode
-                ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
-                : default(T);
+{{>ToModel}}
         }
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/ToModel.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/ToModel.mustache
@@ -1,0 +1,4 @@
+            // This logic may be modified with the ToModel.mustache template
+            return IsSuccessStatusCode
+                ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
+                : default(T);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/ApiResponse`1.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/ApiResponse`1.cs
@@ -118,6 +118,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public T? ToModel(System.Text.Json.JsonSerializerOptions? options = null)
         {
+            // This logic may be modified with the ToModel.mustache template
             return IsSuccessStatusCode
                 ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
                 : default(T);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/ApiResponse`1.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/ApiResponse`1.cs
@@ -116,6 +116,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public T ToModel(System.Text.Json.JsonSerializerOptions options = null)
         {
+            // This logic may be modified with the ToModel.mustache template
             return IsSuccessStatusCode
                 ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
                 : default(T);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/ApiResponse`1.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/ApiResponse`1.cs
@@ -118,6 +118,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public T? ToModel(System.Text.Json.JsonSerializerOptions? options = null)
         {
+            // This logic may be modified with the ToModel.mustache template
             return IsSuccessStatusCode
                 ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
                 : default(T);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/ApiResponse`1.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/ApiResponse`1.cs
@@ -118,6 +118,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public T? ToModel(System.Text.Json.JsonSerializerOptions? options = null)
         {
+            // This logic may be modified with the ToModel.mustache template
             return IsSuccessStatusCode
                 ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
                 : default(T);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/ApiResponse`1.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/ApiResponse`1.cs
@@ -118,6 +118,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public T? ToModel(System.Text.Json.JsonSerializerOptions? options = null)
         {
+            // This logic may be modified with the ToModel.mustache template
             return IsSuccessStatusCode
                 ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
                 : default(T);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/ApiResponse`1.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/ApiResponse`1.cs
@@ -116,6 +116,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public T ToModel(System.Text.Json.JsonSerializerOptions options = null)
         {
+            // This logic may be modified with the ToModel.mustache template
             return IsSuccessStatusCode
                 ? System.Text.Json.JsonSerializer.Deserialize<T>(RawContent, options ?? _jsonSerializerOptions)
                 : default(T);


### PR DESCRIPTION
Moved logic to a template so users may modify if needed.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
