### PR TITLE
[kotlin-spring] Fix inheritance compile error because of missing use-…

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceOptVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceOptVar.mustache
@@ -1,4 +1,4 @@
 {{#swagger2AnnotationLibrary}}
-        @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}requiredMode = Schema.RequiredMode.REQUIRED, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
-        @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}
+        @get:Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}requiredMode = Schema.RequiredMode.REQUIRED, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
+        @get:ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}
         {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? {{^discriminator}}= {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}{{/discriminator}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceReqVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/interfaceReqVar.mustache
@@ -1,4 +1,4 @@
 {{#swagger2AnnotationLibrary}}
-        @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}requiredMode = Schema.RequiredMode.REQUIRED, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
-        @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}
+        @get:Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}requiredMode = Schema.RequiredMode.REQUIRED, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}description = "{{{description}}}"){{/swagger2AnnotationLibrary}}{{#swagger1AnnotationLibrary}}
+        @get:ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swagger1AnnotationLibrary}}
         {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -14,6 +14,8 @@ import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.kotlin.KotlinTestUtils;
 import org.openapitools.codegen.languages.KotlinSpringServerCodegen;
 import org.openapitools.codegen.languages.features.CXFServerFeatures;
+import org.openapitools.codegen.languages.features.DocumentationProviderFeatures.AnnotationLibrary;
+import org.openapitools.codegen.languages.features.DocumentationProviderFeatures.DocumentationProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,6 +28,8 @@ import java.util.List;
 
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 import static org.openapitools.codegen.TestUtils.assertFileNotContains;
+import static org.openapitools.codegen.languages.features.DocumentationProviderFeatures.ANNOTATION_LIBRARY;
+import static org.openapitools.codegen.languages.features.DocumentationProviderFeatures.DOCUMENTATION_PROVIDER;
 
 public class KotlinSpringServerCodegenTest {
 
@@ -478,6 +482,72 @@ public class KotlinSpringServerCodegenTest {
                 + "It:\n"
                 + "- has multiple lines\n"
                 + "- uses Markdown (CommonMark) for rich text representation\"\"\""
+        );
+    }
+
+    @Test(description = "use get Annotation use-site target on kotlin interface attributes")
+    public void useTargetOnInterfaceAnnotations() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/kotlin/issue3596-use-correct-get-annotation-target.yaml"))
+                        .config(codegen))
+                .generate();
+
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@Schema(example = \"null\", description = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:Schema(example = \"null\", description = \"\")"
+        );
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@Schema(example = \"null\", requiredMode = Schema.RequiredMode.REQUIRED, description = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:Schema(example = \"null\", requiredMode = Schema.RequiredMode.REQUIRED, description = \"\")"
+        );
+    }
+
+    @Test(description = "use get Annotation use-site target on kotlin interface attributes (swagger1)")
+    public void useTargetOnInterfaceAnnotationsWithSwagger1() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(ANNOTATION_LIBRARY, AnnotationLibrary.SWAGGER1.toCliOptValue());
+        codegen.additionalProperties().put(DOCUMENTATION_PROVIDER, DocumentationProvider.SPRINGFOX.toCliOptValue());
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/kotlin/issue3596-use-correct-get-annotation-target.yaml"))
+                        .config(codegen))
+                .generate();
+
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@ApiModelProperty(example = \"null\", value = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:ApiModelProperty(example = \"null\", value = \"\")"
+        );
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@ApiModelProperty(example = \"null\", required = true, value = \"\")"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/model/Animal.kt"),
+                "@get:ApiModelProperty(example = \"null\", required = true, value = \"\")"
         );
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue3596-use-correct-get-annotation-target.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue3596-use-correct-get-annotation-target.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.1
+info:
+  title: example
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: successful operation
+components:
+  schemas:
+    Animal:
+      type: object
+      properties:
+        weight:
+          type: number
+        hasLegs:
+          type: boolean
+      discriminator:
+        propertyName: animalType
+      required:
+        - animalType
+        - hasLegs
+    Pet:
+      allOf:
+        - $ref: "#/components/schemas/Animal"
+        - type: object
+          properties:
+            name:
+              type: string


### PR DESCRIPTION
# [kotlin-spring] Fix inheritance compile error because of missing use-site target on annotation (#3596)

This PR fixes annotation generation on kotlin interface attributes when using inheritance.

Using this example openapi spec:

```yaml
openapi: 3.0.1
info:
  title: example
  version: 1.0.0
paths:
  /test:
    get:
      responses:
        200:
          description: successful operation
components:
  schemas:
    Animal:
      type: object
      properties:
        weight:
          type: number
        hasLegs:
          type: boolean
      discriminator:
        propertyName: animalType
      required:
        - animalType
        - hasLegs
    Pet:
      allOf:
        - $ref: "#/components/schemas/Animal"
        - type: object
          properties:
            name:
              type: string
```

With the existing code, it would generate the Animal class like this:

```kotlin
package org.openapitools.model

import java.util.Objects
import com.fasterxml.jackson.annotation.JsonProperty
import com.fasterxml.jackson.annotation.JsonSubTypes
import com.fasterxml.jackson.annotation.JsonTypeInfo
import javax.validation.constraints.DecimalMax
import javax.validation.constraints.DecimalMin
import javax.validation.constraints.Email
import javax.validation.constraints.Max
import javax.validation.constraints.Min
import javax.validation.constraints.NotNull
import javax.validation.constraints.Pattern
import javax.validation.constraints.Size
import javax.validation.Valid
import io.swagger.v3.oas.annotations.media.Schema

/**
 *
 * @param hasLegs
 * @param weight
 */

@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "animalType", visible = true)
@JsonSubTypes(
      JsonSubTypes.Type(value = Pet::class, name = "Pet")
)

interface Animal{
                @Schema(example = "null", requiredMode = Schema.RequiredMode.REQUIRED, description = "")
        val hasLegs: kotlin.Boolean

                @Schema(example = "null", description = "")
        val weight: java.math.BigDecimal?


}
```

This does not compile because the `@Schema` annotations cannot be applied on an interface field. We must specify the use-site target: `get`.  
With this commit it becomes:

```kotlin
package org.openapitools.model

import java.util.Objects
import com.fasterxml.jackson.annotation.JsonProperty
import com.fasterxml.jackson.annotation.JsonSubTypes
import com.fasterxml.jackson.annotation.JsonTypeInfo
import javax.validation.constraints.DecimalMax
import javax.validation.constraints.DecimalMin
import javax.validation.constraints.Email
import javax.validation.constraints.Max
import javax.validation.constraints.Min
import javax.validation.constraints.NotNull
import javax.validation.constraints.Pattern
import javax.validation.constraints.Size
import javax.validation.Valid
import io.swagger.v3.oas.annotations.media.Schema

/**
 *
 * @param hasLegs
 * @param weight
 */

@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "animalType", visible = true)
@JsonSubTypes(
      JsonSubTypes.Type(value = Pet::class, name = "Pet")
)

interface Animal{
                @get:Schema(example = "null", requiredMode = Schema.RequiredMode.REQUIRED, description = "")
        val hasLegs: kotlin.Boolean

                @get:Schema(example = "null", description = "")
        val weight: java.math.BigDecimal?


}
```

ℹ️ The examples were generated using the KotlinSpringServerCodegenTest#useTargetOnInterfaceAnnotations() unit test and a breakpoint before performing assertions.

In this version you can see the `get` use-site specified in the interface fields.

I have written 2 unit test corresponding to this change in the `KotlinSpringServerCodegenTest` class because the issue impacts Swagger1 and Swagger2 generation and the generated annotations are different.

Thanks for reviewing this ❤️  
@jimschubert, @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
  ⚠️ **Actually there were a lot of python files marked as deleted, but I didn't change anything related to this, so it seems completely unrelated to my commit.**  
  **Also there were tests errors related to _PythonClientTest_, again I didn't change anything regarding python codegen.**
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
