### PR TITLE
[csharp][generichost] Removed unneeded feature

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/DefaultApis.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/DefaultApis.mustache
@@ -1,1 +1,0 @@
-{{#apiInfo}}{{#apis}}{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/HostConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/HostConfiguration.mustache
@@ -10,6 +10,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using {{packageName}}.{{apiPackage}};
+using {{packageName}}.{{interfacePrefix}}{{apiPackage}};
 using {{packageName}}.{{modelPackage}};
 
 namespace {{packageName}}.{{clientPackage}}
@@ -17,12 +19,7 @@ namespace {{packageName}}.{{clientPackage}}
     /// <summary>
     /// Provides hosting configuration for {{packageName}}
     /// </summary>
-    {{>visibility}} class HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>
-        {{#apiInfo}}
-        {{#apis}}
-        where T{{classname}} : class, {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
-        {{/apis}}
-        {{/apiInfo}}
+    {{>visibility}} class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -52,7 +49,7 @@ namespace {{packageName}}.{{clientPackage}}
             {{/models}}
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();{{#apiInfo}}{{#apis}}
-            _services.AddTransient<T{{classname}}, T{{classname}}>();{{/apis}}{{/apiInfo}}
+            _services.AddTransient<{{interfacePrefix}}{{classname}}, {{classname}}>();{{/apis}}{{/apiInfo}}
         }
 
         /// <summary>
@@ -61,7 +58,7 @@ namespace {{packageName}}.{{clientPackage}}
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> Add{{apiName}}HttpClients
+        public HostConfiguration Add{{apiName}}HttpClients
         (
             Action<HttpClient>{{nrt?}} client = null, Action<IHttpClientBuilder>{{nrt?}} builder = null)
         {
@@ -70,7 +67,7 @@ namespace {{packageName}}.{{clientPackage}}
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            {{#apiInfo}}{{#apis}}builders.Add(_services.AddHttpClient<{{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}, T{{classname}}>(client));
+            {{#apiInfo}}{{#apis}}builders.Add(_services.AddHttpClient<{{interfacePrefix}}{{classname}}, {{classname}}>(client));
             {{/apis}}{{/apiInfo}}
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -86,7 +83,7 @@ namespace {{packageName}}.{{clientPackage}}
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -99,7 +96,7 @@ namespace {{packageName}}.{{clientPackage}}
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -110,7 +107,7 @@ namespace {{packageName}}.{{clientPackage}}
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -124,7 +121,7 @@ namespace {{packageName}}.{{clientPackage}}
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/IHostBuilderExtensions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/IHostBuilderExtensions.mustache
@@ -7,7 +7,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using {{packageName}}.{{clientPackage}};
-using {{packageName}}.{{apiPackage}};
 
 namespace {{packageName}}.Extensions
 {
@@ -21,16 +20,11 @@ namespace {{packageName}}.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder Configure{{apiName}}<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(this IHostBuilder builder)
-            {{#apiInfo}}
-            {{#apis}}
-            where T{{classname}} : class, {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
-            {{/apis}}
-            {{/apiInfo}}
+        public static IHostBuilder Configure{{apiName}}(this IHostBuilder builder)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> config = new HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 IServiceCollectionExtensions.Add{{apiName}}(services, config);
             });
@@ -38,29 +32,17 @@ namespace {{packageName}}.Extensions
             return builder;
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        public static IHostBuilder Configure{{apiName}}(this IHostBuilder builder)
-            => Configure{{apiName}}<{{>DefaultApis}}>(builder);
-
         {{/hasAuthMethods}}
         /// <summary>
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder Configure{{apiName}}<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>> options)
-            {{#apiInfo}}
-            {{#apis}}
-            where T{{classname}} : class, {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
-            {{/apis}}
-            {{/apiInfo}}
+        public static IHostBuilder Configure{{apiName}}(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> config = new HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -69,13 +51,5 @@ namespace {{packageName}}.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder Configure{{apiName}}(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<{{>DefaultApis}}>> options)
-            => Configure{{apiName}}<{{>DefaultApis}}>(builder, options);
     }
 }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/IServiceCollectionExtensions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/IServiceCollectionExtensions.mustache
@@ -7,7 +7,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using {{packageName}}.{{clientPackage}};
-using {{packageName}}.{{apiPackage}};
 
 namespace {{packageName}}.Extensions
 {
@@ -21,24 +20,9 @@ namespace {{packageName}}.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void Add{{apiName}}<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(this IServiceCollection services)
-            {{#apiInfo}}
-            {{#apis}}
-            where T{{classname}} : class, {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
-            {{/apis}}
-            {{/apiInfo}}
-        {
-            HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> config = new{{^net70OrLater}} HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>{{/net70OrLater}}(services);
-            Add{{apiName}}(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         public static void Add{{apiName}}(this IServiceCollection services)
         {
-            HostConfiguration<{{>DefaultApis}}> config = new HostConfiguration<{{>DefaultApis}}>(services);
+            HostConfiguration config = new{{^net70OrLater}} HostConfiguration{{/net70OrLater}}(services);
             Add{{apiName}}(services, config);
         }
 
@@ -48,36 +32,14 @@ namespace {{packageName}}.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void Add{{apiName}}<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(this IServiceCollection services, Action<HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>> options)
-            {{#apiInfo}}
-            {{#apis}}
-            where T{{classname}} : class, {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
-            {{/apis}}
-            {{/apiInfo}}
+        public static void Add{{apiName}}(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> config = new{{^net70OrLater}} HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>{{/net70OrLater}}(services);
+            HostConfiguration config = new{{^net70OrLater}} HostConfiguration{{/net70OrLater}}(services);
             options(config);
             Add{{apiName}}(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void Add{{apiName}}(this IServiceCollection services, Action<HostConfiguration<{{>DefaultApis}}>> options)
-        {
-            HostConfiguration<{{>DefaultApis}}> config = new HostConfiguration<{{>DefaultApis}}>(services);
-            options(config);
-            Add{{apiName}}(services, config);
-        }
-
-        internal static void Add{{apiName}}<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}>(IServiceCollection services, HostConfiguration<{{#apiInfo}}{{#apis}}T{{classname}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}}> host)
-            {{#apiInfo}}
-            {{#apis}}
-            where T{{classname}} : class, {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
-            {{/apis}}
-            {{/apiInfo}}
+        internal static void Add{{apiName}}(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.Add{{apiName}}HttpClients();

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/generichost/api.mustache
@@ -65,7 +65,7 @@ namespace {{packageName}}.{{apiPackage}}
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    {{>visibility}} partial class {{classname}} : {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
+    {{>visibility}} sealed partial class {{classname}} : {{interfacePrefix}}{{apiPackage}}.{{interfacePrefix}}{{classname}}
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools.Test/Model/DrawingTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools.Test/Model/DrawingTests.cs
@@ -63,14 +63,6 @@ namespace Org.OpenAPITools.Test.Model
             // TODO unit test for the property 'MainShape'
         }
         /// <summary>
-        /// Test the property 'ShapeOrNull'
-        /// </summary>
-        [Fact]
-        public void ShapeOrNullTest()
-        {
-            // TODO unit test for the property 'ShapeOrNull'
-        }
-        /// <summary>
         /// Test the property 'Shapes'
         /// </summary>
         [Fact]
@@ -85,6 +77,14 @@ namespace Org.OpenAPITools.Test.Model
         public void NullableShapeTest()
         {
             // TODO unit test for the property 'NullableShape'
+        }
+        /// <summary>
+        /// Test the property 'ShapeOrNull'
+        /// </summary>
+        [Fact]
+        public void ShapeOrNullTest()
+        {
+            // TODO unit test for the property 'ShapeOrNull'
         }
 
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class AnotherFakeApi : IApi.IAnotherFakeApi
+    public sealed partial class AnotherFakeApi : IApi.IAnotherFakeApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class DefaultApi : IApi.IDefaultApi
+    public sealed partial class DefaultApi : IApi.IDefaultApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -441,7 +441,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class FakeApi : IApi.IFakeApi
+    public sealed partial class FakeApi : IApi.IFakeApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class FakeClassnameTags123Api : IApi.IFakeClassnameTags123Api
+    public sealed partial class FakeClassnameTags123Api : IApi.IFakeClassnameTags123Api
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
@@ -257,7 +257,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class PetApi : IApi.IPetApi
+    public sealed partial class PetApi : IApi.IPetApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -126,7 +126,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class StoreApi : IApi.IStoreApi
+    public sealed partial class StoreApi : IApi.IStoreApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/UserApi.cs
@@ -222,7 +222,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class UserApi : IApi.IUserApi
+    public sealed partial class UserApi : IApi.IUserApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -16,6 +16,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.IApi;
 using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Client
@@ -23,14 +25,7 @@ namespace Org.OpenAPITools.Client
     /// <summary>
     /// Provides hosting configuration for Org.OpenAPITools
     /// </summary>
-    public class HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>
-        where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-        where TDefaultApi : class, IApi.IDefaultApi
-        where TFakeApi : class, IApi.IFakeApi
-        where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-        where TPetApi : class, IApi.IPetApi
-        where TStoreApi : class, IApi.IStoreApi
-        where TUserApi : class, IApi.IUserApi
+    public class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -142,13 +137,13 @@ namespace Org.OpenAPITools.Client
             _jsonOptions.Converters.Add(new ZeroBasedEnumClassJsonConverter());
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();
-            _services.AddTransient<TAnotherFakeApi, TAnotherFakeApi>();
-            _services.AddTransient<TDefaultApi, TDefaultApi>();
-            _services.AddTransient<TFakeApi, TFakeApi>();
-            _services.AddTransient<TFakeClassnameTags123Api, TFakeClassnameTags123Api>();
-            _services.AddTransient<TPetApi, TPetApi>();
-            _services.AddTransient<TStoreApi, TStoreApi>();
-            _services.AddTransient<TUserApi, TUserApi>();
+            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
+            _services.AddTransient<IDefaultApi, DefaultApi>();
+            _services.AddTransient<IFakeApi, FakeApi>();
+            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
+            _services.AddTransient<IPetApi, PetApi>();
+            _services.AddTransient<IStoreApi, StoreApi>();
+            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>
@@ -157,7 +152,7 @@ namespace Org.OpenAPITools.Client
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddApiHttpClients
+        public HostConfiguration AddApiHttpClients
         (
             Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
         {
@@ -166,13 +161,13 @@ namespace Org.OpenAPITools.Client
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            builders.Add(_services.AddHttpClient<IApi.IAnotherFakeApi, TAnotherFakeApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IDefaultApi, TDefaultApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IFakeApi, TFakeApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IFakeClassnameTags123Api, TFakeClassnameTags123Api>(client));
-            builders.Add(_services.AddHttpClient<IApi.IPetApi, TPetApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IStoreApi, TStoreApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IUserApi, TUserApi>(client));
+            builders.Add(_services.AddHttpClient<IAnotherFakeApi, AnotherFakeApi>(client));
+            builders.Add(_services.AddHttpClient<IDefaultApi, DefaultApi>(client));
+            builders.Add(_services.AddHttpClient<IFakeApi, FakeApi>(client));
+            builders.Add(_services.AddHttpClient<IFakeClassnameTags123Api, FakeClassnameTags123Api>(client));
+            builders.Add(_services.AddHttpClient<IPetApi, PetApi>(client));
+            builders.Add(_services.AddHttpClient<IStoreApi, StoreApi>(client));
+            builders.Add(_services.AddHttpClient<IUserApi, UserApi>(client));
             
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -188,7 +183,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -201,7 +196,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -212,7 +207,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -226,7 +221,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -27,18 +26,11 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>> options)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> config = new HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -47,13 +39,5 @@ namespace Org.OpenAPITools.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>> options)
-            => ConfigureApi<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>(builder, options);
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -27,40 +26,14 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(this IServiceCollection services, Action<HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>> options)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> config = new(services);
+            HostConfiguration config = new(services);
             options(config);
             AddApi(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>> options)
-        {
-            HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi> config = new HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>(services);
-            options(config);
-            AddApi(services, config);
-        }
-
-        internal static void AddApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(IServiceCollection services, HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> host)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        internal static void AddApi(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.AddApiHttpClients();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools.Test/Model/DrawingTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools.Test/Model/DrawingTests.cs
@@ -63,14 +63,6 @@ namespace Org.OpenAPITools.Test.Model
             // TODO unit test for the property 'MainShape'
         }
         /// <summary>
-        /// Test the property 'ShapeOrNull'
-        /// </summary>
-        [Fact]
-        public void ShapeOrNullTest()
-        {
-            // TODO unit test for the property 'ShapeOrNull'
-        }
-        /// <summary>
         /// Test the property 'Shapes'
         /// </summary>
         [Fact]
@@ -85,6 +77,14 @@ namespace Org.OpenAPITools.Test.Model
         public void NullableShapeTest()
         {
             // TODO unit test for the property 'NullableShape'
+        }
+        /// <summary>
+        /// Test the property 'ShapeOrNull'
+        /// </summary>
+        [Fact]
+        public void ShapeOrNullTest()
+        {
+            // TODO unit test for the property 'ShapeOrNull'
         }
 
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class AnotherFakeApi : IApi.IAnotherFakeApi
+    public sealed partial class AnotherFakeApi : IApi.IAnotherFakeApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -99,7 +99,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class DefaultApi : IApi.IDefaultApi
+    public sealed partial class DefaultApi : IApi.IDefaultApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class FakeApi : IApi.IFakeApi
+    public sealed partial class FakeApi : IApi.IFakeApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class FakeClassnameTags123Api : IApi.IFakeClassnameTags123Api
+    public sealed partial class FakeClassnameTags123Api : IApi.IFakeClassnameTags123Api
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class PetApi : IApi.IPetApi
+    public sealed partial class PetApi : IApi.IPetApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class StoreApi : IApi.IStoreApi
+    public sealed partial class StoreApi : IApi.IStoreApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class UserApi : IApi.IUserApi
+    public sealed partial class UserApi : IApi.IUserApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -14,6 +14,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.IApi;
 using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Client
@@ -21,14 +23,7 @@ namespace Org.OpenAPITools.Client
     /// <summary>
     /// Provides hosting configuration for Org.OpenAPITools
     /// </summary>
-    public class HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>
-        where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-        where TDefaultApi : class, IApi.IDefaultApi
-        where TFakeApi : class, IApi.IFakeApi
-        where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-        where TPetApi : class, IApi.IPetApi
-        where TStoreApi : class, IApi.IStoreApi
-        where TUserApi : class, IApi.IUserApi
+    public class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -140,13 +135,13 @@ namespace Org.OpenAPITools.Client
             _jsonOptions.Converters.Add(new ZeroBasedEnumClassJsonConverter());
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();
-            _services.AddTransient<TAnotherFakeApi, TAnotherFakeApi>();
-            _services.AddTransient<TDefaultApi, TDefaultApi>();
-            _services.AddTransient<TFakeApi, TFakeApi>();
-            _services.AddTransient<TFakeClassnameTags123Api, TFakeClassnameTags123Api>();
-            _services.AddTransient<TPetApi, TPetApi>();
-            _services.AddTransient<TStoreApi, TStoreApi>();
-            _services.AddTransient<TUserApi, TUserApi>();
+            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
+            _services.AddTransient<IDefaultApi, DefaultApi>();
+            _services.AddTransient<IFakeApi, FakeApi>();
+            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
+            _services.AddTransient<IPetApi, PetApi>();
+            _services.AddTransient<IStoreApi, StoreApi>();
+            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>
@@ -155,7 +150,7 @@ namespace Org.OpenAPITools.Client
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddApiHttpClients
+        public HostConfiguration AddApiHttpClients
         (
             Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
         {
@@ -164,13 +159,13 @@ namespace Org.OpenAPITools.Client
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            builders.Add(_services.AddHttpClient<IApi.IAnotherFakeApi, TAnotherFakeApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IDefaultApi, TDefaultApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IFakeApi, TFakeApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IFakeClassnameTags123Api, TFakeClassnameTags123Api>(client));
-            builders.Add(_services.AddHttpClient<IApi.IPetApi, TPetApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IStoreApi, TStoreApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IUserApi, TUserApi>(client));
+            builders.Add(_services.AddHttpClient<IAnotherFakeApi, AnotherFakeApi>(client));
+            builders.Add(_services.AddHttpClient<IDefaultApi, DefaultApi>(client));
+            builders.Add(_services.AddHttpClient<IFakeApi, FakeApi>(client));
+            builders.Add(_services.AddHttpClient<IFakeClassnameTags123Api, FakeClassnameTags123Api>(client));
+            builders.Add(_services.AddHttpClient<IPetApi, PetApi>(client));
+            builders.Add(_services.AddHttpClient<IStoreApi, StoreApi>(client));
+            builders.Add(_services.AddHttpClient<IUserApi, UserApi>(client));
             
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -186,7 +181,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -199,7 +194,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -210,7 +205,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -224,7 +219,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
@@ -11,7 +11,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -25,18 +24,11 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>> options)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> config = new HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -45,13 +37,5 @@ namespace Org.OpenAPITools.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>> options)
-            => ConfigureApi<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>(builder, options);
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -25,40 +24,14 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(this IServiceCollection services, Action<HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>> options)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> config = new(services);
+            HostConfiguration config = new(services);
             options(config);
             AddApi(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>> options)
-        {
-            HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi> config = new HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>(services);
-            options(config);
-            AddApi(services, config);
-        }
-
-        internal static void AddApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(IServiceCollection services, HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> host)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        internal static void AddApi(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.AddApiHttpClients();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class DefaultApi : IApi.IDefaultApi
+    public sealed partial class DefaultApi : IApi.IDefaultApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -16,6 +16,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.IApi;
 using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Client
@@ -23,8 +25,7 @@ namespace Org.OpenAPITools.Client
     /// <summary>
     /// Provides hosting configuration for Org.OpenAPITools
     /// </summary>
-    public class HostConfiguration<TDefaultApi>
-        where TDefaultApi : class, IApi.IDefaultApi
+    public class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -48,7 +49,7 @@ namespace Org.OpenAPITools.Client
             _jsonOptions.Converters.Add(new PersonJsonConverter());
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();
-            _services.AddTransient<TDefaultApi, TDefaultApi>();
+            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Org.OpenAPITools.Client
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddApiHttpClients
+        public HostConfiguration AddApiHttpClients
         (
             Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
         {
@@ -66,7 +67,7 @@ namespace Org.OpenAPITools.Client
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            builders.Add(_services.AddHttpClient<IApi.IDefaultApi, TDefaultApi>(client));
+            builders.Add(_services.AddHttpClient<IDefaultApi, DefaultApi>(client));
             
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -82,7 +83,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -95,7 +96,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -106,7 +107,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -120,7 +121,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -26,12 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder ConfigureApi<TDefaultApi>(this IHostBuilder builder)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TDefaultApi> config = new HostConfiguration<TDefaultApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 IServiceCollectionExtensions.AddApi(services, config);
             });
@@ -43,20 +41,12 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder)
-            => ConfigureApi<DefaultApi>(builder);
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi<TDefaultApi>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<TDefaultApi>> options)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TDefaultApi> config = new HostConfiguration<TDefaultApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -65,13 +55,5 @@ namespace Org.OpenAPITools.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<DefaultApi>> options)
-            => ConfigureApi<DefaultApi>(builder, options);
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -26,20 +25,9 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi<TDefaultApi>(this IServiceCollection services)
-            where TDefaultApi : class, IApi.IDefaultApi
-        {
-            HostConfiguration<TDefaultApi> config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         public static void AddApi(this IServiceCollection services)
         {
-            HostConfiguration<DefaultApi> config = new HostConfiguration<DefaultApi>(services);
+            HostConfiguration config = new(services);
             AddApi(services, config);
         }
 
@@ -48,28 +36,14 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi<TDefaultApi>(this IServiceCollection services, Action<HostConfiguration<TDefaultApi>> options)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<TDefaultApi> config = new(services);
+            HostConfiguration config = new(services);
             options(config);
             AddApi(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration<DefaultApi>> options)
-        {
-            HostConfiguration<DefaultApi> config = new HostConfiguration<DefaultApi>(services);
-            options(config);
-            AddApi(services, config);
-        }
-
-        internal static void AddApi<TDefaultApi>(IServiceCollection services, HostConfiguration<TDefaultApi> host)
-            where TDefaultApi : class, IApi.IDefaultApi
+        internal static void AddApi(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.AddApiHttpClients();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class DefaultApi : IApi.IDefaultApi
+    public sealed partial class DefaultApi : IApi.IDefaultApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -16,6 +16,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.IApi;
 using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Client
@@ -23,8 +25,7 @@ namespace Org.OpenAPITools.Client
     /// <summary>
     /// Provides hosting configuration for Org.OpenAPITools
     /// </summary>
-    public class HostConfiguration<TDefaultApi>
-        where TDefaultApi : class, IApi.IDefaultApi
+    public class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -46,7 +47,7 @@ namespace Org.OpenAPITools.Client
             _jsonOptions.Converters.Add(new FruitJsonConverter());
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();
-            _services.AddTransient<TDefaultApi, TDefaultApi>();
+            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Org.OpenAPITools.Client
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddApiHttpClients
+        public HostConfiguration AddApiHttpClients
         (
             Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
         {
@@ -64,7 +65,7 @@ namespace Org.OpenAPITools.Client
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            builders.Add(_services.AddHttpClient<IApi.IDefaultApi, TDefaultApi>(client));
+            builders.Add(_services.AddHttpClient<IDefaultApi, DefaultApi>(client));
             
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -80,7 +81,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -93,7 +94,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -104,7 +105,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -118,7 +119,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -26,12 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder ConfigureApi<TDefaultApi>(this IHostBuilder builder)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TDefaultApi> config = new HostConfiguration<TDefaultApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 IServiceCollectionExtensions.AddApi(services, config);
             });
@@ -43,20 +41,12 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder)
-            => ConfigureApi<DefaultApi>(builder);
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi<TDefaultApi>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<TDefaultApi>> options)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TDefaultApi> config = new HostConfiguration<TDefaultApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -65,13 +55,5 @@ namespace Org.OpenAPITools.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<DefaultApi>> options)
-            => ConfigureApi<DefaultApi>(builder, options);
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -26,20 +25,9 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi<TDefaultApi>(this IServiceCollection services)
-            where TDefaultApi : class, IApi.IDefaultApi
-        {
-            HostConfiguration<TDefaultApi> config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         public static void AddApi(this IServiceCollection services)
         {
-            HostConfiguration<DefaultApi> config = new HostConfiguration<DefaultApi>(services);
+            HostConfiguration config = new(services);
             AddApi(services, config);
         }
 
@@ -48,28 +36,14 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi<TDefaultApi>(this IServiceCollection services, Action<HostConfiguration<TDefaultApi>> options)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<TDefaultApi> config = new(services);
+            HostConfiguration config = new(services);
             options(config);
             AddApi(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration<DefaultApi>> options)
-        {
-            HostConfiguration<DefaultApi> config = new HostConfiguration<DefaultApi>(services);
-            options(config);
-            AddApi(services, config);
-        }
-
-        internal static void AddApi<TDefaultApi>(IServiceCollection services, HostConfiguration<TDefaultApi> host)
-            where TDefaultApi : class, IApi.IDefaultApi
+        internal static void AddApi(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.AddApiHttpClients();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class DefaultApi : IApi.IDefaultApi
+    public sealed partial class DefaultApi : IApi.IDefaultApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -16,6 +16,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.IApi;
 using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Client
@@ -23,8 +25,7 @@ namespace Org.OpenAPITools.Client
     /// <summary>
     /// Provides hosting configuration for Org.OpenAPITools
     /// </summary>
-    public class HostConfiguration<TDefaultApi>
-        where TDefaultApi : class, IApi.IDefaultApi
+    public class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -46,7 +47,7 @@ namespace Org.OpenAPITools.Client
             _jsonOptions.Converters.Add(new FruitJsonConverter());
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();
-            _services.AddTransient<TDefaultApi, TDefaultApi>();
+            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Org.OpenAPITools.Client
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddApiHttpClients
+        public HostConfiguration AddApiHttpClients
         (
             Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
         {
@@ -64,7 +65,7 @@ namespace Org.OpenAPITools.Client
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            builders.Add(_services.AddHttpClient<IApi.IDefaultApi, TDefaultApi>(client));
+            builders.Add(_services.AddHttpClient<IDefaultApi, DefaultApi>(client));
             
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -80,7 +81,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -93,7 +94,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -104,7 +105,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -118,7 +119,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<TDefaultApi> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -26,12 +25,11 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder ConfigureApi<TDefaultApi>(this IHostBuilder builder)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TDefaultApi> config = new HostConfiguration<TDefaultApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 IServiceCollectionExtensions.AddApi(services, config);
             });
@@ -43,20 +41,12 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="builder"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder)
-            => ConfigureApi<DefaultApi>(builder);
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi<TDefaultApi>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<TDefaultApi>> options)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TDefaultApi> config = new HostConfiguration<TDefaultApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -65,13 +55,5 @@ namespace Org.OpenAPITools.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<DefaultApi>> options)
-            => ConfigureApi<DefaultApi>(builder, options);
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -13,7 +13,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -26,20 +25,9 @@ namespace Org.OpenAPITools.Extensions
         /// Add the api to your host builder.
         /// </summary>
         /// <param name="services"></param>
-        public static void AddApi<TDefaultApi>(this IServiceCollection services)
-            where TDefaultApi : class, IApi.IDefaultApi
-        {
-            HostConfiguration<TDefaultApi> config = new(services);
-            AddApi(services, config);
-        }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
         public static void AddApi(this IServiceCollection services)
         {
-            HostConfiguration<DefaultApi> config = new HostConfiguration<DefaultApi>(services);
+            HostConfiguration config = new(services);
             AddApi(services, config);
         }
 
@@ -48,28 +36,14 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi<TDefaultApi>(this IServiceCollection services, Action<HostConfiguration<TDefaultApi>> options)
-            where TDefaultApi : class, IApi.IDefaultApi
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<TDefaultApi> config = new(services);
+            HostConfiguration config = new(services);
             options(config);
             AddApi(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration<DefaultApi>> options)
-        {
-            HostConfiguration<DefaultApi> config = new HostConfiguration<DefaultApi>(services);
-            options(config);
-            AddApi(services, config);
-        }
-
-        internal static void AddApi<TDefaultApi>(IServiceCollection services, HostConfiguration<TDefaultApi> host)
-            where TDefaultApi : class, IApi.IDefaultApi
+        internal static void AddApi(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.AddApiHttpClients();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools.Test/Model/DrawingTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools.Test/Model/DrawingTests.cs
@@ -63,14 +63,6 @@ namespace Org.OpenAPITools.Test.Model
             // TODO unit test for the property 'MainShape'
         }
         /// <summary>
-        /// Test the property 'ShapeOrNull'
-        /// </summary>
-        [Fact]
-        public void ShapeOrNullTest()
-        {
-            // TODO unit test for the property 'ShapeOrNull'
-        }
-        /// <summary>
         /// Test the property 'Shapes'
         /// </summary>
         [Fact]
@@ -85,6 +77,14 @@ namespace Org.OpenAPITools.Test.Model
         public void NullableShapeTest()
         {
             // TODO unit test for the property 'NullableShape'
+        }
+        /// <summary>
+        /// Test the property 'ShapeOrNull'
+        /// </summary>
+        [Fact]
+        public void ShapeOrNullTest()
+        {
+            // TODO unit test for the property 'ShapeOrNull'
         }
 
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class AnotherFakeApi : IApi.IAnotherFakeApi
+    public sealed partial class AnotherFakeApi : IApi.IAnotherFakeApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -99,7 +99,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class DefaultApi : IApi.IDefaultApi
+    public sealed partial class DefaultApi : IApi.IDefaultApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -439,7 +439,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class FakeApi : IApi.IFakeApi
+    public sealed partial class FakeApi : IApi.IFakeApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class FakeClassnameTags123Api : IApi.IFakeClassnameTags123Api
+    public sealed partial class FakeClassnameTags123Api : IApi.IFakeClassnameTags123Api
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class PetApi : IApi.IPetApi
+    public sealed partial class PetApi : IApi.IPetApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class StoreApi : IApi.IStoreApi
+    public sealed partial class StoreApi : IApi.IStoreApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -220,7 +220,7 @@ namespace Org.OpenAPITools.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class UserApi : IApi.IUserApi
+    public sealed partial class UserApi : IApi.IUserApi
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -14,6 +14,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.IApi;
 using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Client
@@ -21,14 +23,7 @@ namespace Org.OpenAPITools.Client
     /// <summary>
     /// Provides hosting configuration for Org.OpenAPITools
     /// </summary>
-    public class HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>
-        where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-        where TDefaultApi : class, IApi.IDefaultApi
-        where TFakeApi : class, IApi.IFakeApi
-        where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-        where TPetApi : class, IApi.IPetApi
-        where TStoreApi : class, IApi.IStoreApi
-        where TUserApi : class, IApi.IUserApi
+    public class HostConfiguration
     {
         private readonly IServiceCollection _services;
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions();
@@ -140,13 +135,13 @@ namespace Org.OpenAPITools.Client
             _jsonOptions.Converters.Add(new ZeroBasedEnumClassJsonConverter());
             _services.AddSingleton(new JsonSerializerOptionsProvider(_jsonOptions));
             _services.AddSingleton<IApiFactory, ApiFactory>();
-            _services.AddTransient<TAnotherFakeApi, TAnotherFakeApi>();
-            _services.AddTransient<TDefaultApi, TDefaultApi>();
-            _services.AddTransient<TFakeApi, TFakeApi>();
-            _services.AddTransient<TFakeClassnameTags123Api, TFakeClassnameTags123Api>();
-            _services.AddTransient<TPetApi, TPetApi>();
-            _services.AddTransient<TStoreApi, TStoreApi>();
-            _services.AddTransient<TUserApi, TUserApi>();
+            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
+            _services.AddTransient<IDefaultApi, DefaultApi>();
+            _services.AddTransient<IFakeApi, FakeApi>();
+            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
+            _services.AddTransient<IPetApi, PetApi>();
+            _services.AddTransient<IStoreApi, StoreApi>();
+            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>
@@ -155,7 +150,7 @@ namespace Org.OpenAPITools.Client
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddApiHttpClients
+        public HostConfiguration AddApiHttpClients
         (
             Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
         {
@@ -164,13 +159,13 @@ namespace Org.OpenAPITools.Client
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 
-            builders.Add(_services.AddHttpClient<IApi.IAnotherFakeApi, TAnotherFakeApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IDefaultApi, TDefaultApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IFakeApi, TFakeApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IFakeClassnameTags123Api, TFakeClassnameTags123Api>(client));
-            builders.Add(_services.AddHttpClient<IApi.IPetApi, TPetApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IStoreApi, TStoreApi>(client));
-            builders.Add(_services.AddHttpClient<IApi.IUserApi, TUserApi>(client));
+            builders.Add(_services.AddHttpClient<IAnotherFakeApi, AnotherFakeApi>(client));
+            builders.Add(_services.AddHttpClient<IDefaultApi, DefaultApi>(client));
+            builders.Add(_services.AddHttpClient<IFakeApi, FakeApi>(client));
+            builders.Add(_services.AddHttpClient<IFakeClassnameTags123Api, FakeClassnameTags123Api>(client));
+            builders.Add(_services.AddHttpClient<IPetApi, PetApi>(client));
+            builders.Add(_services.AddHttpClient<IStoreApi, StoreApi>(client));
+            builders.Add(_services.AddHttpClient<IUserApi, UserApi>(client));
             
             if (builder != null)
                 foreach (IHttpClientBuilder instance in builders)
@@ -186,7 +181,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> ConfigureJsonOptions(Action<JsonSerializerOptions> options)
+        public HostConfiguration ConfigureJsonOptions(Action<JsonSerializerOptions> options)
         {
             options(_jsonOptions);
 
@@ -199,7 +194,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(TTokenBase token) where TTokenBase : TokenBase
         {
             return AddTokens(new TTokenBase[]{ token });
         }
@@ -210,7 +205,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenBase"></typeparam>
         /// <param name="tokens"></param>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
+        public HostConfiguration AddTokens<TTokenBase>(IEnumerable<TTokenBase> tokens) where TTokenBase : TokenBase
         {
             TokenContainer<TTokenBase> container = new TokenContainer<TTokenBase>(tokens);
             _services.AddSingleton(services => container);
@@ -224,7 +219,7 @@ namespace Org.OpenAPITools.Client
         /// <typeparam name="TTokenProvider"></typeparam>
         /// <typeparam name="TTokenBase"></typeparam>
         /// <returns></returns>
-        public HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> UseProvider<TTokenProvider, TTokenBase>() 
+        public HostConfiguration UseProvider<TTokenProvider, TTokenBase>() 
             where TTokenProvider : TokenProvider<TTokenBase>
             where TTokenBase : TokenBase
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Extensions/IHostBuilderExtensions.cs
@@ -11,7 +11,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -25,18 +24,11 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>> options)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> options)
         {
             builder.ConfigureServices((context, services) => 
             {
-                HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> config = new HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(services);
+                HostConfiguration config = new HostConfiguration(services);
 
                 options(context, services, config);
 
@@ -45,13 +37,5 @@ namespace Org.OpenAPITools.Extensions
 
             return builder;
         }
-
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="options"></param>
-        public static IHostBuilder ConfigureApi(this IHostBuilder builder, Action<HostBuilderContext, IServiceCollection, HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>> options)
-            => ConfigureApi<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>(builder, options);
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Extensions/IServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Api;
 
 namespace Org.OpenAPITools.Extensions
 {
@@ -25,40 +24,14 @@ namespace Org.OpenAPITools.Extensions
         /// </summary>
         /// <param name="services"></param>
         /// <param name="options"></param>
-        public static void AddApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(this IServiceCollection services, Action<HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>> options)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        public static void AddApi(this IServiceCollection services, Action<HostConfiguration> options)
         {
-            HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> config = new HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(services);
+            HostConfiguration config = new HostConfiguration(services);
             options(config);
             AddApi(services, config);
         }
 
-        /// <summary>
-        /// Add the api to your host builder.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="options"></param>
-        public static void AddApi(this IServiceCollection services, Action<HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>> options)
-        {
-            HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi> config = new HostConfiguration<AnotherFakeApi, DefaultApi, FakeApi, FakeClassnameTags123Api, PetApi, StoreApi, UserApi>(services);
-            options(config);
-            AddApi(services, config);
-        }
-
-        internal static void AddApi<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi>(IServiceCollection services, HostConfiguration<TAnotherFakeApi, TDefaultApi, TFakeApi, TFakeClassnameTags123Api, TPetApi, TStoreApi, TUserApi> host)
-            where TAnotherFakeApi : class, IApi.IAnotherFakeApi
-            where TDefaultApi : class, IApi.IDefaultApi
-            where TFakeApi : class, IApi.IFakeApi
-            where TFakeClassnameTags123Api : class, IApi.IFakeClassnameTags123Api
-            where TPetApi : class, IApi.IPetApi
-            where TStoreApi : class, IApi.IStoreApi
-            where TUserApi : class, IApi.IUserApi
+        internal static void AddApi(IServiceCollection services, HostConfiguration host)
         {
             if (!host.HttpClientsAdded)
                 host.AddApiHttpClients();


### PR DESCRIPTION
There is no longer a need to inherit the api as the custom code was moved to partial methods or templates. This pr removes the ability to inherit the api classes.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
