### PR TITLE
[C] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
@@ -90,10 +90,18 @@ Category | Method | HTTP request | Description
 - **API key parameter name**: {{keyParamName}}
 - **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
 {{/isApiKey}}
-{{#isBasic}}
+{{#isBasicBasic}}
 
 - **Type**: HTTP basic authentication
-{{/isBasic}}
+{{/isBasicBasic}}
+{{#isBasicBearer}}
+
+- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
+{{/isBasicBearer}}
+{{#isHttpSignature}}
+
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}
 
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -18,10 +18,10 @@ apiClient_t *apiClient_create() {
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
     {{#authMethods}}
-    {{#isBasic}}
+    {{#isBasicBasic}}
     apiClient->username = NULL;
     apiClient->password = NULL;
-    {{/isBasic}}
+    {{/isBasicBasic}}
     {{#isOAuth}}
     apiClient->accessToken = NULL;
     {{/isOAuth}}
@@ -65,10 +65,10 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
     apiClient->response_code = 0;
     {{#hasAuthMethods}}
     {{#authMethods}}
-    {{#isBasic}}
+    {{#isBasicBasic}}
     apiClient->username = NULL;
     apiClient->password = NULL;
-    {{/isBasic}}
+    {{/isBasicBasic}}
     {{#isOAuth}}
     apiClient->accessToken = NULL;
     {{/isOAuth}}
@@ -100,14 +100,14 @@ void apiClient_free(apiClient_t *apiClient) {
     apiClient->progress_data = NULL;
     {{#hasAuthMethods}}
     {{#authMethods}}
-    {{#isBasic}}
+    {{#isBasicBasic}}
     if(apiClient->username) {
         free(apiClient->username);
     }
     if(apiClient->password) {
         free(apiClient->password);
     }
-    {{/isBasic}}
+    {{/isBasicBasic}}
     {{#isOAuth}}
     if(apiClient->accessToken) {
         free(apiClient->accessToken);
@@ -487,7 +487,7 @@ void apiClient_invoke(apiClient_t    *apiClient,
 
         {{#hasAuthMethods}}
         {{#authMethods}}
-        {{#isBasic}}
+        {{#isBasicBasic}}
         // this would only be generated for basic authentication:
         char *authenticationToken;
 
@@ -511,7 +511,7 @@ void apiClient_invoke(apiClient_t    *apiClient,
                              CURLOPT_USERPWD,
                              authenticationToken);
         }
-        {{/isBasic}}
+        {{/isBasicBasic}}
         {{#isOAuth}}
         // this would only be generated for OAuth2 authentication
         if(apiClient->accessToken != NULL) {
@@ -548,13 +548,13 @@ void apiClient_invoke(apiClient_t    *apiClient,
         }
         {{#hasAuthMethods}}
         {{#authMethods}}
-        {{#isBasic}}
+        {{#isBasicBasic}}
         if((apiClient->username != NULL) &&
         (apiClient->password != NULL) )
         {
         free(authenticationToken);
         }
-        {{/isBasic}}
+        {{/isBasicBasic}}
         {{/authMethods}}
         {{/hasAuthMethods}}
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -30,10 +30,10 @@ typedef struct apiClient_t {
     long response_code;
     {{#hasAuthMethods}}
     {{#authMethods}}
-    {{#isBasic}}
+    {{#isBasicBasic}}
     char *username;
     char *password;
-    {{/isBasic}}
+    {{/isBasicBasic}}
     {{#isOAuth}}
     char *accessToken;
     {{/isOAuth}}


### PR DESCRIPTION
Follow-up of #15220 but for C


**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@zhemant (2018/11) @ityuhui (2019/12) @michelealbano (2020/03)