### PR TITLE
[openapi-normalizer] Support normalizing null types using OAS 3.1 syntax

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -141,11 +141,11 @@ public class OpenAPINormalizerTest {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml");
 
         Schema schema = openAPI.getComponents().getSchemas().get("AnyOfTest");
-        assertEquals(schema.getAnyOf().size(), 2);
+        assertEquals(schema.getAnyOf().size(), 4);
         assertNull(schema.getNullable());
 
         Schema schema2 = openAPI.getComponents().getSchemas().get("OneOfTest");
-        assertEquals(schema2.getOneOf().size(), 2);
+        assertEquals(schema2.getOneOf().size(), 4);
         assertNull(schema2.getNullable());
 
         Schema schema5 = openAPI.getComponents().getSchemas().get("OneOfNullableTest");
@@ -168,6 +168,7 @@ public class OpenAPINormalizerTest {
         Schema schema4 = openAPI.getComponents().getSchemas().get("OneOfTest");
         assertNull(schema4.getOneOf());
         assertTrue(schema4 instanceof IntegerSchema);
+        assertTrue(schema4.getNullable());
 
         Schema schema6 = openAPI.getComponents().getSchemas().get("OneOfNullableTest");
         assertEquals(schema6.getOneOf().size(), 2);
@@ -273,7 +274,7 @@ public class OpenAPINormalizerTest {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/convertEnumNullToNullable_test.yaml");
 
         Schema schema = openAPI.getComponents().getSchemas().get("AnyOfTest");
-        assertEquals(schema.getAnyOf().size(), 3);
+        assertEquals(schema.getAnyOf().size(), 4);
         assertNull(schema.getNullable());
 
         Map<String, String> options = new HashMap<>();
@@ -292,7 +293,7 @@ public class OpenAPINormalizerTest {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/convertEnumNullToNullable_test.yaml");
 
         Schema schema = openAPI.getComponents().getSchemas().get("AnyOfTest");
-        assertEquals(schema.getAnyOf().size(), 3);
+        assertEquals(schema.getAnyOf().size(), 4);
         assertNull(schema.getNullable());
 
         Map<String, String> options = new HashMap<>();
@@ -313,7 +314,7 @@ public class OpenAPINormalizerTest {
 
         // before test
         Schema schema = openAPI.getComponents().getSchemas().get("AnyOfTest");
-        assertEquals(schema.getAnyOf().size(), 3);
+        assertEquals(schema.getAnyOf().size(), 4);
         assertNull(schema.getNullable());
 
         Map<String, String> options = new HashMap<>();
@@ -323,7 +324,7 @@ public class OpenAPINormalizerTest {
 
         // checks should be the same after test
         Schema schema3 = openAPI.getComponents().getSchemas().get("AnyOfTest");
-        assertEquals(schema3.getAnyOf().size(), 3);
+        assertEquals(schema3.getAnyOf().size(), 4);
         assertNull(schema3.getNullable());
     }
 

--- a/modules/openapi-generator/src/test/resources/3_0/convertEnumNullToNullable_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/convertEnumNullToNullable_test.yaml
@@ -31,12 +31,17 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/EnumString'
+        - $ref: '#/components/schemas/EnumNullString'
         - $ref: '#/components/schemas/EnumNull'
     EnumString:
       type: string
       enum:
         - A
         - B
+    EnumNullString:
+      type: string
+      enum:
+        - 'null'
     EnumNull:
       type: string
       enum:

--- a/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/simplifyOneOfAnyOf_test.yaml
@@ -30,11 +30,15 @@ components:
       description: to test anyOf
       anyOf:
         - type: string
+        - type: 'null'
         - type: null
+        - $ref: null
     OneOfTest:
       description: to test oneOf
       oneOf:
         - type: integer
+        - type: 'null'
+        - type: null
         - $ref: null
     OneOfNullableTest:
       description: to test oneOf nullable

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Drawing.cs
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull
         {
             get{ return _ShapeOrNull;}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/docs/models/Drawing.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/docs/models/Drawing.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MainShape** | [**Shape**](Shape.md) |  | [optional] 
-**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
 **Shapes** | [**List&lt;Shape&gt;**](Shape.md) |  | [optional] 
 **NullableShape** | [**NullableShape**](NullableShape.md) |  | [optional] 
+**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Drawing.cs
@@ -34,16 +34,16 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
         /// <param name="mainShape">mainShape</param>
-        /// <param name="shapeOrNull">shapeOrNull</param>
         /// <param name="shapes">shapes</param>
         /// <param name="nullableShape">nullableShape</param>
+        /// <param name="shapeOrNull">shapeOrNull</param>
         [JsonConstructor]
-        public Drawing(Shape mainShape, ShapeOrNull shapeOrNull, List<Shape> shapes, NullableShape? nullableShape = default) : base()
+        public Drawing(Shape mainShape, List<Shape> shapes, NullableShape? nullableShape = default, ShapeOrNull? shapeOrNull = default) : base()
         {
             MainShape = mainShape;
-            ShapeOrNull = shapeOrNull;
             Shapes = shapes;
             NullableShape = nullableShape;
+            ShapeOrNull = shapeOrNull;
             OnCreated();
         }
 
@@ -54,12 +54,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("mainShape")]
         public Shape MainShape { get; set; }
-
-        /// <summary>
-        /// Gets or Sets ShapeOrNull
-        /// </summary>
-        [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>
         /// Gets or Sets Shapes
@@ -74,6 +68,12 @@ namespace Org.OpenAPITools.Model
         public NullableShape? NullableShape { get; set; }
 
         /// <summary>
+        /// Gets or Sets ShapeOrNull
+        /// </summary>
+        [JsonPropertyName("shapeOrNull")]
+        public ShapeOrNull? ShapeOrNull { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -83,9 +83,9 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Drawing {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  MainShape: ").Append(MainShape).Append("\n");
-            sb.Append("  ShapeOrNull: ").Append(ShapeOrNull).Append("\n");
             sb.Append("  Shapes: ").Append(Shapes).Append("\n");
             sb.Append("  NullableShape: ").Append(NullableShape).Append("\n");
+            sb.Append("  ShapeOrNull: ").Append(ShapeOrNull).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -124,9 +124,9 @@ namespace Org.OpenAPITools.Model
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
             Shape? mainShape = default;
-            ShapeOrNull? shapeOrNull = default;
             List<Shape>? shapes = default;
             NullableShape? nullableShape = default;
+            ShapeOrNull? shapeOrNull = default;
 
             while (utf8JsonReader.Read())
             {
@@ -147,10 +147,6 @@ namespace Org.OpenAPITools.Model
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 mainShape = JsonSerializer.Deserialize<Shape>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
-                        case "shapeOrNull":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                shapeOrNull = JsonSerializer.Deserialize<ShapeOrNull>(ref utf8JsonReader, jsonSerializerOptions);
-                            break;
                         case "shapes":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 shapes = JsonSerializer.Deserialize<List<Shape>>(ref utf8JsonReader, jsonSerializerOptions);
@@ -158,6 +154,10 @@ namespace Org.OpenAPITools.Model
                         case "nullableShape":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 nullableShape = JsonSerializer.Deserialize<NullableShape>(ref utf8JsonReader, jsonSerializerOptions);
+                            break;
+                        case "shapeOrNull":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                shapeOrNull = JsonSerializer.Deserialize<ShapeOrNull>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
                         default:
                             break;
@@ -168,13 +168,10 @@ namespace Org.OpenAPITools.Model
             if (mainShape == null)
                 throw new ArgumentNullException(nameof(mainShape), "Property is required for class Drawing.");
 
-            if (shapeOrNull == null)
-                throw new ArgumentNullException(nameof(shapeOrNull), "Property is required for class Drawing.");
-
             if (shapes == null)
                 throw new ArgumentNullException(nameof(shapes), "Property is required for class Drawing.");
 
-            return new Drawing(mainShape, shapeOrNull, shapes, nullableShape);
+            return new Drawing(mainShape, shapes, nullableShape, shapeOrNull);
         }
 
         /// <summary>
@@ -190,12 +187,12 @@ namespace Org.OpenAPITools.Model
 
             writer.WritePropertyName("mainShape");
             JsonSerializer.Serialize(writer, drawing.MainShape, jsonSerializerOptions);
-            writer.WritePropertyName("shapeOrNull");
-            JsonSerializer.Serialize(writer, drawing.ShapeOrNull, jsonSerializerOptions);
             writer.WritePropertyName("shapes");
             JsonSerializer.Serialize(writer, drawing.Shapes, jsonSerializerOptions);
             writer.WritePropertyName("nullableShape");
             JsonSerializer.Serialize(writer, drawing.NullableShape, jsonSerializerOptions);
+            writer.WritePropertyName("shapeOrNull");
+            JsonSerializer.Serialize(writer, drawing.ShapeOrNull, jsonSerializerOptions);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/docs/models/Drawing.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/docs/models/Drawing.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MainShape** | [**Shape**](Shape.md) |  | [optional] 
-**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
 **Shapes** | [**List&lt;Shape&gt;**](Shape.md) |  | [optional] 
 **NullableShape** | [**NullableShape**](NullableShape.md) |  | [optional] 
+**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -32,16 +32,16 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
         /// <param name="mainShape">mainShape</param>
-        /// <param name="shapeOrNull">shapeOrNull</param>
         /// <param name="shapes">shapes</param>
         /// <param name="nullableShape">nullableShape</param>
+        /// <param name="shapeOrNull">shapeOrNull</param>
         [JsonConstructor]
-        public Drawing(Shape mainShape, ShapeOrNull shapeOrNull, List<Shape> shapes, NullableShape nullableShape = default) : base()
+        public Drawing(Shape mainShape, List<Shape> shapes, NullableShape nullableShape = default, ShapeOrNull shapeOrNull = default) : base()
         {
             MainShape = mainShape;
-            ShapeOrNull = shapeOrNull;
             Shapes = shapes;
             NullableShape = nullableShape;
+            ShapeOrNull = shapeOrNull;
             OnCreated();
         }
 
@@ -52,12 +52,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("mainShape")]
         public Shape MainShape { get; set; }
-
-        /// <summary>
-        /// Gets or Sets ShapeOrNull
-        /// </summary>
-        [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>
         /// Gets or Sets Shapes
@@ -72,6 +66,12 @@ namespace Org.OpenAPITools.Model
         public NullableShape NullableShape { get; set; }
 
         /// <summary>
+        /// Gets or Sets ShapeOrNull
+        /// </summary>
+        [JsonPropertyName("shapeOrNull")]
+        public ShapeOrNull ShapeOrNull { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -81,9 +81,9 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Drawing {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  MainShape: ").Append(MainShape).Append("\n");
-            sb.Append("  ShapeOrNull: ").Append(ShapeOrNull).Append("\n");
             sb.Append("  Shapes: ").Append(Shapes).Append("\n");
             sb.Append("  NullableShape: ").Append(NullableShape).Append("\n");
+            sb.Append("  ShapeOrNull: ").Append(ShapeOrNull).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -122,9 +122,9 @@ namespace Org.OpenAPITools.Model
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
             Shape mainShape = default;
-            ShapeOrNull shapeOrNull = default;
             List<Shape> shapes = default;
             NullableShape nullableShape = default;
+            ShapeOrNull shapeOrNull = default;
 
             while (utf8JsonReader.Read())
             {
@@ -145,10 +145,6 @@ namespace Org.OpenAPITools.Model
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 mainShape = JsonSerializer.Deserialize<Shape>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
-                        case "shapeOrNull":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                shapeOrNull = JsonSerializer.Deserialize<ShapeOrNull>(ref utf8JsonReader, jsonSerializerOptions);
-                            break;
                         case "shapes":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 shapes = JsonSerializer.Deserialize<List<Shape>>(ref utf8JsonReader, jsonSerializerOptions);
@@ -156,6 +152,10 @@ namespace Org.OpenAPITools.Model
                         case "nullableShape":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 nullableShape = JsonSerializer.Deserialize<NullableShape>(ref utf8JsonReader, jsonSerializerOptions);
+                            break;
+                        case "shapeOrNull":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                shapeOrNull = JsonSerializer.Deserialize<ShapeOrNull>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
                         default:
                             break;
@@ -166,13 +166,10 @@ namespace Org.OpenAPITools.Model
             if (mainShape == null)
                 throw new ArgumentNullException(nameof(mainShape), "Property is required for class Drawing.");
 
-            if (shapeOrNull == null)
-                throw new ArgumentNullException(nameof(shapeOrNull), "Property is required for class Drawing.");
-
             if (shapes == null)
                 throw new ArgumentNullException(nameof(shapes), "Property is required for class Drawing.");
 
-            return new Drawing(mainShape, shapeOrNull, shapes, nullableShape);
+            return new Drawing(mainShape, shapes, nullableShape, shapeOrNull);
         }
 
         /// <summary>
@@ -188,12 +185,12 @@ namespace Org.OpenAPITools.Model
 
             writer.WritePropertyName("mainShape");
             JsonSerializer.Serialize(writer, drawing.MainShape, jsonSerializerOptions);
-            writer.WritePropertyName("shapeOrNull");
-            JsonSerializer.Serialize(writer, drawing.ShapeOrNull, jsonSerializerOptions);
             writer.WritePropertyName("shapes");
             JsonSerializer.Serialize(writer, drawing.Shapes, jsonSerializerOptions);
             writer.WritePropertyName("nullableShape");
             JsonSerializer.Serialize(writer, drawing.NullableShape, jsonSerializerOptions);
+            writer.WritePropertyName("shapeOrNull");
+            JsonSerializer.Serialize(writer, drawing.ShapeOrNull, jsonSerializerOptions);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/docs/models/Drawing.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/docs/models/Drawing.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MainShape** | [**Shape**](Shape.md) |  | [optional] 
-**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
 **Shapes** | [**List&lt;Shape&gt;**](Shape.md) |  | [optional] 
 **NullableShape** | [**NullableShape**](NullableShape.md) |  | [optional] 
+**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -32,16 +32,16 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Drawing" /> class.
         /// </summary>
         /// <param name="mainShape">mainShape</param>
-        /// <param name="shapeOrNull">shapeOrNull</param>
         /// <param name="shapes">shapes</param>
         /// <param name="nullableShape">nullableShape</param>
+        /// <param name="shapeOrNull">shapeOrNull</param>
         [JsonConstructor]
-        public Drawing(Shape mainShape, ShapeOrNull shapeOrNull, List<Shape> shapes, NullableShape nullableShape = default) : base()
+        public Drawing(Shape mainShape, List<Shape> shapes, NullableShape nullableShape = default, ShapeOrNull shapeOrNull = default) : base()
         {
             MainShape = mainShape;
-            ShapeOrNull = shapeOrNull;
             Shapes = shapes;
             NullableShape = nullableShape;
+            ShapeOrNull = shapeOrNull;
             OnCreated();
         }
 
@@ -52,12 +52,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonPropertyName("mainShape")]
         public Shape MainShape { get; set; }
-
-        /// <summary>
-        /// Gets or Sets ShapeOrNull
-        /// </summary>
-        [JsonPropertyName("shapeOrNull")]
-        public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>
         /// Gets or Sets Shapes
@@ -72,6 +66,12 @@ namespace Org.OpenAPITools.Model
         public NullableShape NullableShape { get; set; }
 
         /// <summary>
+        /// Gets or Sets ShapeOrNull
+        /// </summary>
+        [JsonPropertyName("shapeOrNull")]
+        public ShapeOrNull ShapeOrNull { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -81,9 +81,9 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Drawing {\n");
             sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  MainShape: ").Append(MainShape).Append("\n");
-            sb.Append("  ShapeOrNull: ").Append(ShapeOrNull).Append("\n");
             sb.Append("  Shapes: ").Append(Shapes).Append("\n");
             sb.Append("  NullableShape: ").Append(NullableShape).Append("\n");
+            sb.Append("  ShapeOrNull: ").Append(ShapeOrNull).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -122,9 +122,9 @@ namespace Org.OpenAPITools.Model
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
             Shape mainShape = default;
-            ShapeOrNull shapeOrNull = default;
             List<Shape> shapes = default;
             NullableShape nullableShape = default;
+            ShapeOrNull shapeOrNull = default;
 
             while (utf8JsonReader.Read())
             {
@@ -145,10 +145,6 @@ namespace Org.OpenAPITools.Model
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 mainShape = JsonSerializer.Deserialize<Shape>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
-                        case "shapeOrNull":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                shapeOrNull = JsonSerializer.Deserialize<ShapeOrNull>(ref utf8JsonReader, jsonSerializerOptions);
-                            break;
                         case "shapes":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 shapes = JsonSerializer.Deserialize<List<Shape>>(ref utf8JsonReader, jsonSerializerOptions);
@@ -156,6 +152,10 @@ namespace Org.OpenAPITools.Model
                         case "nullableShape":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 nullableShape = JsonSerializer.Deserialize<NullableShape>(ref utf8JsonReader, jsonSerializerOptions);
+                            break;
+                        case "shapeOrNull":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                shapeOrNull = JsonSerializer.Deserialize<ShapeOrNull>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
                         default:
                             break;
@@ -166,13 +166,10 @@ namespace Org.OpenAPITools.Model
             if (mainShape == null)
                 throw new ArgumentNullException(nameof(mainShape), "Property is required for class Drawing.");
 
-            if (shapeOrNull == null)
-                throw new ArgumentNullException(nameof(shapeOrNull), "Property is required for class Drawing.");
-
             if (shapes == null)
                 throw new ArgumentNullException(nameof(shapes), "Property is required for class Drawing.");
 
-            return new Drawing(mainShape, shapeOrNull, shapes, nullableShape);
+            return new Drawing(mainShape, shapes, nullableShape, shapeOrNull);
         }
 
         /// <summary>
@@ -188,12 +185,12 @@ namespace Org.OpenAPITools.Model
 
             writer.WritePropertyName("mainShape");
             JsonSerializer.Serialize(writer, drawing.MainShape, jsonSerializerOptions);
-            writer.WritePropertyName("shapeOrNull");
-            JsonSerializer.Serialize(writer, drawing.ShapeOrNull, jsonSerializerOptions);
             writer.WritePropertyName("shapes");
             JsonSerializer.Serialize(writer, drawing.Shapes, jsonSerializerOptions);
             writer.WritePropertyName("nullableShape");
             JsonSerializer.Serialize(writer, drawing.NullableShape, jsonSerializerOptions);
+            writer.WritePropertyName("shapeOrNull");
+            JsonSerializer.Serialize(writer, drawing.ShapeOrNull, jsonSerializerOptions);
 
             writer.WriteEndObject();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Drawing.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Drawing.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Drawing.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-unityWebRequest/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-unityWebRequest/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Drawing.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Drawing.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/api/openapi.yaml
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/api/openapi.yaml
@@ -1971,8 +1971,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2021,8 +2021,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
-        [DataMember(Name = "shapeOrNull", EmitDefaultValue = false)]
+        [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
         public ShapeOrNull ShapeOrNull { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/java/jersey3/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey3/api/openapi.yaml
@@ -1973,8 +1973,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2023,8 +2023,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/Drawing.java
@@ -55,7 +55,7 @@ public class Drawing {
   private Shape mainShape;
 
   public static final String JSON_PROPERTY_SHAPE_OR_NULL = "shapeOrNull";
-  private ShapeOrNull shapeOrNull;
+  private JsonNullable<ShapeOrNull> shapeOrNull = JsonNullable.<ShapeOrNull>undefined();
 
   public static final String JSON_PROPERTY_NULLABLE_SHAPE = "nullableShape";
   private JsonNullable<NullableShape> nullableShape = JsonNullable.<NullableShape>undefined();
@@ -92,7 +92,7 @@ public class Drawing {
 
 
   public Drawing shapeOrNull(ShapeOrNull shapeOrNull) {
-    this.shapeOrNull = shapeOrNull;
+    this.shapeOrNull = JsonNullable.<ShapeOrNull>of(shapeOrNull);
     return this;
   }
 
@@ -101,18 +101,26 @@ public class Drawing {
    * @return shapeOrNull
   **/
   @jakarta.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonIgnore
 
   public ShapeOrNull getShapeOrNull() {
-    return shapeOrNull;
+        return shapeOrNull.orElse(null);
   }
-
 
   @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setShapeOrNull(ShapeOrNull shapeOrNull) {
+
+  public JsonNullable<ShapeOrNull> getShapeOrNull_JsonNullable() {
+    return shapeOrNull;
+  }
+  
+  @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
+  public void setShapeOrNull_JsonNullable(JsonNullable<ShapeOrNull> shapeOrNull) {
     this.shapeOrNull = shapeOrNull;
+  }
+
+  public void setShapeOrNull(ShapeOrNull shapeOrNull) {
+    this.shapeOrNull = JsonNullable.<ShapeOrNull>of(shapeOrNull);
   }
 
 
@@ -232,7 +240,7 @@ public class Drawing {
     }
     Drawing drawing = (Drawing) o;
     return Objects.equals(this.mainShape, drawing.mainShape) &&
-        Objects.equals(this.shapeOrNull, drawing.shapeOrNull) &&
+        equalsNullable(this.shapeOrNull, drawing.shapeOrNull) &&
         equalsNullable(this.nullableShape, drawing.nullableShape) &&
         Objects.equals(this.shapes, drawing.shapes)&&
         Objects.equals(this.additionalProperties, drawing.additionalProperties);
@@ -244,7 +252,7 @@ public class Drawing {
 
   @Override
   public int hashCode() {
-    return Objects.hash(mainShape, shapeOrNull, hashCodeNullable(nullableShape), shapes, additionalProperties);
+    return Objects.hash(mainShape, hashCodeNullable(shapeOrNull), hashCodeNullable(nullableShape), shapes, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {

--- a/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
@@ -1973,8 +1973,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2023,8 +2023,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -512,7 +512,7 @@ export interface Drawing {
      * @type {ShapeOrNull}
      * @memberof Drawing
      */
-    'shapeOrNull'?: ShapeOrNull;
+    'shapeOrNull'?: ShapeOrNull | null;
     /**
      * 
      * @type {NullableShape}
@@ -846,7 +846,7 @@ export type Fruit = Apple | Banana;
  * @type FruitReq
  * @export
  */
-export type FruitReq = AppleReq | BananaReq | Null;
+export type FruitReq = AppleReq | BananaReq;
 
 /**
  * 
@@ -1520,7 +1520,7 @@ export interface ShapeInterface {
  * The value may be a shape or the \'null\' value. This is introduced in OAS schema >= 3.1.
  * @export
  */
-export type ShapeOrNull = Null | Quadrilateral | Triangle;
+export type ShapeOrNull = Quadrilateral | Triangle;
 
 /**
  * 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -1973,8 +1973,8 @@ components:
           type: string
     fruitReq:
       additionalProperties: false
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/appleReq'
       - $ref: '#/components/schemas/bananaReq'
     appleReq:
@@ -2023,8 +2023,8 @@ components:
         in OAS schema >= 3.1.
       discriminator:
         propertyName: shapeType
+      nullable: true
       oneOf:
-      - type: "null"
       - $ref: '#/components/schemas/Triangle'
       - $ref: '#/components/schemas/Quadrilateral'
     NullableShape:

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
@@ -55,7 +55,7 @@ public class Drawing {
   private Shape mainShape;
 
   public static final String JSON_PROPERTY_SHAPE_OR_NULL = "shapeOrNull";
-  private ShapeOrNull shapeOrNull;
+  private JsonNullable<ShapeOrNull> shapeOrNull = JsonNullable.<ShapeOrNull>undefined();
 
   public static final String JSON_PROPERTY_NULLABLE_SHAPE = "nullableShape";
   private JsonNullable<NullableShape> nullableShape = JsonNullable.<NullableShape>undefined();
@@ -92,7 +92,7 @@ public class Drawing {
 
 
   public Drawing shapeOrNull(ShapeOrNull shapeOrNull) {
-    this.shapeOrNull = shapeOrNull;
+    this.shapeOrNull = JsonNullable.<ShapeOrNull>of(shapeOrNull);
     return this;
   }
 
@@ -101,18 +101,26 @@ public class Drawing {
    * @return shapeOrNull
   **/
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonIgnore
 
   public ShapeOrNull getShapeOrNull() {
-    return shapeOrNull;
+        return shapeOrNull.orElse(null);
   }
-
 
   @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setShapeOrNull(ShapeOrNull shapeOrNull) {
+
+  public JsonNullable<ShapeOrNull> getShapeOrNull_JsonNullable() {
+    return shapeOrNull;
+  }
+  
+  @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
+  public void setShapeOrNull_JsonNullable(JsonNullable<ShapeOrNull> shapeOrNull) {
     this.shapeOrNull = shapeOrNull;
+  }
+
+  public void setShapeOrNull(ShapeOrNull shapeOrNull) {
+    this.shapeOrNull = JsonNullable.<ShapeOrNull>of(shapeOrNull);
   }
 
 
@@ -232,7 +240,7 @@ public class Drawing {
     }
     Drawing drawing = (Drawing) o;
     return Objects.equals(this.mainShape, drawing.mainShape) &&
-        Objects.equals(this.shapeOrNull, drawing.shapeOrNull) &&
+        equalsNullable(this.shapeOrNull, drawing.shapeOrNull) &&
         equalsNullable(this.nullableShape, drawing.nullableShape) &&
         Objects.equals(this.shapes, drawing.shapes)&&
         Objects.equals(this.additionalProperties, drawing.additionalProperties);
@@ -244,7 +252,7 @@ public class Drawing {
 
   @Override
   public int hashCode() {
-    return Objects.hash(mainShape, shapeOrNull, hashCodeNullable(nullableShape), shapes, additionalProperties);
+    return Objects.hash(mainShape, hashCodeNullable(shapeOrNull), hashCodeNullable(nullableShape), shapes, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {


### PR DESCRIPTION
In some test specifications OAS 3.1 syntax is used to define`nullable` schemas in `oneOf`/`anyOf`. This change supports normalizing these definitions and avoids generating unnecessary code for `null` types using the `SIMPLIFY_ONEOF_ANYOF` option.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
 Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).

- [x] In case you are adding a new generator, run the following additional script :
  ```
  ./bin/utils/ensure-up-to-date
  ```

- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 