### PR TITLE
[cpp C++] fix use of isBasic condition

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/README.mustache
@@ -70,11 +70,11 @@ void Example::exampleFunction1(){
       apiInstance.setUsername("YOUR USERNAME");
       apiInstance.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
       // Configure HTTP bearer authorization: {{{name}}}
-      apiInstance.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+      apiInstance.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{#isHttpSignature}}
+      //No Http Signature Authentication supported right now{{/isHttpSignature}}{{/isBasic}}{{#isApiKey}}
       // Configure API key authorization: {{{name}}}
       apiInstance.setApiKey("YOUR API KEY NAME","YOUR API KEY");{{/isApiKey}}{{#isOAuth}}
-      //OAuth Authentication supported right now{{/isOAuth}}{{#isHttpSignature}}
-      //No Http Signature Authentication supported right now{{/isHttpSignature}}
+      //OAuth Authentication supported right now{{/isOAuth}}
       {{/authMethods}}
       {{/hasAuthMethods}}
         {{#allParams}}
@@ -165,8 +165,13 @@ servers:
 - **Type**: HTTP basic authentication
 {{/isBasicBasic}}
 {{#isBasicBearer}}
-- **Type**: HTTP Bearer Token authentication
+
+- **Type**: HTTP Bearer Token authentication{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}
 {{/isBasicBearer}}
+{{#isHttpSignature}}
+
+- **Type**: HTTP signature authentication
+{{/isHttpSignature}}
 {{#isOAuth}}
 
 - **Type**: OAuth

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
@@ -256,9 +256,9 @@ pplx::task<{{{returnType}}}{{^returnType}}void{{/returnType}}> {{classname}}::{{
     }
     {{/isKeyInQuery}}
     {{/isApiKey}}
-    {{#isBasic}}
+    {{#isBasicBasic}}
     // Basic authentication is added automatically as part of the http_client_config
-    {{/isBasic}}
+    {{/isBasicBasic}}
     {{#isOAuth}}
     // oauth2 authentication is added automatically as part of the http_client_config
     {{/isOAuth}}


### PR DESCRIPTION
Follow-up of #15220 but for C++


**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)