### PR TITLE
[eiffel] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/Eiffel/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Eiffel/README.mustache
@@ -47,8 +47,12 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: {{{keyParamName}}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}- **Type**: HTTP basic authentication
-{{/isBasic}}
+{{#isBasicBasic}}- **Type**: HTTP basic authentication
+{{/isBasicBasic}}
+{{#isBasicBearer}}- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}- **Type**: OAuth
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}

--- a/modules/openapi-generator/src/main/resources/Eiffel/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/Eiffel/api_client.mustache
@@ -16,9 +16,9 @@ feature {NONE} -- Initialization
 				--set default user_agent
 			set_user_agent("{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/Eiffel{{/httpUserAgent}}");
 
-			create authentications.make (3) {{#authMethods}}{{#isBasic}}
+			create authentications.make (3) {{#authMethods}}{{#isBasicBasic}}
 			authentications.force (create {HTTP_BASIC_AUTH}, "{{name}}")
-			is_basic_auth_configured := True {{/isBasic}}{{#isApiKey}}
+			is_basic_auth_configured := True {{/isBasicBasic}}{{#isApiKey}}
 			authentications.force (create {API_KEY_AUTH}.make ({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"), "{{name}}")
 			is_api_key_configured := True {{/isApiKey}}{{#isOAuth}}
 			authentications.force (create {OAUTH},"{{name}}")


### PR DESCRIPTION
Follow-up of #15220 but for Eiffel

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jvelilla (2017/09)