### PR TITLE
[lua] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/lua/README.mustache
+++ b/modules/openapi-generator/src/main/resources/lua/README.mustache
@@ -53,7 +53,7 @@ Example
     r, err := client.Service.Operation(auth, args)
 ```
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
 
 Example
 ```
@@ -63,7 +63,11 @@ Example
 	})
     r, err := client.Service.Operation(auth, args)
 ```
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/lua/api.mustache
+++ b/modules/openapi-generator/src/main/resources/lua/api.mustache
@@ -92,10 +92,10 @@ function {{classname}}:{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{
 	-- TODO: api key in query '{{keyParamName}}'
 	{{/isKeyInQuery}}
 	{{/isApiKey}}
-	{{#isBasic}}
+	{{#isBasicBasic}}
 	-- HTTP basic auth
 	req.readers:upsert("authorization", "Basic " .. basexx.to_base64(self.http_username .. " " .. self.http_password))
-	{{/isBasic}}
+	{{/isBasicBasic}}
 	{{#isOAuth}}
 	-- oAuth
 	if self.access_token then


### PR DESCRIPTION
Follow-up of #15220 but for other generators

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@daurnimator (2017/08)