### PR TITLE
[groovy] support enum generation in groovy client

### DIFF
--- a/docs/generators/groovy.md
+++ b/docs/generators/groovy.md
@@ -39,7 +39,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |discriminatorCaseSensitive|Whether the discriminator value lookup should be case-sensitive or not. This option only works for Java API client| |true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
-|fullJavaUtil|whether to use fully qualified name for classes under java.util. This option only works for Java API client| |false|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|
 |ignoreAnyOfInEnum|Ignore anyOf keyword in enum| |false|

--- a/modules/openapi-generator/src/main/resources/Groovy/ApiUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/ApiUtils.mustache
@@ -5,12 +5,30 @@ import static java.net.URI.create
 
 class ApiUtils {
 
+    static def jsonGenerator = new JsonGenerator.Options()
+            .addConverter(Enum) { Enum u, String key ->
+                u.toString()
+            }
+            .build()
+
     void invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType, method, container, type)  {
         def (url, uriPath) = buildUrlAndUriPath(basePath, versionPath, resourcePath)
         println "url=$url uriPath=$uriPath"
         def http = configure {
             request.uri = url
             request.uri.path = uriPath
+            request.encoder(ContentTypes.JSON, { final ChainedHttpConfig config, final ToServer ts ->
+                final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
+                if (NativeHandlers.Encoders.handleRawUpload(config, ts)) {
+                    return;
+                }
+
+                final Object body = NativeHandlers.Encoders.checkNull(request.actualBody());
+                final String json = ((body instanceof String || body instanceof GString)
+                        ? body.toString()
+                        : new JsonBuilder(body, jsonGenerator).toString());
+                ts.toServer(NativeHandlers.Encoders.stringToStream(json, request.actualCharset()));
+            })
         }
         .invokeMethod(String.valueOf(method).toLowerCase()) {
             request.uri.query = queryParams

--- a/modules/openapi-generator/src/main/resources/Groovy/ApiUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/ApiUtils.mustache
@@ -1,5 +1,12 @@
 package {{invokerPackage}}
 
+import groovy.json.JsonBuilder
+import groovy.json.JsonGenerator
+import groovyx.net.http.ChainedHttpConfig
+import groovyx.net.http.ContentTypes
+import groovyx.net.http.NativeHandlers
+import groovyx.net.http.ToServer
+
 import static groovyx.net.http.HttpBuilder.configure
 import static java.net.URI.create
 

--- a/modules/openapi-generator/src/main/resources/Groovy/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/model.mustache
@@ -7,12 +7,6 @@ import {{import}};
 
 {{#models}}
 {{#model}}
-@Canonical
-class {{classname}} {
-    {{#vars}}
-    {{#description}}/* {{{.}}} */{{/description}}
-    {{{dataType}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}
-    {{/vars}}
-}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelClass}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
@@ -1,7 +1,19 @@
 @Canonical
 class {{classname}} {
 {{#vars}}
+        {{#isEnum}}
+
+        {{^isContainer}}
+    {{>modelEnum}}
+        {{/isContainer}}
+        {{#isContainer}}
+        {{#mostInnerItems}}
+    {{>modelEnum}}
+        {{/mostInnerItems}}
+        {{/isContainer}}
+        {{/isEnum}}
+
     {{#description}}/* {{{.}}} */{{/description}}
-    {{{dataType}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}
+    {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}
 {{/vars}}
 }

--- a/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
@@ -1,0 +1,7 @@
+@Canonical
+class {{classname}} {
+{{#vars}}
+    {{#description}}/* {{{.}}} */{{/description}}
+    {{{dataType}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}
+{{/vars}}
+}

--- a/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
@@ -1,18 +1,20 @@
 @Canonical
 class {{classname}} {
 {{#vars}}
-        {{#isEnum}}
+    {{#isEnum}}
 
-        {{^isContainer}}
-    {{>modelEnum}}
-        {{/isContainer}}
-        {{#isContainer}}
-        {{#mostInnerItems}}
-    {{>modelEnum}}
-        {{/mostInnerItems}}
-        {{/isContainer}}
-        {{/isEnum}}
+    {{^isContainer}}
+{{#lambda.indented}}
+    {{>modelEnum}}{{/lambda.indented}}
+    {{/isContainer}}
+    {{#isContainer}}
+    {{#mostInnerItems}}
+{{#lambda.indented}}
+    {{>modelEnum}}{{/lambda.indented}}
+    {{/mostInnerItems}}
+    {{/isContainer}}
 
+    {{/isEnum}}
     {{#description}}/* {{{.}}} */{{/description}}
     {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}
 {{/vars}}

--- a/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
@@ -1,4 +1,4 @@
-enum {{classname}} {
+enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
 {{#allowableValues}}{{#enumVars}}
     {{#enumDescription}}
         /**

--- a/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
@@ -1,0 +1,25 @@
+enum {{classname}} {
+{{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+        /**
+        * {{.}}
+        */
+    {{/enumDescription}}
+    {{{name}}}({{{value}}}){{^-last}},
+    {{/-last}}{{/enumVars}}{{/allowableValues}}
+
+    private final {{{dataType}}} value
+
+    {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+        this.value = value
+    }
+
+    {{{dataType}}} getValue() {
+        value
+    }
+
+    @Override
+    String toString() {
+        String.valueOf(value)
+    }
+}

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/ApiUtils.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/ApiUtils.groovy
@@ -1,9 +1,22 @@
 package org.openapitools.api
 
+import groovy.json.JsonBuilder
+import groovy.json.JsonGenerator
+import groovyx.net.http.ChainedHttpConfig
+import groovyx.net.http.ContentTypes
+import groovyx.net.http.NativeHandlers
+import groovyx.net.http.ToServer
+
 import static groovyx.net.http.HttpBuilder.configure
 import static java.net.URI.create
 
 class ApiUtils {
+
+    static def jsonGenerator = new JsonGenerator.Options()
+            .addConverter(Enum) { Enum u, String key ->
+                u.toString()
+            }
+            .build()
 
     void invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType, method, container, type)  {
         def (url, uriPath) = buildUrlAndUriPath(basePath, versionPath, resourcePath)
@@ -11,6 +24,18 @@ class ApiUtils {
         def http = configure {
             request.uri = url
             request.uri.path = uriPath
+            request.encoder(ContentTypes.JSON, { final ChainedHttpConfig config, final ToServer ts ->
+                final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
+                if (NativeHandlers.Encoders.handleRawUpload(config, ts)) {
+                    return;
+                }
+
+                final Object body = NativeHandlers.Encoders.checkNull(request.actualBody());
+                final String json = ((body instanceof String || body instanceof GString)
+                        ? body.toString()
+                        : new JsonBuilder(body, jsonGenerator).toString());
+                ts.toServer(NativeHandlers.Encoders.stringToStream(json, request.actualCharset()));
+            })
         }
         .invokeMethod(String.valueOf(method).toLowerCase()) {
             request.uri.query = queryParams

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Order.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Order.groovy
@@ -14,8 +14,33 @@ class Order {
     Integer quantity
     
     Date shipDate
+
+    enum StatusEnum {
+    
+        PLACED("placed"),
+        
+        APPROVED("approved"),
+        
+        DELIVERED("delivered")
+    
+        private final String value
+    
+        StatusEnum(String value) {
+            this.value = value
+        }
+    
+        String getValue() {
+            value
+        }
+    
+        @Override
+        String toString() {
+            String.valueOf(value)
+        }
+    }
+
     /* Order Status */
-    String status
+    StatusEnum status
     
     Boolean complete = false
 }

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Pet.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Pet.groovy
@@ -20,6 +20,31 @@ class Pet {
     List<String> photoUrls = new ArrayList<>()
     
     List<Tag> tags
+
+    enum StatusEnum {
+    
+        AVAILABLE("available"),
+        
+        PENDING("pending"),
+        
+        SOLD("sold")
+    
+        private final String value
+    
+        StatusEnum(String value) {
+            this.value = value
+        }
+    
+        String getValue() {
+            value
+        }
+    
+        @Override
+        String toString() {
+            String.valueOf(value)
+        }
+    }
+
     /* pet status in the store */
-    String status
+    StatusEnum status
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
# Description

Adds enum generation instead of empty classes in groovy client. This problem could be fixed using new template with `-t` params, but I found an issue #14420  and decided to open this PR. 

Changes:
* model: added generation of enums in separate classes and nested enums
* ApiUtils: added custom request encoder. JsonGenerator in groovy allows  by default usage of Enum.name() instead of value field. groovyx.net.http.HttpBuilder does not support customizing of JsonGenerator, but it supports overriding of encoder.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
