### PR TITLE
Do JSON serialization only if requested by mime-type (#13456)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -168,7 +168,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -161,16 +161,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -179,7 +179,9 @@ export class BaseAPI {
                 overriddenInit.body instanceof URLSearchParams ||
                 isBlob(overriddenInit.body)
                     ? overriddenInit.body
-                    : JSON.stringify(overriddenInit.body),
+                    : this.isJsonMime(headers['Content-Type'])
+                    ? JSON.stringify(overriddenInit.body)
+                    : overriddenInit.body,
         };
 
         return { url, init };

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -172,16 +172,20 @@ export class BaseAPI {
             }))
         };
 
+        let body: any;
+        if (isFormData(overriddenInit.body)
+            || (overriddenInit.body instanceof URLSearchParams)
+            || isBlob(overriddenInit.body)) {
+          body = overriddenInit.body;
+        } else if (this.isJsonMime(headers['Content-Type'])) {
+          body = JSON.stringify(overriddenInit.body);
+        } else {
+          body = overriddenInit.body;
+        }
+
         const init: RequestInit = {
             ...overriddenInit,
-            body:
-                isFormData(overriddenInit.body) ||
-                overriddenInit.body instanceof URLSearchParams ||
-                isBlob(overriddenInit.body)
-                    ? overriddenInit.body
-                    : this.isJsonMime(headers['Content-Type'])
-                    ? JSON.stringify(overriddenInit.body)
-                    : overriddenInit.body,
+            body
         };
 
         return { url, init };


### PR DESCRIPTION
Fix for #13456: JSON serialization is used as a default. I changed to have `toString()` as a default and JSON only in case of requested by mime-type.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka: Please review 😃 .

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
