### PR TITLE
[PHP] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/README.mustache
@@ -144,11 +144,11 @@ No model defined in this package
 {{/-last}}
 {{/authMethods}}
 {{#authMethods}}
-{{#isBasic}}
+{{#isBasicBasic}}
 ### Security schema `{{name}}`
 > Important! To make Basic authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\BasicAuthenticator](./src/Auth/BasicAuthenticator.php) class.
 
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isApiKey}}
 ### Security schema `{{name}}`
 > Important! To make ApiKey authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\ApiKeyAuthenticator](./src/Auth/ApiKeyAuthenticator.php) class.

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
@@ -194,11 +194,11 @@ No model defined in this package
 {{/-last}}
 {{/authMethods}}
 {{#authMethods}}
-{{#isBasic}}
+{{#isBasicBasic}}
 ### Security schema `{{name}}`
 > Important! To make Basic authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\BasicAuthenticator](./src/Auth/BasicAuthenticator.php) class.
 
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isApiKey}}
 ### Security schema `{{name}}`
 > Important! To make ApiKey authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\ApiKeyAuthenticator](./src/Auth/ApiKeyAuthenticator.php) class.

--- a/modules/openapi-generator/src/main/resources/php-symfony/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/README.mustache
@@ -156,8 +156,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
@@ -97,10 +97,10 @@ class {{controllerName}} extends Controller
         $security{{name}} = $request->cookies->get('{{keyParamName}}');
         {{/isKeyInCookie}}
         {{/isApiKey}}
-        {{#isBasic}}
+        {{#isBasicBasic}}
         // HTTP basic authentication required
         $security{{name}} = $request->headers->get('authorization');
-        {{/isBasic}}
+        {{/isBasicBasic}}
         {{#isOAuth}}
         // Oauth required
         $security{{name}} = $request->headers->get('authorization');

--- a/modules/openapi-generator/src/main/resources/php/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php/README.mustache
@@ -106,6 +106,10 @@ Class | Method | HTTP request | Description
 
 - **Type**: Bearer authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}
 

--- a/samples/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/README.md
@@ -201,6 +201,8 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
+
 ## Tests
 
 To run the tests, use:


### PR DESCRIPTION
Follow-up of #15220 but for PHP

**isBasic is true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)