### PR TITLE
[Python] Added BadRequestException as a subclass in python exceptions

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/exceptions.mustache
+++ b/modules/openapi-generator/src/main/resources/python/exceptions.mustache
@@ -116,6 +116,10 @@ class ApiException(OpenApiException):
 
         return error_message
 
+class BadRequestException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(BadRequestException, self).__init__(status, reason, http_resp)
 
 class NotFoundException(ApiException):
 

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -11,7 +11,7 @@ import ssl
 from urllib.parse import urlencode, quote_plus
 import urllib3
 
-from {{packageName}}.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
+from {{packageName}}.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException
 
 
 logger = logging.getLogger(__name__)
@@ -208,6 +208,9 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            if r.status == 400:
+                raise BadRequestException(http_resp=r)
+
             if r.status == 401:
                 raise UnauthorizedException(http_resp=r)
 

--- a/samples/client/echo_api/python/openapi_client/exceptions.py
+++ b/samples/client/echo_api/python/openapi_client/exceptions.py
@@ -127,6 +127,10 @@ class ApiException(OpenApiException):
 
         return error_message
 
+class BadRequestException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(BadRequestException, self).__init__(status, reason, http_resp)
 
 class NotFoundException(ApiException):
 

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -22,7 +22,7 @@ import ssl
 from urllib.parse import urlencode, quote_plus
 import urllib3
 
-from openapi_client.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
+from openapi_client.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException
 
 
 logger = logging.getLogger(__name__)
@@ -219,6 +219,9 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            if r.status == 400:
+                raise BadRequestException(http_resp=r)
+
             if r.status == 401:
                 raise UnauthorizedException(http_resp=r)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/exceptions.py
@@ -126,6 +126,10 @@ class ApiException(OpenApiException):
 
         return error_message
 
+class BadRequestException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(BadRequestException, self).__init__(status, reason, http_resp)
 
 class NotFoundException(ApiException):
 

--- a/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
@@ -126,6 +126,10 @@ class ApiException(OpenApiException):
 
         return error_message
 
+class BadRequestException(ApiException):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        super(BadRequestException, self).__init__(status, reason, http_resp)
 
 class NotFoundException(ApiException):
 

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -21,7 +21,7 @@ import ssl
 from urllib.parse import urlencode, quote_plus
 import urllib3
 
-from petstore_api.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
+from petstore_api.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException
 
 
 logger = logging.getLogger(__name__)
@@ -218,6 +218,9 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            if r.status == 400:
+                raise BadRequestException(http_resp=r)
+
             if r.status == 401:
                 raise UnauthorizedException(http_resp=r)
 


### PR DESCRIPTION
Added BadRequestException as a subclass in python exceptions in order to validate the exceptions precisely

@spacether  @krjakbrjak 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
