### PR TITLE
[Python] default values escaping more appropriate

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -153,11 +153,15 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 return p.getDefault().toString();
             }
         } else if (ModelUtils.isStringSchema(p)) {
-            if (p.getDefault() != null) {
-                if (Pattern.compile("\r\n|\r|\n").matcher((String) p.getDefault()).find())
-                    return "'''" + p.getDefault() + "'''";
-                else
-                    return "'" + ((String) p.getDefault()).replace("'", "\'") + "'";
+            String defaultValue = (String)p.getDefault();
+            if (defaultValue != null) {
+                defaultValue = defaultValue.replace("\\", "\\\\")
+                    .replace("'", "\'");
+                if (Pattern.compile("\r\n|\r|\n").matcher(defaultValue).find()) {
+                    return "'''" + defaultValue + "'''";
+                } else {
+                    return "'" + defaultValue + "'";
+                }
             }
         } else if (ModelUtils.isArraySchema(p)) {
             if (p.getDefault() != null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -136,6 +136,15 @@ public class PythonClientCodegenTest {
         Assert.assertEquals("'Text containing \'single\' quote'", defaultValue);
     }
 
+    @Test(description = "test backslash default")
+    public void testBackslashDefault() {
+        final PythonClientCodegen codegen = new PythonClientCodegen();
+        StringSchema schema = new StringSchema();
+        schema.setDefault("\\");
+        String defaultValue = codegen.toDefaultValue(schema);
+        Assert.assertEquals("'\\\\'", defaultValue);
+    }
+
     @Test(description = "convert a python model with dots")
     public void modelTest() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/v1beta3.yaml");


### PR DESCRIPTION
Fixes #15541

Default Value: Backslash value needs an escaped backslash in generated python code.
Single quotes needs escapng on multilines as well (at least if there were three in a row)

Added a small unit test.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  Commit all changed files. 
- [~] In case you are adding a new generator, run the following additional script : 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
 @spacether @krjakbrjak
