### PR TITLE
[csharp-netcore][generichost] Removed many warnings

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/ApiFactory.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/ApiFactory.mustache
@@ -28,7 +28,7 @@ namespace {{packageName}}.{{clientPackage}}
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="{{classname}}"/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/JsonConverter.mustache
@@ -1,5 +1,5 @@
     /// <summary>
-    /// A Json converter for type {{classname}}
+    /// A Json converter for type <see cref="{{classname}}" />
     /// </summary>
     {{>visibility}} class {{classname}}JsonConverter : JsonConverter<{{classname}}>
     {
@@ -20,7 +20,7 @@
         {{/isDate}}
         {{/allVars}}
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="{{classname}}" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -131,12 +131,16 @@
                                 {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = ({{#isInnerEnum}}{{classname}}.{{/isInnerEnum}}{{{datatypeWithEnum}}})utf8JsonReader.Get{{#vendorExtensions.x-unsigned}}U{{/vendorExtensions.x-unsigned}}Int32();
                         {{/isNumeric}}
                         {{^isNumeric}}
-                            string {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue = utf8JsonReader.GetString();
+                            string{{nrt?}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue = utf8JsonReader.GetString();
                             {{^isInnerEnum}}
-                            {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{{datatypeWithEnum}}}Converter.FromString{{#isNullable}}OrDefault{{/isNullable}}({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue);
+                            {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue == null
+                                ? null
+                                : {{{datatypeWithEnum}}}Converter.FromStringOrDefault({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue);
                             {{/isInnerEnum}}
                             {{#isInnerEnum}}
-                            {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{classname}}.{{{datatypeWithEnum}}}FromString({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue);
+                            {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue == null
+                                ? null
+                                : {{classname}}.{{{datatypeWithEnum}}}FromStringOrDefault({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}RawValue);
                             {{/isInnerEnum}}
                         {{/isNumeric}}
                         {{/isMap}}
@@ -191,7 +195,7 @@
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="{{classname}}" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="{{#lambda.camelcase_param}}{{classname}}{{/lambda.camelcase_param}}"></param>

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/TokenBase.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/TokenBase.mustache
@@ -64,7 +64,7 @@ namespace {{packageName}}.{{clientPackage}}
                 _nextAvailable = DateTime.UtcNow.AddSeconds(5);
         }
 
-        private void OnTimer(object sender, System.Timers.ElapsedEventArgs e)
+        private void OnTimer(object{{nrt?}} sender, System.Timers.ElapsedEventArgs e)
         {
             if (TokenBecameAvailable != null && !IsRateLimited)
                 TokenBecameAvailable.Invoke(this);

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/api.mustache
@@ -146,9 +146,9 @@ namespace {{packageName}}.{{apiPackage}}
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        {{#allParams}}
+        {{/-first}}
         /// <param name="{{paramName}}"></param>
-        {{/allParams}}
+        {{#-last}}
         /// <returns></returns>
         private void Validate{{operationId}}({{#requiredAndNotNullableParams}}{{#lambda.required}}{{{dataType}}}{{/lambda.required}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredAndNotNullableParams}})
         {
@@ -177,7 +177,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/requiredAndNotNullableParams}}
         }
 
-        {{/-first}}
+        {{/-last}}
         {{/requiredAndNotNullableParams}}
         /// <summary>
         /// Processes the server response
@@ -211,7 +211,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}</param>
         {{/allParams}}
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}object{{/returnType}}"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="{{#returnProperty}}{{baseType}}{{#isContainer}}{{#isMap}}{TKey, TValue}{{/isMap}}{{^isMap}}{TValue}{{/isMap}}{{/isContainer}}{{/returnProperty}}{{^returnProperty}}object{{/returnProperty}}"/></returns>
         public async Task<ApiResponse<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}object{{/returnType}}>{{nrt?}}> {{operationId}}OrDefaultAsync({{>OperationSignature}})
         {
             try
@@ -232,7 +232,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}</param>
         {{/allParams}}
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}object{{/returnType}}"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="{{#returnProperty}}{{baseType}}{{#isContainer}}{{#isMap}}{TKey, TValue}{{/isMap}}{{^isMap}}{TValue}{{/isMap}}{{/isContainer}}{{/returnProperty}}{{^returnProperty}}object{{/returnProperty}}"/></returns>
         public async Task<ApiResponse<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}object{{/returnType}}>> {{operationId}}Async({{>OperationSignature}})
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelEnum.mustache
@@ -43,8 +43,17 @@
     }
     {{#useGenericHost}}
 
+    /// <summary>
+    /// A Json converter for type <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}Converter : JsonConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} FromString(string value)
         {
             {{#allowableValues}}
@@ -57,6 +66,11 @@
             throw new NotImplementedException($"Could not convert value to type {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? FromStringOrDefault(string value)
         {
             {{#allowableValues}}
@@ -69,6 +83,12 @@
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static {{>EnumValueDataType}} ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
         {
             {{^isString}}
@@ -97,8 +117,10 @@
         {
             string{{nrt?}} rawValue = reader.GetString();
 
-            {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? result = {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}Converter.FromString(rawValue);
-            
+            {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? result = rawValue == null
+                ? null
+                : {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}Converter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -117,6 +139,9 @@
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
+    /// </summary>
     public class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}NullableConverter : JsonConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}?>
     {
         /// <summary>
@@ -130,10 +155,9 @@
         {
             string{{nrt?}} rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? result = {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}Converter.FromString(rawValue);
+            {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? result = rawValue == null
+                ? null
+                : {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}Converter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
@@ -32,11 +32,12 @@
         {{#useGenericHost}}
 
         /// <summary>
-        /// Returns a {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
+        /// Returns a <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#isNullable}}?{{/isNullable}} {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}FromString(string value)
+        /// <exception cref="NotImplementedException"></exception>
+        public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}FromString(string value)
         {
             {{#allowableValues}}
             {{#enumVars}}
@@ -45,20 +46,34 @@
 
             {{/enumVars}}
             {{/allowableValues}}
-            {{#isNullable}}
-            return null;
-            {{/isNullable}}
-            {{^isNullable}}
             throw new NotImplementedException($"Could not convert value to type {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}: '{value}'");
-            {{/isNullable}}
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}FromStringOrDefault(string value)
+        {
+            {{#allowableValues}}
+            {{#enumVars}}
+            if (value == {{^isString}}({{{value}}}).ToString(){{/isString}}{{#isString}}"{{{value}}}"{{/isString}})
+                return {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.{{name}};
+
+            {{/enumVars}}
+            {{/allowableValues}}
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        {{#isString}}
         /// <exception cref="NotImplementedException"></exception>
+        {{/isString}}
         public static {{>EnumValueDataType}} {{datatypeWithEnum}}ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
         {
             {{^isString}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
         /// Hello Hello
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Guid&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Guid>>?> HelloOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -434,7 +434,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Guid&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Guid>>> HelloAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -951,7 +951,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="requiredStringUuid"></param>
-        /// <param name="body"></param>
         /// <returns></returns>
         private void ValidateFakeOuterStringSerialize(Guid requiredStringUuid)
         {
@@ -1112,7 +1111,7 @@ namespace Org.OpenAPITools.Api
         /// Array of Enums 
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;OuterEnum&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<OuterEnum>>?> GetArrayOfEnumsOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -1130,7 +1129,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;OuterEnum&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<OuterEnum>>> GetArrayOfEnumsAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -1586,16 +1585,6 @@ namespace Org.OpenAPITools.Api
         /// <param name="number"></param>
         /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
-        /// <param name="date"></param>
-        /// <param name="binary"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varString"></param>
-        /// <param name="password"></param>
-        /// <param name="callback"></param>
-        /// <param name="dateTime"></param>
         /// <returns></returns>
         private void ValidateTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter)
         {
@@ -2005,9 +1994,6 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredStringGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="booleanGroup"></param>
-        /// <param name="stringGroup"></param>
-        /// <param name="int64Group"></param>
         /// <returns></returns>
         private void ValidateTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
@@ -481,7 +481,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="apiKey"></param>
         /// <returns></returns>
         private void ValidateDeletePet(long petId)
         {
@@ -651,7 +650,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>?> FindPetsByStatusOrDefaultAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -670,7 +669,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -802,7 +801,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="tags">Tags to filter by</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>?> FindPetsByTagsOrDefaultAsync(List<string> tags, System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -821,7 +820,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="tags">Tags to filter by</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByTagsAsync(List<string> tags, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -1194,8 +1193,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="name"></param>
-        /// <param name="status"></param>
         /// <returns></returns>
         private void ValidateUpdatePetWithForm(long petId)
         {
@@ -1348,8 +1345,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="file"></param>
-        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
         private void ValidateUploadFile(long petId)
         {
@@ -1512,7 +1507,6 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="requiredFile"></param>
         /// <param name="petId"></param>
-        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
         private void ValidateUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -329,7 +329,7 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary&lt;string, int&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary{TKey, TValue}"/></returns>
         public async Task<ApiResponse<Dictionary<string, int>>?> GetInventoryOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -347,7 +347,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary&lt;string, int&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary{TKey, TValue}"/></returns>
         public async Task<ApiResponse<Dictionary<string, int>>> GetInventoryAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/ApiFactory.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/ApiFactory.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Client
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref=""/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Client
                 _nextAvailable = DateTime.UtcNow.AddSeconds(5);
         }
 
-        private void OnTimer(object sender, System.Timers.ElapsedEventArgs e)
+        private void OnTimer(object? sender, System.Timers.ElapsedEventArgs e)
         {
             if (TokenBecameAvailable != null && !IsRateLimited)
                 TokenBecameAvailable.Invoke(this);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Activity.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Activity
+    /// A Json converter for type <see cref="Activity" />
     /// </summary>
     public class ActivityJsonConverter : JsonConverter<Activity>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Activity" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Activity" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="activity"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ActivityOutputElementRepresentation
+    /// A Json converter for type <see cref="ActivityOutputElementRepresentation" />
     /// </summary>
     public class ActivityOutputElementRepresentationJsonConverter : JsonConverter<ActivityOutputElementRepresentation>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ActivityOutputElementRepresentation" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ActivityOutputElementRepresentation" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="activityOutputElementRepresentation"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -145,12 +145,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AdditionalPropertiesClass
+    /// A Json converter for type <see cref="AdditionalPropertiesClass" />
     /// </summary>
     public class AdditionalPropertiesClassJsonConverter : JsonConverter<AdditionalPropertiesClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AdditionalPropertiesClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -253,7 +253,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AdditionalPropertiesClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="additionalPropertiesClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Animal.cs
@@ -100,12 +100,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Animal
+    /// A Json converter for type <see cref="Animal" />
     /// </summary>
     public class AnimalJsonConverter : JsonConverter<Animal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Animal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Animal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="animal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -99,12 +99,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ApiResponse
+    /// A Json converter for type <see cref="ApiResponse" />
     /// </summary>
     public class ApiResponseJsonConverter : JsonConverter<ApiResponse>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ApiResponse" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ApiResponse" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apiResponse"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
@@ -104,12 +104,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Apple
+    /// A Json converter for type <see cref="Apple" />
     /// </summary>
     public class AppleJsonConverter : JsonConverter<Apple>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Apple" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Apple" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apple"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -83,12 +83,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AppleReq
+    /// A Json converter for type <see cref="AppleReq" />
     /// </summary>
     public class AppleReqJsonConverter : JsonConverter<AppleReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AppleReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AppleReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="appleReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayOfArrayOfNumberOnly
+    /// A Json converter for type <see cref="ArrayOfArrayOfNumberOnly" />
     /// </summary>
     public class ArrayOfArrayOfNumberOnlyJsonConverter : JsonConverter<ArrayOfArrayOfNumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayOfArrayOfNumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayOfArrayOfNumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayOfArrayOfNumberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayOfNumberOnly
+    /// A Json converter for type <see cref="ArrayOfNumberOnly" />
     /// </summary>
     public class ArrayOfNumberOnlyJsonConverter : JsonConverter<ArrayOfNumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayOfNumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayOfNumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayOfNumberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -99,12 +99,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayTest
+    /// A Json converter for type <see cref="ArrayTest" />
     /// </summary>
     public class ArrayTestJsonConverter : JsonConverter<ArrayTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Banana.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Banana
+    /// A Json converter for type <see cref="Banana" />
     /// </summary>
     public class BananaJsonConverter : JsonConverter<Banana>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Banana" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Banana" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="banana"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -83,12 +83,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type BananaReq
+    /// A Json converter for type <see cref="BananaReq" />
     /// </summary>
     public class BananaReqJsonConverter : JsonConverter<BananaReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="BananaReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="BananaReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="bananaReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type BasquePig
+    /// A Json converter for type <see cref="BasquePig" />
     /// </summary>
     public class BasquePigJsonConverter : JsonConverter<BasquePig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="BasquePig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="BasquePig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="basquePig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -127,12 +127,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Capitalization
+    /// A Json converter for type <see cref="Capitalization" />
     /// </summary>
     public class CapitalizationJsonConverter : JsonConverter<Capitalization>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Capitalization" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -216,7 +216,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Capitalization" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="capitalization"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Cat.cs
@@ -72,12 +72,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Cat
+    /// A Json converter for type <see cref="Cat" />
     /// </summary>
     public class CatJsonConverter : JsonConverter<Cat>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Cat" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Cat" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="cat"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type CatAllOf
+    /// A Json converter for type <see cref="CatAllOf" />
     /// </summary>
     public class CatAllOfJsonConverter : JsonConverter<CatAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="CatAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="CatAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="catAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Category.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Category
+    /// A Json converter for type <see cref="Category" />
     /// </summary>
     public class CategoryJsonConverter : JsonConverter<Category>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Category" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Category" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="category"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -64,12 +64,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildCat
+    /// A Json converter for type <see cref="ChildCat" />
     /// </summary>
     public class ChildCatJsonConverter : JsonConverter<ChildCat>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildCat" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -118,7 +118,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildCat" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childCat"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -57,10 +57,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a PetTypeEnum
+        /// Returns a <see cref="PetTypeEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static PetTypeEnum PetTypeEnumFromString(string value)
         {
             if (value == "ChildCat")
@@ -70,7 +71,20 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="PetTypeEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static PetTypeEnum? PetTypeEnumFromStringOrDefault(string value)
+        {
+            if (value == "ChildCat")
+                return PetTypeEnum.ChildCat;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="PetTypeEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -128,12 +142,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildCatAllOf
+    /// A Json converter for type <see cref="ChildCatAllOf" />
     /// </summary>
     public class ChildCatAllOfJsonConverter : JsonConverter<ChildCatAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildCatAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -171,8 +185,10 @@ namespace Org.OpenAPITools.Model
                             name = utf8JsonReader.GetString();
                             break;
                         case "pet_type":
-                            string petTypeRawValue = utf8JsonReader.GetString();
-                            petType = ChildCatAllOf.PetTypeEnumFromString(petTypeRawValue);
+                            string? petTypeRawValue = utf8JsonReader.GetString();
+                            petType = petTypeRawValue == null
+                                ? null
+                                : ChildCatAllOf.PetTypeEnumFromStringOrDefault(petTypeRawValue);
                             break;
                         default:
                             break;
@@ -190,7 +206,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildCatAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childCatAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ClassModel
+    /// A Json converter for type <see cref="ClassModel" />
     /// </summary>
     public class ClassModelJsonConverter : JsonConverter<ClassModel>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ClassModel" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ClassModel" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="classModel"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ComplexQuadrilateral
+    /// A Json converter for type <see cref="ComplexQuadrilateral" />
     /// </summary>
     public class ComplexQuadrilateralJsonConverter : JsonConverter<ComplexQuadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ComplexQuadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ComplexQuadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="complexQuadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DanishPig
+    /// A Json converter for type <see cref="DanishPig" />
     /// </summary>
     public class DanishPigJsonConverter : JsonConverter<DanishPig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DanishPig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DanishPig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="danishPig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DateOnlyClass
+    /// A Json converter for type <see cref="DateOnlyClass" />
     /// </summary>
     public class DateOnlyClassJsonConverter : JsonConverter<DateOnlyClass>
     {
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         public static string DateOnlyPropertyFormat { get; set; } = "yyyy'-'MM'-'dd";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DateOnlyClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DateOnlyClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dateOnlyClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DeprecatedObject
+    /// A Json converter for type <see cref="DeprecatedObject" />
     /// </summary>
     public class DeprecatedObjectJsonConverter : JsonConverter<DeprecatedObject>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DeprecatedObject" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DeprecatedObject" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="deprecatedObject"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Dog.cs
@@ -65,12 +65,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Dog
+    /// A Json converter for type <see cref="Dog" />
     /// </summary>
     public class DogJsonConverter : JsonConverter<Dog>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Dog" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Dog" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dog"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DogAllOf
+    /// A Json converter for type <see cref="DogAllOf" />
     /// </summary>
     public class DogAllOfJsonConverter : JsonConverter<DogAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DogAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DogAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dogAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Drawing.cs
@@ -102,12 +102,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Drawing
+    /// A Json converter for type <see cref="Drawing" />
     /// </summary>
     public class DrawingJsonConverter : JsonConverter<Drawing>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Drawing" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Drawing" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="drawing"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -62,10 +62,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a ArrayEnumEnum
+        /// Returns a <see cref="ArrayEnumEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static ArrayEnumEnum ArrayEnumEnumFromString(string value)
         {
             if (value == "fish")
@@ -78,7 +79,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="ArrayEnumEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ArrayEnumEnum? ArrayEnumEnumFromStringOrDefault(string value)
+        {
+            if (value == "fish")
+                return ArrayEnumEnum.Fish;
+
+            if (value == "crab")
+                return ArrayEnumEnum.Crab;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ArrayEnumEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -111,10 +128,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a JustSymbolEnum
+        /// Returns a <see cref="JustSymbolEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static JustSymbolEnum JustSymbolEnumFromString(string value)
         {
             if (value == ">=")
@@ -127,7 +145,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="JustSymbolEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static JustSymbolEnum? JustSymbolEnumFromStringOrDefault(string value)
+        {
+            if (value == ">=")
+                return JustSymbolEnum.GreaterThanOrEqualTo;
+
+            if (value == "$")
+                return JustSymbolEnum.Dollar;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="JustSymbolEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -188,12 +222,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EnumArrays
+    /// A Json converter for type <see cref="EnumArrays" />
     /// </summary>
     public class EnumArraysJsonConverter : JsonConverter<EnumArrays>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EnumArrays" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -232,8 +266,10 @@ namespace Org.OpenAPITools.Model
                                 arrayEnum = JsonSerializer.Deserialize<List<EnumArrays.ArrayEnumEnum>>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
                         case "just_symbol":
-                            string justSymbolRawValue = utf8JsonReader.GetString();
-                            justSymbol = EnumArrays.JustSymbolEnumFromString(justSymbolRawValue);
+                            string? justSymbolRawValue = utf8JsonReader.GetString();
+                            justSymbol = justSymbolRawValue == null
+                                ? null
+                                : EnumArrays.JustSymbolEnumFromStringOrDefault(justSymbolRawValue);
                             break;
                         default:
                             break;
@@ -251,7 +287,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EnumArrays" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="enumArrays"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumClass.cs
@@ -46,8 +46,17 @@ namespace Org.OpenAPITools.Model
         Xyz = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="EnumClass"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class EnumClassConverter : JsonConverter<EnumClass>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="EnumClass"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static EnumClass FromString(string value)
         {
             if (value == "_abc")
@@ -62,6 +71,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type EnumClass: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="EnumClass"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static EnumClass? FromStringOrDefault(string value)
         {
             if (value == "_abc")
@@ -76,6 +90,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="EnumClass"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(EnumClass value)
         {
             if (value == EnumClass.Abc)
@@ -101,8 +121,10 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            EnumClass? result = EnumClassConverter.FromString(rawValue);
-            
+            EnumClass? result = rawValue == null
+                ? null
+                : EnumClassConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -121,6 +143,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="EnumClass"/>
+    /// </summary>
     public class EnumClassNullableConverter : JsonConverter<EnumClass?>
     {
         /// <summary>
@@ -134,10 +159,9 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            EnumClass? result = EnumClassConverter.FromString(rawValue);
+            EnumClass? result = rawValue == null
+                ? null
+                : EnumClassConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -76,10 +76,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumIntegerEnum
+        /// Returns a <see cref="EnumIntegerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumIntegerEnum EnumIntegerEnumFromString(string value)
         {
             if (value == (1).ToString())
@@ -92,11 +93,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumIntegerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        public static EnumIntegerEnum? EnumIntegerEnumFromStringOrDefault(string value)
+        {
+            if (value == (1).ToString())
+                return EnumIntegerEnum.NUMBER_1;
+
+            if (value == (-1).ToString())
+                return EnumIntegerEnum.NUMBER_MINUS_1;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumIntegerEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int EnumIntegerEnumToJsonValue(EnumIntegerEnum value)
         {
             return (int) value;
@@ -125,10 +141,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumIntegerOnlyEnum
+        /// Returns a <see cref="EnumIntegerOnlyEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumIntegerOnlyEnum EnumIntegerOnlyEnumFromString(string value)
         {
             if (value == (2).ToString())
@@ -141,11 +158,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumIntegerOnlyEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        public static EnumIntegerOnlyEnum? EnumIntegerOnlyEnumFromStringOrDefault(string value)
+        {
+            if (value == (2).ToString())
+                return EnumIntegerOnlyEnum.NUMBER_2;
+
+            if (value == (-2).ToString())
+                return EnumIntegerOnlyEnum.NUMBER_MINUS_2;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumIntegerOnlyEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int EnumIntegerOnlyEnumToJsonValue(EnumIntegerOnlyEnum value)
         {
             return (int) value;
@@ -174,10 +206,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumNumberEnum
+        /// Returns a <see cref="EnumNumberEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumNumberEnum EnumNumberEnumFromString(string value)
         {
             if (value == "1.1")
@@ -190,7 +223,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumNumberEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumNumberEnum? EnumNumberEnumFromStringOrDefault(string value)
+        {
+            if (value == "1.1")
+                return EnumNumberEnum.NUMBER_1_DOT_1;
+
+            if (value == "-1.2")
+                return EnumNumberEnum.NUMBER_MINUS_1_DOT_2;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumNumberEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -234,10 +283,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumStringEnum
+        /// Returns a <see cref="EnumStringEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumStringEnum EnumStringEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -253,7 +303,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumStringEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumStringEnum? EnumStringEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return EnumStringEnum.UPPER;
+
+            if (value == "lower")
+                return EnumStringEnum.Lower;
+
+            if (value == "")
+                return EnumStringEnum.Empty;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumStringEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -300,10 +369,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumStringRequiredEnum
+        /// Returns a <see cref="EnumStringRequiredEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumStringRequiredEnum EnumStringRequiredEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -319,7 +389,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumStringRequiredEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumStringRequiredEnum? EnumStringRequiredEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return EnumStringRequiredEnum.UPPER;
+
+            if (value == "lower")
+                return EnumStringRequiredEnum.Lower;
+
+            if (value == "")
+                return EnumStringRequiredEnum.Empty;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumStringRequiredEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -408,12 +497,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EnumTest
+    /// A Json converter for type <see cref="EnumTest" />
     /// </summary>
     public class EnumTestJsonConverter : JsonConverter<EnumTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EnumTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -467,28 +556,40 @@ namespace Org.OpenAPITools.Model
                                 enumNumber = (EnumTest.EnumNumberEnum)utf8JsonReader.GetInt32();
                             break;
                         case "enum_string":
-                            string enumStringRawValue = utf8JsonReader.GetString();
-                            enumString = EnumTest.EnumStringEnumFromString(enumStringRawValue);
+                            string? enumStringRawValue = utf8JsonReader.GetString();
+                            enumString = enumStringRawValue == null
+                                ? null
+                                : EnumTest.EnumStringEnumFromStringOrDefault(enumStringRawValue);
                             break;
                         case "enum_string_required":
-                            string enumStringRequiredRawValue = utf8JsonReader.GetString();
-                            enumStringRequired = EnumTest.EnumStringRequiredEnumFromString(enumStringRequiredRawValue);
+                            string? enumStringRequiredRawValue = utf8JsonReader.GetString();
+                            enumStringRequired = enumStringRequiredRawValue == null
+                                ? null
+                                : EnumTest.EnumStringRequiredEnumFromStringOrDefault(enumStringRequiredRawValue);
                             break;
                         case "outerEnumDefaultValue":
-                            string outerEnumDefaultValueRawValue = utf8JsonReader.GetString();
-                            outerEnumDefaultValue = OuterEnumDefaultValueConverter.FromString(outerEnumDefaultValueRawValue);
+                            string? outerEnumDefaultValueRawValue = utf8JsonReader.GetString();
+                            outerEnumDefaultValue = outerEnumDefaultValueRawValue == null
+                                ? null
+                                : OuterEnumDefaultValueConverter.FromStringOrDefault(outerEnumDefaultValueRawValue);
                             break;
                         case "outerEnumInteger":
-                            string outerEnumIntegerRawValue = utf8JsonReader.GetString();
-                            outerEnumInteger = OuterEnumIntegerConverter.FromString(outerEnumIntegerRawValue);
+                            string? outerEnumIntegerRawValue = utf8JsonReader.GetString();
+                            outerEnumInteger = outerEnumIntegerRawValue == null
+                                ? null
+                                : OuterEnumIntegerConverter.FromStringOrDefault(outerEnumIntegerRawValue);
                             break;
                         case "outerEnumIntegerDefaultValue":
-                            string outerEnumIntegerDefaultValueRawValue = utf8JsonReader.GetString();
-                            outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValueConverter.FromString(outerEnumIntegerDefaultValueRawValue);
+                            string? outerEnumIntegerDefaultValueRawValue = utf8JsonReader.GetString();
+                            outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValueRawValue == null
+                                ? null
+                                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(outerEnumIntegerDefaultValueRawValue);
                             break;
                         case "outerEnum":
-                            string outerEnumRawValue = utf8JsonReader.GetString();
-                            outerEnum = OuterEnumConverter.FromStringOrDefault(outerEnumRawValue);
+                            string? outerEnumRawValue = utf8JsonReader.GetString();
+                            outerEnum = outerEnumRawValue == null
+                                ? null
+                                : OuterEnumConverter.FromStringOrDefault(outerEnumRawValue);
                             break;
                         default:
                             break;
@@ -524,7 +625,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EnumTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="enumTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EquilateralTriangle
+    /// A Json converter for type <see cref="EquilateralTriangle" />
     /// </summary>
     public class EquilateralTriangleJsonConverter : JsonConverter<EquilateralTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EquilateralTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EquilateralTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="equilateralTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/File.cs
@@ -82,12 +82,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type File
+    /// A Json converter for type <see cref="File" />
     /// </summary>
     public class FileJsonConverter : JsonConverter<File>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="File" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="File" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="file"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FileSchemaTestClass
+    /// A Json converter for type <see cref="FileSchemaTestClass" />
     /// </summary>
     public class FileSchemaTestClassJsonConverter : JsonConverter<FileSchemaTestClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FileSchemaTestClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FileSchemaTestClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fileSchemaTestClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Foo.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Foo
+    /// A Json converter for type <see cref="Foo" />
     /// </summary>
     public class FooJsonConverter : JsonConverter<Foo>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Foo" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Foo" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="foo"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FooGetDefaultResponse
+    /// A Json converter for type <see cref="FooGetDefaultResponse" />
     /// </summary>
     public class FooGetDefaultResponseJsonConverter : JsonConverter<FooGetDefaultResponse>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FooGetDefaultResponse" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FooGetDefaultResponse" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fooGetDefaultResponse"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -361,7 +361,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FormatTest
+    /// A Json converter for type <see cref="FormatTest" />
     /// </summary>
     public class FormatTestJsonConverter : JsonConverter<FormatTest>
     {
@@ -376,7 +376,7 @@ namespace Org.OpenAPITools.Model
         public static string DateTimeFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FormatTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -565,7 +565,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FormatTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="formatTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Fruit.cs
@@ -99,12 +99,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Fruit
+    /// A Json converter for type <see cref="Fruit" />
     /// </summary>
     public class FruitJsonConverter : JsonConverter<Fruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Fruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Fruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FruitReq
+    /// A Json converter for type <see cref="FruitReq" />
     /// </summary>
     public class FruitReqJsonConverter : JsonConverter<FruitReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FruitReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -142,7 +142,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FruitReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruitReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type GmFruit
+    /// A Json converter for type <see cref="GmFruit" />
     /// </summary>
     public class GmFruitJsonConverter : JsonConverter<GmFruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="GmFruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -148,7 +148,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="GmFruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="gmFruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -91,12 +91,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type GrandparentAnimal
+    /// A Json converter for type <see cref="GrandparentAnimal" />
     /// </summary>
     public class GrandparentAnimalJsonConverter : JsonConverter<GrandparentAnimal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="GrandparentAnimal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="GrandparentAnimal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="grandparentAnimal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -127,12 +127,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type HasOnlyReadOnly
+    /// A Json converter for type <see cref="HasOnlyReadOnly" />
     /// </summary>
     public class HasOnlyReadOnlyJsonConverter : JsonConverter<HasOnlyReadOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="HasOnlyReadOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -188,7 +188,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="HasOnlyReadOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="hasOnlyReadOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type HealthCheckResult
+    /// A Json converter for type <see cref="HealthCheckResult" />
     /// </summary>
     public class HealthCheckResultJsonConverter : JsonConverter<HealthCheckResult>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="HealthCheckResult" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="HealthCheckResult" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="healthCheckResult"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type IsoscelesTriangle
+    /// A Json converter for type <see cref="IsoscelesTriangle" />
     /// </summary>
     public class IsoscelesTriangleJsonConverter : JsonConverter<IsoscelesTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="IsoscelesTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="IsoscelesTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="isoscelesTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/List.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type List
+    /// A Json converter for type <see cref="List" />
     /// </summary>
     public class ListJsonConverter : JsonConverter<List>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="List" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="List" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="list"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type LiteralStringClass
+    /// A Json converter for type <see cref="LiteralStringClass" />
     /// </summary>
     public class LiteralStringClassJsonConverter : JsonConverter<LiteralStringClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="LiteralStringClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="LiteralStringClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="literalStringClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Mammal.cs
@@ -121,12 +121,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Mammal
+    /// A Json converter for type <see cref="Mammal" />
     /// </summary>
     public class MammalJsonConverter : JsonConverter<Mammal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Mammal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Mammal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mammal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MapTest.cs
@@ -66,10 +66,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a InnerEnum
+        /// Returns a <see cref="InnerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static InnerEnum InnerEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -82,7 +83,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="InnerEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static InnerEnum? InnerEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return InnerEnum.UPPER;
+
+            if (value == "lower")
+                return InnerEnum.Lower;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="InnerEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -157,12 +174,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type MapTest
+    /// A Json converter for type <see cref="MapTest" />
     /// </summary>
     public class MapTestJsonConverter : JsonConverter<MapTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="MapTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -236,7 +253,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="MapTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mapTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -115,7 +115,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type MixedPropertiesAndAdditionalPropertiesClass
+    /// A Json converter for type <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
     /// </summary>
     public class MixedPropertiesAndAdditionalPropertiesClassJsonConverter : JsonConverter<MixedPropertiesAndAdditionalPropertiesClass>
     {
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
         public static string DateTimeFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -199,7 +199,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mixedPropertiesAndAdditionalPropertiesClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Model200Response
+    /// A Json converter for type <see cref="Model200Response" />
     /// </summary>
     public class Model200ResponseJsonConverter : JsonConverter<Model200Response>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Model200Response" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Model200Response" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="model200Response"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ModelClient
+    /// A Json converter for type <see cref="ModelClient" />
     /// </summary>
     public class ModelClientJsonConverter : JsonConverter<ModelClient>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ModelClient" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ModelClient" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="modelClient"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Name.cs
@@ -145,12 +145,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Name
+    /// A Json converter for type <see cref="Name" />
     /// </summary>
     public class NameJsonConverter : JsonConverter<Name>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Name" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -223,7 +223,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Name" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="name"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -174,7 +174,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableClass
+    /// A Json converter for type <see cref="NullableClass" />
     /// </summary>
     public class NullableClassJsonConverter : JsonConverter<NullableClass>
     {
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
         public static string DatetimePropFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -296,7 +296,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -82,12 +82,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableGuidClass
+    /// A Json converter for type <see cref="NullableGuidClass" />
     /// </summary>
     public class NullableGuidClassJsonConverter : JsonConverter<NullableGuidClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableGuidClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableGuidClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableGuidClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -105,12 +105,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableShape
+    /// A Json converter for type <see cref="NullableShape" />
     /// </summary>
     public class NullableShapeJsonConverter : JsonConverter<NullableShape>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableShape" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableShape" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableShape"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NumberOnly
+    /// A Json converter for type <see cref="NumberOnly" />
     /// </summary>
     public class NumberOnlyJsonConverter : JsonConverter<NumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="numberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -111,12 +111,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ObjectWithDeprecatedFields
+    /// A Json converter for type <see cref="ObjectWithDeprecatedFields" />
     /// </summary>
     public class ObjectWithDeprecatedFieldsJsonConverter : JsonConverter<ObjectWithDeprecatedFields>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ObjectWithDeprecatedFields" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ObjectWithDeprecatedFields" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="objectWithDeprecatedFields"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type OneOfString
+    /// A Json converter for type <see cref="OneOfString" />
     /// </summary>
     public class OneOfStringJsonConverter : JsonConverter<OneOfString>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="OneOfString" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="OneOfString" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="oneOfString"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Order.cs
@@ -76,10 +76,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a StatusEnum
+        /// Returns a <see cref="StatusEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static StatusEnum StatusEnumFromString(string value)
         {
             if (value == "placed")
@@ -95,7 +96,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="StatusEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static StatusEnum? StatusEnumFromStringOrDefault(string value)
+        {
+            if (value == "placed")
+                return StatusEnum.Placed;
+
+            if (value == "approved")
+                return StatusEnum.Approved;
+
+            if (value == "delivered")
+                return StatusEnum.Delivered;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StatusEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -189,7 +209,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Order
+    /// A Json converter for type <see cref="Order" />
     /// </summary>
     public class OrderJsonConverter : JsonConverter<Order>
     {
@@ -199,7 +219,7 @@ namespace Org.OpenAPITools.Model
         public static string ShipDateFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Order" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -254,8 +274,10 @@ namespace Org.OpenAPITools.Model
                                 shipDate = JsonSerializer.Deserialize<DateTime>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
                         case "status":
-                            string statusRawValue = utf8JsonReader.GetString();
-                            status = Order.StatusEnumFromString(statusRawValue);
+                            string? statusRawValue = utf8JsonReader.GetString();
+                            status = statusRawValue == null
+                                ? null
+                                : Order.StatusEnumFromStringOrDefault(statusRawValue);
                             break;
                         case "complete":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -289,7 +311,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Order" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="order"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -99,12 +99,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type OuterComposite
+    /// A Json converter for type <see cref="OuterComposite" />
     /// </summary>
     public class OuterCompositeJsonConverter : JsonConverter<OuterComposite>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="OuterComposite" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="OuterComposite" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="outerComposite"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnum.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnum.cs
@@ -46,8 +46,17 @@ namespace Org.OpenAPITools.Model
         Delivered = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnum"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumConverter : JsonConverter<OuterEnum>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnum FromString(string value)
         {
             if (value == "placed")
@@ -62,6 +71,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnum: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnum? FromStringOrDefault(string value)
         {
             if (value == "placed")
@@ -76,6 +90,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(OuterEnum value)
         {
             if (value == OuterEnum.Placed)
@@ -101,8 +121,10 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            OuterEnum? result = OuterEnumConverter.FromString(rawValue);
-            
+            OuterEnum? result = rawValue == null
+                ? null
+                : OuterEnumConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -121,6 +143,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnum"/>
+    /// </summary>
     public class OuterEnumNullableConverter : JsonConverter<OuterEnum?>
     {
         /// <summary>
@@ -134,10 +159,9 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnum? result = OuterEnumConverter.FromString(rawValue);
+            OuterEnum? result = rawValue == null
+                ? null
+                : OuterEnumConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnumDefaultValue.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnumDefaultValue.cs
@@ -46,8 +46,17 @@ namespace Org.OpenAPITools.Model
         Delivered = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumDefaultValue"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumDefaultValueConverter : JsonConverter<OuterEnumDefaultValue>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumDefaultValue FromString(string value)
         {
             if (value == "placed")
@@ -62,6 +71,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumDefaultValue: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumDefaultValue? FromStringOrDefault(string value)
         {
             if (value == "placed")
@@ -76,6 +90,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumDefaultValue"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(OuterEnumDefaultValue value)
         {
             if (value == OuterEnumDefaultValue.Placed)
@@ -101,8 +121,10 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            OuterEnumDefaultValue? result = OuterEnumDefaultValueConverter.FromString(rawValue);
-            
+            OuterEnumDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumDefaultValueConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -121,6 +143,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumDefaultValue"/>
+    /// </summary>
     public class OuterEnumDefaultValueNullableConverter : JsonConverter<OuterEnumDefaultValue?>
     {
         /// <summary>
@@ -134,10 +159,9 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumDefaultValue? result = OuterEnumDefaultValueConverter.FromString(rawValue);
+            OuterEnumDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumDefaultValueConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnumInteger.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnumInteger.cs
@@ -46,8 +46,17 @@ namespace Org.OpenAPITools.Model
         NUMBER_2 = 2
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumInteger"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumIntegerConverter : JsonConverter<OuterEnumInteger>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumInteger"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumInteger FromString(string value)
         {
             if (value == (0).ToString())
@@ -62,6 +71,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumInteger: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumInteger"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumInteger? FromStringOrDefault(string value)
         {
             if (value == (0).ToString())
@@ -76,6 +90,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumInteger"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static int ToJsonValue(OuterEnumInteger value)
         {
             return (int) value;
@@ -92,8 +112,10 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            OuterEnumInteger? result = OuterEnumIntegerConverter.FromString(rawValue);
-            
+            OuterEnumInteger? result = rawValue == null
+                ? null
+                : OuterEnumIntegerConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -112,6 +134,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumInteger"/>
+    /// </summary>
     public class OuterEnumIntegerNullableConverter : JsonConverter<OuterEnumInteger?>
     {
         /// <summary>
@@ -125,10 +150,9 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumInteger? result = OuterEnumIntegerConverter.FromString(rawValue);
+            OuterEnumInteger? result = rawValue == null
+                ? null
+                : OuterEnumIntegerConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnumIntegerDefaultValue.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OuterEnumIntegerDefaultValue.cs
@@ -46,8 +46,17 @@ namespace Org.OpenAPITools.Model
         NUMBER_2 = 2
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumIntegerDefaultValue"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumIntegerDefaultValueConverter : JsonConverter<OuterEnumIntegerDefaultValue>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumIntegerDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumIntegerDefaultValue FromString(string value)
         {
             if (value == (0).ToString())
@@ -62,6 +71,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumIntegerDefaultValue: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumIntegerDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumIntegerDefaultValue? FromStringOrDefault(string value)
         {
             if (value == (0).ToString())
@@ -76,6 +90,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumIntegerDefaultValue"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static int ToJsonValue(OuterEnumIntegerDefaultValue value)
         {
             return (int) value;
@@ -92,8 +112,10 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            OuterEnumIntegerDefaultValue? result = OuterEnumIntegerDefaultValueConverter.FromString(rawValue);
-            
+            OuterEnumIntegerDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -112,6 +134,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumIntegerDefaultValue"/>
+    /// </summary>
     public class OuterEnumIntegerDefaultValueNullableConverter : JsonConverter<OuterEnumIntegerDefaultValue?>
     {
         /// <summary>
@@ -125,10 +150,9 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumIntegerDefaultValue? result = OuterEnumIntegerDefaultValueConverter.FromString(rawValue);
+            OuterEnumIntegerDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -57,12 +57,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ParentPet
+    /// A Json converter for type <see cref="ParentPet" />
     /// </summary>
     public class ParentPetJsonConverter : JsonConverter<ParentPet>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ParentPet" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -108,7 +108,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ParentPet" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="parentPet"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pet.cs
@@ -76,10 +76,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a StatusEnum
+        /// Returns a <see cref="StatusEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static StatusEnum StatusEnumFromString(string value)
         {
             if (value == "available")
@@ -95,7 +96,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="StatusEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static StatusEnum? StatusEnumFromStringOrDefault(string value)
+        {
+            if (value == "available")
+                return StatusEnum.Available;
+
+            if (value == "pending")
+                return StatusEnum.Pending;
+
+            if (value == "sold")
+                return StatusEnum.Sold;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StatusEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -189,12 +209,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Pet
+    /// A Json converter for type <see cref="Pet" />
     /// </summary>
     public class PetJsonConverter : JsonConverter<Pet>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Pet" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -248,8 +268,10 @@ namespace Org.OpenAPITools.Model
                                 photoUrls = JsonSerializer.Deserialize<List<string>>(ref utf8JsonReader, jsonSerializerOptions);
                             break;
                         case "status":
-                            string statusRawValue = utf8JsonReader.GetString();
-                            status = Pet.StatusEnumFromString(statusRawValue);
+                            string? statusRawValue = utf8JsonReader.GetString();
+                            status = statusRawValue == null
+                                ? null
+                                : Pet.StatusEnumFromStringOrDefault(statusRawValue);
                             break;
                         case "tags":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -283,7 +305,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Pet" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="pet"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pig.cs
@@ -105,12 +105,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Pig
+    /// A Json converter for type <see cref="Pig" />
     /// </summary>
     public class PigJsonConverter : JsonConverter<Pig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Pig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Pig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="pig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -127,12 +127,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type PolymorphicProperty
+    /// A Json converter for type <see cref="PolymorphicProperty" />
     /// </summary>
     public class PolymorphicPropertyJsonConverter : JsonConverter<PolymorphicProperty>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="PolymorphicProperty" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="PolymorphicProperty" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="polymorphicProperty"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -105,12 +105,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Quadrilateral
+    /// A Json converter for type <see cref="Quadrilateral" />
     /// </summary>
     public class QuadrilateralJsonConverter : JsonConverter<Quadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Quadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Quadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="quadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type QuadrilateralInterface
+    /// A Json converter for type <see cref="QuadrilateralInterface" />
     /// </summary>
     public class QuadrilateralInterfaceJsonConverter : JsonConverter<QuadrilateralInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="QuadrilateralInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="QuadrilateralInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="quadrilateralInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -126,12 +126,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ReadOnlyFirst
+    /// A Json converter for type <see cref="ReadOnlyFirst" />
     /// </summary>
     public class ReadOnlyFirstJsonConverter : JsonConverter<ReadOnlyFirst>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ReadOnlyFirst" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ReadOnlyFirst" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="readOnlyFirst"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Return.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Return
+    /// A Json converter for type <see cref="Return" />
     /// </summary>
     public class ReturnJsonConverter : JsonConverter<Return>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Return" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Return" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="varReturn"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ScaleneTriangle
+    /// A Json converter for type <see cref="ScaleneTriangle" />
     /// </summary>
     public class ScaleneTriangleJsonConverter : JsonConverter<ScaleneTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ScaleneTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ScaleneTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="scaleneTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Shape.cs
@@ -116,12 +116,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Shape
+    /// A Json converter for type <see cref="Shape" />
     /// </summary>
     public class ShapeJsonConverter : JsonConverter<Shape>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Shape" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Shape" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shape"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ShapeInterface
+    /// A Json converter for type <see cref="ShapeInterface" />
     /// </summary>
     public class ShapeInterfaceJsonConverter : JsonConverter<ShapeInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ShapeInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ShapeInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shapeInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -116,12 +116,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ShapeOrNull
+    /// A Json converter for type <see cref="ShapeOrNull" />
     /// </summary>
     public class ShapeOrNullJsonConverter : JsonConverter<ShapeOrNull>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ShapeOrNull" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ShapeOrNull" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shapeOrNull"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type SimpleQuadrilateral
+    /// A Json converter for type <see cref="SimpleQuadrilateral" />
     /// </summary>
     public class SimpleQuadrilateralJsonConverter : JsonConverter<SimpleQuadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="SimpleQuadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -138,7 +138,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="SimpleQuadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="simpleQuadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type SpecialModelName
+    /// A Json converter for type <see cref="SpecialModelName" />
     /// </summary>
     public class SpecialModelNameJsonConverter : JsonConverter<SpecialModelName>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="SpecialModelName" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="SpecialModelName" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="specialModelName"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Tag.cs
@@ -90,12 +90,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Tag
+    /// A Json converter for type <see cref="Tag" />
     /// </summary>
     public class TagJsonConverter : JsonConverter<Tag>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Tag" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Tag" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="tag"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TestCollectionEndingWithWordList
+    /// A Json converter for type <see cref="TestCollectionEndingWithWordList" />
     /// </summary>
     public class TestCollectionEndingWithWordListJsonConverter : JsonConverter<TestCollectionEndingWithWordList>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TestCollectionEndingWithWordList" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TestCollectionEndingWithWordList" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="testCollectionEndingWithWordList"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TestCollectionEndingWithWordListObject
+    /// A Json converter for type <see cref="TestCollectionEndingWithWordListObject" />
     /// </summary>
     public class TestCollectionEndingWithWordListObjectJsonConverter : JsonConverter<TestCollectionEndingWithWordListObject>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TestCollectionEndingWithWordListObject" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TestCollectionEndingWithWordListObject" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="testCollectionEndingWithWordListObject"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Triangle.cs
@@ -147,12 +147,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Triangle
+    /// A Json converter for type <see cref="Triangle" />
     /// </summary>
     public class TriangleJsonConverter : JsonConverter<Triangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Triangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Triangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="triangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TriangleInterface
+    /// A Json converter for type <see cref="TriangleInterface" />
     /// </summary>
     public class TriangleInterfaceJsonConverter : JsonConverter<TriangleInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TriangleInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TriangleInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="triangleInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/User.cs
@@ -185,12 +185,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type User
+    /// A Json converter for type <see cref="User" />
     /// </summary>
     public class UserJsonConverter : JsonConverter<User>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="User" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="User" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="user"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Whale.cs
@@ -99,12 +99,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Whale
+    /// A Json converter for type <see cref="Whale" />
     /// </summary>
     public class WhaleJsonConverter : JsonConverter<Whale>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Whale" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Whale" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="whale"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Zebra.cs
@@ -67,10 +67,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a TypeEnum
+        /// Returns a <see cref="TypeEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static TypeEnum TypeEnumFromString(string value)
         {
             if (value == "plains")
@@ -86,7 +87,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="TypeEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static TypeEnum? TypeEnumFromStringOrDefault(string value)
+        {
+            if (value == "plains")
+                return TypeEnum.Plains;
+
+            if (value == "mountain")
+                return TypeEnum.Mountain;
+
+            if (value == "grevys")
+                return TypeEnum.Grevys;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="TypeEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -151,12 +171,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Zebra
+    /// A Json converter for type <see cref="Zebra" />
     /// </summary>
     public class ZebraJsonConverter : JsonConverter<Zebra>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Zebra" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -194,8 +214,10 @@ namespace Org.OpenAPITools.Model
                             className = utf8JsonReader.GetString();
                             break;
                         case "type":
-                            string typeRawValue = utf8JsonReader.GetString();
-                            type = Zebra.TypeEnumFromString(typeRawValue);
+                            string? typeRawValue = utf8JsonReader.GetString();
+                            type = typeRawValue == null
+                                ? null
+                                : Zebra.TypeEnumFromStringOrDefault(typeRawValue);
                             break;
                         default:
                             break;
@@ -213,7 +235,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Zebra" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="zebra"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ZeroBasedEnum.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ZeroBasedEnum.cs
@@ -41,8 +41,17 @@ namespace Org.OpenAPITools.Model
         NotUnknown
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="ZeroBasedEnum"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class ZeroBasedEnumConverter : JsonConverter<ZeroBasedEnum>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="ZeroBasedEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static ZeroBasedEnum FromString(string value)
         {
             if (value == "unknown")
@@ -54,6 +63,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type ZeroBasedEnum: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="ZeroBasedEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static ZeroBasedEnum? FromStringOrDefault(string value)
         {
             if (value == "unknown")
@@ -65,6 +79,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="ZeroBasedEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(ZeroBasedEnum value)
         {
             if (value == ZeroBasedEnum.Unknown)
@@ -87,8 +107,10 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            ZeroBasedEnum? result = ZeroBasedEnumConverter.FromString(rawValue);
-            
+            ZeroBasedEnum? result = rawValue == null
+                ? null
+                : ZeroBasedEnumConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -107,6 +129,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="ZeroBasedEnum"/>
+    /// </summary>
     public class ZeroBasedEnumNullableConverter : JsonConverter<ZeroBasedEnum?>
     {
         /// <summary>
@@ -120,10 +145,9 @@ namespace Org.OpenAPITools.Model
         {
             string? rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            ZeroBasedEnum? result = ZeroBasedEnumConverter.FromString(rawValue);
+            ZeroBasedEnum? result = rawValue == null
+                ? null
+                : ZeroBasedEnumConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -60,10 +60,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a ZeroBasedEnumEnum
+        /// Returns a <see cref="ZeroBasedEnumEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static ZeroBasedEnumEnum ZeroBasedEnumEnumFromString(string value)
         {
             if (value == "unknown")
@@ -76,7 +77,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="ZeroBasedEnumEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ZeroBasedEnumEnum? ZeroBasedEnumEnumFromStringOrDefault(string value)
+        {
+            if (value == "unknown")
+                return ZeroBasedEnumEnum.Unknown;
+
+            if (value == "notUnknown")
+                return ZeroBasedEnumEnum.NotUnknown;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ZeroBasedEnumEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -130,12 +147,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ZeroBasedEnumClass
+    /// A Json converter for type <see cref="ZeroBasedEnumClass" />
     /// </summary>
     public class ZeroBasedEnumClassJsonConverter : JsonConverter<ZeroBasedEnumClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ZeroBasedEnumClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -169,8 +186,10 @@ namespace Org.OpenAPITools.Model
                     switch (propertyName)
                     {
                         case "ZeroBasedEnum":
-                            string zeroBasedEnumRawValue = utf8JsonReader.GetString();
-                            zeroBasedEnum = ZeroBasedEnumClass.ZeroBasedEnumEnumFromString(zeroBasedEnumRawValue);
+                            string? zeroBasedEnumRawValue = utf8JsonReader.GetString();
+                            zeroBasedEnum = zeroBasedEnumRawValue == null
+                                ? null
+                                : ZeroBasedEnumClass.ZeroBasedEnumEnumFromStringOrDefault(zeroBasedEnumRawValue);
                             break;
                         default:
                             break;
@@ -185,7 +204,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ZeroBasedEnumClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="zeroBasedEnumClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -414,7 +414,7 @@ namespace Org.OpenAPITools.Api
         /// Hello Hello
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Guid&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Guid>>> HelloOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -432,7 +432,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Guid&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Guid>>> HelloAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -949,7 +949,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="requiredStringUuid"></param>
-        /// <param name="body"></param>
         /// <returns></returns>
         private void ValidateFakeOuterStringSerialize(Guid requiredStringUuid)
         {
@@ -1110,7 +1109,7 @@ namespace Org.OpenAPITools.Api
         /// Array of Enums 
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;OuterEnum&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<OuterEnum>>> GetArrayOfEnumsOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -1128,7 +1127,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;OuterEnum&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<OuterEnum>>> GetArrayOfEnumsAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -1584,16 +1583,6 @@ namespace Org.OpenAPITools.Api
         /// <param name="number"></param>
         /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
-        /// <param name="date"></param>
-        /// <param name="binary"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varString"></param>
-        /// <param name="password"></param>
-        /// <param name="callback"></param>
-        /// <param name="dateTime"></param>
         /// <returns></returns>
         private void ValidateTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter)
         {
@@ -2003,9 +1992,6 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredStringGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="booleanGroup"></param>
-        /// <param name="stringGroup"></param>
-        /// <param name="int64Group"></param>
         /// <returns></returns>
         private void ValidateTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -479,7 +479,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="apiKey"></param>
         /// <returns></returns>
         private void ValidateDeletePet(long petId)
         {
@@ -649,7 +648,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByStatusOrDefaultAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -668,7 +667,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -800,7 +799,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="tags">Tags to filter by</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByTagsOrDefaultAsync(List<string> tags, System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -819,7 +818,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="tags">Tags to filter by</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByTagsAsync(List<string> tags, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -1192,8 +1191,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="name"></param>
-        /// <param name="status"></param>
         /// <returns></returns>
         private void ValidateUpdatePetWithForm(long petId)
         {
@@ -1346,8 +1343,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="file"></param>
-        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
         private void ValidateUploadFile(long petId)
         {
@@ -1510,7 +1505,6 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="requiredFile"></param>
         /// <param name="petId"></param>
-        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
         private void ValidateUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -327,7 +327,7 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary&lt;string, int&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary{TKey, TValue}"/></returns>
         public async Task<ApiResponse<Dictionary<string, int>>> GetInventoryOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -345,7 +345,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary&lt;string, int&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary{TKey, TValue}"/></returns>
         public async Task<ApiResponse<Dictionary<string, int>>> GetInventoryAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/ApiFactory.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/ApiFactory.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Client
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref=""/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Activity.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Activity
+    /// A Json converter for type <see cref="Activity" />
     /// </summary>
     public class ActivityJsonConverter : JsonConverter<Activity>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Activity" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Activity" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="activity"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ActivityOutputElementRepresentation
+    /// A Json converter for type <see cref="ActivityOutputElementRepresentation" />
     /// </summary>
     public class ActivityOutputElementRepresentationJsonConverter : JsonConverter<ActivityOutputElementRepresentation>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ActivityOutputElementRepresentation" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ActivityOutputElementRepresentation" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="activityOutputElementRepresentation"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -143,12 +143,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AdditionalPropertiesClass
+    /// A Json converter for type <see cref="AdditionalPropertiesClass" />
     /// </summary>
     public class AdditionalPropertiesClassJsonConverter : JsonConverter<AdditionalPropertiesClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AdditionalPropertiesClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -251,7 +251,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AdditionalPropertiesClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="additionalPropertiesClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -98,12 +98,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Animal
+    /// A Json converter for type <see cref="Animal" />
     /// </summary>
     public class AnimalJsonConverter : JsonConverter<Animal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Animal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Animal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="animal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ApiResponse
+    /// A Json converter for type <see cref="ApiResponse" />
     /// </summary>
     public class ApiResponseJsonConverter : JsonConverter<ApiResponse>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ApiResponse" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ApiResponse" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apiResponse"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -102,12 +102,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Apple
+    /// A Json converter for type <see cref="Apple" />
     /// </summary>
     public class AppleJsonConverter : JsonConverter<Apple>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Apple" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -163,7 +163,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Apple" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apple"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AppleReq
+    /// A Json converter for type <see cref="AppleReq" />
     /// </summary>
     public class AppleReqJsonConverter : JsonConverter<AppleReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AppleReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AppleReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="appleReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayOfArrayOfNumberOnly
+    /// A Json converter for type <see cref="ArrayOfArrayOfNumberOnly" />
     /// </summary>
     public class ArrayOfArrayOfNumberOnlyJsonConverter : JsonConverter<ArrayOfArrayOfNumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayOfArrayOfNumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayOfArrayOfNumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayOfArrayOfNumberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayOfNumberOnly
+    /// A Json converter for type <see cref="ArrayOfNumberOnly" />
     /// </summary>
     public class ArrayOfNumberOnlyJsonConverter : JsonConverter<ArrayOfNumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayOfNumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayOfNumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayOfNumberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayTest
+    /// A Json converter for type <see cref="ArrayTest" />
     /// </summary>
     public class ArrayTestJsonConverter : JsonConverter<ArrayTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Banana
+    /// A Json converter for type <see cref="Banana" />
     /// </summary>
     public class BananaJsonConverter : JsonConverter<Banana>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Banana" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Banana" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="banana"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type BananaReq
+    /// A Json converter for type <see cref="BananaReq" />
     /// </summary>
     public class BananaReqJsonConverter : JsonConverter<BananaReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="BananaReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="BananaReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="bananaReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type BasquePig
+    /// A Json converter for type <see cref="BasquePig" />
     /// </summary>
     public class BasquePigJsonConverter : JsonConverter<BasquePig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="BasquePig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="BasquePig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="basquePig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -125,12 +125,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Capitalization
+    /// A Json converter for type <see cref="Capitalization" />
     /// </summary>
     public class CapitalizationJsonConverter : JsonConverter<Capitalization>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Capitalization" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -214,7 +214,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Capitalization" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="capitalization"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Cat.cs
@@ -70,12 +70,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Cat
+    /// A Json converter for type <see cref="Cat" />
     /// </summary>
     public class CatJsonConverter : JsonConverter<Cat>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Cat" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Cat" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="cat"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type CatAllOf
+    /// A Json converter for type <see cref="CatAllOf" />
     /// </summary>
     public class CatAllOfJsonConverter : JsonConverter<CatAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="CatAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="CatAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="catAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Category.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Category
+    /// A Json converter for type <see cref="Category" />
     /// </summary>
     public class CategoryJsonConverter : JsonConverter<Category>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Category" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Category" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="category"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -62,12 +62,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildCat
+    /// A Json converter for type <see cref="ChildCat" />
     /// </summary>
     public class ChildCatJsonConverter : JsonConverter<ChildCat>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildCat" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildCat" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childCat"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,10 +55,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a PetTypeEnum
+        /// Returns a <see cref="PetTypeEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static PetTypeEnum PetTypeEnumFromString(string value)
         {
             if (value == "ChildCat")
@@ -68,7 +69,20 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="PetTypeEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static PetTypeEnum? PetTypeEnumFromStringOrDefault(string value)
+        {
+            if (value == "ChildCat")
+                return PetTypeEnum.ChildCat;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="PetTypeEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -126,12 +140,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildCatAllOf
+    /// A Json converter for type <see cref="ChildCatAllOf" />
     /// </summary>
     public class ChildCatAllOfJsonConverter : JsonConverter<ChildCatAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildCatAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -170,7 +184,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
-                            petType = ChildCatAllOf.PetTypeEnumFromString(petTypeRawValue);
+                            petType = petTypeRawValue == null
+                                ? null
+                                : ChildCatAllOf.PetTypeEnumFromStringOrDefault(petTypeRawValue);
                             break;
                         default:
                             break;
@@ -188,7 +204,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildCatAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childCatAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ClassModel
+    /// A Json converter for type <see cref="ClassModel" />
     /// </summary>
     public class ClassModelJsonConverter : JsonConverter<ClassModel>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ClassModel" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ClassModel" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="classModel"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ComplexQuadrilateral
+    /// A Json converter for type <see cref="ComplexQuadrilateral" />
     /// </summary>
     public class ComplexQuadrilateralJsonConverter : JsonConverter<ComplexQuadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ComplexQuadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ComplexQuadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="complexQuadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DanishPig
+    /// A Json converter for type <see cref="DanishPig" />
     /// </summary>
     public class DanishPigJsonConverter : JsonConverter<DanishPig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DanishPig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DanishPig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="danishPig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DateOnlyClass
+    /// A Json converter for type <see cref="DateOnlyClass" />
     /// </summary>
     public class DateOnlyClassJsonConverter : JsonConverter<DateOnlyClass>
     {
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         public static string DateOnlyPropertyFormat { get; set; } = "yyyy'-'MM'-'dd";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DateOnlyClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DateOnlyClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dateOnlyClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DeprecatedObject
+    /// A Json converter for type <see cref="DeprecatedObject" />
     /// </summary>
     public class DeprecatedObjectJsonConverter : JsonConverter<DeprecatedObject>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DeprecatedObject" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DeprecatedObject" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="deprecatedObject"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Dog.cs
@@ -63,12 +63,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Dog
+    /// A Json converter for type <see cref="Dog" />
     /// </summary>
     public class DogJsonConverter : JsonConverter<Dog>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Dog" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -121,7 +121,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Dog" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dog"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DogAllOf
+    /// A Json converter for type <see cref="DogAllOf" />
     /// </summary>
     public class DogAllOfJsonConverter : JsonConverter<DogAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DogAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DogAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dogAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -100,12 +100,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Drawing
+    /// A Json converter for type <see cref="Drawing" />
     /// </summary>
     public class DrawingJsonConverter : JsonConverter<Drawing>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Drawing" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Drawing" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="drawing"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -60,10 +60,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a ArrayEnumEnum
+        /// Returns a <see cref="ArrayEnumEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static ArrayEnumEnum ArrayEnumEnumFromString(string value)
         {
             if (value == "fish")
@@ -76,7 +77,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="ArrayEnumEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ArrayEnumEnum? ArrayEnumEnumFromStringOrDefault(string value)
+        {
+            if (value == "fish")
+                return ArrayEnumEnum.Fish;
+
+            if (value == "crab")
+                return ArrayEnumEnum.Crab;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ArrayEnumEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -109,10 +126,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a JustSymbolEnum
+        /// Returns a <see cref="JustSymbolEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static JustSymbolEnum JustSymbolEnumFromString(string value)
         {
             if (value == ">=")
@@ -125,7 +143,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="JustSymbolEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static JustSymbolEnum? JustSymbolEnumFromStringOrDefault(string value)
+        {
+            if (value == ">=")
+                return JustSymbolEnum.GreaterThanOrEqualTo;
+
+            if (value == "$")
+                return JustSymbolEnum.Dollar;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="JustSymbolEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -186,12 +220,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EnumArrays
+    /// A Json converter for type <see cref="EnumArrays" />
     /// </summary>
     public class EnumArraysJsonConverter : JsonConverter<EnumArrays>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EnumArrays" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -231,7 +265,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "just_symbol":
                             string justSymbolRawValue = utf8JsonReader.GetString();
-                            justSymbol = EnumArrays.JustSymbolEnumFromString(justSymbolRawValue);
+                            justSymbol = justSymbolRawValue == null
+                                ? null
+                                : EnumArrays.JustSymbolEnumFromStringOrDefault(justSymbolRawValue);
                             break;
                         default:
                             break;
@@ -249,7 +285,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EnumArrays" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="enumArrays"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumClass.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         Xyz = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="EnumClass"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class EnumClassConverter : JsonConverter<EnumClass>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="EnumClass"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static EnumClass FromString(string value)
         {
             if (value == "_abc")
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type EnumClass: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="EnumClass"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static EnumClass? FromStringOrDefault(string value)
         {
             if (value == "_abc")
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="EnumClass"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(EnumClass value)
         {
             if (value == EnumClass.Abc)
@@ -99,8 +119,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            EnumClass? result = EnumClassConverter.FromString(rawValue);
-            
+            EnumClass? result = rawValue == null
+                ? null
+                : EnumClassConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -119,6 +141,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="EnumClass"/>
+    /// </summary>
     public class EnumClassNullableConverter : JsonConverter<EnumClass?>
     {
         /// <summary>
@@ -132,10 +157,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            EnumClass? result = EnumClassConverter.FromString(rawValue);
+            EnumClass? result = rawValue == null
+                ? null
+                : EnumClassConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -74,10 +74,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumIntegerEnum
+        /// Returns a <see cref="EnumIntegerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumIntegerEnum EnumIntegerEnumFromString(string value)
         {
             if (value == (1).ToString())
@@ -90,11 +91,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumIntegerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        public static EnumIntegerEnum? EnumIntegerEnumFromStringOrDefault(string value)
+        {
+            if (value == (1).ToString())
+                return EnumIntegerEnum.NUMBER_1;
+
+            if (value == (-1).ToString())
+                return EnumIntegerEnum.NUMBER_MINUS_1;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumIntegerEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int EnumIntegerEnumToJsonValue(EnumIntegerEnum value)
         {
             return (int) value;
@@ -123,10 +139,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumIntegerOnlyEnum
+        /// Returns a <see cref="EnumIntegerOnlyEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumIntegerOnlyEnum EnumIntegerOnlyEnumFromString(string value)
         {
             if (value == (2).ToString())
@@ -139,11 +156,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumIntegerOnlyEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        public static EnumIntegerOnlyEnum? EnumIntegerOnlyEnumFromStringOrDefault(string value)
+        {
+            if (value == (2).ToString())
+                return EnumIntegerOnlyEnum.NUMBER_2;
+
+            if (value == (-2).ToString())
+                return EnumIntegerOnlyEnum.NUMBER_MINUS_2;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumIntegerOnlyEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int EnumIntegerOnlyEnumToJsonValue(EnumIntegerOnlyEnum value)
         {
             return (int) value;
@@ -172,10 +204,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumNumberEnum
+        /// Returns a <see cref="EnumNumberEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumNumberEnum EnumNumberEnumFromString(string value)
         {
             if (value == "1.1")
@@ -188,7 +221,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumNumberEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumNumberEnum? EnumNumberEnumFromStringOrDefault(string value)
+        {
+            if (value == "1.1")
+                return EnumNumberEnum.NUMBER_1_DOT_1;
+
+            if (value == "-1.2")
+                return EnumNumberEnum.NUMBER_MINUS_1_DOT_2;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumNumberEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -232,10 +281,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumStringEnum
+        /// Returns a <see cref="EnumStringEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumStringEnum EnumStringEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -251,7 +301,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumStringEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumStringEnum? EnumStringEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return EnumStringEnum.UPPER;
+
+            if (value == "lower")
+                return EnumStringEnum.Lower;
+
+            if (value == "")
+                return EnumStringEnum.Empty;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumStringEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -298,10 +367,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumStringRequiredEnum
+        /// Returns a <see cref="EnumStringRequiredEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumStringRequiredEnum EnumStringRequiredEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -317,7 +387,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumStringRequiredEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumStringRequiredEnum? EnumStringRequiredEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return EnumStringRequiredEnum.UPPER;
+
+            if (value == "lower")
+                return EnumStringRequiredEnum.Lower;
+
+            if (value == "")
+                return EnumStringRequiredEnum.Empty;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumStringRequiredEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -406,12 +495,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EnumTest
+    /// A Json converter for type <see cref="EnumTest" />
     /// </summary>
     public class EnumTestJsonConverter : JsonConverter<EnumTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EnumTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -466,27 +555,39 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "enum_string":
                             string enumStringRawValue = utf8JsonReader.GetString();
-                            enumString = EnumTest.EnumStringEnumFromString(enumStringRawValue);
+                            enumString = enumStringRawValue == null
+                                ? null
+                                : EnumTest.EnumStringEnumFromStringOrDefault(enumStringRawValue);
                             break;
                         case "enum_string_required":
                             string enumStringRequiredRawValue = utf8JsonReader.GetString();
-                            enumStringRequired = EnumTest.EnumStringRequiredEnumFromString(enumStringRequiredRawValue);
+                            enumStringRequired = enumStringRequiredRawValue == null
+                                ? null
+                                : EnumTest.EnumStringRequiredEnumFromStringOrDefault(enumStringRequiredRawValue);
                             break;
                         case "outerEnumDefaultValue":
                             string outerEnumDefaultValueRawValue = utf8JsonReader.GetString();
-                            outerEnumDefaultValue = OuterEnumDefaultValueConverter.FromString(outerEnumDefaultValueRawValue);
+                            outerEnumDefaultValue = outerEnumDefaultValueRawValue == null
+                                ? null
+                                : OuterEnumDefaultValueConverter.FromStringOrDefault(outerEnumDefaultValueRawValue);
                             break;
                         case "outerEnumInteger":
                             string outerEnumIntegerRawValue = utf8JsonReader.GetString();
-                            outerEnumInteger = OuterEnumIntegerConverter.FromString(outerEnumIntegerRawValue);
+                            outerEnumInteger = outerEnumIntegerRawValue == null
+                                ? null
+                                : OuterEnumIntegerConverter.FromStringOrDefault(outerEnumIntegerRawValue);
                             break;
                         case "outerEnumIntegerDefaultValue":
                             string outerEnumIntegerDefaultValueRawValue = utf8JsonReader.GetString();
-                            outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValueConverter.FromString(outerEnumIntegerDefaultValueRawValue);
+                            outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValueRawValue == null
+                                ? null
+                                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(outerEnumIntegerDefaultValueRawValue);
                             break;
                         case "outerEnum":
                             string outerEnumRawValue = utf8JsonReader.GetString();
-                            outerEnum = OuterEnumConverter.FromStringOrDefault(outerEnumRawValue);
+                            outerEnum = outerEnumRawValue == null
+                                ? null
+                                : OuterEnumConverter.FromStringOrDefault(outerEnumRawValue);
                             break;
                         default:
                             break;
@@ -522,7 +623,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EnumTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="enumTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EquilateralTriangle
+    /// A Json converter for type <see cref="EquilateralTriangle" />
     /// </summary>
     public class EquilateralTriangleJsonConverter : JsonConverter<EquilateralTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EquilateralTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EquilateralTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="equilateralTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/File.cs
@@ -80,12 +80,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type File
+    /// A Json converter for type <see cref="File" />
     /// </summary>
     public class FileJsonConverter : JsonConverter<File>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="File" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="File" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="file"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FileSchemaTestClass
+    /// A Json converter for type <see cref="FileSchemaTestClass" />
     /// </summary>
     public class FileSchemaTestClassJsonConverter : JsonConverter<FileSchemaTestClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FileSchemaTestClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FileSchemaTestClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fileSchemaTestClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Foo.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Foo
+    /// A Json converter for type <see cref="Foo" />
     /// </summary>
     public class FooJsonConverter : JsonConverter<Foo>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Foo" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Foo" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="foo"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FooGetDefaultResponse
+    /// A Json converter for type <see cref="FooGetDefaultResponse" />
     /// </summary>
     public class FooGetDefaultResponseJsonConverter : JsonConverter<FooGetDefaultResponse>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FooGetDefaultResponse" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FooGetDefaultResponse" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fooGetDefaultResponse"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -359,7 +359,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FormatTest
+    /// A Json converter for type <see cref="FormatTest" />
     /// </summary>
     public class FormatTestJsonConverter : JsonConverter<FormatTest>
     {
@@ -374,7 +374,7 @@ namespace Org.OpenAPITools.Model
         public static string DateTimeFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FormatTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -563,7 +563,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FormatTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="formatTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Fruit.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Fruit
+    /// A Json converter for type <see cref="Fruit" />
     /// </summary>
     public class FruitJsonConverter : JsonConverter<Fruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Fruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Fruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FruitReq
+    /// A Json converter for type <see cref="FruitReq" />
     /// </summary>
     public class FruitReqJsonConverter : JsonConverter<FruitReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FruitReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FruitReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruitReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type GmFruit
+    /// A Json converter for type <see cref="GmFruit" />
     /// </summary>
     public class GmFruitJsonConverter : JsonConverter<GmFruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="GmFruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="GmFruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="gmFruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -89,12 +89,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type GrandparentAnimal
+    /// A Json converter for type <see cref="GrandparentAnimal" />
     /// </summary>
     public class GrandparentAnimalJsonConverter : JsonConverter<GrandparentAnimal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="GrandparentAnimal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="GrandparentAnimal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="grandparentAnimal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -125,12 +125,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type HasOnlyReadOnly
+    /// A Json converter for type <see cref="HasOnlyReadOnly" />
     /// </summary>
     public class HasOnlyReadOnlyJsonConverter : JsonConverter<HasOnlyReadOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="HasOnlyReadOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="HasOnlyReadOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="hasOnlyReadOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type HealthCheckResult
+    /// A Json converter for type <see cref="HealthCheckResult" />
     /// </summary>
     public class HealthCheckResultJsonConverter : JsonConverter<HealthCheckResult>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="HealthCheckResult" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="HealthCheckResult" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="healthCheckResult"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -77,12 +77,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type IsoscelesTriangle
+    /// A Json converter for type <see cref="IsoscelesTriangle" />
     /// </summary>
     public class IsoscelesTriangleJsonConverter : JsonConverter<IsoscelesTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="IsoscelesTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="IsoscelesTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="isoscelesTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/List.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type List
+    /// A Json converter for type <see cref="List" />
     /// </summary>
     public class ListJsonConverter : JsonConverter<List>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="List" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="List" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="list"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type LiteralStringClass
+    /// A Json converter for type <see cref="LiteralStringClass" />
     /// </summary>
     public class LiteralStringClassJsonConverter : JsonConverter<LiteralStringClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="LiteralStringClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="LiteralStringClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="literalStringClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Mammal.cs
@@ -119,12 +119,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Mammal
+    /// A Json converter for type <see cref="Mammal" />
     /// </summary>
     public class MammalJsonConverter : JsonConverter<Mammal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Mammal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Mammal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mammal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -64,10 +64,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a InnerEnum
+        /// Returns a <see cref="InnerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static InnerEnum InnerEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -80,7 +81,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="InnerEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static InnerEnum? InnerEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return InnerEnum.UPPER;
+
+            if (value == "lower")
+                return InnerEnum.Lower;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="InnerEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -155,12 +172,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type MapTest
+    /// A Json converter for type <see cref="MapTest" />
     /// </summary>
     public class MapTestJsonConverter : JsonConverter<MapTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="MapTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -234,7 +251,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="MapTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mapTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -113,7 +113,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type MixedPropertiesAndAdditionalPropertiesClass
+    /// A Json converter for type <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
     /// </summary>
     public class MixedPropertiesAndAdditionalPropertiesClassJsonConverter : JsonConverter<MixedPropertiesAndAdditionalPropertiesClass>
     {
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Model
         public static string DateTimeFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mixedPropertiesAndAdditionalPropertiesClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Model200Response
+    /// A Json converter for type <see cref="Model200Response" />
     /// </summary>
     public class Model200ResponseJsonConverter : JsonConverter<Model200Response>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Model200Response" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Model200Response" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="model200Response"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ModelClient
+    /// A Json converter for type <see cref="ModelClient" />
     /// </summary>
     public class ModelClientJsonConverter : JsonConverter<ModelClient>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ModelClient" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ModelClient" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="modelClient"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Name.cs
@@ -143,12 +143,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Name
+    /// A Json converter for type <see cref="Name" />
     /// </summary>
     public class NameJsonConverter : JsonConverter<Name>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Name" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Name" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="name"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -172,7 +172,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableClass
+    /// A Json converter for type <see cref="NullableClass" />
     /// </summary>
     public class NullableClassJsonConverter : JsonConverter<NullableClass>
     {
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         public static string DatetimePropFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -294,7 +294,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -80,12 +80,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableGuidClass
+    /// A Json converter for type <see cref="NullableGuidClass" />
     /// </summary>
     public class NullableGuidClassJsonConverter : JsonConverter<NullableGuidClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableGuidClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableGuidClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableGuidClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -103,12 +103,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableShape
+    /// A Json converter for type <see cref="NullableShape" />
     /// </summary>
     public class NullableShapeJsonConverter : JsonConverter<NullableShape>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableShape" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -157,7 +157,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableShape" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableShape"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NumberOnly
+    /// A Json converter for type <see cref="NumberOnly" />
     /// </summary>
     public class NumberOnlyJsonConverter : JsonConverter<NumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="numberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -109,12 +109,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ObjectWithDeprecatedFields
+    /// A Json converter for type <see cref="ObjectWithDeprecatedFields" />
     /// </summary>
     public class ObjectWithDeprecatedFieldsJsonConverter : JsonConverter<ObjectWithDeprecatedFields>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ObjectWithDeprecatedFields" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ObjectWithDeprecatedFields" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="objectWithDeprecatedFields"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -77,12 +77,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type OneOfString
+    /// A Json converter for type <see cref="OneOfString" />
     /// </summary>
     public class OneOfStringJsonConverter : JsonConverter<OneOfString>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="OneOfString" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="OneOfString" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="oneOfString"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Order.cs
@@ -74,10 +74,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a StatusEnum
+        /// Returns a <see cref="StatusEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static StatusEnum StatusEnumFromString(string value)
         {
             if (value == "placed")
@@ -93,7 +94,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="StatusEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static StatusEnum? StatusEnumFromStringOrDefault(string value)
+        {
+            if (value == "placed")
+                return StatusEnum.Placed;
+
+            if (value == "approved")
+                return StatusEnum.Approved;
+
+            if (value == "delivered")
+                return StatusEnum.Delivered;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StatusEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -187,7 +207,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Order
+    /// A Json converter for type <see cref="Order" />
     /// </summary>
     public class OrderJsonConverter : JsonConverter<Order>
     {
@@ -197,7 +217,7 @@ namespace Org.OpenAPITools.Model
         public static string ShipDateFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Order" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -253,7 +273,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "status":
                             string statusRawValue = utf8JsonReader.GetString();
-                            status = Order.StatusEnumFromString(statusRawValue);
+                            status = statusRawValue == null
+                                ? null
+                                : Order.StatusEnumFromStringOrDefault(statusRawValue);
                             break;
                         case "complete":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -287,7 +309,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Order" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="order"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type OuterComposite
+    /// A Json converter for type <see cref="OuterComposite" />
     /// </summary>
     public class OuterCompositeJsonConverter : JsonConverter<OuterComposite>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="OuterComposite" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="OuterComposite" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="outerComposite"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnum.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnum.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         Delivered = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnum"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumConverter : JsonConverter<OuterEnum>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnum FromString(string value)
         {
             if (value == "placed")
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnum: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnum? FromStringOrDefault(string value)
         {
             if (value == "placed")
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(OuterEnum value)
         {
             if (value == OuterEnum.Placed)
@@ -99,8 +119,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnum? result = OuterEnumConverter.FromString(rawValue);
-            
+            OuterEnum? result = rawValue == null
+                ? null
+                : OuterEnumConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -119,6 +141,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnum"/>
+    /// </summary>
     public class OuterEnumNullableConverter : JsonConverter<OuterEnum?>
     {
         /// <summary>
@@ -132,10 +157,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnum? result = OuterEnumConverter.FromString(rawValue);
+            OuterEnum? result = rawValue == null
+                ? null
+                : OuterEnumConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnumDefaultValue.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnumDefaultValue.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         Delivered = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumDefaultValue"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumDefaultValueConverter : JsonConverter<OuterEnumDefaultValue>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumDefaultValue FromString(string value)
         {
             if (value == "placed")
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumDefaultValue: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumDefaultValue? FromStringOrDefault(string value)
         {
             if (value == "placed")
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumDefaultValue"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(OuterEnumDefaultValue value)
         {
             if (value == OuterEnumDefaultValue.Placed)
@@ -99,8 +119,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnumDefaultValue? result = OuterEnumDefaultValueConverter.FromString(rawValue);
-            
+            OuterEnumDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumDefaultValueConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -119,6 +141,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumDefaultValue"/>
+    /// </summary>
     public class OuterEnumDefaultValueNullableConverter : JsonConverter<OuterEnumDefaultValue?>
     {
         /// <summary>
@@ -132,10 +157,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumDefaultValue? result = OuterEnumDefaultValueConverter.FromString(rawValue);
+            OuterEnumDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumDefaultValueConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnumInteger.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnumInteger.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         NUMBER_2 = 2
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumInteger"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumIntegerConverter : JsonConverter<OuterEnumInteger>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumInteger"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumInteger FromString(string value)
         {
             if (value == (0).ToString())
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumInteger: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumInteger"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumInteger? FromStringOrDefault(string value)
         {
             if (value == (0).ToString())
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumInteger"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static int ToJsonValue(OuterEnumInteger value)
         {
             return (int) value;
@@ -90,8 +110,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnumInteger? result = OuterEnumIntegerConverter.FromString(rawValue);
-            
+            OuterEnumInteger? result = rawValue == null
+                ? null
+                : OuterEnumIntegerConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -110,6 +132,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumInteger"/>
+    /// </summary>
     public class OuterEnumIntegerNullableConverter : JsonConverter<OuterEnumInteger?>
     {
         /// <summary>
@@ -123,10 +148,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumInteger? result = OuterEnumIntegerConverter.FromString(rawValue);
+            OuterEnumInteger? result = rawValue == null
+                ? null
+                : OuterEnumIntegerConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnumIntegerDefaultValue.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OuterEnumIntegerDefaultValue.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         NUMBER_2 = 2
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumIntegerDefaultValue"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumIntegerDefaultValueConverter : JsonConverter<OuterEnumIntegerDefaultValue>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumIntegerDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumIntegerDefaultValue FromString(string value)
         {
             if (value == (0).ToString())
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumIntegerDefaultValue: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumIntegerDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumIntegerDefaultValue? FromStringOrDefault(string value)
         {
             if (value == (0).ToString())
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumIntegerDefaultValue"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static int ToJsonValue(OuterEnumIntegerDefaultValue value)
         {
             return (int) value;
@@ -90,8 +110,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnumIntegerDefaultValue? result = OuterEnumIntegerDefaultValueConverter.FromString(rawValue);
-            
+            OuterEnumIntegerDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -110,6 +132,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumIntegerDefaultValue"/>
+    /// </summary>
     public class OuterEnumIntegerDefaultValueNullableConverter : JsonConverter<OuterEnumIntegerDefaultValue?>
     {
         /// <summary>
@@ -123,10 +148,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumIntegerDefaultValue? result = OuterEnumIntegerDefaultValueConverter.FromString(rawValue);
+            OuterEnumIntegerDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ParentPet
+    /// A Json converter for type <see cref="ParentPet" />
     /// </summary>
     public class ParentPetJsonConverter : JsonConverter<ParentPet>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ParentPet" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ParentPet" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="parentPet"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -74,10 +74,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a StatusEnum
+        /// Returns a <see cref="StatusEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static StatusEnum StatusEnumFromString(string value)
         {
             if (value == "available")
@@ -93,7 +94,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="StatusEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static StatusEnum? StatusEnumFromStringOrDefault(string value)
+        {
+            if (value == "available")
+                return StatusEnum.Available;
+
+            if (value == "pending")
+                return StatusEnum.Pending;
+
+            if (value == "sold")
+                return StatusEnum.Sold;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StatusEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -187,12 +207,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Pet
+    /// A Json converter for type <see cref="Pet" />
     /// </summary>
     public class PetJsonConverter : JsonConverter<Pet>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Pet" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -247,7 +267,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "status":
                             string statusRawValue = utf8JsonReader.GetString();
-                            status = Pet.StatusEnumFromString(statusRawValue);
+                            status = statusRawValue == null
+                                ? null
+                                : Pet.StatusEnumFromStringOrDefault(statusRawValue);
                             break;
                         case "tags":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -281,7 +303,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Pet" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="pet"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pig.cs
@@ -103,12 +103,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Pig
+    /// A Json converter for type <see cref="Pig" />
     /// </summary>
     public class PigJsonConverter : JsonConverter<Pig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Pig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -157,7 +157,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Pig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="pig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -125,12 +125,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type PolymorphicProperty
+    /// A Json converter for type <see cref="PolymorphicProperty" />
     /// </summary>
     public class PolymorphicPropertyJsonConverter : JsonConverter<PolymorphicProperty>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="PolymorphicProperty" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="PolymorphicProperty" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="polymorphicProperty"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -103,12 +103,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Quadrilateral
+    /// A Json converter for type <see cref="Quadrilateral" />
     /// </summary>
     public class QuadrilateralJsonConverter : JsonConverter<Quadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Quadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -157,7 +157,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Quadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="quadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type QuadrilateralInterface
+    /// A Json converter for type <see cref="QuadrilateralInterface" />
     /// </summary>
     public class QuadrilateralInterfaceJsonConverter : JsonConverter<QuadrilateralInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="QuadrilateralInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="QuadrilateralInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="quadrilateralInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -124,12 +124,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ReadOnlyFirst
+    /// A Json converter for type <see cref="ReadOnlyFirst" />
     /// </summary>
     public class ReadOnlyFirstJsonConverter : JsonConverter<ReadOnlyFirst>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ReadOnlyFirst" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ReadOnlyFirst" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="readOnlyFirst"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Return.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Return
+    /// A Json converter for type <see cref="Return" />
     /// </summary>
     public class ReturnJsonConverter : JsonConverter<Return>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Return" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Return" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="varReturn"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ScaleneTriangle
+    /// A Json converter for type <see cref="ScaleneTriangle" />
     /// </summary>
     public class ScaleneTriangleJsonConverter : JsonConverter<ScaleneTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ScaleneTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ScaleneTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="scaleneTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -114,12 +114,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Shape
+    /// A Json converter for type <see cref="Shape" />
     /// </summary>
     public class ShapeJsonConverter : JsonConverter<Shape>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Shape" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Shape" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shape"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ShapeInterface
+    /// A Json converter for type <see cref="ShapeInterface" />
     /// </summary>
     public class ShapeInterfaceJsonConverter : JsonConverter<ShapeInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ShapeInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ShapeInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shapeInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -114,12 +114,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ShapeOrNull
+    /// A Json converter for type <see cref="ShapeOrNull" />
     /// </summary>
     public class ShapeOrNullJsonConverter : JsonConverter<ShapeOrNull>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ShapeOrNull" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ShapeOrNull" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shapeOrNull"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type SimpleQuadrilateral
+    /// A Json converter for type <see cref="SimpleQuadrilateral" />
     /// </summary>
     public class SimpleQuadrilateralJsonConverter : JsonConverter<SimpleQuadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="SimpleQuadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="SimpleQuadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="simpleQuadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type SpecialModelName
+    /// A Json converter for type <see cref="SpecialModelName" />
     /// </summary>
     public class SpecialModelNameJsonConverter : JsonConverter<SpecialModelName>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="SpecialModelName" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="SpecialModelName" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="specialModelName"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Tag
+    /// A Json converter for type <see cref="Tag" />
     /// </summary>
     public class TagJsonConverter : JsonConverter<Tag>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Tag" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Tag" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="tag"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TestCollectionEndingWithWordList
+    /// A Json converter for type <see cref="TestCollectionEndingWithWordList" />
     /// </summary>
     public class TestCollectionEndingWithWordListJsonConverter : JsonConverter<TestCollectionEndingWithWordList>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TestCollectionEndingWithWordList" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TestCollectionEndingWithWordList" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="testCollectionEndingWithWordList"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TestCollectionEndingWithWordListObject
+    /// A Json converter for type <see cref="TestCollectionEndingWithWordListObject" />
     /// </summary>
     public class TestCollectionEndingWithWordListObjectJsonConverter : JsonConverter<TestCollectionEndingWithWordListObject>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TestCollectionEndingWithWordListObject" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TestCollectionEndingWithWordListObject" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="testCollectionEndingWithWordListObject"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Triangle.cs
@@ -145,12 +145,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Triangle
+    /// A Json converter for type <see cref="Triangle" />
     /// </summary>
     public class TriangleJsonConverter : JsonConverter<Triangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Triangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Triangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="triangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TriangleInterface
+    /// A Json converter for type <see cref="TriangleInterface" />
     /// </summary>
     public class TriangleInterfaceJsonConverter : JsonConverter<TriangleInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TriangleInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TriangleInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="triangleInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/User.cs
@@ -183,12 +183,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type User
+    /// A Json converter for type <see cref="User" />
     /// </summary>
     public class UserJsonConverter : JsonConverter<User>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="User" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -311,7 +311,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="User" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="user"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Whale
+    /// A Json converter for type <see cref="Whale" />
     /// </summary>
     public class WhaleJsonConverter : JsonConverter<Whale>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Whale" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Whale" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="whale"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -65,10 +65,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a TypeEnum
+        /// Returns a <see cref="TypeEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static TypeEnum TypeEnumFromString(string value)
         {
             if (value == "plains")
@@ -84,7 +85,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="TypeEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static TypeEnum? TypeEnumFromStringOrDefault(string value)
+        {
+            if (value == "plains")
+                return TypeEnum.Plains;
+
+            if (value == "mountain")
+                return TypeEnum.Mountain;
+
+            if (value == "grevys")
+                return TypeEnum.Grevys;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="TypeEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -149,12 +169,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Zebra
+    /// A Json converter for type <see cref="Zebra" />
     /// </summary>
     public class ZebraJsonConverter : JsonConverter<Zebra>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Zebra" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -193,7 +213,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "type":
                             string typeRawValue = utf8JsonReader.GetString();
-                            type = Zebra.TypeEnumFromString(typeRawValue);
+                            type = typeRawValue == null
+                                ? null
+                                : Zebra.TypeEnumFromStringOrDefault(typeRawValue);
                             break;
                         default:
                             break;
@@ -211,7 +233,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Zebra" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="zebra"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ZeroBasedEnum.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ZeroBasedEnum.cs
@@ -39,8 +39,17 @@ namespace Org.OpenAPITools.Model
         NotUnknown
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="ZeroBasedEnum"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class ZeroBasedEnumConverter : JsonConverter<ZeroBasedEnum>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="ZeroBasedEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static ZeroBasedEnum FromString(string value)
         {
             if (value == "unknown")
@@ -52,6 +61,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type ZeroBasedEnum: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="ZeroBasedEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static ZeroBasedEnum? FromStringOrDefault(string value)
         {
             if (value == "unknown")
@@ -63,6 +77,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="ZeroBasedEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(ZeroBasedEnum value)
         {
             if (value == ZeroBasedEnum.Unknown)
@@ -85,8 +105,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            ZeroBasedEnum? result = ZeroBasedEnumConverter.FromString(rawValue);
-            
+            ZeroBasedEnum? result = rawValue == null
+                ? null
+                : ZeroBasedEnumConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -105,6 +127,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="ZeroBasedEnum"/>
+    /// </summary>
     public class ZeroBasedEnumNullableConverter : JsonConverter<ZeroBasedEnum?>
     {
         /// <summary>
@@ -118,10 +143,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            ZeroBasedEnum? result = ZeroBasedEnumConverter.FromString(rawValue);
+            ZeroBasedEnum? result = rawValue == null
+                ? null
+                : ZeroBasedEnumConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -58,10 +58,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a ZeroBasedEnumEnum
+        /// Returns a <see cref="ZeroBasedEnumEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static ZeroBasedEnumEnum ZeroBasedEnumEnumFromString(string value)
         {
             if (value == "unknown")
@@ -74,7 +75,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="ZeroBasedEnumEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ZeroBasedEnumEnum? ZeroBasedEnumEnumFromStringOrDefault(string value)
+        {
+            if (value == "unknown")
+                return ZeroBasedEnumEnum.Unknown;
+
+            if (value == "notUnknown")
+                return ZeroBasedEnumEnum.NotUnknown;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ZeroBasedEnumEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -128,12 +145,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ZeroBasedEnumClass
+    /// A Json converter for type <see cref="ZeroBasedEnumClass" />
     /// </summary>
     public class ZeroBasedEnumClassJsonConverter : JsonConverter<ZeroBasedEnumClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ZeroBasedEnumClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -168,7 +185,9 @@ namespace Org.OpenAPITools.Model
                     {
                         case "ZeroBasedEnum":
                             string zeroBasedEnumRawValue = utf8JsonReader.GetString();
-                            zeroBasedEnum = ZeroBasedEnumClass.ZeroBasedEnumEnumFromString(zeroBasedEnumRawValue);
+                            zeroBasedEnum = zeroBasedEnumRawValue == null
+                                ? null
+                                : ZeroBasedEnumClass.ZeroBasedEnumEnumFromStringOrDefault(zeroBasedEnumRawValue);
                             break;
                         default:
                             break;
@@ -183,7 +202,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ZeroBasedEnumClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="zeroBasedEnumClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/ApiFactory.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/ApiFactory.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Client
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref=""/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Client
                 _nextAvailable = DateTime.UtcNow.AddSeconds(5);
         }
 
-        private void OnTimer(object sender, System.Timers.ElapsedEventArgs e)
+        private void OnTimer(object? sender, System.Timers.ElapsedEventArgs e)
         {
             if (TokenBecameAvailable != null && !IsRateLimited)
                 TokenBecameAvailable.Invoke(this);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -66,12 +66,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Adult
+    /// A Json converter for type <see cref="Adult" />
     /// </summary>
     public class AdultJsonConverter : JsonConverter<Adult>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Adult" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Adult" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="adult"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/AdultAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/AdultAllOf.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AdultAllOf
+    /// A Json converter for type <see cref="AdultAllOf" />
     /// </summary>
     public class AdultAllOfJsonConverter : JsonConverter<AdultAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AdultAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AdultAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="adultAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Child.cs
@@ -75,12 +75,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Child
+    /// A Json converter for type <see cref="Child" />
     /// </summary>
     public class ChildJsonConverter : JsonConverter<Child>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Child" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -145,7 +145,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Child" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="child"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/ChildAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/ChildAllOf.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildAllOf
+    /// A Json converter for type <see cref="ChildAllOf" />
     /// </summary>
     public class ChildAllOfJsonConverter : JsonConverter<ChildAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Person.cs
@@ -109,12 +109,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Person
+    /// A Json converter for type <see cref="Person" />
     /// </summary>
     public class PersonJsonConverter : JsonConverter<Person>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Person" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Person" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="person"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/ApiFactory.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/ApiFactory.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Client
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref=""/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Client
                 _nextAvailable = DateTime.UtcNow.AddSeconds(5);
         }
 
-        private void OnTimer(object sender, System.Timers.ElapsedEventArgs e)
+        private void OnTimer(object? sender, System.Timers.ElapsedEventArgs e)
         {
             if (TokenBecameAvailable != null && !IsRateLimited)
                 TokenBecameAvailable.Invoke(this);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Apple
+    /// A Json converter for type <see cref="Apple" />
     /// </summary>
     public class AppleJsonConverter : JsonConverter<Apple>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Apple" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Apple" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apple"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Banana
+    /// A Json converter for type <see cref="Banana" />
     /// </summary>
     public class BananaJsonConverter : JsonConverter<Banana>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Banana" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Banana" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="banana"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -95,12 +95,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Fruit
+    /// A Json converter for type <see cref="Fruit" />
     /// </summary>
     public class FruitJsonConverter : JsonConverter<Fruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Fruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -155,7 +155,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Fruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/ApiFactory.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/ApiFactory.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Client
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref=""/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Client
                 _nextAvailable = DateTime.UtcNow.AddSeconds(5);
         }
 
-        private void OnTimer(object sender, System.Timers.ElapsedEventArgs e)
+        private void OnTimer(object? sender, System.Timers.ElapsedEventArgs e)
         {
             if (TokenBecameAvailable != null && !IsRateLimited)
                 TokenBecameAvailable.Invoke(this);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Apple
+    /// A Json converter for type <see cref="Apple" />
     /// </summary>
     public class AppleJsonConverter : JsonConverter<Apple>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Apple" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -135,7 +135,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Apple" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apple"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Banana
+    /// A Json converter for type <see cref="Banana" />
     /// </summary>
     public class BananaJsonConverter : JsonConverter<Banana>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Banana" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Banana" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="banana"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -106,12 +106,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Fruit
+    /// A Json converter for type <see cref="Fruit" />
     /// </summary>
     public class FruitJsonConverter : JsonConverter<Fruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Fruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Fruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -414,7 +414,7 @@ namespace Org.OpenAPITools.Api
         /// Hello Hello
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Guid&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Guid>>> HelloOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -432,7 +432,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Guid&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Guid>>> HelloAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -949,7 +949,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="requiredStringUuid"></param>
-        /// <param name="body"></param>
         /// <returns></returns>
         private void ValidateFakeOuterStringSerialize(Guid requiredStringUuid)
         {
@@ -1110,7 +1109,7 @@ namespace Org.OpenAPITools.Api
         /// Array of Enums 
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;OuterEnum&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<OuterEnum>>> GetArrayOfEnumsOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -1128,7 +1127,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;OuterEnum&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<OuterEnum>>> GetArrayOfEnumsAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -1584,16 +1583,6 @@ namespace Org.OpenAPITools.Api
         /// <param name="number"></param>
         /// <param name="varDouble"></param>
         /// <param name="patternWithoutDelimiter"></param>
-        /// <param name="date"></param>
-        /// <param name="binary"></param>
-        /// <param name="varFloat"></param>
-        /// <param name="integer"></param>
-        /// <param name="int32"></param>
-        /// <param name="int64"></param>
-        /// <param name="varString"></param>
-        /// <param name="password"></param>
-        /// <param name="callback"></param>
-        /// <param name="dateTime"></param>
         /// <returns></returns>
         private void ValidateTestEndpointParameters(byte[] varByte, decimal number, double varDouble, string patternWithoutDelimiter)
         {
@@ -2003,9 +1992,6 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredBooleanGroup"></param>
         /// <param name="requiredStringGroup"></param>
         /// <param name="requiredInt64Group"></param>
-        /// <param name="booleanGroup"></param>
-        /// <param name="stringGroup"></param>
-        /// <param name="int64Group"></param>
         /// <returns></returns>
         private void ValidateTestGroupParameters(bool requiredBooleanGroup, int requiredStringGroup, long requiredInt64Group)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -479,7 +479,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="apiKey"></param>
         /// <returns></returns>
         private void ValidateDeletePet(long petId)
         {
@@ -649,7 +648,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByStatusOrDefaultAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -668,7 +667,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -800,7 +799,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="tags">Tags to filter by</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByTagsOrDefaultAsync(List<string> tags, System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -819,7 +818,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="tags">Tags to filter by</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List&lt;Pet&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="List{TValue}"/></returns>
         public async Task<ApiResponse<List<Pet>>> FindPetsByTagsAsync(List<string> tags, System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();
@@ -1192,8 +1191,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="name"></param>
-        /// <param name="status"></param>
         /// <returns></returns>
         private void ValidateUpdatePetWithForm(long petId)
         {
@@ -1346,8 +1343,6 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="petId"></param>
-        /// <param name="file"></param>
-        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
         private void ValidateUploadFile(long petId)
         {
@@ -1510,7 +1505,6 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <param name="requiredFile"></param>
         /// <param name="petId"></param>
-        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
         private void ValidateUploadFileWithRequiredFile(System.IO.Stream requiredFile, long petId)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -327,7 +327,7 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary&lt;string, int&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary{TKey, TValue}"/></returns>
         public async Task<ApiResponse<Dictionary<string, int>>> GetInventoryOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             try
@@ -345,7 +345,7 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary&lt;string, int&gt;"/></returns>
+        /// <returns><see cref="Task"/>&lt;<see cref="ApiResponse{T}"/>&gt; where T : <see cref="Dictionary{TKey, TValue}"/></returns>
         public async Task<ApiResponse<Dictionary<string, int>>> GetInventoryAsync(System.Threading.CancellationToken cancellationToken = default)
         {
             UriBuilder uriBuilderLocalVar = new UriBuilder();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/ApiFactory.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/ApiFactory.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Client
         public IServiceProvider Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref=""/> class.
+        /// Initializes a new instance of the <see cref="ApiFactory"/> class.
         /// </summary>
         /// <param name="services"></param>
         public ApiFactory(IServiceProvider services)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Activity.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Activity
+    /// A Json converter for type <see cref="Activity" />
     /// </summary>
     public class ActivityJsonConverter : JsonConverter<Activity>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Activity" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Activity" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="activity"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ActivityOutputElementRepresentation
+    /// A Json converter for type <see cref="ActivityOutputElementRepresentation" />
     /// </summary>
     public class ActivityOutputElementRepresentationJsonConverter : JsonConverter<ActivityOutputElementRepresentation>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ActivityOutputElementRepresentation" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ActivityOutputElementRepresentation" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="activityOutputElementRepresentation"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -143,12 +143,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AdditionalPropertiesClass
+    /// A Json converter for type <see cref="AdditionalPropertiesClass" />
     /// </summary>
     public class AdditionalPropertiesClassJsonConverter : JsonConverter<AdditionalPropertiesClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AdditionalPropertiesClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -251,7 +251,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AdditionalPropertiesClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="additionalPropertiesClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -98,12 +98,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Animal
+    /// A Json converter for type <see cref="Animal" />
     /// </summary>
     public class AnimalJsonConverter : JsonConverter<Animal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Animal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Animal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="animal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ApiResponse
+    /// A Json converter for type <see cref="ApiResponse" />
     /// </summary>
     public class ApiResponseJsonConverter : JsonConverter<ApiResponse>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ApiResponse" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ApiResponse" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apiResponse"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -102,12 +102,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Apple
+    /// A Json converter for type <see cref="Apple" />
     /// </summary>
     public class AppleJsonConverter : JsonConverter<Apple>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Apple" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -163,7 +163,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Apple" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="apple"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type AppleReq
+    /// A Json converter for type <see cref="AppleReq" />
     /// </summary>
     public class AppleReqJsonConverter : JsonConverter<AppleReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="AppleReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="AppleReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="appleReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayOfArrayOfNumberOnly
+    /// A Json converter for type <see cref="ArrayOfArrayOfNumberOnly" />
     /// </summary>
     public class ArrayOfArrayOfNumberOnlyJsonConverter : JsonConverter<ArrayOfArrayOfNumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayOfArrayOfNumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayOfArrayOfNumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayOfArrayOfNumberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayOfNumberOnly
+    /// A Json converter for type <see cref="ArrayOfNumberOnly" />
     /// </summary>
     public class ArrayOfNumberOnlyJsonConverter : JsonConverter<ArrayOfNumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayOfNumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayOfNumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayOfNumberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ArrayTest
+    /// A Json converter for type <see cref="ArrayTest" />
     /// </summary>
     public class ArrayTestJsonConverter : JsonConverter<ArrayTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ArrayTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -168,7 +168,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ArrayTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="arrayTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Banana
+    /// A Json converter for type <see cref="Banana" />
     /// </summary>
     public class BananaJsonConverter : JsonConverter<Banana>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Banana" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Banana" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="banana"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -81,12 +81,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type BananaReq
+    /// A Json converter for type <see cref="BananaReq" />
     /// </summary>
     public class BananaReqJsonConverter : JsonConverter<BananaReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="BananaReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -144,7 +144,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="BananaReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="bananaReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type BasquePig
+    /// A Json converter for type <see cref="BasquePig" />
     /// </summary>
     public class BasquePigJsonConverter : JsonConverter<BasquePig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="BasquePig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="BasquePig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="basquePig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -125,12 +125,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Capitalization
+    /// A Json converter for type <see cref="Capitalization" />
     /// </summary>
     public class CapitalizationJsonConverter : JsonConverter<Capitalization>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Capitalization" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -214,7 +214,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Capitalization" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="capitalization"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Cat.cs
@@ -70,12 +70,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Cat
+    /// A Json converter for type <see cref="Cat" />
     /// </summary>
     public class CatJsonConverter : JsonConverter<Cat>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Cat" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Cat" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="cat"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type CatAllOf
+    /// A Json converter for type <see cref="CatAllOf" />
     /// </summary>
     public class CatAllOfJsonConverter : JsonConverter<CatAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="CatAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="CatAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="catAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Category.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Category
+    /// A Json converter for type <see cref="Category" />
     /// </summary>
     public class CategoryJsonConverter : JsonConverter<Category>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Category" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Category" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="category"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -62,12 +62,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildCat
+    /// A Json converter for type <see cref="ChildCat" />
     /// </summary>
     public class ChildCatJsonConverter : JsonConverter<ChildCat>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildCat" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildCat" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childCat"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -55,10 +55,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a PetTypeEnum
+        /// Returns a <see cref="PetTypeEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static PetTypeEnum PetTypeEnumFromString(string value)
         {
             if (value == "ChildCat")
@@ -68,7 +69,20 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="PetTypeEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static PetTypeEnum? PetTypeEnumFromStringOrDefault(string value)
+        {
+            if (value == "ChildCat")
+                return PetTypeEnum.ChildCat;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="PetTypeEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -126,12 +140,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ChildCatAllOf
+    /// A Json converter for type <see cref="ChildCatAllOf" />
     /// </summary>
     public class ChildCatAllOfJsonConverter : JsonConverter<ChildCatAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ChildCatAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -170,7 +184,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "pet_type":
                             string petTypeRawValue = utf8JsonReader.GetString();
-                            petType = ChildCatAllOf.PetTypeEnumFromString(petTypeRawValue);
+                            petType = petTypeRawValue == null
+                                ? null
+                                : ChildCatAllOf.PetTypeEnumFromStringOrDefault(petTypeRawValue);
                             break;
                         default:
                             break;
@@ -188,7 +204,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ChildCatAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="childCatAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ClassModel
+    /// A Json converter for type <see cref="ClassModel" />
     /// </summary>
     public class ClassModelJsonConverter : JsonConverter<ClassModel>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ClassModel" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ClassModel" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="classModel"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ComplexQuadrilateral
+    /// A Json converter for type <see cref="ComplexQuadrilateral" />
     /// </summary>
     public class ComplexQuadrilateralJsonConverter : JsonConverter<ComplexQuadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ComplexQuadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ComplexQuadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="complexQuadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DanishPig
+    /// A Json converter for type <see cref="DanishPig" />
     /// </summary>
     public class DanishPigJsonConverter : JsonConverter<DanishPig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DanishPig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DanishPig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="danishPig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DateOnlyClass
+    /// A Json converter for type <see cref="DateOnlyClass" />
     /// </summary>
     public class DateOnlyClassJsonConverter : JsonConverter<DateOnlyClass>
     {
@@ -90,7 +90,7 @@ namespace Org.OpenAPITools.Model
         public static string DateOnlyPropertyFormat { get; set; } = "yyyy'-'MM'-'dd";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DateOnlyClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DateOnlyClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dateOnlyClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DeprecatedObject
+    /// A Json converter for type <see cref="DeprecatedObject" />
     /// </summary>
     public class DeprecatedObjectJsonConverter : JsonConverter<DeprecatedObject>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DeprecatedObject" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DeprecatedObject" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="deprecatedObject"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Dog.cs
@@ -63,12 +63,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Dog
+    /// A Json converter for type <see cref="Dog" />
     /// </summary>
     public class DogJsonConverter : JsonConverter<Dog>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Dog" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -121,7 +121,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Dog" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dog"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DogAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/DogAllOf.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type DogAllOf
+    /// A Json converter for type <see cref="DogAllOf" />
     /// </summary>
     public class DogAllOfJsonConverter : JsonConverter<DogAllOf>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="DogAllOf" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="DogAllOf" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="dogAllOf"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -100,12 +100,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Drawing
+    /// A Json converter for type <see cref="Drawing" />
     /// </summary>
     public class DrawingJsonConverter : JsonConverter<Drawing>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Drawing" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Drawing" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="drawing"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -60,10 +60,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a ArrayEnumEnum
+        /// Returns a <see cref="ArrayEnumEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static ArrayEnumEnum ArrayEnumEnumFromString(string value)
         {
             if (value == "fish")
@@ -76,7 +77,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="ArrayEnumEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ArrayEnumEnum? ArrayEnumEnumFromStringOrDefault(string value)
+        {
+            if (value == "fish")
+                return ArrayEnumEnum.Fish;
+
+            if (value == "crab")
+                return ArrayEnumEnum.Crab;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ArrayEnumEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -109,10 +126,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a JustSymbolEnum
+        /// Returns a <see cref="JustSymbolEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static JustSymbolEnum JustSymbolEnumFromString(string value)
         {
             if (value == ">=")
@@ -125,7 +143,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="JustSymbolEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static JustSymbolEnum? JustSymbolEnumFromStringOrDefault(string value)
+        {
+            if (value == ">=")
+                return JustSymbolEnum.GreaterThanOrEqualTo;
+
+            if (value == "$")
+                return JustSymbolEnum.Dollar;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="JustSymbolEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -186,12 +220,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EnumArrays
+    /// A Json converter for type <see cref="EnumArrays" />
     /// </summary>
     public class EnumArraysJsonConverter : JsonConverter<EnumArrays>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EnumArrays" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -231,7 +265,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "just_symbol":
                             string justSymbolRawValue = utf8JsonReader.GetString();
-                            justSymbol = EnumArrays.JustSymbolEnumFromString(justSymbolRawValue);
+                            justSymbol = justSymbolRawValue == null
+                                ? null
+                                : EnumArrays.JustSymbolEnumFromStringOrDefault(justSymbolRawValue);
                             break;
                         default:
                             break;
@@ -249,7 +285,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EnumArrays" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="enumArrays"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumClass.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         Xyz = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="EnumClass"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class EnumClassConverter : JsonConverter<EnumClass>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="EnumClass"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static EnumClass FromString(string value)
         {
             if (value == "_abc")
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type EnumClass: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="EnumClass"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static EnumClass? FromStringOrDefault(string value)
         {
             if (value == "_abc")
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="EnumClass"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(EnumClass value)
         {
             if (value == EnumClass.Abc)
@@ -99,8 +119,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            EnumClass? result = EnumClassConverter.FromString(rawValue);
-            
+            EnumClass? result = rawValue == null
+                ? null
+                : EnumClassConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -119,6 +141,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="EnumClass"/>
+    /// </summary>
     public class EnumClassNullableConverter : JsonConverter<EnumClass?>
     {
         /// <summary>
@@ -132,10 +157,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            EnumClass? result = EnumClassConverter.FromString(rawValue);
+            EnumClass? result = rawValue == null
+                ? null
+                : EnumClassConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -74,10 +74,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumIntegerEnum
+        /// Returns a <see cref="EnumIntegerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumIntegerEnum EnumIntegerEnumFromString(string value)
         {
             if (value == (1).ToString())
@@ -90,11 +91,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumIntegerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        public static EnumIntegerEnum? EnumIntegerEnumFromStringOrDefault(string value)
+        {
+            if (value == (1).ToString())
+                return EnumIntegerEnum.NUMBER_1;
+
+            if (value == (-1).ToString())
+                return EnumIntegerEnum.NUMBER_MINUS_1;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumIntegerEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int EnumIntegerEnumToJsonValue(EnumIntegerEnum value)
         {
             return (int) value;
@@ -123,10 +139,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumIntegerOnlyEnum
+        /// Returns a <see cref="EnumIntegerOnlyEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumIntegerOnlyEnum EnumIntegerOnlyEnumFromString(string value)
         {
             if (value == (2).ToString())
@@ -139,11 +156,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumIntegerOnlyEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        public static EnumIntegerOnlyEnum? EnumIntegerOnlyEnumFromStringOrDefault(string value)
+        {
+            if (value == (2).ToString())
+                return EnumIntegerOnlyEnum.NUMBER_2;
+
+            if (value == (-2).ToString())
+                return EnumIntegerOnlyEnum.NUMBER_MINUS_2;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumIntegerOnlyEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static int EnumIntegerOnlyEnumToJsonValue(EnumIntegerOnlyEnum value)
         {
             return (int) value;
@@ -172,10 +204,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumNumberEnum
+        /// Returns a <see cref="EnumNumberEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumNumberEnum EnumNumberEnumFromString(string value)
         {
             if (value == "1.1")
@@ -188,7 +221,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumNumberEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumNumberEnum? EnumNumberEnumFromStringOrDefault(string value)
+        {
+            if (value == "1.1")
+                return EnumNumberEnum.NUMBER_1_DOT_1;
+
+            if (value == "-1.2")
+                return EnumNumberEnum.NUMBER_MINUS_1_DOT_2;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumNumberEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -232,10 +281,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumStringEnum
+        /// Returns a <see cref="EnumStringEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumStringEnum EnumStringEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -251,7 +301,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumStringEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumStringEnum? EnumStringEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return EnumStringEnum.UPPER;
+
+            if (value == "lower")
+                return EnumStringEnum.Lower;
+
+            if (value == "")
+                return EnumStringEnum.Empty;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumStringEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -298,10 +367,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a EnumStringRequiredEnum
+        /// Returns a <see cref="EnumStringRequiredEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static EnumStringRequiredEnum EnumStringRequiredEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -317,7 +387,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="EnumStringRequiredEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static EnumStringRequiredEnum? EnumStringRequiredEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return EnumStringRequiredEnum.UPPER;
+
+            if (value == "lower")
+                return EnumStringRequiredEnum.Lower;
+
+            if (value == "")
+                return EnumStringRequiredEnum.Empty;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="EnumStringRequiredEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -406,12 +495,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EnumTest
+    /// A Json converter for type <see cref="EnumTest" />
     /// </summary>
     public class EnumTestJsonConverter : JsonConverter<EnumTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EnumTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -466,27 +555,39 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "enum_string":
                             string enumStringRawValue = utf8JsonReader.GetString();
-                            enumString = EnumTest.EnumStringEnumFromString(enumStringRawValue);
+                            enumString = enumStringRawValue == null
+                                ? null
+                                : EnumTest.EnumStringEnumFromStringOrDefault(enumStringRawValue);
                             break;
                         case "enum_string_required":
                             string enumStringRequiredRawValue = utf8JsonReader.GetString();
-                            enumStringRequired = EnumTest.EnumStringRequiredEnumFromString(enumStringRequiredRawValue);
+                            enumStringRequired = enumStringRequiredRawValue == null
+                                ? null
+                                : EnumTest.EnumStringRequiredEnumFromStringOrDefault(enumStringRequiredRawValue);
                             break;
                         case "outerEnumDefaultValue":
                             string outerEnumDefaultValueRawValue = utf8JsonReader.GetString();
-                            outerEnumDefaultValue = OuterEnumDefaultValueConverter.FromString(outerEnumDefaultValueRawValue);
+                            outerEnumDefaultValue = outerEnumDefaultValueRawValue == null
+                                ? null
+                                : OuterEnumDefaultValueConverter.FromStringOrDefault(outerEnumDefaultValueRawValue);
                             break;
                         case "outerEnumInteger":
                             string outerEnumIntegerRawValue = utf8JsonReader.GetString();
-                            outerEnumInteger = OuterEnumIntegerConverter.FromString(outerEnumIntegerRawValue);
+                            outerEnumInteger = outerEnumIntegerRawValue == null
+                                ? null
+                                : OuterEnumIntegerConverter.FromStringOrDefault(outerEnumIntegerRawValue);
                             break;
                         case "outerEnumIntegerDefaultValue":
                             string outerEnumIntegerDefaultValueRawValue = utf8JsonReader.GetString();
-                            outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValueConverter.FromString(outerEnumIntegerDefaultValueRawValue);
+                            outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValueRawValue == null
+                                ? null
+                                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(outerEnumIntegerDefaultValueRawValue);
                             break;
                         case "outerEnum":
                             string outerEnumRawValue = utf8JsonReader.GetString();
-                            outerEnum = OuterEnumConverter.FromStringOrDefault(outerEnumRawValue);
+                            outerEnum = outerEnumRawValue == null
+                                ? null
+                                : OuterEnumConverter.FromStringOrDefault(outerEnumRawValue);
                             break;
                         default:
                             break;
@@ -522,7 +623,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EnumTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="enumTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type EquilateralTriangle
+    /// A Json converter for type <see cref="EquilateralTriangle" />
     /// </summary>
     public class EquilateralTriangleJsonConverter : JsonConverter<EquilateralTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="EquilateralTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="EquilateralTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="equilateralTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/File.cs
@@ -80,12 +80,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type File
+    /// A Json converter for type <see cref="File" />
     /// </summary>
     public class FileJsonConverter : JsonConverter<File>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="File" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="File" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="file"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FileSchemaTestClass
+    /// A Json converter for type <see cref="FileSchemaTestClass" />
     /// </summary>
     public class FileSchemaTestClassJsonConverter : JsonConverter<FileSchemaTestClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FileSchemaTestClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FileSchemaTestClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fileSchemaTestClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Foo.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Foo
+    /// A Json converter for type <see cref="Foo" />
     /// </summary>
     public class FooJsonConverter : JsonConverter<Foo>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Foo" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Foo" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="foo"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FooGetDefaultResponse
+    /// A Json converter for type <see cref="FooGetDefaultResponse" />
     /// </summary>
     public class FooGetDefaultResponseJsonConverter : JsonConverter<FooGetDefaultResponse>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FooGetDefaultResponse" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FooGetDefaultResponse" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fooGetDefaultResponse"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -359,7 +359,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FormatTest
+    /// A Json converter for type <see cref="FormatTest" />
     /// </summary>
     public class FormatTestJsonConverter : JsonConverter<FormatTest>
     {
@@ -374,7 +374,7 @@ namespace Org.OpenAPITools.Model
         public static string DateTimeFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FormatTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -563,7 +563,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FormatTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="formatTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Fruit.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Fruit
+    /// A Json converter for type <see cref="Fruit" />
     /// </summary>
     public class FruitJsonConverter : JsonConverter<Fruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Fruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -159,7 +159,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Fruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type FruitReq
+    /// A Json converter for type <see cref="FruitReq" />
     /// </summary>
     public class FruitReqJsonConverter : JsonConverter<FruitReq>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="FruitReq" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="FruitReq" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="fruitReq"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -86,12 +86,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type GmFruit
+    /// A Json converter for type <see cref="GmFruit" />
     /// </summary>
     public class GmFruitJsonConverter : JsonConverter<GmFruit>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="GmFruit" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="GmFruit" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="gmFruit"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -89,12 +89,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type GrandparentAnimal
+    /// A Json converter for type <see cref="GrandparentAnimal" />
     /// </summary>
     public class GrandparentAnimalJsonConverter : JsonConverter<GrandparentAnimal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="GrandparentAnimal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="GrandparentAnimal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="grandparentAnimal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -125,12 +125,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type HasOnlyReadOnly
+    /// A Json converter for type <see cref="HasOnlyReadOnly" />
     /// </summary>
     public class HasOnlyReadOnlyJsonConverter : JsonConverter<HasOnlyReadOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="HasOnlyReadOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -186,7 +186,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="HasOnlyReadOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="hasOnlyReadOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type HealthCheckResult
+    /// A Json converter for type <see cref="HealthCheckResult" />
     /// </summary>
     public class HealthCheckResultJsonConverter : JsonConverter<HealthCheckResult>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="HealthCheckResult" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="HealthCheckResult" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="healthCheckResult"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -77,12 +77,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type IsoscelesTriangle
+    /// A Json converter for type <see cref="IsoscelesTriangle" />
     /// </summary>
     public class IsoscelesTriangleJsonConverter : JsonConverter<IsoscelesTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="IsoscelesTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="IsoscelesTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="isoscelesTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/List.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type List
+    /// A Json converter for type <see cref="List" />
     /// </summary>
     public class ListJsonConverter : JsonConverter<List>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="List" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="List" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="list"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type LiteralStringClass
+    /// A Json converter for type <see cref="LiteralStringClass" />
     /// </summary>
     public class LiteralStringClassJsonConverter : JsonConverter<LiteralStringClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="LiteralStringClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="LiteralStringClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="literalStringClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Mammal.cs
@@ -119,12 +119,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Mammal
+    /// A Json converter for type <see cref="Mammal" />
     /// </summary>
     public class MammalJsonConverter : JsonConverter<Mammal>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Mammal" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -177,7 +177,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Mammal" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mammal"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -64,10 +64,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a InnerEnum
+        /// Returns a <see cref="InnerEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static InnerEnum InnerEnumFromString(string value)
         {
             if (value == "UPPER")
@@ -80,7 +81,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="InnerEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static InnerEnum? InnerEnumFromStringOrDefault(string value)
+        {
+            if (value == "UPPER")
+                return InnerEnum.UPPER;
+
+            if (value == "lower")
+                return InnerEnum.Lower;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="InnerEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -155,12 +172,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type MapTest
+    /// A Json converter for type <see cref="MapTest" />
     /// </summary>
     public class MapTestJsonConverter : JsonConverter<MapTest>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="MapTest" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -234,7 +251,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="MapTest" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mapTest"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -113,7 +113,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type MixedPropertiesAndAdditionalPropertiesClass
+    /// A Json converter for type <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
     /// </summary>
     public class MixedPropertiesAndAdditionalPropertiesClassJsonConverter : JsonConverter<MixedPropertiesAndAdditionalPropertiesClass>
     {
@@ -123,7 +123,7 @@ namespace Org.OpenAPITools.Model
         public static string DateTimeFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -197,7 +197,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="MixedPropertiesAndAdditionalPropertiesClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="mixedPropertiesAndAdditionalPropertiesClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Model200Response
+    /// A Json converter for type <see cref="Model200Response" />
     /// </summary>
     public class Model200ResponseJsonConverter : JsonConverter<Model200Response>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Model200Response" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Model200Response" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="model200Response"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ModelClient
+    /// A Json converter for type <see cref="ModelClient" />
     /// </summary>
     public class ModelClientJsonConverter : JsonConverter<ModelClient>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ModelClient" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ModelClient" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="modelClient"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Name.cs
@@ -143,12 +143,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Name
+    /// A Json converter for type <see cref="Name" />
     /// </summary>
     public class NameJsonConverter : JsonConverter<Name>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Name" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -221,7 +221,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Name" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="name"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -172,7 +172,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableClass
+    /// A Json converter for type <see cref="NullableClass" />
     /// </summary>
     public class NullableClassJsonConverter : JsonConverter<NullableClass>
     {
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         public static string DatetimePropFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -294,7 +294,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -80,12 +80,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableGuidClass
+    /// A Json converter for type <see cref="NullableGuidClass" />
     /// </summary>
     public class NullableGuidClassJsonConverter : JsonConverter<NullableGuidClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableGuidClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableGuidClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableGuidClass"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -103,12 +103,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NullableShape
+    /// A Json converter for type <see cref="NullableShape" />
     /// </summary>
     public class NullableShapeJsonConverter : JsonConverter<NullableShape>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NullableShape" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -157,7 +157,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NullableShape" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="nullableShape"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type NumberOnly
+    /// A Json converter for type <see cref="NumberOnly" />
     /// </summary>
     public class NumberOnlyJsonConverter : JsonConverter<NumberOnly>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="NumberOnly" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="NumberOnly" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="numberOnly"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -109,12 +109,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ObjectWithDeprecatedFields
+    /// A Json converter for type <see cref="ObjectWithDeprecatedFields" />
     /// </summary>
     public class ObjectWithDeprecatedFieldsJsonConverter : JsonConverter<ObjectWithDeprecatedFields>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ObjectWithDeprecatedFields" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ObjectWithDeprecatedFields" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="objectWithDeprecatedFields"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -77,12 +77,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type OneOfString
+    /// A Json converter for type <see cref="OneOfString" />
     /// </summary>
     public class OneOfStringJsonConverter : JsonConverter<OneOfString>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="OneOfString" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="OneOfString" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="oneOfString"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Order.cs
@@ -74,10 +74,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a StatusEnum
+        /// Returns a <see cref="StatusEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static StatusEnum StatusEnumFromString(string value)
         {
             if (value == "placed")
@@ -93,7 +94,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="StatusEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static StatusEnum? StatusEnumFromStringOrDefault(string value)
+        {
+            if (value == "placed")
+                return StatusEnum.Placed;
+
+            if (value == "approved")
+                return StatusEnum.Approved;
+
+            if (value == "delivered")
+                return StatusEnum.Delivered;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StatusEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -187,7 +207,7 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Order
+    /// A Json converter for type <see cref="Order" />
     /// </summary>
     public class OrderJsonConverter : JsonConverter<Order>
     {
@@ -197,7 +217,7 @@ namespace Org.OpenAPITools.Model
         public static string ShipDateFormat { get; set; } = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK";
 
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Order" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -253,7 +273,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "status":
                             string statusRawValue = utf8JsonReader.GetString();
-                            status = Order.StatusEnumFromString(statusRawValue);
+                            status = statusRawValue == null
+                                ? null
+                                : Order.StatusEnumFromStringOrDefault(statusRawValue);
                             break;
                         case "complete":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -287,7 +309,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Order" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="order"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type OuterComposite
+    /// A Json converter for type <see cref="OuterComposite" />
     /// </summary>
     public class OuterCompositeJsonConverter : JsonConverter<OuterComposite>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="OuterComposite" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="OuterComposite" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="outerComposite"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnum.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnum.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         Delivered = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnum"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumConverter : JsonConverter<OuterEnum>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnum FromString(string value)
         {
             if (value == "placed")
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnum: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnum? FromStringOrDefault(string value)
         {
             if (value == "placed")
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(OuterEnum value)
         {
             if (value == OuterEnum.Placed)
@@ -99,8 +119,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnum? result = OuterEnumConverter.FromString(rawValue);
-            
+            OuterEnum? result = rawValue == null
+                ? null
+                : OuterEnumConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -119,6 +141,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnum"/>
+    /// </summary>
     public class OuterEnumNullableConverter : JsonConverter<OuterEnum?>
     {
         /// <summary>
@@ -132,10 +157,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnum? result = OuterEnumConverter.FromString(rawValue);
+            OuterEnum? result = rawValue == null
+                ? null
+                : OuterEnumConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnumDefaultValue.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnumDefaultValue.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         Delivered = 3
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumDefaultValue"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumDefaultValueConverter : JsonConverter<OuterEnumDefaultValue>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumDefaultValue FromString(string value)
         {
             if (value == "placed")
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumDefaultValue: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumDefaultValue? FromStringOrDefault(string value)
         {
             if (value == "placed")
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumDefaultValue"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(OuterEnumDefaultValue value)
         {
             if (value == OuterEnumDefaultValue.Placed)
@@ -99,8 +119,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnumDefaultValue? result = OuterEnumDefaultValueConverter.FromString(rawValue);
-            
+            OuterEnumDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumDefaultValueConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -119,6 +141,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumDefaultValue"/>
+    /// </summary>
     public class OuterEnumDefaultValueNullableConverter : JsonConverter<OuterEnumDefaultValue?>
     {
         /// <summary>
@@ -132,10 +157,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumDefaultValue? result = OuterEnumDefaultValueConverter.FromString(rawValue);
+            OuterEnumDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumDefaultValueConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnumInteger.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnumInteger.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         NUMBER_2 = 2
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumInteger"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumIntegerConverter : JsonConverter<OuterEnumInteger>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumInteger"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumInteger FromString(string value)
         {
             if (value == (0).ToString())
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumInteger: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumInteger"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumInteger? FromStringOrDefault(string value)
         {
             if (value == (0).ToString())
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumInteger"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static int ToJsonValue(OuterEnumInteger value)
         {
             return (int) value;
@@ -90,8 +110,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnumInteger? result = OuterEnumIntegerConverter.FromString(rawValue);
-            
+            OuterEnumInteger? result = rawValue == null
+                ? null
+                : OuterEnumIntegerConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -110,6 +132,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumInteger"/>
+    /// </summary>
     public class OuterEnumIntegerNullableConverter : JsonConverter<OuterEnumInteger?>
     {
         /// <summary>
@@ -123,10 +148,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumInteger? result = OuterEnumIntegerConverter.FromString(rawValue);
+            OuterEnumInteger? result = rawValue == null
+                ? null
+                : OuterEnumIntegerConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnumIntegerDefaultValue.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OuterEnumIntegerDefaultValue.cs
@@ -44,8 +44,17 @@ namespace Org.OpenAPITools.Model
         NUMBER_2 = 2
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumIntegerDefaultValue"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class OuterEnumIntegerDefaultValueConverter : JsonConverter<OuterEnumIntegerDefaultValue>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumIntegerDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumIntegerDefaultValue FromString(string value)
         {
             if (value == (0).ToString())
@@ -60,6 +69,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type OuterEnumIntegerDefaultValue: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="OuterEnumIntegerDefaultValue"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static OuterEnumIntegerDefaultValue? FromStringOrDefault(string value)
         {
             if (value == (0).ToString())
@@ -74,6 +88,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="OuterEnumIntegerDefaultValue"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static int ToJsonValue(OuterEnumIntegerDefaultValue value)
         {
             return (int) value;
@@ -90,8 +110,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            OuterEnumIntegerDefaultValue? result = OuterEnumIntegerDefaultValueConverter.FromString(rawValue);
-            
+            OuterEnumIntegerDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -110,6 +132,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="OuterEnumIntegerDefaultValue"/>
+    /// </summary>
     public class OuterEnumIntegerDefaultValueNullableConverter : JsonConverter<OuterEnumIntegerDefaultValue?>
     {
         /// <summary>
@@ -123,10 +148,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            OuterEnumIntegerDefaultValue? result = OuterEnumIntegerDefaultValueConverter.FromString(rawValue);
+            OuterEnumIntegerDefaultValue? result = rawValue == null
+                ? null
+                : OuterEnumIntegerDefaultValueConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -55,12 +55,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ParentPet
+    /// A Json converter for type <see cref="ParentPet" />
     /// </summary>
     public class ParentPetJsonConverter : JsonConverter<ParentPet>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ParentPet" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -106,7 +106,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ParentPet" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="parentPet"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -74,10 +74,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a StatusEnum
+        /// Returns a <see cref="StatusEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static StatusEnum StatusEnumFromString(string value)
         {
             if (value == "available")
@@ -93,7 +94,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="StatusEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static StatusEnum? StatusEnumFromStringOrDefault(string value)
+        {
+            if (value == "available")
+                return StatusEnum.Available;
+
+            if (value == "pending")
+                return StatusEnum.Pending;
+
+            if (value == "sold")
+                return StatusEnum.Sold;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StatusEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -187,12 +207,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Pet
+    /// A Json converter for type <see cref="Pet" />
     /// </summary>
     public class PetJsonConverter : JsonConverter<Pet>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Pet" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -247,7 +267,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "status":
                             string statusRawValue = utf8JsonReader.GetString();
-                            status = Pet.StatusEnumFromString(statusRawValue);
+                            status = statusRawValue == null
+                                ? null
+                                : Pet.StatusEnumFromStringOrDefault(statusRawValue);
                             break;
                         case "tags":
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
@@ -281,7 +303,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Pet" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="pet"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pig.cs
@@ -103,12 +103,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Pig
+    /// A Json converter for type <see cref="Pig" />
     /// </summary>
     public class PigJsonConverter : JsonConverter<Pig>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Pig" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -157,7 +157,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Pig" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="pig"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -125,12 +125,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type PolymorphicProperty
+    /// A Json converter for type <see cref="PolymorphicProperty" />
     /// </summary>
     public class PolymorphicPropertyJsonConverter : JsonConverter<PolymorphicProperty>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="PolymorphicProperty" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -187,7 +187,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="PolymorphicProperty" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="polymorphicProperty"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -103,12 +103,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Quadrilateral
+    /// A Json converter for type <see cref="Quadrilateral" />
     /// </summary>
     public class QuadrilateralJsonConverter : JsonConverter<Quadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Quadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -157,7 +157,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Quadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="quadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type QuadrilateralInterface
+    /// A Json converter for type <see cref="QuadrilateralInterface" />
     /// </summary>
     public class QuadrilateralInterfaceJsonConverter : JsonConverter<QuadrilateralInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="QuadrilateralInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="QuadrilateralInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="quadrilateralInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -124,12 +124,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ReadOnlyFirst
+    /// A Json converter for type <see cref="ReadOnlyFirst" />
     /// </summary>
     public class ReadOnlyFirstJsonConverter : JsonConverter<ReadOnlyFirst>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ReadOnlyFirst" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ReadOnlyFirst" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="readOnlyFirst"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Return.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Return
+    /// A Json converter for type <see cref="Return" />
     /// </summary>
     public class ReturnJsonConverter : JsonConverter<Return>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Return" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Return" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="varReturn"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ScaleneTriangle
+    /// A Json converter for type <see cref="ScaleneTriangle" />
     /// </summary>
     public class ScaleneTriangleJsonConverter : JsonConverter<ScaleneTriangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ScaleneTriangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ScaleneTriangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="scaleneTriangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -114,12 +114,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Shape
+    /// A Json converter for type <see cref="Shape" />
     /// </summary>
     public class ShapeJsonConverter : JsonConverter<Shape>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Shape" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Shape" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shape"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ShapeInterface
+    /// A Json converter for type <see cref="ShapeInterface" />
     /// </summary>
     public class ShapeInterfaceJsonConverter : JsonConverter<ShapeInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ShapeInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ShapeInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shapeInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -114,12 +114,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ShapeOrNull
+    /// A Json converter for type <see cref="ShapeOrNull" />
     /// </summary>
     public class ShapeOrNullJsonConverter : JsonConverter<ShapeOrNull>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ShapeOrNull" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ShapeOrNull" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="shapeOrNull"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -84,12 +84,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type SimpleQuadrilateral
+    /// A Json converter for type <see cref="SimpleQuadrilateral" />
     /// </summary>
     public class SimpleQuadrilateralJsonConverter : JsonConverter<SimpleQuadrilateral>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="SimpleQuadrilateral" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="SimpleQuadrilateral" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="simpleQuadrilateral"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type SpecialModelName
+    /// A Json converter for type <see cref="SpecialModelName" />
     /// </summary>
     public class SpecialModelNameJsonConverter : JsonConverter<SpecialModelName>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="SpecialModelName" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="SpecialModelName" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="specialModelName"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -88,12 +88,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Tag
+    /// A Json converter for type <see cref="Tag" />
     /// </summary>
     public class TagJsonConverter : JsonConverter<Tag>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Tag" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Tag" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="tag"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TestCollectionEndingWithWordList
+    /// A Json converter for type <see cref="TestCollectionEndingWithWordList" />
     /// </summary>
     public class TestCollectionEndingWithWordListJsonConverter : JsonConverter<TestCollectionEndingWithWordList>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TestCollectionEndingWithWordList" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TestCollectionEndingWithWordList" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="testCollectionEndingWithWordList"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TestCollectionEndingWithWordListObject
+    /// A Json converter for type <see cref="TestCollectionEndingWithWordListObject" />
     /// </summary>
     public class TestCollectionEndingWithWordListObjectJsonConverter : JsonConverter<TestCollectionEndingWithWordListObject>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TestCollectionEndingWithWordListObject" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TestCollectionEndingWithWordListObject" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="testCollectionEndingWithWordListObject"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Triangle.cs
@@ -145,12 +145,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Triangle
+    /// A Json converter for type <see cref="Triangle" />
     /// </summary>
     public class TriangleJsonConverter : JsonConverter<Triangle>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Triangle" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -218,7 +218,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Triangle" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="triangle"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -79,12 +79,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type TriangleInterface
+    /// A Json converter for type <see cref="TriangleInterface" />
     /// </summary>
     public class TriangleInterfaceJsonConverter : JsonConverter<TriangleInterface>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="TriangleInterface" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="TriangleInterface" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="triangleInterface"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/User.cs
@@ -183,12 +183,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type User
+    /// A Json converter for type <see cref="User" />
     /// </summary>
     public class UserJsonConverter : JsonConverter<User>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="User" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -311,7 +311,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="User" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="user"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -97,12 +97,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Whale
+    /// A Json converter for type <see cref="Whale" />
     /// </summary>
     public class WhaleJsonConverter : JsonConverter<Whale>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Whale" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Whale" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="whale"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -65,10 +65,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a TypeEnum
+        /// Returns a <see cref="TypeEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static TypeEnum TypeEnumFromString(string value)
         {
             if (value == "plains")
@@ -84,7 +85,26 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="TypeEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static TypeEnum? TypeEnumFromStringOrDefault(string value)
+        {
+            if (value == "plains")
+                return TypeEnum.Plains;
+
+            if (value == "mountain")
+                return TypeEnum.Mountain;
+
+            if (value == "grevys")
+                return TypeEnum.Grevys;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="TypeEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -149,12 +169,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type Zebra
+    /// A Json converter for type <see cref="Zebra" />
     /// </summary>
     public class ZebraJsonConverter : JsonConverter<Zebra>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="Zebra" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -193,7 +213,9 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "type":
                             string typeRawValue = utf8JsonReader.GetString();
-                            type = Zebra.TypeEnumFromString(typeRawValue);
+                            type = typeRawValue == null
+                                ? null
+                                : Zebra.TypeEnumFromStringOrDefault(typeRawValue);
                             break;
                         default:
                             break;
@@ -211,7 +233,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="Zebra" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="zebra"></param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ZeroBasedEnum.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ZeroBasedEnum.cs
@@ -39,8 +39,17 @@ namespace Org.OpenAPITools.Model
         NotUnknown
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="ZeroBasedEnum"/>
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
     public class ZeroBasedEnumConverter : JsonConverter<ZeroBasedEnum>
     {
+        /// <summary>
+        /// Parses a given value to <see cref="ZeroBasedEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static ZeroBasedEnum FromString(string value)
         {
             if (value == "unknown")
@@ -52,6 +61,11 @@ namespace Org.OpenAPITools.Model
             throw new NotImplementedException($"Could not convert value to type ZeroBasedEnum: '{value}'");
         }
 
+        /// <summary>
+        /// Parses a given value to <see cref="ZeroBasedEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static ZeroBasedEnum? FromStringOrDefault(string value)
         {
             if (value == "unknown")
@@ -63,6 +77,12 @@ namespace Org.OpenAPITools.Model
             return null;
         }
 
+        /// <summary>
+        /// Converts the <see cref="ZeroBasedEnum"/> to the json value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static string ToJsonValue(ZeroBasedEnum value)
         {
             if (value == ZeroBasedEnum.Unknown)
@@ -85,8 +105,10 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            ZeroBasedEnum? result = ZeroBasedEnumConverter.FromString(rawValue);
-            
+            ZeroBasedEnum? result = rawValue == null
+                ? null
+                : ZeroBasedEnumConverter.FromStringOrDefault(rawValue);
+
             if (result != null)
                 return result.Value;
 
@@ -105,6 +127,9 @@ namespace Org.OpenAPITools.Model
         }
     }
 
+    /// <summary>
+    /// A Json converter for type <see cref="ZeroBasedEnum"/>
+    /// </summary>
     public class ZeroBasedEnumNullableConverter : JsonConverter<ZeroBasedEnum?>
     {
         /// <summary>
@@ -118,10 +143,9 @@ namespace Org.OpenAPITools.Model
         {
             string rawValue = reader.GetString();
 
-            if (rawValue == null)
-                return null;
-
-            ZeroBasedEnum? result = ZeroBasedEnumConverter.FromString(rawValue);
+            ZeroBasedEnum? result = rawValue == null
+                ? null
+                : ZeroBasedEnumConverter.FromStringOrDefault(rawValue);
 
             if (result != null)
                 return result.Value;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -58,10 +58,11 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns a ZeroBasedEnumEnum
+        /// Returns a <see cref="ZeroBasedEnumEnum"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         public static ZeroBasedEnumEnum ZeroBasedEnumEnumFromString(string value)
         {
             if (value == "unknown")
@@ -74,7 +75,23 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Returns equivalent json value
+        /// Returns a <see cref="ZeroBasedEnumEnum"/>
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ZeroBasedEnumEnum? ZeroBasedEnumEnumFromStringOrDefault(string value)
+        {
+            if (value == "unknown")
+                return ZeroBasedEnumEnum.Unknown;
+
+            if (value == "notUnknown")
+                return ZeroBasedEnumEnum.NotUnknown;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="ZeroBasedEnumEnum"/> to the json value
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
@@ -128,12 +145,12 @@ namespace Org.OpenAPITools.Model
     }
 
     /// <summary>
-    /// A Json converter for type ZeroBasedEnumClass
+    /// A Json converter for type <see cref="ZeroBasedEnumClass" />
     /// </summary>
     public class ZeroBasedEnumClassJsonConverter : JsonConverter<ZeroBasedEnumClass>
     {
         /// <summary>
-        /// A Json reader.
+        /// Deserializes json to <see cref="ZeroBasedEnumClass" />
         /// </summary>
         /// <param name="utf8JsonReader"></param>
         /// <param name="typeToConvert"></param>
@@ -168,7 +185,9 @@ namespace Org.OpenAPITools.Model
                     {
                         case "ZeroBasedEnum":
                             string zeroBasedEnumRawValue = utf8JsonReader.GetString();
-                            zeroBasedEnum = ZeroBasedEnumClass.ZeroBasedEnumEnumFromString(zeroBasedEnumRawValue);
+                            zeroBasedEnum = zeroBasedEnumRawValue == null
+                                ? null
+                                : ZeroBasedEnumClass.ZeroBasedEnumEnumFromStringOrDefault(zeroBasedEnumRawValue);
                             break;
                         default:
                             break;
@@ -183,7 +202,7 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// A Json writer
+        /// Serializes a <see cref="ZeroBasedEnumClass" />
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="zeroBasedEnumClass"></param>


### PR DESCRIPTION
Breaking change due to the enum's FromString method can throw now, but their is a FromStringOrDefault which will not.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
