### PR TITLE
[typescript] Fix support for relative URLs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -63,6 +63,20 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    {{#platforms}}
+    {{#node}}
+    throw new Error("You need to define an absolute base url for the server.");
+    {{/node}}
+    {{^node}}
+    return window.location.origin + url;
+    {{/node}}
+    {{/platforms}}
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -83,7 +97,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -101,7 +115,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/client/others/typescript/builds/with-unique-items/http/http.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/http/http.ts
@@ -33,6 +33,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    return window.location.origin + url;
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -48,7 +55,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -66,7 +73,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
@@ -33,6 +33,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    return window.location.origin + url;
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -48,7 +55,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -66,7 +73,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -33,6 +33,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    return window.location.origin + url;
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -48,7 +55,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -66,7 +73,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -41,6 +41,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    throw new Error("You need to define an absolute base url for the server.");
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -57,7 +64,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -75,7 +82,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -32,6 +32,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    return window.location.origin + url;
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -47,7 +54,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -65,7 +72,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -41,6 +41,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    throw new Error("You need to define an absolute base url for the server.");
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -57,7 +64,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -75,7 +82,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -33,6 +33,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    return window.location.origin + url;
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -48,7 +55,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -66,7 +73,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -41,6 +41,13 @@ export class HttpException extends Error {
  */
 export type RequestBody = undefined | string | FormData | URLSearchParams;
 
+function ensureAbsoluteUrl(url: string) {
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+        return url;
+    }
+    throw new Error("You need to define an absolute base url for the server.");
+}
+
 /**
  * Represents an HTTP request context
  */
@@ -57,7 +64,7 @@ export class RequestContext {
      * @param httpMethod http method
      */
     public constructor(url: string, private httpMethod: HttpMethod) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /*
@@ -75,7 +82,7 @@ export class RequestContext {
      *
      */
     public setUrl(url: string) {
-        this.url = new URL(url);
+        this.url = new URL(ensureAbsoluteUrl(url));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/tests/browser/test/ServerConfiguration.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/browser/test/ServerConfiguration.test.ts
@@ -1,0 +1,19 @@
+import { expect } from '@esm-bundle/chai';
+import { ServerConfiguration, HttpMethod } from 'ts-petstore-client'
+
+describe("ServerConfiguration", () => {
+    it("supports absolute http URLs", async () => {
+        const config = new ServerConfiguration("http://localhost/v2", {});
+        expect(config.makeRequestContext("/resource", HttpMethod.PUT).getUrl()).to.equal("http://localhost/v2/resource");
+    })
+
+    it("supports absolute https URLs", async () => {
+        const config = new ServerConfiguration("https://localhost/v2", {});
+        expect(config.makeRequestContext("/resource", HttpMethod.PUT).getUrl()).to.equal("https://localhost/v2/resource");
+    })
+
+    it("supports relative URLs", async () => {
+        const config = new ServerConfiguration("/api", {});
+        expect(config.makeRequestContext("/resource", HttpMethod.PUT).getUrl()).to.equal("http://localhost:8080/api/resource");
+    })
+})

--- a/samples/openapi3/client/petstore/typescript/tests/browser/web-test-runner.config.js
+++ b/samples/openapi3/client/petstore/typescript/tests/browser/web-test-runner.config.js
@@ -4,6 +4,7 @@ export default {
   files: "./dist/*.test.js",
   nodeResolve: true,
   manual: false,
+  port: 8080,
   browsers: [
     puppeteerLauncher(),
   ],

--- a/samples/openapi3/client/petstore/typescript/tests/inversify/test/services.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/inversify/test/services.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { Container } from "inversify";
 
 import * as petstore from "ts-petstore-client";
-import * as petstoreInternals from "ts-petstore-client/dist/apis/PetApi";
+import * as petstoreInternals from "../../../builds/inversify/dist/apis/PetApi";
 
 import { expect, assert } from "chai";
 import * as fs from "fs";
@@ -20,7 +20,7 @@ describe("ApiServiceBinder", () => {
     });
 
     it("binds server config", async () => {
-        const url = "foobar";
+        const url = "http://foobar";
         let callCount = 0;
         const mockServer = {
             makeRequestContext(endpoint: string, httpMethod: petstore.HttpMethod): petstore.RequestContext {
@@ -45,7 +45,7 @@ describe("ApiServiceBinder", () => {
     });
 
     it("binds server config to url", async () => {
-        const url = "foobar";
+        const url = "http://foobar";
         const petId = 42;
         apiServiceBinder.bindServerConfigurationToURL(url);
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

In the previous PR #14319 the code was changed to use the standard `URL` constructor instead of url-parse. In principal I am always in favour of getting rid of extra dependencies. This constructor however does not allow relative URLs. So that use case was broken since 6.3.0.

This PR prefixes the URL with `window.location.origin`, when there is no protocol. I hope this is close enough to the original behaviour to work for everybody.

Test output without the change:

>  ❌ ServerConfiguration > supports relative URLs
>       TypeError: Failed to construct 'URL': Invalid URL
>         at new RequestContext (dist/ServerConfiguration.test.js:2176:18)
>         at ServerConfiguration.makeRequestContext (dist/ServerConfiguration.test.js:2477:14)
>         at dist/ServerConfiguration.test.js:2494:16
>         at Generator.next (<anonymous>)
>         at dist/ServerConfiguration.test.js:19:63
>         at new Promise (<anonymous>)
>         at __async (dist/ServerConfiguration.test.js:3:12)
>         at o.<anonymous> (dist/ServerConfiguration.test.js:2492:40)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)