### PR TITLE
Fix Default Values for Referenced Enums (#1981)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2183,6 +2183,10 @@ public class DefaultCodegen implements CodegenConfig {
         if (schema.getDefault() != null) {
             return schema.getDefault().toString();
         }
+        Schema refSchema = ModelUtils.getReferencedSchema(openAPI, schema);
+        if (refSchema != null && refSchema.getDefault() != null) {
+            return refSchema.getDefault().toString();
+        }
 
         return "null";
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4778,4 +4778,82 @@ public class DefaultCodegenTest {
         Assert.assertTrue(codegen.isXmlMimeType("application/xml"));
         Assert.assertTrue(codegen.isXmlMimeType("application/rss+xml"));
     }
+
+    @Test
+    public void testEnumsDefaultValueWithInlineEnum() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue-1981-enum-default-values.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final String modelName = "EnumDefaultValueTest";
+        Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel model = codegen.fromModel(modelName, schema);
+        CodegenProperty inlineEnumSchemaProperty = model.vars
+                .stream().filter(var -> var.name.equals("inlineWithDefault")).findAny().get();
+
+        Assert.assertNotNull(schema);
+        Assert.assertTrue(model.hasEnums);
+
+        Assert.assertTrue(inlineEnumSchemaProperty.isEnum);
+        Assert.assertTrue(inlineEnumSchemaProperty.isInnerEnum);
+        Assert.assertFalse(inlineEnumSchemaProperty.isEnumRef);
+        Assert.assertTrue(inlineEnumSchemaProperty.getIsEnumOrRef());
+        Assert.assertTrue(inlineEnumSchemaProperty.isString);
+        Assert.assertFalse(inlineEnumSchemaProperty.isContainer);
+        Assert.assertFalse(inlineEnumSchemaProperty.isPrimitiveType);
+        Assert.assertEquals(inlineEnumSchemaProperty.defaultValue, "INLINE_FIRSTVALUE");
+    }
+
+    @Test
+    public void testEnumsDefaultValueWithReferencedEnum() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue-1981-enum-default-values.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final String modelName = "EnumDefaultValueTest";
+        Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel model = codegen.fromModel(modelName, schema);
+        CodegenProperty refEnumSchemaProperty = model.vars
+                .stream().filter(var -> var.name.equals("refWithSchemaDefault")).findAny().get();
+
+        Assert.assertNotNull(schema);
+        Assert.assertTrue(model.hasEnums);
+
+        Assert.assertFalse(refEnumSchemaProperty.isEnum);
+        Assert.assertFalse(refEnumSchemaProperty.isInnerEnum);
+        Assert.assertTrue(refEnumSchemaProperty.isEnumRef);
+        Assert.assertTrue(refEnumSchemaProperty.getIsEnumOrRef());
+        Assert.assertFalse(refEnumSchemaProperty.isInnerEnum);
+        Assert.assertFalse(refEnumSchemaProperty.isString);
+        Assert.assertFalse(refEnumSchemaProperty.isContainer);
+        Assert.assertFalse(refEnumSchemaProperty.isPrimitiveType);
+        Assert.assertEquals(refEnumSchemaProperty.defaultValue, "SCHEMA_FIRSTVALUE");
+    }
+
+    @Test
+    public void testEnumsDefaultValueReferencedEnumAndDefaultOverride() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue-1981-enum-default-values.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final String modelName = "EnumDefaultValueTest";
+        Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel model = codegen.fromModel(modelName, schema);
+        CodegenProperty refEnumSchemaProperty = model.vars
+                .stream().filter(var -> var.name.equals("refWithOverrideDefault")).findAny().get();
+
+        Assert.assertNotNull(schema);
+        Assert.assertTrue(model.hasEnums);
+
+        Assert.assertFalse(refEnumSchemaProperty.isEnum);
+        Assert.assertFalse(refEnumSchemaProperty.isInnerEnum);
+        Assert.assertTrue(refEnumSchemaProperty.isEnumRef);
+        Assert.assertTrue(refEnumSchemaProperty.getIsEnumOrRef());
+        Assert.assertFalse(refEnumSchemaProperty.isInnerEnum);
+        Assert.assertFalse(refEnumSchemaProperty.isString);
+        Assert.assertFalse(refEnumSchemaProperty.isContainer);
+        Assert.assertFalse(refEnumSchemaProperty.isPrimitiveType);
+        Assert.assertEquals(refEnumSchemaProperty.defaultValue, "SCHEMA_SECONDVALUE");
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelEnumTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelEnumTest.java
@@ -194,4 +194,40 @@ public class JavaModelEnumTest {
         CodegenProperty cp7 = cm.getVars().get(7);
         Assert.assertEquals(cp7.dataType, "OuterEnumIntegerDefaultValue");
     }
+
+    @Test
+    public void testEnumDefaultValue() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue-1981-enum-default-values.yaml");
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final String modelName = "EnumDefaultValueTest";
+        Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel model = codegen.fromModel(modelName, schema);
+        CodegenProperty refEnumSchemaProperty = model.vars
+                .stream().filter(var -> var.name.equals("refWithSchemaDefault")).findAny().get();
+
+        Assert.assertNotNull(refEnumSchemaProperty);
+        Assert.assertTrue(refEnumSchemaProperty.getIsEnumOrRef());
+        Assert.assertEquals(refEnumSchemaProperty.getDataType(), "EnumWithDefaultValue");
+        Assert.assertEquals(refEnumSchemaProperty.defaultValue, "SCHEMA_FIRSTVALUE");
+    }
+
+    @Test
+    public void testEnumDefaultValueWithOverride() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue-1981-enum-default-values.yaml");
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final String modelName = "EnumDefaultValueTest";
+        Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel model = codegen.fromModel(modelName, schema);
+        CodegenProperty refEnumSchemaProperty = model.vars
+                .stream().filter(var -> var.name.equals("refWithOverrideDefault")).findAny().get();
+
+        Assert.assertNotNull(refEnumSchemaProperty);
+        Assert.assertTrue(refEnumSchemaProperty.getIsEnumOrRef());
+        Assert.assertEquals(refEnumSchemaProperty.getDataType(), "EnumWithDefaultValue");
+        Assert.assertEquals(refEnumSchemaProperty.defaultValue, "SCHEMA_SECONDVALUE");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue-1981-enum-default-values.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue-1981-enum-default-values.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Enum Default Value Test
+servers:
+  - url: http://localhost:3000
+paths:
+  /fake-request:
+    post:
+      operationId: fakeRequest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnumDefaultValueTest'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  response:
+                    type: string
+components:
+  schemas:
+    EnumDefaultValueTest:
+      type: object
+      properties:
+        refWithSchemaDefault:
+          $ref: '#/components/schemas/EnumWithDefaultValue'
+        refWithOverrideDefault:
+          default: SCHEMA_SECONDVALUE
+          allOf:
+            - $ref: '#/components/schemas/EnumWithDefaultValue'
+        inlineWithDefault:
+          type: string
+          default: INLINE_FIRSTVALUE
+          enum:
+            - INLINE_FIRSTVALUE
+            - INLINE_SECONDVALUE
+    EnumWithDefaultValue:
+      type: string
+      default: SCHEMA_FIRSTVALUE
+      enum:
+        - SCHEMA_FIRSTVALUE
+        - SCHEMA_SECONDVALUE

--- a/samples/schema/petstore/mysql/mysql_schema.sql
+++ b/samples/schema/petstore/mysql/mysql_schema.sql
@@ -165,8 +165,8 @@ CREATE TABLE IF NOT EXISTS `Enum_Test` (
   `enum_number` ENUM('1.1', '-1.2') DEFAULT NULL,
   `outerEnum` TEXT DEFAULT NULL,
   `outerEnumInteger` TEXT DEFAULT NULL,
-  `outerEnumDefaultValue` TEXT DEFAULT NULL,
-  `outerEnumIntegerDefaultValue` TEXT DEFAULT NULL
+  `outerEnumDefaultValue` TEXT,
+  `outerEnumIntegerDefaultValue` TEXT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Properties that were typed as a referenced Enum would not properly default to the Enum's default (raised in #1981), for example bellow would not default `refWithSchemaDefault` to "SCHEMA_FIRSTVALUE":

```
components:
  schemas:
    EnumDefaultValueTest:
      type: object
      properties:
        refWithSchemaDefault:
          $ref: '#/components/schemas/EnumWithDefaultValue'
    EnumWithDefaultValue:
      type: string
      default: SCHEMA_FIRSTVALUE
      enum:
        - SCHEMA_FIRSTVALUE
        - SCHEMA_SECONDVALUE
```

This fixes that by checking in `toDefaultValue` if the schema is a referenced enum, and if so grabbing the default from the referenced schema.

A number of tests were added to verify the handling around enums and default values:
1. property which is an inline enum with a default value
2. property which is a referenced enum with a default value in the enum's schema
3. property which is an "allOf" referenced enum with a default value at the property level.

Test case (3) is unique in that it asserts the current behavior of the system even though I'm not sure its a documented behavior, but something at least our teams have come to depend on it behaving that way. In detail the following schema allows for overriding the default value of the field `refWithOverrideDefault` to "SCHEMA_SECONDVALUE" which is different than the default value defined in the Enum's schema:

```
components:
  schemas:
    EnumDefaultValueTest:
      type: object
      properties:
        refWithOverrideDefault:
          default: SCHEMA_SECONDVALUE
          allOf:
            - $ref: '#/components/schemas/EnumWithDefaultValue'
    EnumWithDefaultValue:
      type: string
      default: SCHEMA_FIRSTVALUE
      enum:
        - SCHEMA_FIRSTVALUE
        - SCHEMA_SECONDVALUE
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] ~In case you are adding a new generator, run the following additional script :~ 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request: 
  - *JAVA:* @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
