### PR TITLE
[dart] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/README.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/README.mustache
@@ -104,8 +104,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api_doc.mustache
@@ -27,11 +27,11 @@ Method | HTTP request | Description
 import 'package:{{pubName}}/api.dart';
 {{#hasAuthMethods}}
 {{#authMethods}}
-{{#isBasic}}
+{{#isBasicBasic}}
 // TODO Configure HTTP basic authorization: {{{name}}}
 //defaultApiClient.getAuthentication<HttpBasicAuth>('{{{name}}}').username = 'YOUR_USERNAME'
 //defaultApiClient.getAuthentication<HttpBasicAuth>('{{{name}}}').password = 'YOUR_PASSWORD';
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isApiKey}}
 // TODO Configure API key authorization: {{{name}}}
 //defaultApiClient.getAuthentication<ApiKeyAuth>('{{{name}}}').apiKey = 'YOUR_API_KEY';

--- a/modules/openapi-generator/src/main/resources/dart2/README.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/README.mustache
@@ -128,6 +128,9 @@ Class | Method | HTTP request | Description
 {{#isBasicBearer}}
 - **Type**: HTTP Bearer authentication
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{/isBasic}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/README.md
@@ -191,11 +191,11 @@ Authentication schemes defined for the API:
 
 ### bearer_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP Bearer Token authentication (JWT)
 
 ### http_signature_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP signature authentication
 
 
 ## Author

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/FakeApi.md
@@ -73,9 +73,6 @@ test http signature authentication
 ### Example
 ```dart
 import 'package:openapi/api.dart';
-// TODO Configure HTTP basic authorization: http_signature_test
-//defaultApiClient.getAuthentication<HttpBasicAuth>('http_signature_test').username = 'YOUR_USERNAME'
-//defaultApiClient.getAuthentication<HttpBasicAuth>('http_signature_test').password = 'YOUR_PASSWORD';
 
 final api = Openapi().getFakeApi();
 final Pet pet = ; // Pet | Pet object that needs to be added to the store
@@ -635,9 +632,6 @@ Fake endpoint to test group parameters (optional)
 ### Example
 ```dart
 import 'package:openapi/api.dart';
-// TODO Configure HTTP basic authorization: bearer_test
-//defaultApiClient.getAuthentication<HttpBasicAuth>('bearer_test').username = 'YOUR_USERNAME'
-//defaultApiClient.getAuthentication<HttpBasicAuth>('bearer_test').password = 'YOUR_PASSWORD';
 
 final api = Openapi().getFakeApi();
 final int requiredStringGroup = 56; // int | Required String in group parameters

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
@@ -190,11 +190,11 @@ Authentication schemes defined for the API:
 
 ### bearer_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP Bearer Token authentication (JWT)
 
 ### http_signature_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP signature authentication
 
 
 ## Author

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
@@ -73,9 +73,6 @@ test http signature authentication
 ### Example
 ```dart
 import 'package:openapi/api.dart';
-// TODO Configure HTTP basic authorization: http_signature_test
-//defaultApiClient.getAuthentication<HttpBasicAuth>('http_signature_test').username = 'YOUR_USERNAME'
-//defaultApiClient.getAuthentication<HttpBasicAuth>('http_signature_test').password = 'YOUR_PASSWORD';
 
 final api = Openapi().getFakeApi();
 final Pet pet = ; // Pet | Pet object that needs to be added to the store
@@ -635,9 +632,6 @@ Fake endpoint to test group parameters (optional)
 ### Example
 ```dart
 import 'package:openapi/api.dart';
-// TODO Configure HTTP basic authorization: bearer_test
-//defaultApiClient.getAuthentication<HttpBasicAuth>('bearer_test').username = 'YOUR_USERNAME'
-//defaultApiClient.getAuthentication<HttpBasicAuth>('bearer_test').password = 'YOUR_PASSWORD';
 
 final api = Openapi().getFakeApi();
 final int requiredStringGroup = 56; // int | Required String in group parameters

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
@@ -188,6 +188,7 @@ Authentication schemes defined for the API:
 
 ### http_signature_test
 
+- **Type**: HTTP signature authentication
 
 
 ## Author


### PR DESCRIPTION
Follow-up of #15220 but for dart

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)