### PR TITLE
[Go] Serialize readonly fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -311,7 +311,6 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	{{/isNullable}}
 	{{! if argument is not nullable, don't set it if it is nil}}
 	{{^isNullable}}
-	{{^isReadOnly}}
 	{{#required}}
 	toSerialize["{{baseName}}"] = o.{{name}}
 	{{/required}}
@@ -320,10 +319,6 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 		toSerialize["{{baseName}}"] = o.{{name}}
 	}
 	{{/required}}
-	{{/isReadOnly}}
-	{{#isReadOnly}}
-	// skip: {{baseName}} is readOnly
-	{{/isReadOnly}}
 	{{/isNullable}}
 	{{/vars}}
 	{{#isAdditionalPropertiesTrue}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -291,23 +291,4 @@ public class GoClientCodegenTest {
                 "httpRes, err := apiClient.PetAPI.PetDelete(context.Background()).Execute()");
     }
 
-    @Test
-    public void verifyReadOnlyAttributes() throws IOException {
-        File output = Files.createTempDirectory("test").toFile();
-        output.deleteOnExit();
-
-        final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("go")
-                .setInputSpec("src/test/resources/3_0/property-readonly.yaml")
-                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
-
-        DefaultGenerator generator = new DefaultGenerator();
-        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
-        files.forEach(File::deleteOnExit);
-
-        TestUtils.assertFileExists(Paths.get(output + "/model_request.go"));
-        TestUtils.assertFileContains(Paths.get(output + "/model_request.go"),
-                "// skip: customerCode is readOnly");
-    }
-
 }

--- a/samples/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -114,8 +114,12 @@ func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
 
 func (o HasOnlyReadOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: bar is readOnly
-	// skip: foo is readOnly
+	if !IsNil(o.Bar) {
+		toSerialize["bar"] = o.Bar
+	}
+	if !IsNil(o.Foo) {
+		toSerialize["foo"] = o.Foo
+	}
 	return toSerialize, nil
 }
 

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -174,11 +174,15 @@ func (o Name) MarshalJSON() ([]byte, error) {
 func (o Name) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	// skip: snake_case is readOnly
+	if !IsNil(o.SnakeCase) {
+		toSerialize["snake_case"] = o.SnakeCase
+	}
 	if !IsNil(o.Property) {
 		toSerialize["property"] = o.Property
 	}
-	// skip: 123Number is readOnly
+	if !IsNil(o.Var123Number) {
+		toSerialize["123Number"] = o.Var123Number
+	}
 	return toSerialize, nil
 }
 

--- a/samples/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go/go-petstore/model_read_only_first.go
@@ -114,7 +114,9 @@ func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
 
 func (o ReadOnlyFirst) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: bar is readOnly
+	if !IsNil(o.Bar) {
+		toSerialize["bar"] = o.Bar
+	}
 	if !IsNil(o.Baz) {
 		toSerialize["baz"] = o.Baz
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -117,8 +117,12 @@ func (o HasOnlyReadOnly) MarshalJSON() ([]byte, error) {
 
 func (o HasOnlyReadOnly) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: bar is readOnly
-	// skip: foo is readOnly
+	if !IsNil(o.Bar) {
+		toSerialize["bar"] = o.Bar
+	}
+	if !IsNil(o.Foo) {
+		toSerialize["foo"] = o.Foo
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -177,11 +177,15 @@ func (o Name) MarshalJSON() ([]byte, error) {
 func (o Name) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	// skip: snake_case is readOnly
+	if !IsNil(o.SnakeCase) {
+		toSerialize["snake_case"] = o.SnakeCase
+	}
 	if !IsNil(o.Property) {
 		toSerialize["property"] = o.Property
 	}
-	// skip: 123Number is readOnly
+	if !IsNil(o.Var123Number) {
+		toSerialize["123Number"] = o.Var123Number
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
@@ -117,7 +117,9 @@ func (o ReadOnlyFirst) MarshalJSON() ([]byte, error) {
 
 func (o ReadOnlyFirst) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: bar is readOnly
+	if !IsNil(o.Bar) {
+		toSerialize["bar"] = o.Bar
+	}
 	if !IsNil(o.Baz) {
 		toSerialize["baz"] = o.Baz
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
@@ -294,16 +294,24 @@ func (o ReadOnlyWithDefault) MarshalJSON() ([]byte, error) {
 
 func (o ReadOnlyWithDefault) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	// skip: prop1 is readOnly
-	// skip: prop2 is readOnly
+	if !IsNil(o.Prop1) {
+		toSerialize["prop1"] = o.Prop1
+	}
+	if !IsNil(o.Prop2) {
+		toSerialize["prop2"] = o.Prop2
+	}
 	if !IsNil(o.Prop3) {
 		toSerialize["prop3"] = o.Prop3
 	}
-	// skip: boolProp1 is readOnly
+	if !IsNil(o.BoolProp1) {
+		toSerialize["boolProp1"] = o.BoolProp1
+	}
 	if !IsNil(o.BoolProp2) {
 		toSerialize["boolProp2"] = o.BoolProp2
 	}
-	// skip: intProp1 is readOnly
+	if !IsNil(o.IntProp1) {
+		toSerialize["intProp1"] = o.IntProp1
+	}
 	if !IsNil(o.IntProp2) {
 		toSerialize["intProp2"] = o.IntProp2
 	}

--- a/samples/openapi3/client/petstore/go/model_test.go
+++ b/samples/openapi3/client/petstore/go/model_test.go
@@ -41,3 +41,13 @@ func TestDog(t *testing.T) {
 	//assert.Nil(newDog)
 	assert.Equal(*newDog.Breed, breedString, "Breed should be `Shepherd`")
 }
+
+func TestReadOnlyFirst(t *testing.T) {
+	assert := assert.New(t)
+
+	newReadOnlyFirst := (sw.ReadOnlyFirst{Bar: sw.PtrString("Bar value"), Baz: sw.PtrString("Baz value")})
+	json, _ := newReadOnlyFirst.MarshalJSON()
+	expected := `{"Bar":"Bar value","Baz":"Baz value"}`
+
+	assert.Equal(t, expected, (string)(json))
+}

--- a/samples/openapi3/client/petstore/go/model_test.go
+++ b/samples/openapi3/client/petstore/go/model_test.go
@@ -47,7 +47,7 @@ func TestReadOnlyFirst(t *testing.T) {
 
 	newReadOnlyFirst := (sw.ReadOnlyFirst{Bar: sw.PtrString("Bar value"), Baz: sw.PtrString("Baz value")})
 	json, _ := newReadOnlyFirst.MarshalJSON()
-	expected := `{"Bar":"Bar value","Baz":"Baz value"}`
+	expected := `{"bar":"Bar value","baz":"Baz value"}`
 
-	assert.Equal(t, expected, (string)(json))
+	assert.Equal(expected, (string)(json), "ReadOnlyFirst JSON is incorrect")
 }


### PR DESCRIPTION
PR #14335 has mistakenly removed the readOnly fields during the JSON serialization, resulting in models with missing fields.

This PR reverts those changes.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
