### PR TITLE
[xojo] rename private method to avoid confusion

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/XojoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/XojoClientCodegen.java
@@ -662,7 +662,7 @@ public class XojoClientCodegen extends DefaultCodegen implements CodegenConfig {
             return schema.getExample().toString();
         }
 
-        return getPropertyDefaultValue(schema);
+        return getDefaultPropertyValue(schema);
     }
 
     @Override
@@ -671,7 +671,7 @@ public class XojoClientCodegen extends DefaultCodegen implements CodegenConfig {
             return schema.getDefault().toString();
         }
 
-        return getPropertyDefaultValue(schema);
+        return getDefaultPropertyValue(schema);
     }
 
     @Override
@@ -716,7 +716,7 @@ public class XojoClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
     }
 
-    private String getPropertyDefaultValue(Schema schema) {
+    private String getDefaultPropertyValue(Schema schema) {
         if (ModelUtils.isBooleanSchema(schema)) {
             return "False";
         } else if (ModelUtils.isDateSchema(schema)) {


### PR DESCRIPTION
rename private method to avoid confusion as default codegen also has a method named `getPropertyDefaultValue`

cc @Topheee

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
