### PR TITLE
[JAVA] fix import mapping for return types, use addSchemaImportsFromV3SpecLocations=true

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4385,17 +4385,15 @@ public class DefaultCodegen implements CodegenConfig {
                 String mediaTypeSchemaSuffix = String.format(Locale.ROOT, "%sResponseBody", r.code);
                 r.setContent(getContent(response.getContent(), imports, mediaTypeSchemaSuffix));
 
-//            if (!addSchemaImportsFromV3SpecLocations) {
-                    if (r.baseType != null &&
-                            !defaultIncludes.contains(r.baseType) &&
-                            !languageSpecificPrimitives.contains(r.baseType)) {
-                        imports.add(r.baseType);
-                    }
-                    if ("set".equals(r.containerType) && typeMapping.containsKey(r.containerType)) {
-                        op.uniqueItems = true;
-                        imports.add(typeMapping.get(r.containerType));
-                    }
-//            }
+                if (r.baseType != null &&
+                        !defaultIncludes.contains(r.baseType) &&
+                        !languageSpecificPrimitives.contains(r.baseType)) {
+                    imports.add(r.baseType);
+                }
+                if ("set".equals(r.containerType) && typeMapping.containsKey(r.containerType)) {
+                    op.uniqueItems = true;
+                    imports.add(typeMapping.get(r.containerType));
+                }
 
                 op.responses.add(r);
                 if (Boolean.TRUE.equals(r.isBinary) && Boolean.TRUE.equals(r.is2xx) && Boolean.FALSE.equals(op.isResponseBinary)) {
@@ -5548,18 +5546,16 @@ public class DefaultCodegen implements CodegenConfig {
         final CodegenProperty property = fromProperty(name, schema, false);
         addImport(model, property.complexType);
         model.parent = toInstantiationType(schema);
-//        if (!addSchemaImportsFromV3SpecLocations) {
-            final String containerType = property.containerType;
-            final String instantiationType = instantiationTypes.get(containerType);
-            if (instantiationType != null) {
-                addImport(model, instantiationType);
-            }
+        final String containerType = property.containerType;
+        final String instantiationType = instantiationTypes.get(containerType);
+        if (instantiationType != null) {
+            addImport(model, instantiationType);
+        }
 
-            final String mappedType = typeMapping.get(containerType);
-            if (mappedType != null) {
-                addImport(model, mappedType);
-            }
-//        }
+        final String mappedType = typeMapping.get(containerType);
+        if (mappedType != null) {
+            addImport(model, mappedType);
+        }
     }
 
     /**
@@ -5767,9 +5763,7 @@ public class DefaultCodegen implements CodegenConfig {
                 if (!Boolean.TRUE.equals(cp.isReadOnly)) {
                     cm.hasOnlyReadOnly = false;
                 }
-//                if (!addSchemaImportsFromV3SpecLocations) {
-                    addImportsForPropertyType(cm, cp);
-//                }
+                addImportsForPropertyType(cm, cp);
 
                 // if required, add to the list "requiredVars"
                 if (Boolean.FALSE.equals(cp.required)) {
@@ -6959,12 +6953,10 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
 
-//        if (!addSchemaImportsFromV3SpecLocations) {
-            // import
-            if (codegenProperty.complexType != null) {
-                imports.add(codegenProperty.complexType);
-            }
-//        }
+        // import
+        if (codegenProperty.complexType != null) {
+            imports.add(codegenProperty.complexType);
+        }
         setParameterExampleValue(codegenParameter);
         // set nullable
         setParameterNullable(codegenParameter, codegenProperty);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4385,7 +4385,7 @@ public class DefaultCodegen implements CodegenConfig {
                 String mediaTypeSchemaSuffix = String.format(Locale.ROOT, "%sResponseBody", r.code);
                 r.setContent(getContent(response.getContent(), imports, mediaTypeSchemaSuffix));
 
-                if (!addSchemaImportsFromV3SpecLocations) {
+//            if (!addSchemaImportsFromV3SpecLocations) {
                     if (r.baseType != null &&
                             !defaultIncludes.contains(r.baseType) &&
                             !languageSpecificPrimitives.contains(r.baseType)) {
@@ -4395,7 +4395,7 @@ public class DefaultCodegen implements CodegenConfig {
                         op.uniqueItems = true;
                         imports.add(typeMapping.get(r.containerType));
                     }
-                }
+//            }
 
                 op.responses.add(r);
                 if (Boolean.TRUE.equals(r.isBinary) && Boolean.TRUE.equals(r.is2xx) && Boolean.FALSE.equals(op.isResponseBinary)) {
@@ -4982,7 +4982,11 @@ public class DefaultCodegen implements CodegenConfig {
             }
             codegenParameter.setSchema(prop);
             if (addSchemaImportsFromV3SpecLocations) {
-                addImports(imports, prop.getImports(importContainerType, importBaseType, generatorMetadata.getFeatureSet()));
+                addImports(
+                        imports,
+                        fromProperty(parameter.getName(), parameterSchema, false)
+                                .getImports(importContainerType, importBaseType, generatorMetadata.getFeatureSet())
+                );
             }
         } else if (parameter.getContent() != null) {
             Content content = parameter.getContent();
@@ -5544,7 +5548,7 @@ public class DefaultCodegen implements CodegenConfig {
         final CodegenProperty property = fromProperty(name, schema, false);
         addImport(model, property.complexType);
         model.parent = toInstantiationType(schema);
-        if (!addSchemaImportsFromV3SpecLocations) {
+//        if (!addSchemaImportsFromV3SpecLocations) {
             final String containerType = property.containerType;
             final String instantiationType = instantiationTypes.get(containerType);
             if (instantiationType != null) {
@@ -5555,7 +5559,7 @@ public class DefaultCodegen implements CodegenConfig {
             if (mappedType != null) {
                 addImport(model, mappedType);
             }
-        }
+//        }
     }
 
     /**
@@ -5763,9 +5767,9 @@ public class DefaultCodegen implements CodegenConfig {
                 if (!Boolean.TRUE.equals(cp.isReadOnly)) {
                     cm.hasOnlyReadOnly = false;
                 }
-                if (!addSchemaImportsFromV3SpecLocations) {
+//                if (!addSchemaImportsFromV3SpecLocations) {
                     addImportsForPropertyType(cm, cp);
-                }
+//                }
 
                 // if required, add to the list "requiredVars"
                 if (Boolean.FALSE.equals(cp.required)) {
@@ -6955,12 +6959,12 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
 
-        if (!addSchemaImportsFromV3SpecLocations) {
+//        if (!addSchemaImportsFromV3SpecLocations) {
             // import
             if (codegenProperty.complexType != null) {
                 imports.add(codegenProperty.complexType);
             }
-        }
+//        }
         setParameterExampleValue(codegenParameter);
         // set nullable
         setParameterNullable(codegenParameter, codegenProperty);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -183,6 +183,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         apiPackage = "org.openapitools.client.api";
         modelPackage = "org.openapitools.client.model";
         rootJavaEEPackage = MICROPROFILE_REST_CLIENT_DEFAULT_ROOT_PACKAGE;
+        addSchemaImportsFromV3SpecLocations = true;
 
         // cliOptions default redefinition need to be updated
         updateOption(CodegenConstants.INVOKER_PACKAGE, this.getInvokerPackage());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1699,6 +1699,28 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testReturnTypeMapping() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setInputSpec("src/test/resources/3_0/issue14525.yaml")
+                .addTypeMapping("array","Stack")
+                .addImportMapping("Stack","java.util.Stack")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        TestUtils.assertFileContains(Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
+                "import java.util.Stack;"
+        );
+
+    }
+
+    @Test
     public void testNativeClientExplodedQueryParamWithArrayProperty() throws IOException {
         Map<String, Object> properties = new HashMap<>();
         properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");

--- a/modules/openapi-generator/src/test/resources/3_0/issue14525.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue14525.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Demo app
+  version: 1.0.0
+paths:
+  /demo:
+    get:
+      summary: Demo
+      operationId: demo
+      responses:
+        '200':
+          description: Demo response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string


### PR DESCRIPTION
inspired by https://github.com/OpenAPITools/openapi-generator/issues/14525, but targeting a different generator

The original import problem described in https://github.com/OpenAPITools/openapi-generator/issues/14525 is solved by setting `addSchemaImportsFromV3SpecLocations=true` in the Java generator.
And as far as I understand this setting, migrating  generators to set it to true is an improvement anyway.

Setting `addSchemaImportsFromV3SpecLocations=true` for Java caused some problems with generated imports, which needed some additional import logic fixes.

`addSchemaImportsFromV3SpecLocations=true` was used only for the Python generator before.
My changes do not cause any differences in any generated sample files.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608