### PR TITLE
Fix dry-run output and add tests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DryRunTemplateManager.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DryRunTemplateManager.java
@@ -5,7 +5,9 @@ import org.openapitools.codegen.templating.TemplateManagerOptions;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,29 +47,35 @@ public class DryRunTemplateManager implements TemplateProcessor {
      */
     @Override
     public File write(Map<String, Object> data, String template, File target) throws IOException {
-        if (this.options.isSkipOverwrite() && target.exists()) {
-            dryRunStatusMap.put(target.toString(),
-                    new DryRunStatus(
-                            target.toPath(),
-                            DryRunStatus.State.SkippedOverwrite,
-                            "File exists and skip overwrite option is enabled."
-                    ));
-        }
-
-        return target;
+        return writeToFile(target.getAbsolutePath(), "dummy".getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public File writeToFile(String filename, byte[] contents) throws IOException {
-        Path path = java.nio.file.Paths.get(filename);
+        final Path path = Paths.get(filename);
+        final File outputFile = path.toFile();
         DryRunStatus status = new DryRunStatus(path);
-        if (this.options.isMinimalUpdate()) {
+
+        if (outputFile.exists()) {
+            if (this.options.isSkipOverwrite()) {
+                status = new DryRunStatus(
+                    path,
+                    DryRunStatus.State.SkippedOverwrite,
+                    "File exists and skip overwrite option is enabled."
+                );
+            } else if (this.options.isMinimalUpdate()) {
+                status.setState(DryRunStatus.State.WriteIfNewer);
+            } else {
+                status.setState(DryRunStatus.State.Write);
+            }
+        } else if (this.options.isMinimalUpdate()) {
             status.setState(DryRunStatus.State.WriteIfNewer);
         } else {
             status.setState(DryRunStatus.State.Write);
         }
         dryRunStatusMap.put(filename, status);
-        return path.toFile();
+
+        return outputFile;
     }
 
     @Override
@@ -82,26 +90,15 @@ public class DryRunTemplateManager implements TemplateProcessor {
 
     @Override
     public void skip(Path path, String context) {
+        final DryRunStatus status = new DryRunStatus(path, DryRunStatus.State.Skipped, context);
         if (this.options.isSkipOverwrite() && path.toFile().exists()) {
-            dryRunStatusMap.put(path.toString(),
-                    new DryRunStatus(
-                            path,
-                            DryRunStatus.State.SkippedOverwrite,
-                            context
-                    ));
-            return;
+            status.setState(DryRunStatus.State.SkippedOverwrite);
         }
-
-        dryRunStatusMap.put(path.toString(),
-                new DryRunStatus(
-                        path,
-                        DryRunStatus.State.Skipped,
-                        context
-                ));
+        dryRunStatusMap.put(path.toString(), status);
     }
 
     @Override
     public void error(Path path, String context) {
-        dryRunStatusMap.put(path.toString(), new DryRunStatus(path, DryRunStatus.State.Error));
+        dryRunStatusMap.put(path.toString(), new DryRunStatus(path, DryRunStatus.State.Error, context));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DryRunTemplateManagerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DryRunTemplateManagerTest.java
@@ -1,0 +1,166 @@
+package org.openapitools.codegen;
+
+import org.openapitools.codegen.templating.TemplateManagerOptions;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class DryRunTemplateManagerTest {
+    @Test
+    public void testError() throws IOException {
+        final DryRunTemplateManager templateManager = getTemplateManager(false, false);
+        final File tempFile = File.createTempFile("dryrun-test", ".txt");
+        tempFile.deleteOnExit();
+
+        templateManager.error(tempFile.toPath(), "errored");
+        final Map<String, DryRunStatus> result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.Error,
+                "errored"
+        );
+    }
+
+    @Test
+    public void testIgnore() throws IOException {
+        final DryRunTemplateManager templateManager = getTemplateManager(false, false);
+        final File tempFile = File.createTempFile("dryrun-test", ".txt");
+        tempFile.deleteOnExit();
+
+        templateManager.ignore(tempFile.toPath(), "ignored");
+        final Map<String, DryRunStatus> result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.Ignored,
+                "ignored"
+        );
+    }
+
+    @Test
+    public void testWrite() throws IOException {
+        DryRunTemplateManager templateManager = getTemplateManager(false, false);
+        final File tempFile = File.createTempFile("dryrun-test", ".txt");
+        final Map<String, Object> dummyData = new HashMap<>();
+
+        templateManager.write(dummyData, "dummy", tempFile);
+        Map<String, DryRunStatus> result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.Write,
+                "File will be written."
+        );
+
+        templateManager = getTemplateManager(true, false);
+        templateManager.write(dummyData, "dummy", tempFile);
+        result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.WriteIfNewer,
+                "File will be written only if it is new or if contents differ from an existing file."
+        );
+
+        templateManager = getTemplateManager(true, true);
+        templateManager.write(dummyData, "dummy", tempFile);
+        result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.SkippedOverwrite,
+                "File exists and skip overwrite option is enabled."
+        );
+
+        tempFile.delete();
+
+        templateManager = getTemplateManager(true, false);
+        templateManager.write(dummyData, "dummy", tempFile);
+        result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.WriteIfNewer,
+                "File will be written only if it is new or if contents differ from an existing file."
+        );
+
+        templateManager = getTemplateManager(false, false);
+        templateManager.write(dummyData, "dummy", tempFile);
+        result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.Write,
+                "File will be written."
+        );
+    }
+
+    @Test
+    public void testSkip() throws IOException {
+        DryRunTemplateManager templateManager = getTemplateManager(false, false);
+        final File tempFile = File.createTempFile("dryrun-test", ".txt");
+        tempFile.deleteOnExit();
+
+        templateManager.skip(tempFile.toPath(), "skipped");
+        Map<String, DryRunStatus> result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.Skipped,
+                "skipped"
+        );
+
+        templateManager = getTemplateManager(false, true);
+
+        templateManager.skip(tempFile.toPath(), "skipped");
+        result = templateManager.getDryRunStatusMap();
+
+        assertEquals(result.size(), 1);
+        assertDryRunStatus(
+                result.get(tempFile.getAbsolutePath()),
+                tempFile.toPath(),
+                DryRunStatus.State.SkippedOverwrite,
+                "File is configured not to overwrite an existing file of the same name."
+        );
+    }
+
+    private DryRunTemplateManager getTemplateManager(final boolean minimalUpdate, final boolean skipOverwrite) {
+        return new DryRunTemplateManager(
+                new TemplateManagerOptions(minimalUpdate, skipOverwrite)
+        );
+    }
+
+    private void assertDryRunStatus(
+            final DryRunStatus dryRunStatus,
+            final Path path,
+            final DryRunStatus.State state,
+            final String reason
+    ) {
+        assertEquals(dryRunStatus.getPath().toString(), path.toString());
+        assertEquals(dryRunStatus.getState().toString(), state.toString());
+        assertEquals(dryRunStatus.getReason(), reason);
+    }
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Currently the dry-run status output only shows metadata files. This PR fixes that and also adds tests for the `DryRunTemplateManager` class.
Fixes #15730.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
