### PR TITLE
[GO] Fix value formatting in url with slices

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -189,7 +189,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", s.Index(i), "{{collectionFormat}}")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", s.Index(i).Interface(), "{{collectionFormat}}")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")
@@ -207,7 +207,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", s.Index(i), "{{collectionFormat}}")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", s.Index(i).Interface(), "{{collectionFormat}}")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "{{baseName}}", t, "{{collectionFormat}}")

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -1944,7 +1944,7 @@ func (a *FakeAPIService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "context", s.Index(i), "multi")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "context", s.Index(i).Interface(), "multi")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "context", t, "multi")

--- a/samples/openapi3/client/petstore/go/fake_api_test.go
+++ b/samples/openapi3/client/petstore/go/fake_api_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	deepObjectURL = `/v2/fake/deep_object_test?inputOptions[F1]=1&inputOptions[F2]=teststring&inputOptions[F3]=null&inputOptions[id]=1&inputOptions[name]=TestCat&test_pet[F1]=1&test_pet[F2]=teststring&test_pet[F3]=null&test_pet[id]=1&test_pet[name]=Test&test_pet[photoUrls]=http%3A%2F%2Flocalhost&test_pet[tags][F1]=1&test_pet[tags][F2]=teststring&test_pet[tags][F3]=null&test_pet[tags][id]=2&test_pet[tags][name]=tag1`
+	deepObjectURL            = `/v2/fake/deep_object_test?inputOptions[F1]=1&inputOptions[F2]=teststring&inputOptions[F3]=null&inputOptions[id]=1&inputOptions[name]=TestCat&test_pet[F1]=1&test_pet[F2]=teststring&test_pet[F3]=null&test_pet[id]=1&test_pet[name]=Test&test_pet[photoUrls]=http%3A%2F%2Flocalhost&test_pet[tags][F1]=1&test_pet[tags][F2]=teststring&test_pet[tags][F3]=null&test_pet[tags][id]=2&test_pet[tags][name]=tag1`
+	paramCollectionFormatURL = `/v2/fake/test-query-parameters?context=context&http=http&ioutil=ioutil&pipe=pipe&url=url`
 )
 
 // TestPutBodyWithFileSchema ensures a model with the name 'File'
@@ -39,12 +40,12 @@ func TestQueryDeepObject(t *testing.T) {
 	var idTag1 = int64(2)
 	var nameTag1 = "tag1"
 	req = req.TestPet(sw.Pet{
-		Id: &id,
-		Name: "Test",
-		PhotoUrls: []string{ "http://localhost" },
+		Id:        &id,
+		Name:      "Test",
+		PhotoUrls: []string{"http://localhost"},
 		Tags: []sw.Tag{
 			{
-				Id: &idTag1,
+				Id:   &idTag1,
 				Name: &nameTag1,
 				AdditionalProperties: map[string]interface{}{
 					"F1": 1,
@@ -61,7 +62,7 @@ func TestQueryDeepObject(t *testing.T) {
 	})
 	var idcat = int64(1)
 	req = req.InputOptions(sw.Category{
-		Id: &idcat,
+		Id:   &idcat,
 		Name: "TestCat",
 		AdditionalProperties: map[string]interface{}{
 			"F1": 1,
@@ -76,5 +77,22 @@ func TestQueryDeepObject(t *testing.T) {
 
 	assert.Equal(t,
 		expectedDeepObjectURL,
-		r.Request.URL.String() )
+		r.Request.URL.String())
+}
+
+func TestQueryParameterCollectionFormat(t *testing.T) {
+	req := client.FakeAPI.TestQueryParameterCollectionFormat(context.Background()).
+		Pipe([]string{"pipe"}).
+		Ioutil([]string{"ioutil"}).
+		Http([]string{"http"}).
+		Url([]string{"url"}).
+		Context([]string{"context"})
+
+	r, _ := req.Execute()
+
+	var expectedParamCollectionFormatURL = testScheme + "://" + testHost + paramCollectionFormatURL
+
+	assert.Equal(t,
+		expectedParamCollectionFormatURL,
+		r.Request.URL.String())
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -1453,7 +1453,7 @@ func (a *FakeAPIService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string_array", s.Index(i), "multi")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string_array", s.Index(i).Interface(), "multi")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string_array", t, "multi")
@@ -2093,7 +2093,7 @@ func (a *FakeAPIService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "pipe", s.Index(i), "multi")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "pipe", s.Index(i).Interface(), "multi")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "pipe", t, "multi")
@@ -2107,7 +2107,7 @@ func (a *FakeAPIService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "context", s.Index(i), "multi")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "context", s.Index(i).Interface(), "multi")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "context", t, "multi")
@@ -2226,7 +2226,7 @@ func (a *FakeAPIService) TestUniqueItemsHeaderAndQueryParameterCollectionFormatE
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "queryUnique", s.Index(i), "multi")
+				parameterAddToHeaderOrQuery(localVarQueryParams, "queryUnique", s.Index(i).Interface(), "multi")
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "queryUnique", t, "multi")


### PR DESCRIPTION
This is to fix the client generation problem related to #14798 where url value ends up being `reflect.Value+value` instead of their real value.




@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
