### PR TITLE
[Postman] fix use of isBasic from #15294

### DIFF
--- a/modules/openapi-generator/src/main/resources/postman-collection/postman.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/postman.mustache
@@ -37,7 +37,7 @@
     				"type": "string"
     			}
     		]
-    	},{{/isApiKey}}{{#isBasic}}"auth": {
+    	},{{/isApiKey}}{{#isBasicBasic}}"auth": {
             		"type": "basic",
             		"basic": [
             			{
@@ -51,7 +51,7 @@
             				"type": "string"
             			}
             		]
-            	},{{/isBasic}}{{/-first}}{{/authMethods}}
+            	},{{/isBasicBasic}}{{/-first}}{{/authMethods}}
 	"variable": [{{#servers}}{{#-first}}
 		{
 			"key": "baseUrl",


### PR DESCRIPTION
Follow-up of the other "fix use of isBasic" PR series, but for code from new postman generator developed in parallel

**isBasic is also true for HTTP bearer auth method and HTTP signature method, not only HTTP basic auth method; it should not be used when we want to apply code changes in the context of HTTP basic auth only!**

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


new generator creator: @gcatanese