### PR TITLE
Use templated value javaxPackage in mustache templates for kotlin-server generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/api.mustache
@@ -3,16 +3,16 @@ package {{package}};
 {{#imports}}import {{import}}
 {{/imports}}
 
-import javax.ws.rs.*
-import javax.ws.rs.core.Response
+import {{javaxPackage}}.ws.rs.*
+import {{javaxPackage}}.ws.rs.core.Response
 
 {{#useSwaggerAnnotations}}
 import io.swagger.annotations.*
 {{/useSwaggerAnnotations}}
 
 import java.io.InputStream
-{{#useBeanValidation}}import javax.validation.constraints.*
-import javax.validation.Valid{{/useBeanValidation}}
+{{#useBeanValidation}}import {{javaxPackage}}.validation.constraints.*
+import {{javaxPackage}}.validation.Valid{{/useBeanValidation}}
 
 {{#useSwaggerAnnotations}}
 @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = arrayOf("{{generatorClass}}"){{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{javaxPackage}}.annotation.Generated(value = arrayOf("{{generatorClass}}"){{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/model.mustache
@@ -4,8 +4,8 @@ package {{modelPackage}}
 {{#imports}}import {{import}}
 {{/imports}}
 {{#useBeanValidation}}
-import javax.validation.constraints.*
-import javax.validation.Valid
+import {{javaxPackage}}.validation.constraints.*
+import {{javaxPackage}}.validation.Valid
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -1,0 +1,56 @@
+package org.openapitools.codegen.kotlin;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.KotlinServerCodegen;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.languages.KotlinServerCodegen.Constants.JAXRS_SPEC;
+
+public class KotlinServerCodegenTest {
+
+    @Test(description = "Use jakarta extension")
+    public void useJakartaExtension() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.setLibrary(JAXRS_SPEC);
+        codegen.additionalProperties().put(KotlinServerCodegen.USE_JAKARTA_EE, true);
+        codegen.additionalProperties().put(KotlinServerCodegen.USE_BEANVALIDATION, true);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/kotlin/use_jakarta_extension.yaml"))
+                        .config(codegen))
+                .generate();
+
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/server/apis/LocationApi.kt"),
+                "import jakarta.ws.rs.*"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/server/apis/LocationApi.kt"),
+                "import jakarta.ws.rs.core.Response"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/server/apis/LocationApi.kt"),
+                "import jakarta.validation.Valid"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/server/models/CreateLocation.kt"),
+                "import jakarta.validation.constraints.*"
+        );
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/server/models/CreateLocation.kt"),
+                "import jakarta.validation.Valid"
+        );
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/use_jakarta_extension.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/use_jakarta_extension.yaml
@@ -1,0 +1,33 @@
+openapi: "3.0.1"
+info:
+  title: example
+  version: "1.0"
+paths:
+  /locations:
+    post:
+      operationId: createLocation
+      tags:
+        - location
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateLocation'
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+components:
+  schemas:
+    CreateLocation:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          nullable: false
+          minLength: 1
+          maxLength: 512


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/15617

This PR switches the hardcoded `javax` in the import statements with the templated value `{{javaxPackage}}` in order to have it correctly replaced with the desired package based on the config option `useJakartaEe`. It includes addes unit tests and test resources.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
