### PR TITLE
[Java][bugfix] hashcode/equals behave incorrectly when inheritance is used in Generated Pojos

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaInflector/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/pojo.mustache
@@ -59,14 +59,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -81,15 +81,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
@@ -134,6 +134,24 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
   {{/vars}}
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
+  }
+
+  @Override
+  public int hashCode() {
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
+  }
+
+  @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class {{classname}} {\n");

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -106,17 +106,15 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
-    }{{#hasVars}}
-    {{classname}} {{classVarName}} = ({{classname}}) o;
-    return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    }
+    {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
@@ -52,14 +52,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
@@ -54,14 +54,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaVertXServer/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXServer/pojo.mustache
@@ -39,14 +39,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/pojo.mustache
@@ -39,14 +39,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
-        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o) && {{/parent}}{{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{#-last}};{{/-last}}{{/vars}}{{/hasVars}}{{^hasVars}}{{#parent}}return super.equals(o);{{/parent}}{{^parent}}return true;{{/parent}}{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}});
+    return {{^hasVars}}{{#parent}}super.hashCode(){{/parent}}{{^parent}}1{{/parent}}{{/hasVars}}{{#hasVars}}Objects.hash({{#vars}}{{#parent}}super.hashCode(), {{/parent}}{{name}}{{^-last}}, {{/-last}}{{/vars}}){{/hasVars}};
   }
 
   @Override

--- a/modules/openapi-generator/src/test/resources/3_0/allOf_no_fields.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf_no_fields.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /example:
+    get:
+      operationId: dummyid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseClass"
+components:
+  schemas:
+    BaseClass:
+      type: object
+      properties:
+        myDiscrim:
+          type: string
+      discriminator:
+        propertyName: myDiscrim
+        mapping:
+          WITHPROPS: '#/components/schemas/ChildWithProperties'
+          WITHOUTPROPS: '#/components/schemas/ChildWithoutProperties'
+    ChildWithoutProperties:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseClass'
+    ChildWithProperties:
+      type: object
+      allOf:
+      - type: object
+        properties:
+          childProperty:
+            type: string
+      - $ref: '#/components/schemas/BaseClass'

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesAnyType.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -68,13 +68,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesArray.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesBoolean.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -383,17 +383,17 @@ public class AdditionalPropertiesClass  implements Serializable {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesInteger.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -68,13 +68,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesNumber.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesObject.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesString.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Animal.java
@@ -99,8 +99,8 @@ public class Animal  implements Serializable {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(className, animal.className) &&
+        Objects.equals(color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -76,7 +76,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -76,7 +76,7 @@ public class ArrayOfNumberOnly  implements Serializable {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -142,9 +142,9 @@ public class ArrayTest  implements Serializable {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/BigCat.java
@@ -102,13 +102,12 @@ public class BigCat extends Cat implements Serializable {
       return false;
     }
     BigCat bigCat = (BigCat) o;
-    return Objects.equals(this.kind, bigCat.kind) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(kind, bigCat.kind);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kind, super.hashCode());
+    return Objects.hash(super.hashCode(), kind);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Capitalization.java
@@ -190,12 +190,12 @@ public class Capitalization  implements Serializable {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
-        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
-        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(smallCamel, capitalization.smallCamel) &&
+        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(smallSnake, capitalization.smallSnake) &&
+        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Cat.java
@@ -66,13 +66,12 @@ public class Cat extends Animal implements Serializable {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(declawed, cat.declawed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(super.hashCode(), declawed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Category.java
@@ -90,8 +90,8 @@ public class Category  implements Serializable {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(this.id, category.id) &&
-        Objects.equals(this.name, category.name);
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ClassModel.java
@@ -66,7 +66,7 @@ public class ClassModel  implements Serializable {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(this.propertyClass, classModel.propertyClass);
+    return Objects.equals(propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Client.java
@@ -65,7 +65,7 @@ public class Client  implements Serializable {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(this.client, client.client);
+    return Objects.equals(client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Dog.java
@@ -66,13 +66,12 @@ public class Dog extends Animal implements Serializable {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(breed, dog.breed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(super.hashCode(), breed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -163,8 +163,8 @@ public class EnumArrays  implements Serializable {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumTest.java
@@ -296,11 +296,11 @@ public class EnumTest  implements Serializable {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(this.enumString, enumTest.enumString) &&
-        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
-        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
-        Objects.equals(this.outerEnum, enumTest.outerEnum);
+    return Objects.equals(enumString, enumTest.enumString) &&
+        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(enumInteger, enumTest.enumInteger) &&
+        Objects.equals(enumNumber, enumTest.enumNumber) &&
+        Objects.equals(outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -101,8 +101,8 @@ public class FileSchemaTestClass  implements Serializable {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(this._file, fileSchemaTestClass._file) &&
-        Objects.equals(this.files, fileSchemaTestClass.files);
+    return Objects.equals(_file, fileSchemaTestClass._file) &&
+        Objects.equals(files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FormatTest.java
@@ -406,20 +406,20 @@ public class FormatTest  implements Serializable {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(this.integer, formatTest.integer) &&
-        Objects.equals(this.int32, formatTest.int32) &&
-        Objects.equals(this.int64, formatTest.int64) &&
-        Objects.equals(this.number, formatTest.number) &&
-        Objects.equals(this._float, formatTest._float) &&
-        Objects.equals(this._double, formatTest._double) &&
-        Objects.equals(this.string, formatTest.string) &&
-        Objects.equals(this._byte, formatTest._byte) &&
-        Objects.equals(this.binary, formatTest.binary) &&
-        Objects.equals(this.date, formatTest.date) &&
-        Objects.equals(this.dateTime, formatTest.dateTime) &&
-        Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password) &&
-        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
+    return Objects.equals(integer, formatTest.integer) &&
+        Objects.equals(int32, formatTest.int32) &&
+        Objects.equals(int64, formatTest.int64) &&
+        Objects.equals(number, formatTest.number) &&
+        Objects.equals(_float, formatTest._float) &&
+        Objects.equals(_double, formatTest._double) &&
+        Objects.equals(string, formatTest.string) &&
+        Objects.equals(_byte, formatTest._byte) &&
+        Objects.equals(binary, formatTest.binary) &&
+        Objects.equals(date, formatTest.date) &&
+        Objects.equals(dateTime, formatTest.dateTime) &&
+        Objects.equals(uuid, formatTest.uuid) &&
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(bigDecimal, formatTest.bigDecimal);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -91,8 +91,8 @@ public class HasOnlyReadOnly  implements Serializable {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(this.foo, hasOnlyReadOnly.foo);
+    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
@@ -206,10 +206,10 @@ public class MapTest  implements Serializable {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(this.directMap, mapTest.directMap) &&
-        Objects.equals(this.indirectMap, mapTest.indirectMap);
+    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(directMap, mapTest.directMap) &&
+        Objects.equals(indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -128,9 +128,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Model200Response.java
@@ -92,8 +92,8 @@ public class Model200Response  implements Serializable {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(this.name, _200response.name) &&
-        Objects.equals(this.propertyClass, _200response.propertyClass);
+    return Objects.equals(name, _200response.name) &&
+        Objects.equals(propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -116,9 +116,9 @@ public class ModelApiResponse  implements Serializable {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(this.code, _apiResponse.code) &&
-        Objects.equals(this.type, _apiResponse.type) &&
-        Objects.equals(this.message, _apiResponse.message);
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelFile.java
@@ -67,7 +67,7 @@ public class ModelFile  implements Serializable {
       return false;
     }
     ModelFile _file = (ModelFile) o;
-    return Objects.equals(this.sourceURI, _file.sourceURI);
+    return Objects.equals(sourceURI, _file.sourceURI);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelList.java
@@ -66,7 +66,7 @@ public class ModelList  implements Serializable {
       return false;
     }
     ModelList _list = (ModelList) o;
-    return Objects.equals(this._123list, _list._123list);
+    return Objects.equals(_123list, _list._123list);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -67,7 +67,7 @@ public class ModelReturn  implements Serializable {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(this._return, _return._return);
+    return Objects.equals(_return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Name.java
@@ -141,10 +141,10 @@ public class Name  implements Serializable {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(this.name, name.name) &&
-        Objects.equals(this.snakeCase, name.snakeCase) &&
-        Objects.equals(this.property, name.property) &&
-        Objects.equals(this._123number, name._123number);
+    return Objects.equals(name, name.name) &&
+        Objects.equals(snakeCase, name.snakeCase) &&
+        Objects.equals(property, name.property) &&
+        Objects.equals(_123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -66,7 +66,7 @@ public class NumberOnly  implements Serializable {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(this.justNumber, numberOnly.justNumber);
+    return Objects.equals(justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
@@ -225,12 +225,12 @@ public class Order  implements Serializable {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(this.id, order.id) &&
-        Objects.equals(this.petId, order.petId) &&
-        Objects.equals(this.quantity, order.quantity) &&
-        Objects.equals(this.shipDate, order.shipDate) &&
-        Objects.equals(this.status, order.status) &&
-        Objects.equals(this.complete, order.complete);
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -116,9 +116,9 @@ public class OuterComposite  implements Serializable {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
-        Objects.equals(this.myString, outerComposite.myString) &&
-        Objects.equals(this.myBoolean, outerComposite.myBoolean);
+    return Objects.equals(myNumber, outerComposite.myNumber) &&
+        Objects.equals(myString, outerComposite.myString) &&
+        Objects.equals(myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
@@ -248,12 +248,12 @@ public class Pet  implements Serializable {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(this.id, pet.id) &&
-        Objects.equals(this.category, pet.category) &&
-        Objects.equals(this.name, pet.name) &&
-        Objects.equals(this.photoUrls, pet.photoUrls) &&
-        Objects.equals(this.tags, pet.tags) &&
-        Objects.equals(this.status, pet.status);
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -90,8 +90,8 @@ public class ReadOnlyFirst  implements Serializable {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(this.bar, readOnlyFirst.bar) &&
-        Objects.equals(this.baz, readOnlyFirst.baz);
+    return Objects.equals(bar, readOnlyFirst.bar) &&
+        Objects.equals(baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -66,7 +66,7 @@ public class SpecialModelName  implements Serializable {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Tag.java
@@ -90,8 +90,8 @@ public class Tag  implements Serializable {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(this.id, tag.id) &&
-        Objects.equals(this.name, tag.name);
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -176,11 +176,11 @@ public class TypeHolderDefault  implements Serializable {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -201,12 +201,12 @@ public class TypeHolderExample  implements Serializable {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(this.floatItem, typeHolderExample.floatItem) &&
-        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(floatItem, typeHolderExample.floatItem) &&
+        Objects.equals(integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/User.java
@@ -240,14 +240,14 @@ public class User  implements Serializable {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(this.id, user.id) &&
-        Objects.equals(this.username, user.username) &&
-        Objects.equals(this.firstName, user.firstName) &&
-        Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.email, user.email) &&
-        Objects.equals(this.password, user.password) &&
-        Objects.equals(this.phone, user.phone) &&
-        Objects.equals(this.userStatus, user.userStatus);
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/XmlItem.java
@@ -840,35 +840,35 @@ public class XmlItem  implements Serializable {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
-        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(this.nameString, xmlItem.nameString) &&
-        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(this.nameArray, xmlItem.nameArray) &&
-        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(this.prefixString, xmlItem.prefixString) &&
-        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(attributeString, xmlItem.attributeString) &&
+        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(nameString, xmlItem.nameString) &&
+        Objects.equals(nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(nameArray, xmlItem.nameArray) &&
+        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(prefixString, xmlItem.prefixString) &&
+        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -107,8 +107,8 @@ public class AdditionalPropertiesClass   {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(this.mapProperty, additionalPropertiesClass.mapProperty) &&
-        Objects.equals(this.mapOfMapProperty, additionalPropertiesClass.mapOfMapProperty);
+    return Objects.equals(mapProperty, additionalPropertiesClass.mapProperty) &&
+        Objects.equals(mapOfMapProperty, additionalPropertiesClass.mapOfMapProperty);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/AllOfWithSingleRef.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/AllOfWithSingleRef.java
@@ -91,8 +91,8 @@ public class AllOfWithSingleRef   {
       return false;
     }
     AllOfWithSingleRef allOfWithSingleRef = (AllOfWithSingleRef) o;
-    return Objects.equals(this.username, allOfWithSingleRef.username) &&
-        Objects.equals(this.singleRefType, allOfWithSingleRef.singleRefType);
+    return Objects.equals(username, allOfWithSingleRef.username) &&
+        Objects.equals(singleRefType, allOfWithSingleRef.singleRefType);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Animal.java
@@ -97,8 +97,8 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(className, animal.className) &&
+        Objects.equals(color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfArrayOfNumberOnly   {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfNumberOnly   {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -141,9 +141,9 @@ public class ArrayTest   {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Capitalization.java
@@ -189,12 +189,12 @@ public class Capitalization   {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
-        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
-        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(smallCamel, capitalization.smallCamel) &&
+        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(smallSnake, capitalization.smallSnake) &&
+        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Cat.java
@@ -65,13 +65,12 @@ public class Cat extends Animal  {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(declawed, cat.declawed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(super.hashCode(), declawed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Category.java
@@ -89,8 +89,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(this.id, category.id) &&
-        Objects.equals(this.name, category.name);
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ClassModel.java
@@ -65,7 +65,7 @@ public class ClassModel   {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(this.propertyClass, classModel.propertyClass);
+    return Objects.equals(propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Client.java
@@ -64,7 +64,7 @@ public class Client   {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(this.client, client.client);
+    return Objects.equals(client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/DeprecatedObject.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/DeprecatedObject.java
@@ -64,7 +64,7 @@ public class DeprecatedObject   {
       return false;
     }
     DeprecatedObject deprecatedObject = (DeprecatedObject) o;
-    return Objects.equals(this.name, deprecatedObject.name);
+    return Objects.equals(name, deprecatedObject.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Dog.java
@@ -65,13 +65,12 @@ public class Dog extends Animal  {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(breed, dog.breed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(super.hashCode(), breed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -162,8 +162,8 @@ public class EnumArrays   {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumTest.java
@@ -373,14 +373,14 @@ public class EnumTest   {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(this.enumString, enumTest.enumString) &&
-        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
-        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
-        Objects.equals(this.outerEnum, enumTest.outerEnum) &&
-        Objects.equals(this.outerEnumInteger, enumTest.outerEnumInteger) &&
-        Objects.equals(this.outerEnumDefaultValue, enumTest.outerEnumDefaultValue) &&
-        Objects.equals(this.outerEnumIntegerDefaultValue, enumTest.outerEnumIntegerDefaultValue);
+    return Objects.equals(enumString, enumTest.enumString) &&
+        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(enumInteger, enumTest.enumInteger) &&
+        Objects.equals(enumNumber, enumTest.enumNumber) &&
+        Objects.equals(outerEnum, enumTest.outerEnum) &&
+        Objects.equals(outerEnumInteger, enumTest.outerEnumInteger) &&
+        Objects.equals(outerEnumDefaultValue, enumTest.outerEnumDefaultValue) &&
+        Objects.equals(outerEnumIntegerDefaultValue, enumTest.outerEnumIntegerDefaultValue);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FakeBigDecimalMap200Response.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FakeBigDecimalMap200Response.java
@@ -101,8 +101,8 @@ public class FakeBigDecimalMap200Response   {
       return false;
     }
     FakeBigDecimalMap200Response fakeBigDecimalMap200Response = (FakeBigDecimalMap200Response) o;
-    return Objects.equals(this.someId, fakeBigDecimalMap200Response.someId) &&
-        Objects.equals(this.someMap, fakeBigDecimalMap200Response.someMap);
+    return Objects.equals(someId, fakeBigDecimalMap200Response.someId) &&
+        Objects.equals(someMap, fakeBigDecimalMap200Response.someMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -100,8 +100,8 @@ public class FileSchemaTestClass   {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(this._file, fileSchemaTestClass._file) &&
-        Objects.equals(this.files, fileSchemaTestClass.files);
+    return Objects.equals(_file, fileSchemaTestClass._file) &&
+        Objects.equals(files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Foo.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Foo.java
@@ -64,7 +64,7 @@ public class Foo   {
       return false;
     }
     Foo foo = (Foo) o;
-    return Objects.equals(this.bar, foo.bar);
+    return Objects.equals(bar, foo.bar);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FooGetDefaultResponse.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FooGetDefaultResponse.java
@@ -66,7 +66,7 @@ public class FooGetDefaultResponse   {
       return false;
     }
     FooGetDefaultResponse fooGetDefaultResponse = (FooGetDefaultResponse) o;
-    return Objects.equals(this.string, fooGetDefaultResponse.string);
+    return Objects.equals(string, fooGetDefaultResponse.string);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FormatTest.java
@@ -454,22 +454,22 @@ public class FormatTest   {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(this.integer, formatTest.integer) &&
-        Objects.equals(this.int32, formatTest.int32) &&
-        Objects.equals(this.int64, formatTest.int64) &&
-        Objects.equals(this.number, formatTest.number) &&
-        Objects.equals(this._float, formatTest._float) &&
-        Objects.equals(this._double, formatTest._double) &&
-        Objects.equals(this.decimal, formatTest.decimal) &&
-        Objects.equals(this.string, formatTest.string) &&
-        Objects.equals(this._byte, formatTest._byte) &&
-        Objects.equals(this.binary, formatTest.binary) &&
-        Objects.equals(this.date, formatTest.date) &&
-        Objects.equals(this.dateTime, formatTest.dateTime) &&
-        Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password) &&
-        Objects.equals(this.patternWithDigits, formatTest.patternWithDigits) &&
-        Objects.equals(this.patternWithDigitsAndDelimiter, formatTest.patternWithDigitsAndDelimiter);
+    return Objects.equals(integer, formatTest.integer) &&
+        Objects.equals(int32, formatTest.int32) &&
+        Objects.equals(int64, formatTest.int64) &&
+        Objects.equals(number, formatTest.number) &&
+        Objects.equals(_float, formatTest._float) &&
+        Objects.equals(_double, formatTest._double) &&
+        Objects.equals(decimal, formatTest.decimal) &&
+        Objects.equals(string, formatTest.string) &&
+        Objects.equals(_byte, formatTest._byte) &&
+        Objects.equals(binary, formatTest.binary) &&
+        Objects.equals(date, formatTest.date) &&
+        Objects.equals(dateTime, formatTest.dateTime) &&
+        Objects.equals(uuid, formatTest.uuid) &&
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(patternWithDigits, formatTest.patternWithDigits) &&
+        Objects.equals(patternWithDigitsAndDelimiter, formatTest.patternWithDigitsAndDelimiter);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -90,8 +90,8 @@ public class HasOnlyReadOnly   {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(this.foo, hasOnlyReadOnly.foo);
+    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HealthCheckResult.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HealthCheckResult.java
@@ -65,7 +65,7 @@ public class HealthCheckResult   {
       return false;
     }
     HealthCheckResult healthCheckResult = (HealthCheckResult) o;
-    return Objects.equals(this.nullableMessage, healthCheckResult.nullableMessage);
+    return Objects.equals(nullableMessage, healthCheckResult.nullableMessage);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MapTest.java
@@ -205,10 +205,10 @@ public class MapTest   {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(this.directMap, mapTest.directMap) &&
-        Objects.equals(this.indirectMap, mapTest.indirectMap);
+    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(directMap, mapTest.directMap) &&
+        Objects.equals(indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -127,9 +127,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Model200Response.java
@@ -91,8 +91,8 @@ public class Model200Response   {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(this.name, _200response.name) &&
-        Objects.equals(this.propertyClass, _200response.propertyClass);
+    return Objects.equals(name, _200response.name) &&
+        Objects.equals(propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -115,9 +115,9 @@ public class ModelApiResponse   {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(this.code, _apiResponse.code) &&
-        Objects.equals(this.type, _apiResponse.type) &&
-        Objects.equals(this.message, _apiResponse.message);
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelFile.java
@@ -66,7 +66,7 @@ public class ModelFile   {
       return false;
     }
     ModelFile _file = (ModelFile) o;
-    return Objects.equals(this.sourceURI, _file.sourceURI);
+    return Objects.equals(sourceURI, _file.sourceURI);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelList.java
@@ -65,7 +65,7 @@ public class ModelList   {
       return false;
     }
     ModelList _list = (ModelList) o;
-    return Objects.equals(this._123list, _list._123list);
+    return Objects.equals(_123list, _list._123list);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -66,7 +66,7 @@ public class ModelReturn   {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(this._return, _return._return);
+    return Objects.equals(_return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Name.java
@@ -140,10 +140,10 @@ public class Name   {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(this.name, name.name) &&
-        Objects.equals(this.snakeCase, name.snakeCase) &&
-        Objects.equals(this.property, name.property) &&
-        Objects.equals(this._123number, name._123number);
+    return Objects.equals(name, name.name) &&
+        Objects.equals(snakeCase, name.snakeCase) &&
+        Objects.equals(property, name.property) &&
+        Objects.equals(_123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NullableClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NullableClass.java
@@ -393,24 +393,23 @@ public class NullableClass extends HashMap<String, Object>  {
       return false;
     }
     NullableClass nullableClass = (NullableClass) o;
-    return Objects.equals(this.integerProp, nullableClass.integerProp) &&
-        Objects.equals(this.numberProp, nullableClass.numberProp) &&
-        Objects.equals(this.booleanProp, nullableClass.booleanProp) &&
-        Objects.equals(this.stringProp, nullableClass.stringProp) &&
-        Objects.equals(this.dateProp, nullableClass.dateProp) &&
-        Objects.equals(this.datetimeProp, nullableClass.datetimeProp) &&
-        Objects.equals(this.arrayNullableProp, nullableClass.arrayNullableProp) &&
-        Objects.equals(this.arrayAndItemsNullableProp, nullableClass.arrayAndItemsNullableProp) &&
-        Objects.equals(this.arrayItemsNullable, nullableClass.arrayItemsNullable) &&
-        Objects.equals(this.objectNullableProp, nullableClass.objectNullableProp) &&
-        Objects.equals(this.objectAndItemsNullableProp, nullableClass.objectAndItemsNullableProp) &&
-        Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(integerProp, nullableClass.integerProp) &&
+        Objects.equals(numberProp, nullableClass.numberProp) &&
+        Objects.equals(booleanProp, nullableClass.booleanProp) &&
+        Objects.equals(stringProp, nullableClass.stringProp) &&
+        Objects.equals(dateProp, nullableClass.dateProp) &&
+        Objects.equals(datetimeProp, nullableClass.datetimeProp) &&
+        Objects.equals(arrayNullableProp, nullableClass.arrayNullableProp) &&
+        Objects.equals(arrayAndItemsNullableProp, nullableClass.arrayAndItemsNullableProp) &&
+        Objects.equals(arrayItemsNullable, nullableClass.arrayItemsNullable) &&
+        Objects.equals(objectNullableProp, nullableClass.objectNullableProp) &&
+        Objects.equals(objectAndItemsNullableProp, nullableClass.objectAndItemsNullableProp) &&
+        Objects.equals(objectItemsNullable, nullableClass.objectItemsNullable);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integerProp, numberProp, booleanProp, stringProp, dateProp, datetimeProp, arrayNullableProp, arrayAndItemsNullableProp, arrayItemsNullable, objectNullableProp, objectAndItemsNullableProp, objectItemsNullable, super.hashCode());
+    return Objects.hash(super.hashCode(), integerProp, super.hashCode(), numberProp, super.hashCode(), booleanProp, super.hashCode(), stringProp, super.hashCode(), dateProp, super.hashCode(), datetimeProp, super.hashCode(), arrayNullableProp, super.hashCode(), arrayAndItemsNullableProp, super.hashCode(), arrayItemsNullable, super.hashCode(), objectNullableProp, super.hashCode(), objectAndItemsNullableProp, super.hashCode(), objectItemsNullable);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -65,7 +65,7 @@ public class NumberOnly   {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(this.justNumber, numberOnly.justNumber);
+    return Objects.equals(justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ObjectWithDeprecatedFields.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ObjectWithDeprecatedFields.java
@@ -151,10 +151,10 @@ public class ObjectWithDeprecatedFields   {
       return false;
     }
     ObjectWithDeprecatedFields objectWithDeprecatedFields = (ObjectWithDeprecatedFields) o;
-    return Objects.equals(this.uuid, objectWithDeprecatedFields.uuid) &&
-        Objects.equals(this.id, objectWithDeprecatedFields.id) &&
-        Objects.equals(this.deprecatedRef, objectWithDeprecatedFields.deprecatedRef) &&
-        Objects.equals(this.bars, objectWithDeprecatedFields.bars);
+    return Objects.equals(uuid, objectWithDeprecatedFields.uuid) &&
+        Objects.equals(id, objectWithDeprecatedFields.id) &&
+        Objects.equals(deprecatedRef, objectWithDeprecatedFields.deprecatedRef) &&
+        Objects.equals(bars, objectWithDeprecatedFields.bars);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Order.java
@@ -224,12 +224,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(this.id, order.id) &&
-        Objects.equals(this.petId, order.petId) &&
-        Objects.equals(this.quantity, order.quantity) &&
-        Objects.equals(this.shipDate, order.shipDate) &&
-        Objects.equals(this.status, order.status) &&
-        Objects.equals(this.complete, order.complete);
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -115,9 +115,9 @@ public class OuterComposite   {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
-        Objects.equals(this.myString, outerComposite.myString) &&
-        Objects.equals(this.myBoolean, outerComposite.myBoolean);
+    return Objects.equals(myNumber, outerComposite.myNumber) &&
+        Objects.equals(myString, outerComposite.myString) &&
+        Objects.equals(myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/OuterObjectWithEnumProperty.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/OuterObjectWithEnumProperty.java
@@ -66,7 +66,7 @@ public class OuterObjectWithEnumProperty   {
       return false;
     }
     OuterObjectWithEnumProperty outerObjectWithEnumProperty = (OuterObjectWithEnumProperty) o;
-    return Objects.equals(this.value, outerObjectWithEnumProperty.value);
+    return Objects.equals(value, outerObjectWithEnumProperty.value);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Pet.java
@@ -247,12 +247,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(this.id, pet.id) &&
-        Objects.equals(this.category, pet.category) &&
-        Objects.equals(this.name, pet.name) &&
-        Objects.equals(this.photoUrls, pet.photoUrls) &&
-        Objects.equals(this.tags, pet.tags) &&
-        Objects.equals(this.status, pet.status);
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -89,8 +89,8 @@ public class ReadOnlyFirst   {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(this.bar, readOnlyFirst.bar) &&
-        Objects.equals(this.baz, readOnlyFirst.baz);
+    return Objects.equals(bar, readOnlyFirst.bar) &&
+        Objects.equals(baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -65,7 +65,7 @@ public class SpecialModelName   {
       return false;
     }
     SpecialModelName specialModelName = (SpecialModelName) o;
-    return Objects.equals(this.$specialPropertyName, specialModelName.$specialPropertyName);
+    return Objects.equals($specialPropertyName, specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Tag.java
@@ -89,8 +89,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(this.id, tag.id) &&
-        Objects.equals(this.name, tag.name);
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/User.java
@@ -239,14 +239,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(this.id, user.id) &&
-        Objects.equals(this.username, user.username) &&
-        Objects.equals(this.firstName, user.firstName) &&
-        Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.email, user.email) &&
-        Objects.equals(this.password, user.password) &&
-        Objects.equals(this.phone, user.phone) &&
-        Objects.equals(this.userStatus, user.userStatus);
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesAnyType.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List>  {
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesArray.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesBoolean.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -382,17 +382,17 @@ public class AdditionalPropertiesClass   {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesInteger.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesNumber.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map>  {
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesObject.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesString extends HashMap<String, String>  {
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesString.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Animal.java
@@ -98,8 +98,8 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(className, animal.className) &&
+        Objects.equals(color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfArrayOfNumberOnly   {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfNumberOnly   {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -141,9 +141,9 @@ public class ArrayTest   {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/BigCat.java
@@ -101,13 +101,12 @@ public class BigCat extends Cat  {
       return false;
     }
     BigCat bigCat = (BigCat) o;
-    return Objects.equals(this.kind, bigCat.kind) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(kind, bigCat.kind);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kind, super.hashCode());
+    return Objects.hash(super.hashCode(), kind);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Capitalization.java
@@ -189,12 +189,12 @@ public class Capitalization   {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
-        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
-        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(smallCamel, capitalization.smallCamel) &&
+        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(smallSnake, capitalization.smallSnake) &&
+        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Cat.java
@@ -65,13 +65,12 @@ public class Cat extends Animal  {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(declawed, cat.declawed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(super.hashCode(), declawed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Category.java
@@ -89,8 +89,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(this.id, category.id) &&
-        Objects.equals(this.name, category.name);
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ClassModel.java
@@ -65,7 +65,7 @@ public class ClassModel   {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(this.propertyClass, classModel.propertyClass);
+    return Objects.equals(propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Client.java
@@ -64,7 +64,7 @@ public class Client   {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(this.client, client.client);
+    return Objects.equals(client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Dog.java
@@ -65,13 +65,12 @@ public class Dog extends Animal  {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(breed, dog.breed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(super.hashCode(), breed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -162,8 +162,8 @@ public class EnumArrays   {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumTest.java
@@ -295,11 +295,11 @@ public class EnumTest   {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(this.enumString, enumTest.enumString) &&
-        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
-        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
-        Objects.equals(this.outerEnum, enumTest.outerEnum);
+    return Objects.equals(enumString, enumTest.enumString) &&
+        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(enumInteger, enumTest.enumInteger) &&
+        Objects.equals(enumNumber, enumTest.enumNumber) &&
+        Objects.equals(outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -100,8 +100,8 @@ public class FileSchemaTestClass   {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(this._file, fileSchemaTestClass._file) &&
-        Objects.equals(this.files, fileSchemaTestClass.files);
+    return Objects.equals(_file, fileSchemaTestClass._file) &&
+        Objects.equals(files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FormatTest.java
@@ -404,20 +404,20 @@ public class FormatTest   {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(this.integer, formatTest.integer) &&
-        Objects.equals(this.int32, formatTest.int32) &&
-        Objects.equals(this.int64, formatTest.int64) &&
-        Objects.equals(this.number, formatTest.number) &&
-        Objects.equals(this._float, formatTest._float) &&
-        Objects.equals(this._double, formatTest._double) &&
-        Objects.equals(this.string, formatTest.string) &&
-        Objects.equals(this._byte, formatTest._byte) &&
-        Objects.equals(this.binary, formatTest.binary) &&
-        Objects.equals(this.date, formatTest.date) &&
-        Objects.equals(this.dateTime, formatTest.dateTime) &&
-        Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password) &&
-        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
+    return Objects.equals(integer, formatTest.integer) &&
+        Objects.equals(int32, formatTest.int32) &&
+        Objects.equals(int64, formatTest.int64) &&
+        Objects.equals(number, formatTest.number) &&
+        Objects.equals(_float, formatTest._float) &&
+        Objects.equals(_double, formatTest._double) &&
+        Objects.equals(string, formatTest.string) &&
+        Objects.equals(_byte, formatTest._byte) &&
+        Objects.equals(binary, formatTest.binary) &&
+        Objects.equals(date, formatTest.date) &&
+        Objects.equals(dateTime, formatTest.dateTime) &&
+        Objects.equals(uuid, formatTest.uuid) &&
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(bigDecimal, formatTest.bigDecimal);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -90,8 +90,8 @@ public class HasOnlyReadOnly   {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(this.foo, hasOnlyReadOnly.foo);
+    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -205,10 +205,10 @@ public class MapTest   {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(this.directMap, mapTest.directMap) &&
-        Objects.equals(this.indirectMap, mapTest.indirectMap);
+    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(directMap, mapTest.directMap) &&
+        Objects.equals(indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -127,9 +127,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Model200Response.java
@@ -91,8 +91,8 @@ public class Model200Response   {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(this.name, _200response.name) &&
-        Objects.equals(this.propertyClass, _200response.propertyClass);
+    return Objects.equals(name, _200response.name) &&
+        Objects.equals(propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -115,9 +115,9 @@ public class ModelApiResponse   {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(this.code, _apiResponse.code) &&
-        Objects.equals(this.type, _apiResponse.type) &&
-        Objects.equals(this.message, _apiResponse.message);
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelFile.java
@@ -66,7 +66,7 @@ public class ModelFile   {
       return false;
     }
     ModelFile _file = (ModelFile) o;
-    return Objects.equals(this.sourceURI, _file.sourceURI);
+    return Objects.equals(sourceURI, _file.sourceURI);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelList.java
@@ -65,7 +65,7 @@ public class ModelList   {
       return false;
     }
     ModelList _list = (ModelList) o;
-    return Objects.equals(this._123list, _list._123list);
+    return Objects.equals(_123list, _list._123list);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -66,7 +66,7 @@ public class ModelReturn   {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(this._return, _return._return);
+    return Objects.equals(_return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Name.java
@@ -140,10 +140,10 @@ public class Name   {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(this.name, name.name) &&
-        Objects.equals(this.snakeCase, name.snakeCase) &&
-        Objects.equals(this.property, name.property) &&
-        Objects.equals(this._123number, name._123number);
+    return Objects.equals(name, name.name) &&
+        Objects.equals(snakeCase, name.snakeCase) &&
+        Objects.equals(property, name.property) &&
+        Objects.equals(_123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -65,7 +65,7 @@ public class NumberOnly   {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(this.justNumber, numberOnly.justNumber);
+    return Objects.equals(justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -224,12 +224,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(this.id, order.id) &&
-        Objects.equals(this.petId, order.petId) &&
-        Objects.equals(this.quantity, order.quantity) &&
-        Objects.equals(this.shipDate, order.shipDate) &&
-        Objects.equals(this.status, order.status) &&
-        Objects.equals(this.complete, order.complete);
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -115,9 +115,9 @@ public class OuterComposite   {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
-        Objects.equals(this.myString, outerComposite.myString) &&
-        Objects.equals(this.myBoolean, outerComposite.myBoolean);
+    return Objects.equals(myNumber, outerComposite.myNumber) &&
+        Objects.equals(myString, outerComposite.myString) &&
+        Objects.equals(myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -247,12 +247,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(this.id, pet.id) &&
-        Objects.equals(this.category, pet.category) &&
-        Objects.equals(this.name, pet.name) &&
-        Objects.equals(this.photoUrls, pet.photoUrls) &&
-        Objects.equals(this.tags, pet.tags) &&
-        Objects.equals(this.status, pet.status);
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -89,8 +89,8 @@ public class ReadOnlyFirst   {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(this.bar, readOnlyFirst.bar) &&
-        Objects.equals(this.baz, readOnlyFirst.baz);
+    return Objects.equals(bar, readOnlyFirst.bar) &&
+        Objects.equals(baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -65,7 +65,7 @@ public class SpecialModelName   {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Tag.java
@@ -89,8 +89,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(this.id, tag.id) &&
-        Objects.equals(this.name, tag.name);
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -175,11 +175,11 @@ public class TypeHolderDefault   {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -200,12 +200,12 @@ public class TypeHolderExample   {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(this.floatItem, typeHolderExample.floatItem) &&
-        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(floatItem, typeHolderExample.floatItem) &&
+        Objects.equals(integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/User.java
@@ -239,14 +239,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(this.id, user.id) &&
-        Objects.equals(this.username, user.username) &&
-        Objects.equals(this.firstName, user.firstName) &&
-        Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.email, user.email) &&
-        Objects.equals(this.password, user.password) &&
-        Objects.equals(this.phone, user.phone) &&
-        Objects.equals(this.userStatus, user.userStatus);
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/XmlItem.java
@@ -839,35 +839,35 @@ public class XmlItem   {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
-        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(this.nameString, xmlItem.nameString) &&
-        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(this.nameArray, xmlItem.nameArray) &&
-        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(this.prefixString, xmlItem.prefixString) &&
-        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(attributeString, xmlItem.attributeString) &&
+        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(nameString, xmlItem.nameString) &&
+        Objects.equals(nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(nameArray, xmlItem.nameArray) &&
+        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(prefixString, xmlItem.prefixString) &&
+        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesAnyType.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List>  {
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesArray.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesBoolean.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -382,17 +382,17 @@ public class AdditionalPropertiesClass   {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesInteger.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesNumber.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map>  {
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesObject.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesString extends HashMap<String, String>  {
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesString.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Animal.java
@@ -98,8 +98,8 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(className, animal.className) &&
+        Objects.equals(color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfArrayOfNumberOnly   {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfNumberOnly   {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -141,9 +141,9 @@ public class ArrayTest   {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/BigCat.java
@@ -101,13 +101,12 @@ public class BigCat extends Cat  {
       return false;
     }
     BigCat bigCat = (BigCat) o;
-    return Objects.equals(this.kind, bigCat.kind) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(kind, bigCat.kind);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kind, super.hashCode());
+    return Objects.hash(super.hashCode(), kind);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Capitalization.java
@@ -189,12 +189,12 @@ public class Capitalization   {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
-        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
-        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(smallCamel, capitalization.smallCamel) &&
+        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(smallSnake, capitalization.smallSnake) &&
+        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Cat.java
@@ -65,13 +65,12 @@ public class Cat extends Animal  {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(declawed, cat.declawed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(super.hashCode(), declawed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Category.java
@@ -89,8 +89,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(this.id, category.id) &&
-        Objects.equals(this.name, category.name);
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ClassModel.java
@@ -65,7 +65,7 @@ public class ClassModel   {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(this.propertyClass, classModel.propertyClass);
+    return Objects.equals(propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Client.java
@@ -64,7 +64,7 @@ public class Client   {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(this.client, client.client);
+    return Objects.equals(client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Dog.java
@@ -65,13 +65,12 @@ public class Dog extends Animal  {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(breed, dog.breed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(super.hashCode(), breed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -162,8 +162,8 @@ public class EnumArrays   {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumTest.java
@@ -295,11 +295,11 @@ public class EnumTest   {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(this.enumString, enumTest.enumString) &&
-        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
-        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
-        Objects.equals(this.outerEnum, enumTest.outerEnum);
+    return Objects.equals(enumString, enumTest.enumString) &&
+        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(enumInteger, enumTest.enumInteger) &&
+        Objects.equals(enumNumber, enumTest.enumNumber) &&
+        Objects.equals(outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -100,8 +100,8 @@ public class FileSchemaTestClass   {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(this._file, fileSchemaTestClass._file) &&
-        Objects.equals(this.files, fileSchemaTestClass.files);
+    return Objects.equals(_file, fileSchemaTestClass._file) &&
+        Objects.equals(files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FormatTest.java
@@ -404,20 +404,20 @@ public class FormatTest   {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(this.integer, formatTest.integer) &&
-        Objects.equals(this.int32, formatTest.int32) &&
-        Objects.equals(this.int64, formatTest.int64) &&
-        Objects.equals(this.number, formatTest.number) &&
-        Objects.equals(this._float, formatTest._float) &&
-        Objects.equals(this._double, formatTest._double) &&
-        Objects.equals(this.string, formatTest.string) &&
-        Objects.equals(this._byte, formatTest._byte) &&
-        Objects.equals(this.binary, formatTest.binary) &&
-        Objects.equals(this.date, formatTest.date) &&
-        Objects.equals(this.dateTime, formatTest.dateTime) &&
-        Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password) &&
-        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
+    return Objects.equals(integer, formatTest.integer) &&
+        Objects.equals(int32, formatTest.int32) &&
+        Objects.equals(int64, formatTest.int64) &&
+        Objects.equals(number, formatTest.number) &&
+        Objects.equals(_float, formatTest._float) &&
+        Objects.equals(_double, formatTest._double) &&
+        Objects.equals(string, formatTest.string) &&
+        Objects.equals(_byte, formatTest._byte) &&
+        Objects.equals(binary, formatTest.binary) &&
+        Objects.equals(date, formatTest.date) &&
+        Objects.equals(dateTime, formatTest.dateTime) &&
+        Objects.equals(uuid, formatTest.uuid) &&
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(bigDecimal, formatTest.bigDecimal);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -90,8 +90,8 @@ public class HasOnlyReadOnly   {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(this.foo, hasOnlyReadOnly.foo);
+    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
@@ -205,10 +205,10 @@ public class MapTest   {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(this.directMap, mapTest.directMap) &&
-        Objects.equals(this.indirectMap, mapTest.indirectMap);
+    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(directMap, mapTest.directMap) &&
+        Objects.equals(indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -127,9 +127,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Model200Response.java
@@ -91,8 +91,8 @@ public class Model200Response   {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(this.name, _200response.name) &&
-        Objects.equals(this.propertyClass, _200response.propertyClass);
+    return Objects.equals(name, _200response.name) &&
+        Objects.equals(propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -115,9 +115,9 @@ public class ModelApiResponse   {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(this.code, _apiResponse.code) &&
-        Objects.equals(this.type, _apiResponse.type) &&
-        Objects.equals(this.message, _apiResponse.message);
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelFile.java
@@ -66,7 +66,7 @@ public class ModelFile   {
       return false;
     }
     ModelFile _file = (ModelFile) o;
-    return Objects.equals(this.sourceURI, _file.sourceURI);
+    return Objects.equals(sourceURI, _file.sourceURI);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelList.java
@@ -65,7 +65,7 @@ public class ModelList   {
       return false;
     }
     ModelList _list = (ModelList) o;
-    return Objects.equals(this._123list, _list._123list);
+    return Objects.equals(_123list, _list._123list);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -66,7 +66,7 @@ public class ModelReturn   {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(this._return, _return._return);
+    return Objects.equals(_return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Name.java
@@ -140,10 +140,10 @@ public class Name   {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(this.name, name.name) &&
-        Objects.equals(this.snakeCase, name.snakeCase) &&
-        Objects.equals(this.property, name.property) &&
-        Objects.equals(this._123number, name._123number);
+    return Objects.equals(name, name.name) &&
+        Objects.equals(snakeCase, name.snakeCase) &&
+        Objects.equals(property, name.property) &&
+        Objects.equals(_123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -65,7 +65,7 @@ public class NumberOnly   {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(this.justNumber, numberOnly.justNumber);
+    return Objects.equals(justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
@@ -224,12 +224,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(this.id, order.id) &&
-        Objects.equals(this.petId, order.petId) &&
-        Objects.equals(this.quantity, order.quantity) &&
-        Objects.equals(this.shipDate, order.shipDate) &&
-        Objects.equals(this.status, order.status) &&
-        Objects.equals(this.complete, order.complete);
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -115,9 +115,9 @@ public class OuterComposite   {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
-        Objects.equals(this.myString, outerComposite.myString) &&
-        Objects.equals(this.myBoolean, outerComposite.myBoolean);
+    return Objects.equals(myNumber, outerComposite.myNumber) &&
+        Objects.equals(myString, outerComposite.myString) &&
+        Objects.equals(myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
@@ -247,12 +247,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(this.id, pet.id) &&
-        Objects.equals(this.category, pet.category) &&
-        Objects.equals(this.name, pet.name) &&
-        Objects.equals(this.photoUrls, pet.photoUrls) &&
-        Objects.equals(this.tags, pet.tags) &&
-        Objects.equals(this.status, pet.status);
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -89,8 +89,8 @@ public class ReadOnlyFirst   {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(this.bar, readOnlyFirst.bar) &&
-        Objects.equals(this.baz, readOnlyFirst.baz);
+    return Objects.equals(bar, readOnlyFirst.bar) &&
+        Objects.equals(baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -65,7 +65,7 @@ public class SpecialModelName   {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Tag.java
@@ -89,8 +89,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(this.id, tag.id) &&
-        Objects.equals(this.name, tag.name);
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -175,11 +175,11 @@ public class TypeHolderDefault   {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -200,12 +200,12 @@ public class TypeHolderExample   {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(this.floatItem, typeHolderExample.floatItem) &&
-        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(floatItem, typeHolderExample.floatItem) &&
+        Objects.equals(integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/User.java
@@ -239,14 +239,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(this.id, user.id) &&
-        Objects.equals(this.username, user.username) &&
-        Objects.equals(this.firstName, user.firstName) &&
-        Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.email, user.email) &&
-        Objects.equals(this.password, user.password) &&
-        Objects.equals(this.phone, user.phone) &&
-        Objects.equals(this.userStatus, user.userStatus);
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/XmlItem.java
@@ -839,35 +839,35 @@ public class XmlItem   {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
-        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(this.nameString, xmlItem.nameString) &&
-        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(this.nameArray, xmlItem.nameArray) &&
-        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(this.prefixString, xmlItem.prefixString) &&
-        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(attributeString, xmlItem.attributeString) &&
+        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(nameString, xmlItem.nameString) &&
+        Objects.equals(nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(nameArray, xmlItem.nameArray) &&
+        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(prefixString, xmlItem.prefixString) &&
+        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesAnyType.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List>  {
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesArray.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesBoolean.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -382,17 +382,17 @@ public class AdditionalPropertiesClass   {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesInteger.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesNumber.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map>  {
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesObject.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesString extends HashMap<String, String>  {
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesString.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Animal.java
@@ -98,8 +98,8 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(className, animal.className) &&
+        Objects.equals(color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfArrayOfNumberOnly   {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfNumberOnly   {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -141,9 +141,9 @@ public class ArrayTest   {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/BigCat.java
@@ -101,13 +101,12 @@ public class BigCat extends Cat  {
       return false;
     }
     BigCat bigCat = (BigCat) o;
-    return Objects.equals(this.kind, bigCat.kind) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(kind, bigCat.kind);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kind, super.hashCode());
+    return Objects.hash(super.hashCode(), kind);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Capitalization.java
@@ -189,12 +189,12 @@ public class Capitalization   {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
-        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
-        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(smallCamel, capitalization.smallCamel) &&
+        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(smallSnake, capitalization.smallSnake) &&
+        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Cat.java
@@ -65,13 +65,12 @@ public class Cat extends Animal  {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(declawed, cat.declawed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(super.hashCode(), declawed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Category.java
@@ -89,8 +89,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(this.id, category.id) &&
-        Objects.equals(this.name, category.name);
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ClassModel.java
@@ -65,7 +65,7 @@ public class ClassModel   {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(this.propertyClass, classModel.propertyClass);
+    return Objects.equals(propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Client.java
@@ -64,7 +64,7 @@ public class Client   {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(this.client, client.client);
+    return Objects.equals(client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Dog.java
@@ -65,13 +65,12 @@ public class Dog extends Animal  {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(breed, dog.breed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(super.hashCode(), breed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -162,8 +162,8 @@ public class EnumArrays   {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumTest.java
@@ -295,11 +295,11 @@ public class EnumTest   {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(this.enumString, enumTest.enumString) &&
-        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
-        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
-        Objects.equals(this.outerEnum, enumTest.outerEnum);
+    return Objects.equals(enumString, enumTest.enumString) &&
+        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(enumInteger, enumTest.enumInteger) &&
+        Objects.equals(enumNumber, enumTest.enumNumber) &&
+        Objects.equals(outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -100,8 +100,8 @@ public class FileSchemaTestClass   {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(this._file, fileSchemaTestClass._file) &&
-        Objects.equals(this.files, fileSchemaTestClass.files);
+    return Objects.equals(_file, fileSchemaTestClass._file) &&
+        Objects.equals(files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FormatTest.java
@@ -404,20 +404,20 @@ public class FormatTest   {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(this.integer, formatTest.integer) &&
-        Objects.equals(this.int32, formatTest.int32) &&
-        Objects.equals(this.int64, formatTest.int64) &&
-        Objects.equals(this.number, formatTest.number) &&
-        Objects.equals(this._float, formatTest._float) &&
-        Objects.equals(this._double, formatTest._double) &&
-        Objects.equals(this.string, formatTest.string) &&
-        Objects.equals(this._byte, formatTest._byte) &&
-        Objects.equals(this.binary, formatTest.binary) &&
-        Objects.equals(this.date, formatTest.date) &&
-        Objects.equals(this.dateTime, formatTest.dateTime) &&
-        Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password) &&
-        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
+    return Objects.equals(integer, formatTest.integer) &&
+        Objects.equals(int32, formatTest.int32) &&
+        Objects.equals(int64, formatTest.int64) &&
+        Objects.equals(number, formatTest.number) &&
+        Objects.equals(_float, formatTest._float) &&
+        Objects.equals(_double, formatTest._double) &&
+        Objects.equals(string, formatTest.string) &&
+        Objects.equals(_byte, formatTest._byte) &&
+        Objects.equals(binary, formatTest.binary) &&
+        Objects.equals(date, formatTest.date) &&
+        Objects.equals(dateTime, formatTest.dateTime) &&
+        Objects.equals(uuid, formatTest.uuid) &&
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(bigDecimal, formatTest.bigDecimal);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -90,8 +90,8 @@ public class HasOnlyReadOnly   {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(this.foo, hasOnlyReadOnly.foo);
+    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -205,10 +205,10 @@ public class MapTest   {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(this.directMap, mapTest.directMap) &&
-        Objects.equals(this.indirectMap, mapTest.indirectMap);
+    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(directMap, mapTest.directMap) &&
+        Objects.equals(indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -127,9 +127,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Model200Response.java
@@ -91,8 +91,8 @@ public class Model200Response   {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(this.name, _200response.name) &&
-        Objects.equals(this.propertyClass, _200response.propertyClass);
+    return Objects.equals(name, _200response.name) &&
+        Objects.equals(propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -115,9 +115,9 @@ public class ModelApiResponse   {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(this.code, _apiResponse.code) &&
-        Objects.equals(this.type, _apiResponse.type) &&
-        Objects.equals(this.message, _apiResponse.message);
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelFile.java
@@ -66,7 +66,7 @@ public class ModelFile   {
       return false;
     }
     ModelFile _file = (ModelFile) o;
-    return Objects.equals(this.sourceURI, _file.sourceURI);
+    return Objects.equals(sourceURI, _file.sourceURI);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelList.java
@@ -65,7 +65,7 @@ public class ModelList   {
       return false;
     }
     ModelList _list = (ModelList) o;
-    return Objects.equals(this._123list, _list._123list);
+    return Objects.equals(_123list, _list._123list);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -66,7 +66,7 @@ public class ModelReturn   {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(this._return, _return._return);
+    return Objects.equals(_return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Name.java
@@ -140,10 +140,10 @@ public class Name   {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(this.name, name.name) &&
-        Objects.equals(this.snakeCase, name.snakeCase) &&
-        Objects.equals(this.property, name.property) &&
-        Objects.equals(this._123number, name._123number);
+    return Objects.equals(name, name.name) &&
+        Objects.equals(snakeCase, name.snakeCase) &&
+        Objects.equals(property, name.property) &&
+        Objects.equals(_123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -65,7 +65,7 @@ public class NumberOnly   {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(this.justNumber, numberOnly.justNumber);
+    return Objects.equals(justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -224,12 +224,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(this.id, order.id) &&
-        Objects.equals(this.petId, order.petId) &&
-        Objects.equals(this.quantity, order.quantity) &&
-        Objects.equals(this.shipDate, order.shipDate) &&
-        Objects.equals(this.status, order.status) &&
-        Objects.equals(this.complete, order.complete);
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -115,9 +115,9 @@ public class OuterComposite   {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
-        Objects.equals(this.myString, outerComposite.myString) &&
-        Objects.equals(this.myBoolean, outerComposite.myBoolean);
+    return Objects.equals(myNumber, outerComposite.myNumber) &&
+        Objects.equals(myString, outerComposite.myString) &&
+        Objects.equals(myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -247,12 +247,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(this.id, pet.id) &&
-        Objects.equals(this.category, pet.category) &&
-        Objects.equals(this.name, pet.name) &&
-        Objects.equals(this.photoUrls, pet.photoUrls) &&
-        Objects.equals(this.tags, pet.tags) &&
-        Objects.equals(this.status, pet.status);
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -89,8 +89,8 @@ public class ReadOnlyFirst   {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(this.bar, readOnlyFirst.bar) &&
-        Objects.equals(this.baz, readOnlyFirst.baz);
+    return Objects.equals(bar, readOnlyFirst.bar) &&
+        Objects.equals(baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -65,7 +65,7 @@ public class SpecialModelName   {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Tag.java
@@ -89,8 +89,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(this.id, tag.id) &&
-        Objects.equals(this.name, tag.name);
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -175,11 +175,11 @@ public class TypeHolderDefault   {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -200,12 +200,12 @@ public class TypeHolderExample   {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(this.floatItem, typeHolderExample.floatItem) &&
-        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(floatItem, typeHolderExample.floatItem) &&
+        Objects.equals(integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/User.java
@@ -239,14 +239,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(this.id, user.id) &&
-        Objects.equals(this.username, user.username) &&
-        Objects.equals(this.firstName, user.firstName) &&
-        Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.email, user.email) &&
-        Objects.equals(this.password, user.password) &&
-        Objects.equals(this.phone, user.phone) &&
-        Objects.equals(this.userStatus, user.userStatus);
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/XmlItem.java
@@ -839,35 +839,35 @@ public class XmlItem   {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
-        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(this.nameString, xmlItem.nameString) &&
-        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(this.nameArray, xmlItem.nameArray) &&
-        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(this.prefixString, xmlItem.prefixString) &&
-        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(attributeString, xmlItem.attributeString) &&
+        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(nameString, xmlItem.nameString) &&
+        Objects.equals(nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(nameArray, xmlItem.nameArray) &&
+        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(prefixString, xmlItem.prefixString) &&
+        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesAnyType.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List>  {
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesArray.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesBoolean.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -382,17 +382,17 @@ public class AdditionalPropertiesClass   {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesInteger.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -67,13 +67,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesNumber.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map>  {
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesObject.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -66,13 +66,12 @@ public class AdditionalPropertiesString extends HashMap<String, String>  {
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(name, additionalPropertiesString.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Animal.java
@@ -98,8 +98,8 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(className, animal.className) &&
+        Objects.equals(color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfArrayOfNumberOnly   {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -75,7 +75,7 @@ public class ArrayOfNumberOnly   {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -141,9 +141,9 @@ public class ArrayTest   {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/BigCat.java
@@ -101,13 +101,12 @@ public class BigCat extends Cat  {
       return false;
     }
     BigCat bigCat = (BigCat) o;
-    return Objects.equals(this.kind, bigCat.kind) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(kind, bigCat.kind);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kind, super.hashCode());
+    return Objects.hash(super.hashCode(), kind);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Capitalization.java
@@ -189,12 +189,12 @@ public class Capitalization   {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
-        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
-        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(smallCamel, capitalization.smallCamel) &&
+        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(smallSnake, capitalization.smallSnake) &&
+        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Cat.java
@@ -65,13 +65,12 @@ public class Cat extends Animal  {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(this.declawed, cat.declawed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(declawed, cat.declawed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed, super.hashCode());
+    return Objects.hash(super.hashCode(), declawed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Category.java
@@ -89,8 +89,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(this.id, category.id) &&
-        Objects.equals(this.name, category.name);
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ClassModel.java
@@ -65,7 +65,7 @@ public class ClassModel   {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(this.propertyClass, classModel.propertyClass);
+    return Objects.equals(propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Client.java
@@ -64,7 +64,7 @@ public class Client   {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(this.client, client.client);
+    return Objects.equals(client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Dog.java
@@ -65,13 +65,12 @@ public class Dog extends Animal  {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(this.breed, dog.breed) &&
-        super.equals(o);
+    return super.equals(o) && Objects.equals(breed, dog.breed);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed, super.hashCode());
+    return Objects.hash(super.hashCode(), breed);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -162,8 +162,8 @@ public class EnumArrays   {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumTest.java
@@ -295,11 +295,11 @@ public class EnumTest   {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(this.enumString, enumTest.enumString) &&
-        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
-        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
-        Objects.equals(this.outerEnum, enumTest.outerEnum);
+    return Objects.equals(enumString, enumTest.enumString) &&
+        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(enumInteger, enumTest.enumInteger) &&
+        Objects.equals(enumNumber, enumTest.enumNumber) &&
+        Objects.equals(outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -100,8 +100,8 @@ public class FileSchemaTestClass   {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(this._file, fileSchemaTestClass._file) &&
-        Objects.equals(this.files, fileSchemaTestClass.files);
+    return Objects.equals(_file, fileSchemaTestClass._file) &&
+        Objects.equals(files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FormatTest.java
@@ -404,20 +404,20 @@ public class FormatTest   {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(this.integer, formatTest.integer) &&
-        Objects.equals(this.int32, formatTest.int32) &&
-        Objects.equals(this.int64, formatTest.int64) &&
-        Objects.equals(this.number, formatTest.number) &&
-        Objects.equals(this._float, formatTest._float) &&
-        Objects.equals(this._double, formatTest._double) &&
-        Objects.equals(this.string, formatTest.string) &&
-        Objects.equals(this._byte, formatTest._byte) &&
-        Objects.equals(this.binary, formatTest.binary) &&
-        Objects.equals(this.date, formatTest.date) &&
-        Objects.equals(this.dateTime, formatTest.dateTime) &&
-        Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password) &&
-        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
+    return Objects.equals(integer, formatTest.integer) &&
+        Objects.equals(int32, formatTest.int32) &&
+        Objects.equals(int64, formatTest.int64) &&
+        Objects.equals(number, formatTest.number) &&
+        Objects.equals(_float, formatTest._float) &&
+        Objects.equals(_double, formatTest._double) &&
+        Objects.equals(string, formatTest.string) &&
+        Objects.equals(_byte, formatTest._byte) &&
+        Objects.equals(binary, formatTest.binary) &&
+        Objects.equals(date, formatTest.date) &&
+        Objects.equals(dateTime, formatTest.dateTime) &&
+        Objects.equals(uuid, formatTest.uuid) &&
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(bigDecimal, formatTest.bigDecimal);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -90,8 +90,8 @@ public class HasOnlyReadOnly   {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(this.foo, hasOnlyReadOnly.foo);
+    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
@@ -205,10 +205,10 @@ public class MapTest   {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(this.directMap, mapTest.directMap) &&
-        Objects.equals(this.indirectMap, mapTest.indirectMap);
+    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(directMap, mapTest.directMap) &&
+        Objects.equals(indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -127,9 +127,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Model200Response.java
@@ -91,8 +91,8 @@ public class Model200Response   {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(this.name, _200response.name) &&
-        Objects.equals(this.propertyClass, _200response.propertyClass);
+    return Objects.equals(name, _200response.name) &&
+        Objects.equals(propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -115,9 +115,9 @@ public class ModelApiResponse   {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(this.code, _apiResponse.code) &&
-        Objects.equals(this.type, _apiResponse.type) &&
-        Objects.equals(this.message, _apiResponse.message);
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelFile.java
@@ -66,7 +66,7 @@ public class ModelFile   {
       return false;
     }
     ModelFile _file = (ModelFile) o;
-    return Objects.equals(this.sourceURI, _file.sourceURI);
+    return Objects.equals(sourceURI, _file.sourceURI);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelList.java
@@ -65,7 +65,7 @@ public class ModelList   {
       return false;
     }
     ModelList _list = (ModelList) o;
-    return Objects.equals(this._123list, _list._123list);
+    return Objects.equals(_123list, _list._123list);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -66,7 +66,7 @@ public class ModelReturn   {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(this._return, _return._return);
+    return Objects.equals(_return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Name.java
@@ -140,10 +140,10 @@ public class Name   {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(this.name, name.name) &&
-        Objects.equals(this.snakeCase, name.snakeCase) &&
-        Objects.equals(this.property, name.property) &&
-        Objects.equals(this._123number, name._123number);
+    return Objects.equals(name, name.name) &&
+        Objects.equals(snakeCase, name.snakeCase) &&
+        Objects.equals(property, name.property) &&
+        Objects.equals(_123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -65,7 +65,7 @@ public class NumberOnly   {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(this.justNumber, numberOnly.justNumber);
+    return Objects.equals(justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
@@ -224,12 +224,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(this.id, order.id) &&
-        Objects.equals(this.petId, order.petId) &&
-        Objects.equals(this.quantity, order.quantity) &&
-        Objects.equals(this.shipDate, order.shipDate) &&
-        Objects.equals(this.status, order.status) &&
-        Objects.equals(this.complete, order.complete);
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -115,9 +115,9 @@ public class OuterComposite   {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
-        Objects.equals(this.myString, outerComposite.myString) &&
-        Objects.equals(this.myBoolean, outerComposite.myBoolean);
+    return Objects.equals(myNumber, outerComposite.myNumber) &&
+        Objects.equals(myString, outerComposite.myString) &&
+        Objects.equals(myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
@@ -247,12 +247,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(this.id, pet.id) &&
-        Objects.equals(this.category, pet.category) &&
-        Objects.equals(this.name, pet.name) &&
-        Objects.equals(this.photoUrls, pet.photoUrls) &&
-        Objects.equals(this.tags, pet.tags) &&
-        Objects.equals(this.status, pet.status);
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -89,8 +89,8 @@ public class ReadOnlyFirst   {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(this.bar, readOnlyFirst.bar) &&
-        Objects.equals(this.baz, readOnlyFirst.baz);
+    return Objects.equals(bar, readOnlyFirst.bar) &&
+        Objects.equals(baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -65,7 +65,7 @@ public class SpecialModelName   {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Tag.java
@@ -89,8 +89,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(this.id, tag.id) &&
-        Objects.equals(this.name, tag.name);
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -175,11 +175,11 @@ public class TypeHolderDefault   {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -200,12 +200,12 @@ public class TypeHolderExample   {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(this.floatItem, typeHolderExample.floatItem) &&
-        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(floatItem, typeHolderExample.floatItem) &&
+        Objects.equals(integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/User.java
@@ -239,14 +239,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(this.id, user.id) &&
-        Objects.equals(this.username, user.username) &&
-        Objects.equals(this.firstName, user.firstName) &&
-        Objects.equals(this.lastName, user.lastName) &&
-        Objects.equals(this.email, user.email) &&
-        Objects.equals(this.password, user.password) &&
-        Objects.equals(this.phone, user.phone) &&
-        Objects.equals(this.userStatus, user.userStatus);
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/XmlItem.java
@@ -839,35 +839,35 @@ public class XmlItem   {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
-        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(this.nameString, xmlItem.nameString) &&
-        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(this.nameArray, xmlItem.nameArray) &&
-        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(this.prefixString, xmlItem.prefixString) &&
-        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(attributeString, xmlItem.attributeString) &&
+        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(nameString, xmlItem.nameString) &&
+        Objects.equals(nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(nameArray, xmlItem.nameArray) &&
+        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(prefixString, xmlItem.prefixString) &&
+        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override


### PR DESCRIPTION
This PR improves the equals and hashCode methods in Java code when inheritance is used. This was previously partially done, but for a much smaller subset of the generators, and was buggy.

* hashCode/equals is now identical for all of JAX-RS codegen, and also in a few other java codegen targets
* Correctly handles cases where child class has no properties. This is a real use case, because the discriminator in the parent class may be unique
* Doesn't change generated code for most codegen targets
* Unit test added to ensure that super.hashCode() and super.equals() are called when appropriate

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas  @sreeshas  @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 
