### PR TITLE
[Ruby] add missing scheme description in README file

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
@@ -142,7 +142,8 @@ Class | Method | HTTP request | Description
 {{#isBasic}}
 {{#isBasicBasic}}- **Type**: HTTP basic authentication
 {{/isBasicBasic}}{{#isBasicBearer}}- **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
-{{/isBasicBearer}}
+{{/isBasicBearer}}{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}
 

--- a/samples/client/petstore/ruby-autoload/README.md
+++ b/samples/client/petstore/ruby-autoload/README.md
@@ -208,4 +208,5 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/ruby-faraday/README.md
+++ b/samples/client/petstore/ruby-faraday/README.md
@@ -208,4 +208,5 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/ruby/README.md
+++ b/samples/client/petstore/ruby/README.md
@@ -208,4 +208,5 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 


### PR DESCRIPTION
Follow-up of #15220 but for Ruby

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)