### PR TITLE
[kotlin-server] add support for jakarta ee namespace

### DIFF
--- a/docs/generators/kotlin-server.md
+++ b/docs/generators/kotlin-server.md
@@ -44,6 +44,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sourceFolder|source folder for generated code| |src/main/kotlin|
 |useBeanValidation|Use BeanValidation API annotations. This option is currently supported only when using jaxrs-spec library.| |false|
 |useCoroutines|Whether to use the Coroutines. This option is currently supported only when using jaxrs-spec library.| |false|
+|useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -133,6 +133,7 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations. This option is currently supported only when using jaxrs-spec library.", useBeanValidation));
         cliOptions.add(CliOption.newBoolean(USE_COROUTINES, "Whether to use the Coroutines. This option is currently supported only when using jaxrs-spec library.", useCoroutines));
         cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE, "Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true. This option is currently supported only when using jaxrs-spec library.").defaultValue(String.valueOf(returnResponse)));
+        cliOptions.add(CliOption.newBoolean(USE_JAKARTA_EE, "whether to use Jakarta EE namespace instead of javax", useJakartaEe));
     }
 
     public Boolean getAutoHeadFeatureEnabled() {

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/api.mustache
@@ -3,16 +3,16 @@ package {{package}};
 {{#imports}}import {{import}}
 {{/imports}}
 
-import javax.ws.rs.*
-import javax.ws.rs.core.Response
+import {{javaxPackage}}.ws.rs.*
+import {{javaxPackage}}.ws.rs.core.Response
 
 {{#useSwaggerAnnotations}}
 import io.swagger.annotations.*
 {{/useSwaggerAnnotations}}
 
 import java.io.InputStream
-{{#useBeanValidation}}import javax.validation.constraints.*
-import javax.validation.Valid{{/useBeanValidation}}
+{{#useBeanValidation}}import {{javaxPackage}}.validation.constraints.*
+import {{javaxPackage}}.validation.Valid{{/useBeanValidation}}
 
 {{#useSwaggerAnnotations}}
 @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/build.gradle.mustache
@@ -8,9 +8,15 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = "1.4.32"
-    ext.jakarta_ws_rs_version = "2.1.6"
     ext.swagger_annotations_version = "1.5.3"
+{{#useJakartaEe}}
+    ext.jakarta_annotations_version = "2.1.1"
+    ext.jakarta_ws_rs_version = "3.1.0"
+{{/useJakartaEe}}
+{{^useJakartaEe}}
     ext.jakarta_annotations_version = "1.3.5"
+    ext.jakarta_ws_rs_version = "2.1.6"
+{{/useJakartaEe}}
     ext.jackson_version = "2.9.9"
 {{#useBeanValidation}}
     ext.beanvalidation_version = "2.0.2"

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = arrayOf("{{generatorClass}}"){{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = arrayOf("{{generatorClass}}"){{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/model.mustache
@@ -4,8 +4,8 @@ package {{modelPackage}}
 {{#imports}}import {{import}}
 {{/imports}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*
-import javax.validation.Valid
+import {{javaxPackage}}.validation.constraints.*
+import {{javaxPackage}}.validation.Valid
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -320,4 +320,18 @@ public class AbstractKotlinCodegenTest {
             .fromModel("MapSchema", mapSchema);
         Assert.assertTrue(mapSchemaModel.isMap);
     }
+
+    @Test
+    public void handleUseJakartaEeTrue() {
+        codegen.additionalProperties().put("useJakartaEe", true);
+        codegen.processOpts();
+        assertEquals(codegen.additionalProperties().get("javaxPackage"), "jakarta");
+    }
+
+    @Test
+    public void handleUseJakartaEeFalse() {
+        codegen.additionalProperties().put("useJakartaEe", false);
+        codegen.processOpts();
+        assertEquals(codegen.additionalProperties().get("javaxPackage"), "javax");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -1,0 +1,167 @@
+package org.openapitools.codegen.kotlin;
+
+import org.junit.Test;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.KotlinServerCodegen;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.openapitools.codegen.CodegenConstants.LIBRARY;
+import static org.openapitools.codegen.languages.AbstractKotlinCodegen.USE_JAKARTA_EE;
+import static org.openapitools.codegen.languages.KotlinServerCodegen.Constants.JAXRS_SPEC;
+import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.TestUtils.assertFileNotContains;
+import static org.openapitools.codegen.languages.features.BeanValidationFeatures.USE_BEANVALIDATION;
+
+public class KotlinServerCodegenTest {
+
+    @Test
+    public void javaxImports() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
+        Path petApi = Paths.get(outputPath + "/apis/PetApi.kt");
+        assertFileNotContains(
+                petApi,
+                "import jakarta.ws.rs.*",
+                "import jakarta.ws.rs.core.Response",
+                "@jakarta.annotation.Generated(value = arrayOf(\"org.openapitools.codegen.languages.KotlinServerCodegen\"))"
+        );
+        assertFileContains(
+                petApi,
+                "import javax.ws.rs.*",
+                "import javax.ws.rs.core.Response",
+                "@javax.annotation.Generated(value = arrayOf(\"org.openapitools.codegen.languages.KotlinServerCodegen\"))"
+        );
+    }
+
+    @Test
+    public void jakartaEeImports() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(USE_JAKARTA_EE, true);
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
+        Path petApi = Paths.get(outputPath + "/apis/PetApi.kt");
+        assertFileContains(
+                petApi,
+                "import jakarta.ws.rs.*",
+                "import jakarta.ws.rs.core.Response",
+                "@jakarta.annotation.Generated(value = arrayOf(\"org.openapitools.codegen.languages.KotlinServerCodegen\"))"
+        );
+        assertFileNotContains(
+                petApi,
+                "import javax.ws.rs.*",
+                "import javax.ws.rs.core.Response",
+                "@javax.annotation.Generated(value = arrayOf(\"org.openapitools.codegen.languages.KotlinServerCodegen\"))"
+        );
+    }
+
+    @Test
+    public void beanValidationJavaxImports() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+        codegen.additionalProperties().put(USE_BEANVALIDATION, true);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
+        Path petApi = Paths.get(outputPath + "/apis/PetApi.kt");
+        assertFileNotContains(
+                petApi,
+                "import jakarta.validation.Valid",
+                "import jakarta.validation.Valid"
+        );
+        assertFileContains(
+                petApi,
+                "import javax.validation.constraints.*",
+                "import javax.validation.Valid"
+        );
+
+        Path petModel = Paths.get(outputPath + "/models/Pet.kt");
+        assertFileNotContains(
+                petApi,
+                "import jakarta.validation.Valid",
+                "import jakarta.validation.Valid"
+        );
+        assertFileContains(
+                petApi,
+                "import javax.validation.constraints.*",
+                "import javax.validation.Valid"
+        );
+    }
+
+    @Test
+    public void beanValidationJakartaEeImports() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(USE_JAKARTA_EE, true);
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+        codegen.additionalProperties().put(USE_BEANVALIDATION, true);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
+        Path petApi = Paths.get(outputPath + "/apis/PetApi.kt");
+        assertFileContains(
+                petApi,
+                "import jakarta.validation.Valid",
+                "import jakarta.validation.Valid"
+        );
+        assertFileNotContains(
+                petApi,
+                "import javax.validation.constraints.*",
+                "import javax.validation.Valid"
+        );
+
+        Path petModel = Paths.get(outputPath + "/models/Pet.kt");
+        assertFileContains(
+                petModel,
+                "import jakarta.validation.Valid",
+                "import jakarta.validation.Valid"
+        );
+        assertFileNotContains(
+                petModel,
+                "import javax.validation.constraints.*",
+                "import javax.validation.Valid"
+        );
+    }
+}

--- a/samples/server/petstore/kotlin-server/jaxrs-spec/build.gradle
+++ b/samples/server/petstore/kotlin-server/jaxrs-spec/build.gradle
@@ -8,9 +8,9 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = "1.4.32"
-    ext.jakarta_ws_rs_version = "2.1.6"
     ext.swagger_annotations_version = "1.5.3"
     ext.jakarta_annotations_version = "1.3.5"
+    ext.jakarta_ws_rs_version = "2.1.6"
     ext.jackson_version = "2.9.9"
     repositories {
         maven { url "https://repo1.maven.org/maven2" }


### PR DESCRIPTION
Support the `jakarta.*` namespace for the kotlin-server generator. This was already implemented in the jaxrs-spec and kotlin-spring generators.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)