### PR TITLE
[powershell] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/README.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/README.mustache
@@ -92,10 +92,18 @@ No model defined in this package
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}
+{{#isBasicBasic}}
 
 - **Type**: HTTP basic authentication
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}
+
+- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}
+
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}
 
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/powershell/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api_doc.mustache
@@ -27,11 +27,11 @@ Method | HTTP request | Description
 # general setting of the PowerShell module, e.g. base URL, authentication, etc
 $Configuration = Get-Configuration
 {{#authMethods}}
-{{#isBasic}}
+{{#isBasicBasic}}
 # Configure HTTP basic authorization: {{{name}}}
 $Configuration.Username = "YOUR_USERNAME"
 $Configuration.Password = "YOUR_PASSWORD"
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isApiKey}}
 # Configure API key authorization: {{{name}}}
 $Configuration.ApiKey.{{{keyParamName}}} = "YOUR_API_KEY"

--- a/samples/client/petstore/powershell/README.md
+++ b/samples/client/petstore/powershell/README.md
@@ -216,11 +216,11 @@ Authentication schemes defined for the API:
 ### bearer_test
 
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP Bearer Token authentication (JWT)
 
 <a id="http_signature_test"></a>
 ### http_signature_test
 
 
-- **Type**: HTTP basic authentication
+- **Type**: HTTP signature authentication
 

--- a/samples/client/petstore/powershell/docs/PSFakeApi.md
+++ b/samples/client/petstore/powershell/docs/PSFakeApi.md
@@ -560,9 +560,6 @@ Fake endpoint to test group parameters (optional)
 ```powershell
 # general setting of the PowerShell module, e.g. base URL, authentication, etc
 $Configuration = Get-Configuration
-# Configure HTTP basic authorization: bearer_test
-$Configuration.Username = "YOUR_USERNAME"
-$Configuration.Password = "YOUR_PASSWORD"
 
 $RequiredStringGroup = 56 # Int32 | Required String in group parameters
 $RequiredBooleanGroup = $true # Boolean | Required Boolean in group parameters

--- a/samples/client/petstore/powershell/docs/PSPetApi.md
+++ b/samples/client/petstore/powershell/docs/PSPetApi.md
@@ -31,9 +31,6 @@ $Configuration = Get-Configuration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration.AccessToken = "YOUR_ACCESS_TOKEN"
 
-# Configure HTTP basic authorization: http_signature_test
-$Configuration.Username = "YOUR_USERNAME"
-$Configuration.Password = "YOUR_PASSWORD"
 # Configure HttpSignature for authorization :http_signature_test
 $httpSigningParams = @{
     KeyId = "xxxxxx1776876789ac747/xxxxxxx564612d31a62c01/xxxxxxxa1d7564612d31a66ee8"
@@ -144,9 +141,6 @@ $Configuration = Get-Configuration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration.AccessToken = "YOUR_ACCESS_TOKEN"
 
-# Configure HTTP basic authorization: http_signature_test
-$Configuration.Username = "YOUR_USERNAME"
-$Configuration.Password = "YOUR_PASSWORD"
 # Configure HttpSignature for authorization :http_signature_test
 $httpSigningParams = @{
     KeyId = "xxxxxx1776876789ac747/xxxxxxx564612d31a62c01/xxxxxxxa1d7564612d31a66ee8"
@@ -204,9 +198,6 @@ $Configuration = Get-Configuration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration.AccessToken = "YOUR_ACCESS_TOKEN"
 
-# Configure HTTP basic authorization: http_signature_test
-$Configuration.Username = "YOUR_USERNAME"
-$Configuration.Password = "YOUR_PASSWORD"
 # Configure HttpSignature for authorization :http_signature_test
 $httpSigningParams = @{
     KeyId = "xxxxxx1776876789ac747/xxxxxxx564612d31a62c01/xxxxxxxa1d7564612d31a66ee8"
@@ -314,9 +305,6 @@ $Configuration = Get-Configuration
 # Configure OAuth2 access token for authorization: petstore_auth
 $Configuration.AccessToken = "YOUR_ACCESS_TOKEN"
 
-# Configure HTTP basic authorization: http_signature_test
-$Configuration.Username = "YOUR_USERNAME"
-$Configuration.Password = "YOUR_PASSWORD"
 # Configure HttpSignature for authorization :http_signature_test
 $httpSigningParams = @{
     KeyId = "xxxxxx1776876789ac747/xxxxxxx564612d31a62c01/xxxxxxxa1d7564612d31a66ee8"


### PR DESCRIPTION
Follow-up of #15220 but for powershell

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 (2020/05)