### PR TITLE
[csharp-netcore][generichost] Created partial method to format arguments

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/api.mustache
@@ -135,6 +135,14 @@ namespace {{packageName}}.{{apiPackage}}
         }
         {{#operation}}
 
+        {{#allParams}}
+        {{#-first}}
+        partial void Format{{operationId}}({{#allParams}}{{#isPrimitiveType}}ref {{/isPrimitiveType}}{{#requiredAndNotNullable}}{{#lambda.required}}{{{dataType}}}{{/lambda.required}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullable}}{{^requiredAndNotNullable}}{{#lambda.optional}}{{{dataType}}}{{/lambda.optional}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullable}}{{/allParams}});
+
+        {{/-first}}
+        {{/allParams}}
+        {{#requiredAndNotNullableParams}}
+        {{#-first}}
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -142,7 +150,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <param name="{{paramName}}"></param>
         {{/allParams}}
         /// <returns></returns>
-        protected virtual {{^allParams}}void{{/allParams}}{{#allParams}}{{#-first}}{{^-last}}({{/-last}}{{/-first}}{{#requiredAndNotNullable}}{{#lambda.required}}{{{dataType}}}{{/lambda.required}}{{^-last}}, {{/-last}}{{/requiredAndNotNullable}}{{^requiredAndNotNullable}}{{#lambda.optional}}{{{dataType}}}{{/lambda.optional}}{{^-last}}, {{/-last}}{{/requiredAndNotNullable}}{{#-last}}{{^-first}}){{/-first}}{{/-last}}{{/allParams}} On{{operationId}}({{#allParams}}{{#requiredAndNotNullable}}{{#lambda.required}}{{{dataType}}}{{/lambda.required}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullable}}{{^requiredAndNotNullable}}{{#lambda.optional}}{{{dataType}}}{{/lambda.optional}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullable}}{{/allParams}})
+        private void Validate{{operationId}}({{#requiredAndNotNullableParams}}{{#lambda.required}}{{{dataType}}}{{/lambda.required}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullableParams}})
         {
             {{#requiredAndNotNullableParams}}
             {{#-first}}
@@ -163,14 +171,14 @@ namespace {{packageName}}.{{apiPackage}}
             {{/vendorExtensions.x-csharp-value-type}}
             {{/nrt}}
             {{#-last}}
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
             {{/-last}}
             {{/requiredAndNotNullableParams}}
-            return{{#allParams}} {{#-first}}{{^-last}}({{/-last}}{{/-first}}{{paramName}}{{^-last}},{{/-last}}{{#-last}}{{^-first}}){{/-first}}{{/-last}}{{/allParams}};
         }
 
+        {{/-first}}
+        {{/requiredAndNotNullableParams}}
         /// <summary>
         /// Processes the server response
         /// </summary>
@@ -231,17 +239,18 @@ namespace {{packageName}}.{{apiPackage}}
 
             try
             {
-                {{#allParams}}{{#-first}}{{#-last}}{{paramName}} = {{/-last}}{{^-last}}var validatedParameterLocalVars = {{/-last}}{{/-first}}{{/allParams}}On{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+                {{#requiredAndNotNullableParams}}
+                {{#-first}}
+                Validate{{operationId}}({{#requiredAndNotNullableParams}}{{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullableParams}});
+
+                {{/-first}}
+                {{/requiredAndNotNullableParams}}
                 {{#allParams}}
                 {{#-first}}
-                {{^-last}}
-                {{#allParams}}
-                {{paramName}} = validatedParameterLocalVars.Item{{-index}};
-                {{/allParams}}
-                {{/-last}}
+                Format{{operationId}}({{#allParams}}{{#isPrimitiveType}}ref {{/isPrimitiveType}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+
                 {{/-first}}
                 {{/allParams}}
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     {{^servers}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -128,12 +128,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatCall123TestSpecialTags(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnCall123TestSpecialTags(ModelClient modelClient)
+        private void ValidateCall123TestSpecialTags(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -141,10 +143,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -199,7 +199,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnCall123TestSpecialTags(modelClient);
+                ValidateCall123TestSpecialTags(modelClient);
+
+                FormatCall123TestSpecialTags(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -171,15 +171,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnFooGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -227,8 +218,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnFooGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
@@ -274,12 +263,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetCountry(ref string country);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="country"></param>
         /// <returns></returns>
-        protected virtual string OnGetCountry(string country)
+        private void ValidateGetCountry(string country)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -287,10 +278,8 @@ namespace Org.OpenAPITools.Api
             if (country == null)
                 throw new ArgumentNullException(nameof(country));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return country;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -345,7 +334,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                country = OnGetCountry(country);
+                ValidateGetCountry(country);
+
+                FormatGetCountry(ref country);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -403,15 +394,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnHello()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -459,8 +441,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnHello();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -511,15 +511,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnFakeHealthGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -567,8 +558,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnFakeHealthGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
@@ -614,15 +603,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        protected virtual bool? OnFakeOuterBooleanSerialize(bool? body)
-        {
-            return body;
-        }
+        partial void FormatFakeOuterBooleanSerialize(ref bool? body);
 
         /// <summary>
         /// Processes the server response
@@ -676,7 +657,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                body = OnFakeOuterBooleanSerialize(body);
+                FormatFakeOuterBooleanSerialize(ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -736,15 +717,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="outerComposite"></param>
-        /// <returns></returns>
-        protected virtual OuterComposite? OnFakeOuterCompositeSerialize(OuterComposite? outerComposite)
-        {
-            return outerComposite;
-        }
+        partial void FormatFakeOuterCompositeSerialize(OuterComposite? outerComposite);
 
         /// <summary>
         /// Processes the server response
@@ -798,7 +771,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                outerComposite = OnFakeOuterCompositeSerialize(outerComposite);
+                FormatFakeOuterCompositeSerialize(outerComposite);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -858,15 +831,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        protected virtual decimal? OnFakeOuterNumberSerialize(decimal? body)
-        {
-            return body;
-        }
+        partial void FormatFakeOuterNumberSerialize(ref decimal? body);
 
         /// <summary>
         /// Processes the server response
@@ -920,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                body = OnFakeOuterNumberSerialize(body);
+                FormatFakeOuterNumberSerialize(ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -980,13 +945,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFakeOuterStringSerialize(ref Guid requiredStringUuid, ref string? body);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="requiredStringUuid"></param>
         /// <param name="body"></param>
         /// <returns></returns>
-        protected virtual (Guid, string?) OnFakeOuterStringSerialize(Guid requiredStringUuid, string? body)
+        private void ValidateFakeOuterStringSerialize(Guid requiredStringUuid)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -994,10 +961,8 @@ namespace Org.OpenAPITools.Api
             if (requiredStringUuid == null)
                 throw new ArgumentNullException(nameof(requiredStringUuid));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredStringUuid, body);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1056,9 +1021,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnFakeOuterStringSerialize(requiredStringUuid, body);
-                requiredStringUuid = validatedParameterLocalVars.Item1;
-                body = validatedParameterLocalVars.Item2;
+                ValidateFakeOuterStringSerialize(requiredStringUuid);
+
+                FormatFakeOuterStringSerialize(ref requiredStringUuid, ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1125,15 +1090,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnGetArrayOfEnums()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -1181,8 +1137,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnGetArrayOfEnums();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
@@ -1228,12 +1182,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="fileSchemaTestClass"></param>
         /// <returns></returns>
-        protected virtual FileSchemaTestClass OnTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass)
+        private void ValidateTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1241,10 +1197,8 @@ namespace Org.OpenAPITools.Api
             if (fileSchemaTestClass == null)
                 throw new ArgumentNullException(nameof(fileSchemaTestClass));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return fileSchemaTestClass;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1299,7 +1253,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                fileSchemaTestClass = OnTestBodyWithFileSchema(fileSchemaTestClass);
+                ValidateTestBodyWithFileSchema(fileSchemaTestClass);
+
+                FormatTestBodyWithFileSchema(fileSchemaTestClass);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1350,13 +1306,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestBodyWithQueryParams(User user, ref string query);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        protected virtual (User, string) OnTestBodyWithQueryParams(User user, string query)
+        private void ValidateTestBodyWithQueryParams(User user, string query)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1367,10 +1325,8 @@ namespace Org.OpenAPITools.Api
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (user, query);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1429,9 +1385,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestBodyWithQueryParams(user, query);
-                user = validatedParameterLocalVars.Item1;
-                query = validatedParameterLocalVars.Item2;
+                ValidateTestBodyWithQueryParams(user, query);
+
+                FormatTestBodyWithQueryParams(user, ref query);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1488,12 +1444,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestClientModel(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnTestClientModel(ModelClient modelClient)
+        private void ValidateTestClientModel(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1501,10 +1459,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1559,7 +1515,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnTestClientModel(modelClient);
+                ValidateTestClientModel(modelClient);
+
+                FormatTestClientModel(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1619,6 +1577,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestEndpointParameters(ref byte[] varByte, ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref DateTime? date, ref System.IO.Stream? binary, ref float? varFloat, ref int? integer, ref int? int32, ref long? int64, ref string? varString, ref string? password, ref string? callback, ref DateTime? dateTime);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1637,7 +1597,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="callback"></param>
         /// <param name="dateTime"></param>
         /// <returns></returns>
-        protected virtual (byte[], decimal, double, string, DateTime?, System.IO.Stream?, float?, int?, int?, long?, string?, string?, string?, DateTime?) OnTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter, DateTime? date, System.IO.Stream? binary, float? varFloat, int? integer, int? int32, long? int64, string? varString, string? password, string? callback, DateTime? dateTime)
+        private void ValidateTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1654,10 +1614,8 @@ namespace Org.OpenAPITools.Api
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (varByte, number, varDouble, patternWithoutDelimiter, date, binary, varFloat, integer, int32, int64, varString, password, callback, dateTime);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1764,21 +1722,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestEndpointParameters(varByte, number, varDouble, patternWithoutDelimiter, date, binary, varFloat, integer, int32, int64, varString, password, callback, dateTime);
-                varByte = validatedParameterLocalVars.Item1;
-                number = validatedParameterLocalVars.Item2;
-                varDouble = validatedParameterLocalVars.Item3;
-                patternWithoutDelimiter = validatedParameterLocalVars.Item4;
-                date = validatedParameterLocalVars.Item5;
-                binary = validatedParameterLocalVars.Item6;
-                varFloat = validatedParameterLocalVars.Item7;
-                integer = validatedParameterLocalVars.Item8;
-                int32 = validatedParameterLocalVars.Item9;
-                int64 = validatedParameterLocalVars.Item10;
-                varString = validatedParameterLocalVars.Item11;
-                password = validatedParameterLocalVars.Item12;
-                callback = validatedParameterLocalVars.Item13;
-                dateTime = validatedParameterLocalVars.Item14;
+                ValidateTestEndpointParameters(varByte, number, varDouble, patternWithoutDelimiter);
+
+                FormatTestEndpointParameters(ref varByte, ref number, ref varDouble, ref patternWithoutDelimiter, ref date, ref binary, ref varFloat, ref integer, ref int32, ref int64, ref varString, ref password, ref callback, ref dateTime);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1889,22 +1835,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumFormStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormString"></param>
-        /// <returns></returns>
-        protected virtual (List<string>?, List<string>?, double?, int?, List<string>?, string?, string?, string?) OnTestEnumParameters(List<string>? enumHeaderStringArray, List<string>? enumQueryStringArray, double? enumQueryDouble, int? enumQueryInteger, List<string>? enumFormStringArray, string? enumHeaderString, string? enumQueryString, string? enumFormString)
-        {
-            return (enumHeaderStringArray, enumQueryStringArray, enumQueryDouble, enumQueryInteger, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
-        }
+        partial void FormatTestEnumParameters(List<string>? enumHeaderStringArray, List<string>? enumQueryStringArray, ref double? enumQueryDouble, ref int? enumQueryInteger, List<string>? enumFormStringArray, ref string? enumHeaderString, ref string? enumQueryString, ref string? enumFormString);
 
         /// <summary>
         /// Processes the server response
@@ -1986,15 +1917,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumQueryDouble, enumQueryInteger, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
-                enumHeaderStringArray = validatedParameterLocalVars.Item1;
-                enumQueryStringArray = validatedParameterLocalVars.Item2;
-                enumQueryDouble = validatedParameterLocalVars.Item3;
-                enumQueryInteger = validatedParameterLocalVars.Item4;
-                enumFormStringArray = validatedParameterLocalVars.Item5;
-                enumHeaderString = validatedParameterLocalVars.Item6;
-                enumQueryString = validatedParameterLocalVars.Item7;
-                enumFormString = validatedParameterLocalVars.Item8;
+                FormatTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, ref enumQueryDouble, ref enumQueryInteger, enumFormStringArray, ref enumHeaderString, ref enumQueryString, ref enumFormString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2074,6 +1997,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref int requiredStringGroup, ref long requiredInt64Group, ref bool? booleanGroup, ref int? stringGroup, ref long? int64Group);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -2084,7 +2009,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="stringGroup"></param>
         /// <param name="int64Group"></param>
         /// <returns></returns>
-        protected virtual (bool, int, long, bool?, int?, long?) OnTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group, bool? booleanGroup, int? stringGroup, long? int64Group)
+        private void ValidateTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2098,10 +2023,8 @@ namespace Org.OpenAPITools.Api
             if (requiredInt64Group == null)
                 throw new ArgumentNullException(nameof(requiredInt64Group));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredBooleanGroup, requiredStringGroup, requiredInt64Group, booleanGroup, stringGroup, int64Group);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2176,13 +2099,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestGroupParameters(requiredBooleanGroup, requiredStringGroup, requiredInt64Group, booleanGroup, stringGroup, int64Group);
-                requiredBooleanGroup = validatedParameterLocalVars.Item1;
-                requiredStringGroup = validatedParameterLocalVars.Item2;
-                requiredInt64Group = validatedParameterLocalVars.Item3;
-                booleanGroup = validatedParameterLocalVars.Item4;
-                stringGroup = validatedParameterLocalVars.Item5;
-                int64Group = validatedParameterLocalVars.Item6;
+                ValidateTestGroupParameters(requiredBooleanGroup, requiredStringGroup, requiredInt64Group);
+
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredStringGroup, ref requiredInt64Group, ref booleanGroup, ref stringGroup, ref int64Group);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2250,12 +2169,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestInlineAdditionalProperties(Dictionary<string, string> requestBody);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="requestBody"></param>
         /// <returns></returns>
-        protected virtual Dictionary<string, string> OnTestInlineAdditionalProperties(Dictionary<string, string> requestBody)
+        private void ValidateTestInlineAdditionalProperties(Dictionary<string, string> requestBody)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2263,10 +2184,8 @@ namespace Org.OpenAPITools.Api
             if (requestBody == null)
                 throw new ArgumentNullException(nameof(requestBody));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return requestBody;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2321,7 +2240,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                requestBody = OnTestInlineAdditionalProperties(requestBody);
+                ValidateTestInlineAdditionalProperties(requestBody);
+
+                FormatTestInlineAdditionalProperties(requestBody);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2372,13 +2293,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestJsonFormData(ref string param, ref string param2);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="param"></param>
         /// <param name="param2"></param>
         /// <returns></returns>
-        protected virtual (string, string) OnTestJsonFormData(string param, string param2)
+        private void ValidateTestJsonFormData(string param, string param2)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2389,10 +2312,8 @@ namespace Org.OpenAPITools.Api
             if (param2 == null)
                 throw new ArgumentNullException(nameof(param2));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (param, param2);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2451,9 +2372,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestJsonFormData(param, param2);
-                param = validatedParameterLocalVars.Item1;
-                param2 = validatedParameterLocalVars.Item2;
+                ValidateTestJsonFormData(param, param2);
+
+                FormatTestJsonFormData(ref param, ref param2);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2514,6 +2435,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -2523,7 +2446,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="url"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        protected virtual (List<string>, List<string>, List<string>, List<string>, List<string>) OnTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2543,10 +2466,8 @@ namespace Org.OpenAPITools.Api
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (pipe, ioutil, http, url, context);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2617,12 +2538,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
-                pipe = validatedParameterLocalVars.Item1;
-                ioutil = validatedParameterLocalVars.Item2;
-                http = validatedParameterLocalVars.Item3;
-                url = validatedParameterLocalVars.Item4;
-                context = validatedParameterLocalVars.Item5;
+                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+
+                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -128,12 +128,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatTestClassname(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnTestClassname(ModelClient modelClient)
+        private void ValidateTestClassname(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -141,10 +143,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -199,7 +199,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnTestClassname(modelClient);
+                ValidateTestClassname(modelClient);
+
+                FormatTestClassname(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
@@ -326,12 +326,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatAddPet(Pet pet);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="pet"></param>
         /// <returns></returns>
-        protected virtual Pet OnAddPet(Pet pet)
+        private void ValidateAddPet(Pet pet)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -339,10 +341,8 @@ namespace Org.OpenAPITools.Api
             if (pet == null)
                 throw new ArgumentNullException(nameof(pet));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return pet;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -397,7 +397,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                pet = OnAddPet(pet);
+                ValidateAddPet(pet);
+
+                FormatAddPet(pet);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -473,13 +475,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatDeletePet(ref long petId, ref string? apiKey);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
         /// <param name="apiKey"></param>
         /// <returns></returns>
-        protected virtual (long, string?) OnDeletePet(long petId, string? apiKey)
+        private void ValidateDeletePet(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -487,10 +491,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, apiKey);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -549,9 +551,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnDeletePet(petId, apiKey);
-                petId = validatedParameterLocalVars.Item1;
-                apiKey = validatedParameterLocalVars.Item2;
+                ValidateDeletePet(petId);
+
+                FormatDeletePet(ref petId, ref apiKey);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -604,12 +606,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFindPetsByStatus(List<string> status);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="status"></param>
         /// <returns></returns>
-        protected virtual List<string> OnFindPetsByStatus(List<string> status)
+        private void ValidateFindPetsByStatus(List<string> status)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -617,10 +621,8 @@ namespace Org.OpenAPITools.Api
             if (status == null)
                 throw new ArgumentNullException(nameof(status));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return status;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -675,7 +677,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                status = OnFindPetsByStatus(status);
+                ValidateFindPetsByStatus(status);
+
+                FormatFindPetsByStatus(status);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -753,12 +757,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFindPetsByTags(List<string> tags);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="tags"></param>
         /// <returns></returns>
-        protected virtual List<string> OnFindPetsByTags(List<string> tags)
+        private void ValidateFindPetsByTags(List<string> tags)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -766,10 +772,8 @@ namespace Org.OpenAPITools.Api
             if (tags == null)
                 throw new ArgumentNullException(nameof(tags));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return tags;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -824,7 +828,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                tags = OnFindPetsByTags(tags);
+                ValidateFindPetsByTags(tags);
+
+                FormatFindPetsByTags(tags);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -902,12 +908,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetPetById(ref long petId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
         /// <returns></returns>
-        protected virtual long OnGetPetById(long petId)
+        private void ValidateGetPetById(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -915,10 +923,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return petId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -973,7 +979,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                petId = OnGetPetById(petId);
+                ValidateGetPetById(petId);
+
+                FormatGetPetById(ref petId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1031,12 +1039,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdatePet(Pet pet);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="pet"></param>
         /// <returns></returns>
-        protected virtual Pet OnUpdatePet(Pet pet)
+        private void ValidateUpdatePet(Pet pet)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1044,10 +1054,8 @@ namespace Org.OpenAPITools.Api
             if (pet == null)
                 throw new ArgumentNullException(nameof(pet));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return pet;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1102,7 +1110,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                pet = OnUpdatePet(pet);
+                ValidateUpdatePet(pet);
+
+                FormatUpdatePet(pet);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1178,6 +1188,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdatePetWithForm(ref long petId, ref string? name, ref string? status);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1185,7 +1197,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name"></param>
         /// <param name="status"></param>
         /// <returns></returns>
-        protected virtual (long, string?, string?) OnUpdatePetWithForm(long petId, string? name, string? status)
+        private void ValidateUpdatePetWithForm(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1193,10 +1205,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, name, status);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1259,10 +1269,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUpdatePetWithForm(petId, name, status);
-                petId = validatedParameterLocalVars.Item1;
-                name = validatedParameterLocalVars.Item2;
-                status = validatedParameterLocalVars.Item3;
+                ValidateUpdatePetWithForm(petId);
+
+                FormatUpdatePetWithForm(ref petId, ref name, ref status);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1333,6 +1342,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUploadFile(ref long petId, ref System.IO.Stream? file, ref string? additionalMetadata);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1340,7 +1351,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="file"></param>
         /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        protected virtual (long, System.IO.Stream?, string?) OnUploadFile(long petId, System.IO.Stream? file, string? additionalMetadata)
+        private void ValidateUploadFile(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1348,10 +1359,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, file, additionalMetadata);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1414,10 +1423,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUploadFile(petId, file, additionalMetadata);
-                petId = validatedParameterLocalVars.Item1;
-                file = validatedParameterLocalVars.Item2;
-                additionalMetadata = validatedParameterLocalVars.Item3;
+                ValidateUploadFile(petId);
+
+                FormatUploadFile(ref petId, ref file, ref additionalMetadata);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1497,6 +1505,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUploadFileWithRequiredFile(ref System.IO.Stream requiredFile, ref long petId, ref string? additionalMetadata);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1504,7 +1514,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId"></param>
         /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        protected virtual (System.IO.Stream, long, string?) OnUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId, string? additionalMetadata)
+        private void ValidateUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1515,10 +1525,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredFile, petId, additionalMetadata);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1581,10 +1589,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
-                requiredFile = validatedParameterLocalVars.Item1;
-                petId = validatedParameterLocalVars.Item2;
-                additionalMetadata = validatedParameterLocalVars.Item3;
+                ValidateUploadFileWithRequiredFile(requiredFile, petId);
+
+                FormatUploadFileWithRequiredFile(ref requiredFile, ref petId, ref additionalMetadata);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -195,12 +195,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatDeleteOrder(ref string orderId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected virtual string OnDeleteOrder(string orderId)
+        private void ValidateDeleteOrder(string orderId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -208,10 +210,8 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new ArgumentNullException(nameof(orderId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return orderId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -266,7 +266,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                orderId = OnDeleteOrder(orderId);
+                ValidateDeleteOrder(orderId);
+
+                FormatDeleteOrder(ref orderId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -302,15 +304,6 @@ namespace Org.OpenAPITools.Api
                 OnErrorDeleteOrder(e, "/store/order/{order_id}", uriBuilderLocalVar.Path, orderId);
                 throw;
             }
-        }
-
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnGetInventory()
-        {
-            return;
         }
 
         /// <summary>
@@ -361,8 +354,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnGetInventory();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
@@ -418,12 +409,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetOrderById(ref long orderId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected virtual long OnGetOrderById(long orderId)
+        private void ValidateGetOrderById(long orderId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -431,10 +424,8 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new ArgumentNullException(nameof(orderId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return orderId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -489,7 +480,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                orderId = OnGetOrderById(orderId);
+                ValidateGetOrderById(orderId);
+
+                FormatGetOrderById(ref orderId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -537,12 +530,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatPlaceOrder(Order order);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="order"></param>
         /// <returns></returns>
-        protected virtual Order OnPlaceOrder(Order order)
+        private void ValidatePlaceOrder(Order order)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -550,10 +545,8 @@ namespace Org.OpenAPITools.Api
             if (order == null)
                 throw new ArgumentNullException(nameof(order));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return order;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -608,7 +601,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                order = OnPlaceOrder(order);
+                ValidatePlaceOrder(order);
+
+                FormatPlaceOrder(order);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/UserApi.cs
@@ -291,12 +291,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatCreateUser(User user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual User OnCreateUser(User user)
+        private void ValidateCreateUser(User user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -304,10 +306,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -362,7 +362,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUser(user);
+                ValidateCreateUser(user);
+
+                FormatCreateUser(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -413,12 +415,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatCreateUsersWithArrayInput(List<User> user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual List<User> OnCreateUsersWithArrayInput(List<User> user)
+        private void ValidateCreateUsersWithArrayInput(List<User> user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -426,10 +430,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -484,7 +486,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUsersWithArrayInput(user);
+                ValidateCreateUsersWithArrayInput(user);
+
+                FormatCreateUsersWithArrayInput(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -535,12 +539,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatCreateUsersWithListInput(List<User> user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual List<User> OnCreateUsersWithListInput(List<User> user)
+        private void ValidateCreateUsersWithListInput(List<User> user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -548,10 +554,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -606,7 +610,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUsersWithListInput(user);
+                ValidateCreateUsersWithListInput(user);
+
+                FormatCreateUsersWithListInput(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -657,12 +663,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatDeleteUser(ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual string OnDeleteUser(string username)
+        private void ValidateDeleteUser(string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -670,10 +678,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return username;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -728,7 +734,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                username = OnDeleteUser(username);
+                ValidateDeleteUser(username);
+
+                FormatDeleteUser(ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -766,12 +774,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetUserByName(ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual string OnGetUserByName(string username)
+        private void ValidateGetUserByName(string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -779,10 +789,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return username;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -837,7 +845,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                username = OnGetUserByName(username);
+                ValidateGetUserByName(username);
+
+                FormatGetUserByName(ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -885,13 +895,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatLoginUser(ref string username, ref string password);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <param name="password"></param>
         /// <returns></returns>
-        protected virtual (string, string) OnLoginUser(string username, string password)
+        private void ValidateLoginUser(string username, string password)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -902,10 +914,8 @@ namespace Org.OpenAPITools.Api
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (username, password);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -964,9 +974,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnLoginUser(username, password);
-                username = validatedParameterLocalVars.Item1;
-                password = validatedParameterLocalVars.Item2;
+                ValidateLoginUser(username, password);
+
+                FormatLoginUser(ref username, ref password);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1022,15 +1032,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnLogoutUser()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -1078,8 +1079,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnLogoutUser();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
@@ -1116,13 +1115,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdateUser(User user, ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual (User, string) OnUpdateUser(User user, string username)
+        private void ValidateUpdateUser(User user, string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1133,10 +1134,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (user, username);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1195,9 +1194,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUpdateUser(user, username);
-                user = validatedParameterLocalVars.Item1;
-                username = validatedParameterLocalVars.Item2;
+                ValidateUpdateUser(user, username);
+
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -126,12 +126,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatCall123TestSpecialTags(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnCall123TestSpecialTags(ModelClient modelClient)
+        private void ValidateCall123TestSpecialTags(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -139,10 +141,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -197,7 +197,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnCall123TestSpecialTags(modelClient);
+                ValidateCall123TestSpecialTags(modelClient);
+
+                FormatCall123TestSpecialTags(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -169,15 +169,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnFooGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -225,8 +216,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnFooGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -272,12 +261,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetCountry(ref string country);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="country"></param>
         /// <returns></returns>
-        protected virtual string OnGetCountry(string country)
+        private void ValidateGetCountry(string country)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -285,10 +276,8 @@ namespace Org.OpenAPITools.Api
             if (country == null)
                 throw new ArgumentNullException(nameof(country));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return country;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -343,7 +332,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                country = OnGetCountry(country);
+                ValidateGetCountry(country);
+
+                FormatGetCountry(ref country);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -401,15 +392,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnHello()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -457,8 +439,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnHello();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -509,15 +509,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnFakeHealthGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -565,8 +556,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnFakeHealthGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -612,15 +601,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        protected virtual bool? OnFakeOuterBooleanSerialize(bool? body)
-        {
-            return body;
-        }
+        partial void FormatFakeOuterBooleanSerialize(ref bool? body);
 
         /// <summary>
         /// Processes the server response
@@ -674,7 +655,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                body = OnFakeOuterBooleanSerialize(body);
+                FormatFakeOuterBooleanSerialize(ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -734,15 +715,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="outerComposite"></param>
-        /// <returns></returns>
-        protected virtual OuterComposite OnFakeOuterCompositeSerialize(OuterComposite outerComposite)
-        {
-            return outerComposite;
-        }
+        partial void FormatFakeOuterCompositeSerialize(OuterComposite outerComposite);
 
         /// <summary>
         /// Processes the server response
@@ -796,7 +769,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                outerComposite = OnFakeOuterCompositeSerialize(outerComposite);
+                FormatFakeOuterCompositeSerialize(outerComposite);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -856,15 +829,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        protected virtual decimal? OnFakeOuterNumberSerialize(decimal? body)
-        {
-            return body;
-        }
+        partial void FormatFakeOuterNumberSerialize(ref decimal? body);
 
         /// <summary>
         /// Processes the server response
@@ -918,7 +883,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                body = OnFakeOuterNumberSerialize(body);
+                FormatFakeOuterNumberSerialize(ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -978,13 +943,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFakeOuterStringSerialize(ref Guid requiredStringUuid, ref string body);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="requiredStringUuid"></param>
         /// <param name="body"></param>
         /// <returns></returns>
-        protected virtual (Guid, string) OnFakeOuterStringSerialize(Guid requiredStringUuid, string body)
+        private void ValidateFakeOuterStringSerialize(Guid requiredStringUuid)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -992,10 +959,8 @@ namespace Org.OpenAPITools.Api
             if (requiredStringUuid == null)
                 throw new ArgumentNullException(nameof(requiredStringUuid));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredStringUuid, body);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1054,9 +1019,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnFakeOuterStringSerialize(requiredStringUuid, body);
-                requiredStringUuid = validatedParameterLocalVars.Item1;
-                body = validatedParameterLocalVars.Item2;
+                ValidateFakeOuterStringSerialize(requiredStringUuid);
+
+                FormatFakeOuterStringSerialize(ref requiredStringUuid, ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1123,15 +1088,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnGetArrayOfEnums()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -1179,8 +1135,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnGetArrayOfEnums();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -1226,12 +1180,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="fileSchemaTestClass"></param>
         /// <returns></returns>
-        protected virtual FileSchemaTestClass OnTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass)
+        private void ValidateTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1239,10 +1195,8 @@ namespace Org.OpenAPITools.Api
             if (fileSchemaTestClass == null)
                 throw new ArgumentNullException(nameof(fileSchemaTestClass));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return fileSchemaTestClass;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1297,7 +1251,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                fileSchemaTestClass = OnTestBodyWithFileSchema(fileSchemaTestClass);
+                ValidateTestBodyWithFileSchema(fileSchemaTestClass);
+
+                FormatTestBodyWithFileSchema(fileSchemaTestClass);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1348,13 +1304,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestBodyWithQueryParams(User user, ref string query);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        protected virtual (User, string) OnTestBodyWithQueryParams(User user, string query)
+        private void ValidateTestBodyWithQueryParams(User user, string query)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1365,10 +1323,8 @@ namespace Org.OpenAPITools.Api
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (user, query);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1427,9 +1383,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestBodyWithQueryParams(user, query);
-                user = validatedParameterLocalVars.Item1;
-                query = validatedParameterLocalVars.Item2;
+                ValidateTestBodyWithQueryParams(user, query);
+
+                FormatTestBodyWithQueryParams(user, ref query);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1486,12 +1442,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestClientModel(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnTestClientModel(ModelClient modelClient)
+        private void ValidateTestClientModel(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1499,10 +1457,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1557,7 +1513,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnTestClientModel(modelClient);
+                ValidateTestClientModel(modelClient);
+
+                FormatTestClientModel(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1617,6 +1575,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestEndpointParameters(ref byte[] varByte, ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref DateTime? date, ref System.IO.Stream binary, ref float? varFloat, ref int? integer, ref int? int32, ref long? int64, ref string varString, ref string password, ref string callback, ref DateTime? dateTime);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1635,7 +1595,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="callback"></param>
         /// <param name="dateTime"></param>
         /// <returns></returns>
-        protected virtual (byte[], decimal, double, string, DateTime?, System.IO.Stream, float?, int?, int?, long?, string, string, string, DateTime?) OnTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter, DateTime? date, System.IO.Stream binary, float? varFloat, int? integer, int? int32, long? int64, string varString, string password, string callback, DateTime? dateTime)
+        private void ValidateTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1652,10 +1612,8 @@ namespace Org.OpenAPITools.Api
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (varByte, number, varDouble, patternWithoutDelimiter, date, binary, varFloat, integer, int32, int64, varString, password, callback, dateTime);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1762,21 +1720,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestEndpointParameters(varByte, number, varDouble, patternWithoutDelimiter, date, binary, varFloat, integer, int32, int64, varString, password, callback, dateTime);
-                varByte = validatedParameterLocalVars.Item1;
-                number = validatedParameterLocalVars.Item2;
-                varDouble = validatedParameterLocalVars.Item3;
-                patternWithoutDelimiter = validatedParameterLocalVars.Item4;
-                date = validatedParameterLocalVars.Item5;
-                binary = validatedParameterLocalVars.Item6;
-                varFloat = validatedParameterLocalVars.Item7;
-                integer = validatedParameterLocalVars.Item8;
-                int32 = validatedParameterLocalVars.Item9;
-                int64 = validatedParameterLocalVars.Item10;
-                varString = validatedParameterLocalVars.Item11;
-                password = validatedParameterLocalVars.Item12;
-                callback = validatedParameterLocalVars.Item13;
-                dateTime = validatedParameterLocalVars.Item14;
+                ValidateTestEndpointParameters(varByte, number, varDouble, patternWithoutDelimiter);
+
+                FormatTestEndpointParameters(ref varByte, ref number, ref varDouble, ref patternWithoutDelimiter, ref date, ref binary, ref varFloat, ref integer, ref int32, ref int64, ref varString, ref password, ref callback, ref dateTime);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1887,22 +1833,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumFormStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormString"></param>
-        /// <returns></returns>
-        protected virtual (List<string>, List<string>, double?, int?, List<string>, string, string, string) OnTestEnumParameters(List<string> enumHeaderStringArray, List<string> enumQueryStringArray, double? enumQueryDouble, int? enumQueryInteger, List<string> enumFormStringArray, string enumHeaderString, string enumQueryString, string enumFormString)
-        {
-            return (enumHeaderStringArray, enumQueryStringArray, enumQueryDouble, enumQueryInteger, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
-        }
+        partial void FormatTestEnumParameters(List<string> enumHeaderStringArray, List<string> enumQueryStringArray, ref double? enumQueryDouble, ref int? enumQueryInteger, List<string> enumFormStringArray, ref string enumHeaderString, ref string enumQueryString, ref string enumFormString);
 
         /// <summary>
         /// Processes the server response
@@ -1984,15 +1915,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumQueryDouble, enumQueryInteger, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
-                enumHeaderStringArray = validatedParameterLocalVars.Item1;
-                enumQueryStringArray = validatedParameterLocalVars.Item2;
-                enumQueryDouble = validatedParameterLocalVars.Item3;
-                enumQueryInteger = validatedParameterLocalVars.Item4;
-                enumFormStringArray = validatedParameterLocalVars.Item5;
-                enumHeaderString = validatedParameterLocalVars.Item6;
-                enumQueryString = validatedParameterLocalVars.Item7;
-                enumFormString = validatedParameterLocalVars.Item8;
+                FormatTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, ref enumQueryDouble, ref enumQueryInteger, enumFormStringArray, ref enumHeaderString, ref enumQueryString, ref enumFormString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2072,6 +1995,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref int requiredStringGroup, ref long requiredInt64Group, ref bool? booleanGroup, ref int? stringGroup, ref long? int64Group);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -2082,7 +2007,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="stringGroup"></param>
         /// <param name="int64Group"></param>
         /// <returns></returns>
-        protected virtual (bool, int, long, bool?, int?, long?) OnTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group, bool? booleanGroup, int? stringGroup, long? int64Group)
+        private void ValidateTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2096,10 +2021,8 @@ namespace Org.OpenAPITools.Api
             if (requiredInt64Group == null)
                 throw new ArgumentNullException(nameof(requiredInt64Group));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredBooleanGroup, requiredStringGroup, requiredInt64Group, booleanGroup, stringGroup, int64Group);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2174,13 +2097,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestGroupParameters(requiredBooleanGroup, requiredStringGroup, requiredInt64Group, booleanGroup, stringGroup, int64Group);
-                requiredBooleanGroup = validatedParameterLocalVars.Item1;
-                requiredStringGroup = validatedParameterLocalVars.Item2;
-                requiredInt64Group = validatedParameterLocalVars.Item3;
-                booleanGroup = validatedParameterLocalVars.Item4;
-                stringGroup = validatedParameterLocalVars.Item5;
-                int64Group = validatedParameterLocalVars.Item6;
+                ValidateTestGroupParameters(requiredBooleanGroup, requiredStringGroup, requiredInt64Group);
+
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredStringGroup, ref requiredInt64Group, ref booleanGroup, ref stringGroup, ref int64Group);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2248,12 +2167,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestInlineAdditionalProperties(Dictionary<string, string> requestBody);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="requestBody"></param>
         /// <returns></returns>
-        protected virtual Dictionary<string, string> OnTestInlineAdditionalProperties(Dictionary<string, string> requestBody)
+        private void ValidateTestInlineAdditionalProperties(Dictionary<string, string> requestBody)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2261,10 +2182,8 @@ namespace Org.OpenAPITools.Api
             if (requestBody == null)
                 throw new ArgumentNullException(nameof(requestBody));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return requestBody;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2319,7 +2238,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                requestBody = OnTestInlineAdditionalProperties(requestBody);
+                ValidateTestInlineAdditionalProperties(requestBody);
+
+                FormatTestInlineAdditionalProperties(requestBody);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2370,13 +2291,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestJsonFormData(ref string param, ref string param2);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="param"></param>
         /// <param name="param2"></param>
         /// <returns></returns>
-        protected virtual (string, string) OnTestJsonFormData(string param, string param2)
+        private void ValidateTestJsonFormData(string param, string param2)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2387,10 +2310,8 @@ namespace Org.OpenAPITools.Api
             if (param2 == null)
                 throw new ArgumentNullException(nameof(param2));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (param, param2);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2449,9 +2370,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestJsonFormData(param, param2);
-                param = validatedParameterLocalVars.Item1;
-                param2 = validatedParameterLocalVars.Item2;
+                ValidateTestJsonFormData(param, param2);
+
+                FormatTestJsonFormData(ref param, ref param2);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2512,6 +2433,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -2521,7 +2444,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="url"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        protected virtual (List<string>, List<string>, List<string>, List<string>, List<string>) OnTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2541,10 +2464,8 @@ namespace Org.OpenAPITools.Api
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (pipe, ioutil, http, url, context);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2615,12 +2536,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
-                pipe = validatedParameterLocalVars.Item1;
-                ioutil = validatedParameterLocalVars.Item2;
-                http = validatedParameterLocalVars.Item3;
-                url = validatedParameterLocalVars.Item4;
-                context = validatedParameterLocalVars.Item5;
+                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+
+                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -126,12 +126,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatTestClassname(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnTestClassname(ModelClient modelClient)
+        private void ValidateTestClassname(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -139,10 +141,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -197,7 +197,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnTestClassname(modelClient);
+                ValidateTestClassname(modelClient);
+
+                FormatTestClassname(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -324,12 +324,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatAddPet(Pet pet);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="pet"></param>
         /// <returns></returns>
-        protected virtual Pet OnAddPet(Pet pet)
+        private void ValidateAddPet(Pet pet)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -337,10 +339,8 @@ namespace Org.OpenAPITools.Api
             if (pet == null)
                 throw new ArgumentNullException(nameof(pet));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return pet;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -395,7 +395,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                pet = OnAddPet(pet);
+                ValidateAddPet(pet);
+
+                FormatAddPet(pet);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -471,13 +473,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatDeletePet(ref long petId, ref string apiKey);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
         /// <param name="apiKey"></param>
         /// <returns></returns>
-        protected virtual (long, string) OnDeletePet(long petId, string apiKey)
+        private void ValidateDeletePet(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -485,10 +489,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, apiKey);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -547,9 +549,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnDeletePet(petId, apiKey);
-                petId = validatedParameterLocalVars.Item1;
-                apiKey = validatedParameterLocalVars.Item2;
+                ValidateDeletePet(petId);
+
+                FormatDeletePet(ref petId, ref apiKey);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -602,12 +604,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFindPetsByStatus(List<string> status);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="status"></param>
         /// <returns></returns>
-        protected virtual List<string> OnFindPetsByStatus(List<string> status)
+        private void ValidateFindPetsByStatus(List<string> status)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -615,10 +619,8 @@ namespace Org.OpenAPITools.Api
             if (status == null)
                 throw new ArgumentNullException(nameof(status));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return status;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -673,7 +675,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                status = OnFindPetsByStatus(status);
+                ValidateFindPetsByStatus(status);
+
+                FormatFindPetsByStatus(status);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -751,12 +755,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFindPetsByTags(List<string> tags);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="tags"></param>
         /// <returns></returns>
-        protected virtual List<string> OnFindPetsByTags(List<string> tags)
+        private void ValidateFindPetsByTags(List<string> tags)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -764,10 +770,8 @@ namespace Org.OpenAPITools.Api
             if (tags == null)
                 throw new ArgumentNullException(nameof(tags));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return tags;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -822,7 +826,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                tags = OnFindPetsByTags(tags);
+                ValidateFindPetsByTags(tags);
+
+                FormatFindPetsByTags(tags);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -900,12 +906,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetPetById(ref long petId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
         /// <returns></returns>
-        protected virtual long OnGetPetById(long petId)
+        private void ValidateGetPetById(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -913,10 +921,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return petId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -971,7 +977,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                petId = OnGetPetById(petId);
+                ValidateGetPetById(petId);
+
+                FormatGetPetById(ref petId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1029,12 +1037,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdatePet(Pet pet);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="pet"></param>
         /// <returns></returns>
-        protected virtual Pet OnUpdatePet(Pet pet)
+        private void ValidateUpdatePet(Pet pet)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1042,10 +1052,8 @@ namespace Org.OpenAPITools.Api
             if (pet == null)
                 throw new ArgumentNullException(nameof(pet));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return pet;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1100,7 +1108,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                pet = OnUpdatePet(pet);
+                ValidateUpdatePet(pet);
+
+                FormatUpdatePet(pet);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1176,6 +1186,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdatePetWithForm(ref long petId, ref string name, ref string status);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1183,7 +1195,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name"></param>
         /// <param name="status"></param>
         /// <returns></returns>
-        protected virtual (long, string, string) OnUpdatePetWithForm(long petId, string name, string status)
+        private void ValidateUpdatePetWithForm(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1191,10 +1203,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, name, status);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1257,10 +1267,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUpdatePetWithForm(petId, name, status);
-                petId = validatedParameterLocalVars.Item1;
-                name = validatedParameterLocalVars.Item2;
-                status = validatedParameterLocalVars.Item3;
+                ValidateUpdatePetWithForm(petId);
+
+                FormatUpdatePetWithForm(ref petId, ref name, ref status);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1331,6 +1340,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUploadFile(ref long petId, ref System.IO.Stream file, ref string additionalMetadata);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1338,7 +1349,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="file"></param>
         /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        protected virtual (long, System.IO.Stream, string) OnUploadFile(long petId, System.IO.Stream file, string additionalMetadata)
+        private void ValidateUploadFile(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1346,10 +1357,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, file, additionalMetadata);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1412,10 +1421,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUploadFile(petId, file, additionalMetadata);
-                petId = validatedParameterLocalVars.Item1;
-                file = validatedParameterLocalVars.Item2;
-                additionalMetadata = validatedParameterLocalVars.Item3;
+                ValidateUploadFile(petId);
+
+                FormatUploadFile(ref petId, ref file, ref additionalMetadata);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1495,6 +1503,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUploadFileWithRequiredFile(ref System.IO.Stream requiredFile, ref long petId, ref string additionalMetadata);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1502,7 +1512,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId"></param>
         /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        protected virtual (System.IO.Stream, long, string) OnUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId, string additionalMetadata)
+        private void ValidateUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1513,10 +1523,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredFile, petId, additionalMetadata);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1579,10 +1587,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
-                requiredFile = validatedParameterLocalVars.Item1;
-                petId = validatedParameterLocalVars.Item2;
-                additionalMetadata = validatedParameterLocalVars.Item3;
+                ValidateUploadFileWithRequiredFile(requiredFile, petId);
+
+                FormatUploadFileWithRequiredFile(ref requiredFile, ref petId, ref additionalMetadata);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -193,12 +193,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatDeleteOrder(ref string orderId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected virtual string OnDeleteOrder(string orderId)
+        private void ValidateDeleteOrder(string orderId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -206,10 +208,8 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new ArgumentNullException(nameof(orderId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return orderId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -264,7 +264,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                orderId = OnDeleteOrder(orderId);
+                ValidateDeleteOrder(orderId);
+
+                FormatDeleteOrder(ref orderId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -300,15 +302,6 @@ namespace Org.OpenAPITools.Api
                 OnErrorDeleteOrder(e, "/store/order/{order_id}", uriBuilderLocalVar.Path, orderId);
                 throw;
             }
-        }
-
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnGetInventory()
-        {
-            return;
         }
 
         /// <summary>
@@ -359,8 +352,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnGetInventory();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -416,12 +407,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetOrderById(ref long orderId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected virtual long OnGetOrderById(long orderId)
+        private void ValidateGetOrderById(long orderId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -429,10 +422,8 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new ArgumentNullException(nameof(orderId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return orderId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -487,7 +478,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                orderId = OnGetOrderById(orderId);
+                ValidateGetOrderById(orderId);
+
+                FormatGetOrderById(ref orderId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -535,12 +528,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatPlaceOrder(Order order);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="order"></param>
         /// <returns></returns>
-        protected virtual Order OnPlaceOrder(Order order)
+        private void ValidatePlaceOrder(Order order)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -548,10 +543,8 @@ namespace Org.OpenAPITools.Api
             if (order == null)
                 throw new ArgumentNullException(nameof(order));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return order;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -606,7 +599,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                order = OnPlaceOrder(order);
+                ValidatePlaceOrder(order);
+
+                FormatPlaceOrder(order);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -289,12 +289,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatCreateUser(User user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual User OnCreateUser(User user)
+        private void ValidateCreateUser(User user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -302,10 +304,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -360,7 +360,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUser(user);
+                ValidateCreateUser(user);
+
+                FormatCreateUser(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -411,12 +413,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatCreateUsersWithArrayInput(List<User> user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual List<User> OnCreateUsersWithArrayInput(List<User> user)
+        private void ValidateCreateUsersWithArrayInput(List<User> user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -424,10 +428,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -482,7 +484,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUsersWithArrayInput(user);
+                ValidateCreateUsersWithArrayInput(user);
+
+                FormatCreateUsersWithArrayInput(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -533,12 +537,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatCreateUsersWithListInput(List<User> user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual List<User> OnCreateUsersWithListInput(List<User> user)
+        private void ValidateCreateUsersWithListInput(List<User> user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -546,10 +552,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -604,7 +608,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUsersWithListInput(user);
+                ValidateCreateUsersWithListInput(user);
+
+                FormatCreateUsersWithListInput(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -655,12 +661,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatDeleteUser(ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual string OnDeleteUser(string username)
+        private void ValidateDeleteUser(string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -668,10 +676,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return username;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -726,7 +732,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                username = OnDeleteUser(username);
+                ValidateDeleteUser(username);
+
+                FormatDeleteUser(ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -764,12 +772,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetUserByName(ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual string OnGetUserByName(string username)
+        private void ValidateGetUserByName(string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -777,10 +787,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return username;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -835,7 +843,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                username = OnGetUserByName(username);
+                ValidateGetUserByName(username);
+
+                FormatGetUserByName(ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -883,13 +893,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatLoginUser(ref string username, ref string password);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <param name="password"></param>
         /// <returns></returns>
-        protected virtual (string, string) OnLoginUser(string username, string password)
+        private void ValidateLoginUser(string username, string password)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -900,10 +912,8 @@ namespace Org.OpenAPITools.Api
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (username, password);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -962,9 +972,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnLoginUser(username, password);
-                username = validatedParameterLocalVars.Item1;
-                password = validatedParameterLocalVars.Item2;
+                ValidateLoginUser(username, password);
+
+                FormatLoginUser(ref username, ref password);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1020,15 +1030,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnLogoutUser()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -1076,8 +1077,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnLogoutUser();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -1114,13 +1113,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdateUser(User user, ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual (User, string) OnUpdateUser(User user, string username)
+        private void ValidateUpdateUser(User user, string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1131,10 +1132,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (user, username);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1193,9 +1192,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUpdateUser(user, username);
-                user = validatedParameterLocalVars.Item1;
-                username = validatedParameterLocalVars.Item2;
+                ValidateUpdateUser(user, username);
+
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -93,12 +93,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatList(ref string personId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="personId"></param>
         /// <returns></returns>
-        protected virtual string OnList(string personId)
+        private void ValidateList(string personId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -106,10 +108,8 @@ namespace Org.OpenAPITools.Api
             if (personId == null)
                 throw new ArgumentNullException(nameof(personId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return personId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -164,7 +164,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                personId = OnList(personId);
+                ValidateList(personId);
+
+                FormatList(ref personId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -92,15 +92,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnRootGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -148,8 +139,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnRootGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -92,15 +92,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnRootGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -148,8 +139,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnRootGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -126,12 +126,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatCall123TestSpecialTags(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnCall123TestSpecialTags(ModelClient modelClient)
+        private void ValidateCall123TestSpecialTags(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -139,10 +141,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -197,7 +197,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnCall123TestSpecialTags(modelClient);
+                ValidateCall123TestSpecialTags(modelClient);
+
+                FormatCall123TestSpecialTags(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -169,15 +169,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnFooGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -225,8 +216,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnFooGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -272,12 +261,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetCountry(ref string country);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="country"></param>
         /// <returns></returns>
-        protected virtual string OnGetCountry(string country)
+        private void ValidateGetCountry(string country)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -285,10 +276,8 @@ namespace Org.OpenAPITools.Api
             if (country == null)
                 throw new ArgumentNullException(nameof(country));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return country;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -343,7 +332,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                country = OnGetCountry(country);
+                ValidateGetCountry(country);
+
+                FormatGetCountry(ref country);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -401,15 +392,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnHello()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -457,8 +439,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnHello();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -509,15 +509,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnFakeHealthGet()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -565,8 +556,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnFakeHealthGet();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -612,15 +601,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        protected virtual bool? OnFakeOuterBooleanSerialize(bool? body)
-        {
-            return body;
-        }
+        partial void FormatFakeOuterBooleanSerialize(ref bool? body);
 
         /// <summary>
         /// Processes the server response
@@ -674,7 +655,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                body = OnFakeOuterBooleanSerialize(body);
+                FormatFakeOuterBooleanSerialize(ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -734,15 +715,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="outerComposite"></param>
-        /// <returns></returns>
-        protected virtual OuterComposite OnFakeOuterCompositeSerialize(OuterComposite outerComposite)
-        {
-            return outerComposite;
-        }
+        partial void FormatFakeOuterCompositeSerialize(OuterComposite outerComposite);
 
         /// <summary>
         /// Processes the server response
@@ -796,7 +769,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                outerComposite = OnFakeOuterCompositeSerialize(outerComposite);
+                FormatFakeOuterCompositeSerialize(outerComposite);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -856,15 +829,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        protected virtual decimal? OnFakeOuterNumberSerialize(decimal? body)
-        {
-            return body;
-        }
+        partial void FormatFakeOuterNumberSerialize(ref decimal? body);
 
         /// <summary>
         /// Processes the server response
@@ -918,7 +883,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                body = OnFakeOuterNumberSerialize(body);
+                FormatFakeOuterNumberSerialize(ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -978,13 +943,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFakeOuterStringSerialize(ref Guid requiredStringUuid, ref string body);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="requiredStringUuid"></param>
         /// <param name="body"></param>
         /// <returns></returns>
-        protected virtual (Guid, string) OnFakeOuterStringSerialize(Guid requiredStringUuid, string body)
+        private void ValidateFakeOuterStringSerialize(Guid requiredStringUuid)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -992,10 +959,8 @@ namespace Org.OpenAPITools.Api
             if (requiredStringUuid == null)
                 throw new ArgumentNullException(nameof(requiredStringUuid));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredStringUuid, body);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1054,9 +1019,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnFakeOuterStringSerialize(requiredStringUuid, body);
-                requiredStringUuid = validatedParameterLocalVars.Item1;
-                body = validatedParameterLocalVars.Item2;
+                ValidateFakeOuterStringSerialize(requiredStringUuid);
+
+                FormatFakeOuterStringSerialize(ref requiredStringUuid, ref body);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1123,15 +1088,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnGetArrayOfEnums()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -1179,8 +1135,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnGetArrayOfEnums();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -1226,12 +1180,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="fileSchemaTestClass"></param>
         /// <returns></returns>
-        protected virtual FileSchemaTestClass OnTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass)
+        private void ValidateTestBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1239,10 +1195,8 @@ namespace Org.OpenAPITools.Api
             if (fileSchemaTestClass == null)
                 throw new ArgumentNullException(nameof(fileSchemaTestClass));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return fileSchemaTestClass;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1297,7 +1251,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                fileSchemaTestClass = OnTestBodyWithFileSchema(fileSchemaTestClass);
+                ValidateTestBodyWithFileSchema(fileSchemaTestClass);
+
+                FormatTestBodyWithFileSchema(fileSchemaTestClass);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1348,13 +1304,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestBodyWithQueryParams(User user, ref string query);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        protected virtual (User, string) OnTestBodyWithQueryParams(User user, string query)
+        private void ValidateTestBodyWithQueryParams(User user, string query)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1365,10 +1323,8 @@ namespace Org.OpenAPITools.Api
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (user, query);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1427,9 +1383,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestBodyWithQueryParams(user, query);
-                user = validatedParameterLocalVars.Item1;
-                query = validatedParameterLocalVars.Item2;
+                ValidateTestBodyWithQueryParams(user, query);
+
+                FormatTestBodyWithQueryParams(user, ref query);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1486,12 +1442,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestClientModel(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnTestClientModel(ModelClient modelClient)
+        private void ValidateTestClientModel(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1499,10 +1457,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1557,7 +1513,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnTestClientModel(modelClient);
+                ValidateTestClientModel(modelClient);
+
+                FormatTestClientModel(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1617,6 +1575,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestEndpointParameters(ref byte[] varByte, ref decimal number, ref double varDouble, ref string patternWithoutDelimiter, ref DateTime? date, ref System.IO.Stream binary, ref float? varFloat, ref int? integer, ref int? int32, ref long? int64, ref string varString, ref string password, ref string callback, ref DateTime? dateTime);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1635,7 +1595,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="callback"></param>
         /// <param name="dateTime"></param>
         /// <returns></returns>
-        protected virtual (byte[], decimal, double, string, DateTime?, System.IO.Stream, float?, int?, int?, long?, string, string, string, DateTime?) OnTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter, DateTime? date, System.IO.Stream binary, float? varFloat, int? integer, int? int32, long? int64, string varString, string password, string callback, DateTime? dateTime)
+        private void ValidateTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1652,10 +1612,8 @@ namespace Org.OpenAPITools.Api
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (varByte, number, varDouble, patternWithoutDelimiter, date, binary, varFloat, integer, int32, int64, varString, password, callback, dateTime);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1762,21 +1720,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestEndpointParameters(varByte, number, varDouble, patternWithoutDelimiter, date, binary, varFloat, integer, int32, int64, varString, password, callback, dateTime);
-                varByte = validatedParameterLocalVars.Item1;
-                number = validatedParameterLocalVars.Item2;
-                varDouble = validatedParameterLocalVars.Item3;
-                patternWithoutDelimiter = validatedParameterLocalVars.Item4;
-                date = validatedParameterLocalVars.Item5;
-                binary = validatedParameterLocalVars.Item6;
-                varFloat = validatedParameterLocalVars.Item7;
-                integer = validatedParameterLocalVars.Item8;
-                int32 = validatedParameterLocalVars.Item9;
-                int64 = validatedParameterLocalVars.Item10;
-                varString = validatedParameterLocalVars.Item11;
-                password = validatedParameterLocalVars.Item12;
-                callback = validatedParameterLocalVars.Item13;
-                dateTime = validatedParameterLocalVars.Item14;
+                ValidateTestEndpointParameters(varByte, number, varDouble, patternWithoutDelimiter);
+
+                FormatTestEndpointParameters(ref varByte, ref number, ref varDouble, ref patternWithoutDelimiter, ref date, ref binary, ref varFloat, ref integer, ref int32, ref int64, ref varString, ref password, ref callback, ref dateTime);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1887,22 +1833,7 @@ namespace Org.OpenAPITools.Api
             }
         }
 
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumQueryStringArray"></param>
-        /// <param name="enumQueryDouble"></param>
-        /// <param name="enumQueryInteger"></param>
-        /// <param name="enumFormStringArray"></param>
-        /// <param name="enumHeaderString"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumFormString"></param>
-        /// <returns></returns>
-        protected virtual (List<string>, List<string>, double?, int?, List<string>, string, string, string) OnTestEnumParameters(List<string> enumHeaderStringArray, List<string> enumQueryStringArray, double? enumQueryDouble, int? enumQueryInteger, List<string> enumFormStringArray, string enumHeaderString, string enumQueryString, string enumFormString)
-        {
-            return (enumHeaderStringArray, enumQueryStringArray, enumQueryDouble, enumQueryInteger, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
-        }
+        partial void FormatTestEnumParameters(List<string> enumHeaderStringArray, List<string> enumQueryStringArray, ref double? enumQueryDouble, ref int? enumQueryInteger, List<string> enumFormStringArray, ref string enumHeaderString, ref string enumQueryString, ref string enumFormString);
 
         /// <summary>
         /// Processes the server response
@@ -1984,15 +1915,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumQueryDouble, enumQueryInteger, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
-                enumHeaderStringArray = validatedParameterLocalVars.Item1;
-                enumQueryStringArray = validatedParameterLocalVars.Item2;
-                enumQueryDouble = validatedParameterLocalVars.Item3;
-                enumQueryInteger = validatedParameterLocalVars.Item4;
-                enumFormStringArray = validatedParameterLocalVars.Item5;
-                enumHeaderString = validatedParameterLocalVars.Item6;
-                enumQueryString = validatedParameterLocalVars.Item7;
-                enumFormString = validatedParameterLocalVars.Item8;
+                FormatTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, ref enumQueryDouble, ref enumQueryInteger, enumFormStringArray, ref enumHeaderString, ref enumQueryString, ref enumFormString);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2072,6 +1995,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestGroupParameters(ref bool requiredBooleanGroup, ref int requiredStringGroup, ref long requiredInt64Group, ref bool? booleanGroup, ref int? stringGroup, ref long? int64Group);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -2082,7 +2007,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="stringGroup"></param>
         /// <param name="int64Group"></param>
         /// <returns></returns>
-        protected virtual (bool, int, long, bool?, int?, long?) OnTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group, bool? booleanGroup, int? stringGroup, long? int64Group)
+        private void ValidateTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2096,10 +2021,8 @@ namespace Org.OpenAPITools.Api
             if (requiredInt64Group == null)
                 throw new ArgumentNullException(nameof(requiredInt64Group));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredBooleanGroup, requiredStringGroup, requiredInt64Group, booleanGroup, stringGroup, int64Group);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2174,13 +2097,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestGroupParameters(requiredBooleanGroup, requiredStringGroup, requiredInt64Group, booleanGroup, stringGroup, int64Group);
-                requiredBooleanGroup = validatedParameterLocalVars.Item1;
-                requiredStringGroup = validatedParameterLocalVars.Item2;
-                requiredInt64Group = validatedParameterLocalVars.Item3;
-                booleanGroup = validatedParameterLocalVars.Item4;
-                stringGroup = validatedParameterLocalVars.Item5;
-                int64Group = validatedParameterLocalVars.Item6;
+                ValidateTestGroupParameters(requiredBooleanGroup, requiredStringGroup, requiredInt64Group);
+
+                FormatTestGroupParameters(ref requiredBooleanGroup, ref requiredStringGroup, ref requiredInt64Group, ref booleanGroup, ref stringGroup, ref int64Group);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2248,12 +2167,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestInlineAdditionalProperties(Dictionary<string, string> requestBody);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="requestBody"></param>
         /// <returns></returns>
-        protected virtual Dictionary<string, string> OnTestInlineAdditionalProperties(Dictionary<string, string> requestBody)
+        private void ValidateTestInlineAdditionalProperties(Dictionary<string, string> requestBody)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2261,10 +2182,8 @@ namespace Org.OpenAPITools.Api
             if (requestBody == null)
                 throw new ArgumentNullException(nameof(requestBody));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return requestBody;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2319,7 +2238,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                requestBody = OnTestInlineAdditionalProperties(requestBody);
+                ValidateTestInlineAdditionalProperties(requestBody);
+
+                FormatTestInlineAdditionalProperties(requestBody);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2370,13 +2291,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestJsonFormData(ref string param, ref string param2);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="param"></param>
         /// <param name="param2"></param>
         /// <returns></returns>
-        protected virtual (string, string) OnTestJsonFormData(string param, string param2)
+        private void ValidateTestJsonFormData(string param, string param2)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2387,10 +2310,8 @@ namespace Org.OpenAPITools.Api
             if (param2 == null)
                 throw new ArgumentNullException(nameof(param2));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (param, param2);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2449,9 +2370,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestJsonFormData(param, param2);
-                param = validatedParameterLocalVars.Item1;
-                param2 = validatedParameterLocalVars.Item2;
+                ValidateTestJsonFormData(param, param2);
+
+                FormatTestJsonFormData(ref param, ref param2);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -2512,6 +2433,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -2521,7 +2444,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="url"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        protected virtual (List<string>, List<string>, List<string>, List<string>, List<string>) OnTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -2541,10 +2464,8 @@ namespace Org.OpenAPITools.Api
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (pipe, ioutil, http, url, context);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -2615,12 +2536,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
-                pipe = validatedParameterLocalVars.Item1;
-                ioutil = validatedParameterLocalVars.Item2;
-                http = validatedParameterLocalVars.Item3;
-                url = validatedParameterLocalVars.Item4;
-                context = validatedParameterLocalVars.Item5;
+                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+
+                FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -126,12 +126,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatTestClassname(ModelClient modelClient);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="modelClient"></param>
         /// <returns></returns>
-        protected virtual ModelClient OnTestClassname(ModelClient modelClient)
+        private void ValidateTestClassname(ModelClient modelClient)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -139,10 +141,8 @@ namespace Org.OpenAPITools.Api
             if (modelClient == null)
                 throw new ArgumentNullException(nameof(modelClient));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return modelClient;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -197,7 +197,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                modelClient = OnTestClassname(modelClient);
+                ValidateTestClassname(modelClient);
+
+                FormatTestClassname(modelClient);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -324,12 +324,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatAddPet(Pet pet);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="pet"></param>
         /// <returns></returns>
-        protected virtual Pet OnAddPet(Pet pet)
+        private void ValidateAddPet(Pet pet)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -337,10 +339,8 @@ namespace Org.OpenAPITools.Api
             if (pet == null)
                 throw new ArgumentNullException(nameof(pet));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return pet;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -395,7 +395,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                pet = OnAddPet(pet);
+                ValidateAddPet(pet);
+
+                FormatAddPet(pet);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -471,13 +473,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatDeletePet(ref long petId, ref string apiKey);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
         /// <param name="apiKey"></param>
         /// <returns></returns>
-        protected virtual (long, string) OnDeletePet(long petId, string apiKey)
+        private void ValidateDeletePet(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -485,10 +489,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, apiKey);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -547,9 +549,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnDeletePet(petId, apiKey);
-                petId = validatedParameterLocalVars.Item1;
-                apiKey = validatedParameterLocalVars.Item2;
+                ValidateDeletePet(petId);
+
+                FormatDeletePet(ref petId, ref apiKey);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -602,12 +604,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFindPetsByStatus(List<string> status);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="status"></param>
         /// <returns></returns>
-        protected virtual List<string> OnFindPetsByStatus(List<string> status)
+        private void ValidateFindPetsByStatus(List<string> status)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -615,10 +619,8 @@ namespace Org.OpenAPITools.Api
             if (status == null)
                 throw new ArgumentNullException(nameof(status));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return status;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -673,7 +675,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                status = OnFindPetsByStatus(status);
+                ValidateFindPetsByStatus(status);
+
+                FormatFindPetsByStatus(status);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -751,12 +755,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatFindPetsByTags(List<string> tags);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="tags"></param>
         /// <returns></returns>
-        protected virtual List<string> OnFindPetsByTags(List<string> tags)
+        private void ValidateFindPetsByTags(List<string> tags)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -764,10 +770,8 @@ namespace Org.OpenAPITools.Api
             if (tags == null)
                 throw new ArgumentNullException(nameof(tags));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return tags;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -822,7 +826,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                tags = OnFindPetsByTags(tags);
+                ValidateFindPetsByTags(tags);
+
+                FormatFindPetsByTags(tags);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -900,12 +906,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetPetById(ref long petId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
         /// <returns></returns>
-        protected virtual long OnGetPetById(long petId)
+        private void ValidateGetPetById(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -913,10 +921,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return petId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -971,7 +977,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                petId = OnGetPetById(petId);
+                ValidateGetPetById(petId);
+
+                FormatGetPetById(ref petId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1029,12 +1037,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdatePet(Pet pet);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="pet"></param>
         /// <returns></returns>
-        protected virtual Pet OnUpdatePet(Pet pet)
+        private void ValidateUpdatePet(Pet pet)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1042,10 +1052,8 @@ namespace Org.OpenAPITools.Api
             if (pet == null)
                 throw new ArgumentNullException(nameof(pet));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return pet;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1100,7 +1108,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                pet = OnUpdatePet(pet);
+                ValidateUpdatePet(pet);
+
+                FormatUpdatePet(pet);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1176,6 +1186,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdatePetWithForm(ref long petId, ref string name, ref string status);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1183,7 +1195,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name"></param>
         /// <param name="status"></param>
         /// <returns></returns>
-        protected virtual (long, string, string) OnUpdatePetWithForm(long petId, string name, string status)
+        private void ValidateUpdatePetWithForm(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1191,10 +1203,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, name, status);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1257,10 +1267,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUpdatePetWithForm(petId, name, status);
-                petId = validatedParameterLocalVars.Item1;
-                name = validatedParameterLocalVars.Item2;
-                status = validatedParameterLocalVars.Item3;
+                ValidateUpdatePetWithForm(petId);
+
+                FormatUpdatePetWithForm(ref petId, ref name, ref status);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1331,6 +1340,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUploadFile(ref long petId, ref System.IO.Stream file, ref string additionalMetadata);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1338,7 +1349,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="file"></param>
         /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        protected virtual (long, System.IO.Stream, string) OnUploadFile(long petId, System.IO.Stream file, string additionalMetadata)
+        private void ValidateUploadFile(long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1346,10 +1357,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (petId, file, additionalMetadata);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1412,10 +1421,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUploadFile(petId, file, additionalMetadata);
-                petId = validatedParameterLocalVars.Item1;
-                file = validatedParameterLocalVars.Item2;
-                additionalMetadata = validatedParameterLocalVars.Item3;
+                ValidateUploadFile(petId);
+
+                FormatUploadFile(ref petId, ref file, ref additionalMetadata);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1495,6 +1503,8 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUploadFileWithRequiredFile(ref System.IO.Stream requiredFile, ref long petId, ref string additionalMetadata);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
@@ -1502,7 +1512,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId"></param>
         /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        protected virtual (System.IO.Stream, long, string) OnUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId, string additionalMetadata)
+        private void ValidateUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1513,10 +1523,8 @@ namespace Org.OpenAPITools.Api
             if (petId == null)
                 throw new ArgumentNullException(nameof(petId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (requiredFile, petId, additionalMetadata);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1579,10 +1587,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
-                requiredFile = validatedParameterLocalVars.Item1;
-                petId = validatedParameterLocalVars.Item2;
-                additionalMetadata = validatedParameterLocalVars.Item3;
+                ValidateUploadFileWithRequiredFile(requiredFile, petId);
+
+                FormatUploadFileWithRequiredFile(ref requiredFile, ref petId, ref additionalMetadata);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -193,12 +193,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatDeleteOrder(ref string orderId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected virtual string OnDeleteOrder(string orderId)
+        private void ValidateDeleteOrder(string orderId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -206,10 +208,8 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new ArgumentNullException(nameof(orderId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return orderId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -264,7 +264,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                orderId = OnDeleteOrder(orderId);
+                ValidateDeleteOrder(orderId);
+
+                FormatDeleteOrder(ref orderId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -300,15 +302,6 @@ namespace Org.OpenAPITools.Api
                 OnErrorDeleteOrder(e, "/store/order/{order_id}", uriBuilderLocalVar.Path, orderId);
                 throw;
             }
-        }
-
-        /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnGetInventory()
-        {
-            return;
         }
 
         /// <summary>
@@ -359,8 +352,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnGetInventory();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -416,12 +407,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetOrderById(ref long orderId);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected virtual long OnGetOrderById(long orderId)
+        private void ValidateGetOrderById(long orderId)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -429,10 +422,8 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new ArgumentNullException(nameof(orderId));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return orderId;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -487,7 +478,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                orderId = OnGetOrderById(orderId);
+                ValidateGetOrderById(orderId);
+
+                FormatGetOrderById(ref orderId);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -535,12 +528,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatPlaceOrder(Order order);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="order"></param>
         /// <returns></returns>
-        protected virtual Order OnPlaceOrder(Order order)
+        private void ValidatePlaceOrder(Order order)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -548,10 +543,8 @@ namespace Org.OpenAPITools.Api
             if (order == null)
                 throw new ArgumentNullException(nameof(order));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return order;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -606,7 +599,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                order = OnPlaceOrder(order);
+                ValidatePlaceOrder(order);
+
+                FormatPlaceOrder(order);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -289,12 +289,14 @@ namespace Org.OpenAPITools.Api
             Logger.LogInformation("{0,-9} | {1} | {3}", (args.ReceivedAt - args.RequestedAt).TotalSeconds, args.HttpStatus, args.Path);
         }
 
+        partial void FormatCreateUser(User user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual User OnCreateUser(User user)
+        private void ValidateCreateUser(User user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -302,10 +304,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -360,7 +360,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUser(user);
+                ValidateCreateUser(user);
+
+                FormatCreateUser(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -411,12 +413,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatCreateUsersWithArrayInput(List<User> user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual List<User> OnCreateUsersWithArrayInput(List<User> user)
+        private void ValidateCreateUsersWithArrayInput(List<User> user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -424,10 +428,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -482,7 +484,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUsersWithArrayInput(user);
+                ValidateCreateUsersWithArrayInput(user);
+
+                FormatCreateUsersWithArrayInput(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -533,12 +537,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatCreateUsersWithListInput(List<User> user);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        protected virtual List<User> OnCreateUsersWithListInput(List<User> user)
+        private void ValidateCreateUsersWithListInput(List<User> user)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -546,10 +552,8 @@ namespace Org.OpenAPITools.Api
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return user;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -604,7 +608,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                user = OnCreateUsersWithListInput(user);
+                ValidateCreateUsersWithListInput(user);
+
+                FormatCreateUsersWithListInput(user);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -655,12 +661,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatDeleteUser(ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual string OnDeleteUser(string username)
+        private void ValidateDeleteUser(string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -668,10 +676,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return username;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -726,7 +732,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                username = OnDeleteUser(username);
+                ValidateDeleteUser(username);
+
+                FormatDeleteUser(ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -764,12 +772,14 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatGetUserByName(ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual string OnGetUserByName(string username)
+        private void ValidateGetUserByName(string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -777,10 +787,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return username;
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -835,7 +843,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                username = OnGetUserByName(username);
+                ValidateGetUserByName(username);
+
+                FormatGetUserByName(ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -883,13 +893,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatLoginUser(ref string username, ref string password);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="username"></param>
         /// <param name="password"></param>
         /// <returns></returns>
-        protected virtual (string, string) OnLoginUser(string username, string password)
+        private void ValidateLoginUser(string username, string password)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -900,10 +912,8 @@ namespace Org.OpenAPITools.Api
             if (password == null)
                 throw new ArgumentNullException(nameof(password));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (username, password);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -962,9 +972,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnLoginUser(username, password);
-                username = validatedParameterLocalVars.Item1;
-                password = validatedParameterLocalVars.Item2;
+                ValidateLoginUser(username, password);
+
+                FormatLoginUser(ref username, ref password);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
@@ -1020,15 +1030,6 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Validates the request parameters
-        /// </summary>
-        /// <returns></returns>
-        protected virtual void OnLogoutUser()
-        {
-            return;
-        }
-
-        /// <summary>
         /// Processes the server response
         /// </summary>
         /// <param name="apiResponseLocalVar"></param>
@@ -1076,8 +1077,6 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                OnLogoutUser();
-
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {
                     uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
@@ -1114,13 +1113,15 @@ namespace Org.OpenAPITools.Api
             }
         }
 
+        partial void FormatUpdateUser(User user, ref string username);
+
         /// <summary>
         /// Validates the request parameters
         /// </summary>
         /// <param name="user"></param>
         /// <param name="username"></param>
         /// <returns></returns>
-        protected virtual (User, string) OnUpdateUser(User user, string username)
+        private void ValidateUpdateUser(User user, string username)
         {
             #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
@@ -1131,10 +1132,8 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            #pragma warning disable CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
-
-            return (user, username);
+            #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+            #pragma warning restore CS8073 // The result of the expression is always the same since a value of this type is never equal to 'null'
         }
 
         /// <summary>
@@ -1193,9 +1192,9 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                var validatedParameterLocalVars = OnUpdateUser(user, username);
-                user = validatedParameterLocalVars.Item1;
-                username = validatedParameterLocalVars.Item2;
+                ValidateUpdateUser(user, username);
+
+                FormatUpdateUser(user, ref username);
 
                 using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
                 {


### PR DESCRIPTION
Created a partial method that enables developers to format arguments before sending to the server. This was achievable before using inheritance, but that feels a bit awkward to use in this  context. Partial methods are better suited for this task.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
