### PR TITLE
[typescript] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
@@ -121,11 +121,11 @@ export class {{classname}} {
         }
 {{/isKeyInQuery}}
 {{/isApiKey}}
-{{#isBasic}}
+{{#isBasicBasic}}
         if (this.APIConfiguration.username || this.APIConfiguration.password) {
             headers['Authorization'] = btoa(this.APIConfiguration.username + ':' + this.APIConfiguration.password);
         }
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isOAuth}}
         if (this.APIConfiguration.accessToken) {
             let accessToken = typeof this.APIConfiguration.accessToken === 'function'

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/api.mustache
@@ -176,13 +176,13 @@ export class {{classname}} {
 
 {{/isKeyInQuery}}
 {{/isApiKey}}
-{{#isBasic}}
+{{#isBasicBasic}}
         // http basic authentication required
         if (this.configuration.username || this.configuration.password) {
             headerParams['Authorization'] = 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password);
         }
 
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isOAuth}}
         // oauth required
         if (this.configuration.accessToken) {

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -136,12 +136,12 @@ export class {{classname}} {
 
 {{/isKeyInQuery}}
 {{/isApiKey}}
-{{#isBasic}}
+{{#isBasicBasic}}
         if (this.configuration.username || this.configuration.password) {
             headers['Authorization'] = 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password);
         }
 
-{{/isBasic}}
+{{/isBasicBasic}}
 {{#isOAuth}}
         if (this.configuration.accessToken) {
             const accessToken = typeof this.configuration.accessToken === 'function'

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -72,9 +72,9 @@ export class {{classname}} extends BaseAPI {
             {{/isArray}}
             {{/headerParams}}
             {{#authMethods}}
-            {{#isBasic}}
+            {{#isBasicBasic}}
             ...(this.configuration.username != null && this.configuration.password != null ? { Authorization: `Basic ${btoa(this.configuration.username + ':' + this.configuration.password)}` } : undefined),
-            {{/isBasic}}
+            {{/isBasicBasic}}
             {{#isApiKey}}
             {{#isKeyInHeader}}
             ...(this.configuration.apiKey && { '{{keyParamName}}': this.configuration.apiKey('{{keyParamName}}') }), // {{name}} authentication


### PR DESCRIPTION
Follow-up of #15220 but for typescript

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)