### PR TITLE
[Go] Update go-echo-server generator to respect the --git-host argument

### DIFF
--- a/bin/configs/go-echo-server-petstore-new.yaml
+++ b/bin/configs/go-echo-server-petstore-new.yaml
@@ -2,5 +2,8 @@ generatorName: go-echo-server
 outputDir: samples/server/petstore/go-echo-server
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/go-echo-server
+gitHost: gitlab.com
+gitUserId: openapitools
+gitRepoId: petstore
 additionalProperties:
   hideGenerationTimestamp: "true"

--- a/modules/openapi-generator/src/main/resources/go-echo-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-echo-server/api.mustache
@@ -1,7 +1,7 @@
 package handlers
 {{#operations}}
 import (
-    "github.com/{{{gitUserId}}}/{{{gitRepoId}}}/models"
+    "{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}/models"
     "github.com/labstack/echo/v4"
     "net/http"
 ){{#operation}}

--- a/modules/openapi-generator/src/main/resources/go-echo-server/go-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-echo-server/go-mod.mustache
@@ -1,4 +1,4 @@
-module github.com/{{{gitUserId}}}/{{{gitRepoId}}}
+module {{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}
 
 go 1.16
 

--- a/modules/openapi-generator/src/main/resources/go-echo-server/main.mustache
+++ b/modules/openapi-generator/src/main/resources/go-echo-server/main.mustache
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/{{{gitUserId}}}/{{{gitRepoId}}}/handlers"
+	"{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}/handlers"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )

--- a/samples/server/petstore/go-echo-server/go.mod
+++ b/samples/server/petstore/go-echo-server/go.mod
@@ -1,4 +1,4 @@
-module github.com/GIT_USER_ID/GIT_REPO_ID
+module gitlab.com/openapitools/petstore
 
 go 1.16
 

--- a/samples/server/petstore/go-echo-server/handlers/api_pet.go
+++ b/samples/server/petstore/go-echo-server/handlers/api_pet.go
@@ -1,6 +1,6 @@
 package handlers
 import (
-    "github.com/GIT_USER_ID/GIT_REPO_ID/models"
+    "gitlab.com/openapitools/petstore/models"
     "github.com/labstack/echo/v4"
     "net/http"
 )

--- a/samples/server/petstore/go-echo-server/handlers/api_store.go
+++ b/samples/server/petstore/go-echo-server/handlers/api_store.go
@@ -1,6 +1,6 @@
 package handlers
 import (
-    "github.com/GIT_USER_ID/GIT_REPO_ID/models"
+    "gitlab.com/openapitools/petstore/models"
     "github.com/labstack/echo/v4"
     "net/http"
 )

--- a/samples/server/petstore/go-echo-server/handlers/api_user.go
+++ b/samples/server/petstore/go-echo-server/handlers/api_user.go
@@ -1,6 +1,6 @@
 package handlers
 import (
-    "github.com/GIT_USER_ID/GIT_REPO_ID/models"
+    "gitlab.com/openapitools/petstore/models"
     "github.com/labstack/echo/v4"
     "net/http"
 )

--- a/samples/server/petstore/go-echo-server/main.go
+++ b/samples/server/petstore/go-echo-server/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/GIT_USER_ID/GIT_REPO_ID/handlers"
+	"gitlab.com/openapitools/petstore/handlers"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )


### PR DESCRIPTION
Hi!
As discussed in #15636, this PR changes the template files of go-echo-server in order to respect the `--git-host` argument. The changes have been tested by running the `./bin/generate-samples.sh ./bin/configs/go-echo-server-petstore-new.yaml` and by hand using the generated `openapi-generator-cli.jar`.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)
