### PR TITLE
[perl] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/perl/README.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/README.mustache
@@ -266,11 +266,11 @@ use Data::Dumper;
 my $api_instance = {{moduleName}}::{{classname}}->new(
 {{#hasAuthMethods}}
 {{#authMethods}}
-{{#isBasic}}
+{{#isBasicBasic}}
     # Configure HTTP basic authorization: {{{name}}}
     username => 'YOUR_USERNAME',
     password => 'YOUR_PASSWORD',
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isApiKey}}
     # Configure API key authorization: {{{name}}}
     api_key => {'{{{keyParamName}}}' => 'YOUR_API_KEY'},
@@ -321,8 +321,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/perl/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/api_doc.mustache
@@ -28,8 +28,8 @@ use Data::Dumper;
 use {{moduleName}}::{{classname}};
 my $api_instance = {{moduleName}}::{{classname}}->new(
 {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
-    # Configure HTTP basic authorization: {{{name}}}
     {{#isBasicBasic}}
+    # Configure HTTP basic authorization: {{{name}}}
     username => 'YOUR_USERNAME',
     password => 'YOUR_PASSWORD',
     {{/isBasicBasic}}

--- a/samples/client/petstore/perl/README.md
+++ b/samples/client/petstore/perl/README.md
@@ -508,9 +508,9 @@ Authentication schemes defined for the API:
 
 ## bearer_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP Bearer Token authentication (JWT)
 
 ## http_signature_test
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -79,7 +79,6 @@ use Data::Dumper;
 use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 
-    # Configure HTTP basic authorization: http_signature_test
     
 );
 
@@ -679,7 +678,6 @@ use Data::Dumper;
 use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 
-    # Configure HTTP basic authorization: bearer_test
     # Configure bearer access token for authorization: bearer_test
     access_token => 'YOUR_BEARER_TOKEN',
     


### PR DESCRIPTION
Follow-up of #15220 but for Perl

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 (2017/07) [❤️](https://www.patreon.com/wing328) @yue9944882 (2019/06)