### PR TITLE
Fix warning when building because of the missing documentation

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Formatters/InputFormatterStream.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Formatters/InputFormatterStream.mustache
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace {{packageName}}.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace {{packageName}}.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-6.0-pocoModels/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-6.0-project4Models/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-6.0-useNewtonsoft/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-6.0-useNewtonsoft/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-6.0-useSwashBuckle/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-6.0-useSwashBuckle/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Formatters/InputFormatterStream.cs
@@ -5,15 +5,23 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Org.OpenAPITools.Formatters
 {
-    // Input Type Formatter to allow model binding to Streams
+    /// <inheritdoc />
     public class InputFormatterStream : InputFormatter
     {
+        /// <inheritdoc />
         public InputFormatterStream()
         {
             SupportedMediaTypes.Add("application/octet-stream");
             SupportedMediaTypes.Add("image/jpeg");
         }
 
+        /// <inheritdoc />
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
+        }
+
+        /// <inheritdoc />
         protected override bool CanReadType(Type type)
         {
             if (type == typeof(Stream))
@@ -22,11 +30,6 @@ namespace Org.OpenAPITools.Formatters
             }
 
             return false;
-        }
-
-        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
-        {
-            return InputFormatterResult.SuccessAsync(context.HttpContext.Request.Body);
         }
     }
 }


### PR DESCRIPTION
Simply add documentation. Without this, it creates warning when building the code.

@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
