### PR TITLE
Fix run-in-docker.sh for OpenAPI Generator 7+ by using JDK 11+

### DIFF
--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -21,4 +21,4 @@ docker run --rm -it \
         -v "${PWD}/CI/run-in-docker-settings.xml:/var/maven/.m2/settings.xml" \
         -v "${maven_cache_repo}:/var/maven/.m2/repository" \
         --entrypoint /gen/docker-entrypoint.sh \
-        maven:3-jdk-8 "$@"
+        maven:3-jdk-11 "$@"


### PR DESCRIPTION
OpenAPI Generator 7 requires JDK 11+, but the `run-in-docker.sh` had not been updated and was still using JDK 8.

Related to #15333.

Before this fix:

```console
$ ./run-in-docker.sh mvn clean install -U
…
13616 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.3.0:enforce (enforce-maven) on project openapi-generator-project:
13616 [ERROR] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
13616 [ERROR] Detected JDK version 1.8.0-342 (JAVA_HOME=/usr/local/openjdk-8/jre) is not in the allowed range [1.11.0,).
```

After this fix, the compile continues to completion.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)