### PR TITLE
Revert "[Ruby] Client: fix base_url when no server_operation_index is…

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -171,7 +171,7 @@ module {{moduleName}}
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])

--- a/samples/client/petstore/ruby-autoload/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/configuration.rb
@@ -200,7 +200,7 @@ module Petstore
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -204,7 +204,7 @@ module Petstore
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -200,7 +200,7 @@ module Petstore
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/configuration.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/configuration.rb
@@ -200,7 +200,7 @@ module XAuthIDAlias
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/configuration.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/configuration.rb
@@ -200,7 +200,7 @@ module DynamicServers
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
@@ -200,7 +200,7 @@ module Petstore
 
     # Returns base URL for specified operation based on server settings
     def base_url(operation = nil)
-      index = server_operation_index[operation]
+      index = server_operation_index.fetch(operation, server_index)
       return "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '') if index == nil
 
       server_url(index, server_operation_variables.fetch(operation, server_variables), operation_server_settings[operation])


### PR DESCRIPTION
… defined (#15162)"

This reverts commit 2679819694ccf8f49a61c83a52f5d9a6fed07810.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

https://github.com/OpenAPITools/openapi-generator/issues/15610

<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
