### PR TITLE
[rust] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/README.mustache
@@ -143,6 +143,8 @@ Example
 	{{! TODO: Add Bearer token authentication }}
 ```
 {{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/rust/hyper/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/hyper/api.mustache
@@ -49,9 +49,9 @@ impl<C: hyper::client::connect::Connect>{{{classname}}} for {{{classname}}}Clien
                 param_name: "{{{keyParamName}}}".to_owned(),
             }))
         {{/isApiKey}}
-        {{#isBasic}}
+        {{#isBasicBasic}}
             .with_auth(__internal_request::Auth::Basic)
-        {{/isBasic}}
+        {{/isBasicBasic}}
         {{#isOAuth}}
             .with_auth(__internal_request::Auth::Oauth)
         {{/isOAuth}}


### PR DESCRIPTION
Follow-up of #15220 but for other generators

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)