### PR TITLE
[Rust] Sanitize enum names correctly

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRustCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRustCodegen.java
@@ -283,7 +283,7 @@ public abstract class AbstractRustCodegen extends DefaultCodegen implements Code
     @Override
     public String toEnumName(CodegenProperty property) {
         // Note: Strangely this function is only used for inline enums, schema enums go through the toModelName function
-        String name = property.name;
+        String name = property.baseName;
         if (!Strings.isNullOrEmpty(enumSuffix)) {
             name = name + "_" + enumSuffix;
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/AbstractRustCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/AbstractRustCodegenTest.java
@@ -121,13 +121,17 @@ public class AbstractRustCodegenTest {
         // Empty strings need to be mapped to "Empty"
         // https://github.com/OpenAPITools/openapi-generator/issues/13453
         Assert.assertEquals(codegen.toEnumVarName("", null), "Empty");
+        // Reserved words should be sanitized properly
+        // https://github.com/OpenAPITools/openapi-generator/pull/15710
+        Assert.assertEquals(codegen.toEnumVarName("type", null), "Type");
+        Assert.assertEquals(codegen.toEnumVarName("Self", null), "VariantSelf");
     }
 
     @Test
     public void testToEnumName() {
         Function<String, String> toEnumName = (String name) -> {
             CodegenProperty property = new CodegenProperty();
-            property.name = name;
+            property.baseName = name;
             return codegen.toEnumName(property);
         };
         // Should be converted to camel case


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Consider a model like the below:
```json
{
  "type": "object",
  "properties": {
    "type": {
      "type": "string",
      "description": "An enum.",
      "enum": [
        "VARIANT",
        "MORE_VARIANT"
      ]
    },
}
```

Currently, the `type` property will be represented in Rust by the name `RHashType`, because the generator tries to sanitize the name first as a variable name (`type` → `r#type`) and then again as a type name (`r#type` → `RHashType`). This PR ensures that the sanitizing happens only once (`type` → `Type`).

This is a breaking change to the generator's output.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol @farcaller @richardwhiuk @paladinzh @jacob-pro