### PR TITLE
Add support for skipping metadata file generation to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ SYNOPSIS
                 [--remove-operation-id-prefix]
                 [--reserved-words-mappings <reserved word mappings>...]
                 [(-s | --skip-overwrite)] [--server-variables <server variables>...]
-                [--skip-validate-spec] [--strict-spec <true/false strict behavior>]
+                [--skip-generate-metadata] [--skip-validate-spec] [--strict-spec <true/false strict behavior>]
                 [(-t <template directory> | --template-dir <template directory>)]
                 [--type-mappings <type mappings>...] [(-v | --verbose)]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -316,7 +316,7 @@ SYNOPSIS
                 [--remove-operation-id-prefix]
                 [--reserved-words-mappings <reserved word mappings>...]
                 [(-s | --skip-overwrite)] [--server-variables <server variables>...]
-                [--skip-operation-example] [--skip-validate-spec]
+                [--skip-generate-metadata] [--skip-operation-example] [--skip-validate-spec]
                 [--strict-spec <true/false strict behavior>]
                 [(-t <template directory> | --template-dir <template directory>)]
                 [--type-mappings <type mappings>...] [(-v | --verbose)]
@@ -482,6 +482,10 @@ OPTIONS
         --server-variables <server variables>
             sets server variables overrides for spec documents which support
             variable templating of servers.
+            
+        --skip-generate-metadata
+            Skip outputting metadata files such as VERSION, FILES and
+            .openapi-generator-ignore.
 
         --skip-operation-example
             Skip examples defined in operations to avoid out of memory errors.

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -103,7 +103,11 @@ public class Generate extends OpenApiGeneratorCommand {
 
     @Option(name = { "--dry-run" }, title = "Dry run",
             description = "Try things out and report on potential changes (without actually making changes).")
-    private Boolean isDryRun;
+    private Boolean isDryRun = false;
+
+    @Option(name = { "--skip-generate-metadata" }, title = "Skip generating metadata files",
+            description = "Do not output metadata files such as FILES, VERSION and .openapi-generator-ignore.")
+    private Boolean isSkipGenerateMetadata = false;
 
     @Option(name = {"--package-name"}, title = "package name",
             description = CodegenConstants.PACKAGE_NAME_DESC)
@@ -484,6 +488,7 @@ public class Generate extends OpenApiGeneratorCommand {
             }
 
             generator.opts(clientOptInput);
+            generator.setGenerateMetadata(!isSkipGenerateMetadata);
             generator.generate();
         } catch (GeneratorNotFoundException e) {
             System.err.println(e.getMessage());

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -440,4 +440,10 @@ public class GenerateTest {
     public void testNPEWithInvalidSpecFile() {
         setupAndRunTest("-i", "src/test/resources/npe-test.yaml", "-g", "java", "-o", "src/main/java", false, null);
     }
+
+    @Test
+    public void testSkipGenerateMetadata() {
+        setupAndRunGenericTest("--skip-generate-metadata");
+        verify(generator).setGenerateMetadata(false);
+    }
 }

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -424,6 +424,11 @@ apply plugin: 'org.openapi.generator'
 |false
 |Defines whether the generator should run in dry-run mode. In dry-run mode no files are written and a summary about
 file states is output.
+
+|generateMetadata
+|Boolean
+|true
+|Defines whether metadata files (FILES, VERSION, .openapi-generator-ignore) should be generated.
 |===
 
 [NOTE]

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -150,6 +150,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     engine.set(generate.engine)
                     cleanupOutput.set(generate.cleanupOutput)
                     dryRun.set(generate.dryRun)
+                    generateMetadata.set(generate.generateMetadata)
                 }
             }
         }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -364,6 +364,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
      */
     val dryRun = project.objects.property<Boolean>()
 
+    /**
+     * Defines whether metadata files should be generated.
+     */
+    val generateMetadata = project.objects.property<Boolean>()
+
     init {
         applyDefaults()
     }
@@ -387,5 +392,6 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
         generateAliasAsModel.set(false)
         cleanupOutput.set(false)
         dryRun.set(false)
+        generateMetadata.set(true)
     }
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -528,6 +528,13 @@ open class GenerateTask : DefaultTask() {
     @Input
     val dryRun = project.objects.property<Boolean>()
 
+    /**
+     * Defines whether metadata files should be generated.
+     */
+    @Optional
+    @Input
+    val generateMetadata = project.objects.property<Boolean>()
+
     private fun <T : Any?> Property<T>.ifNotEmpty(block: Property<T>.(T) -> Unit) {
         if (isPresent) {
             val item: T? = get()
@@ -834,6 +841,11 @@ open class GenerateTask : DefaultTask() {
                 dryRunSetting = setting
             }
 
+            var generateMetadataSetting = true;
+            generateMetadata.ifNotEmpty { setting ->
+                generateMetadataSetting = setting
+            }
+
             val clientOptInput = configurator.toClientOptInput()
             val codegenConfig = clientOptInput.config
 
@@ -850,7 +862,9 @@ open class GenerateTask : DefaultTask() {
                 val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
                 out.withStyle(StyledTextOutput.Style.Success)
 
-                DefaultGenerator(dryRunSetting).opts(clientOptInput).generate()
+                val generator = DefaultGenerator(dryRunSetting).opts(clientOptInput)
+                generator.setGenerateMetadata(generateMetadataSetting)
+                generator.generate()
 
                 out.println("Successfully generated code to ${outputDir.get()}")
             } catch (e: RuntimeException) {

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -499,4 +499,45 @@ class GenerateTaskDslTest : TestBase() {
             "Dry run results message is missing."
         )
     }
+
+    @Test
+    fun `openapiGenerate should set generateMetadata flag`() {
+        // Arrange
+        val projectFiles = mapOf(
+            "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
+        )
+        withProject(
+            """
+        plugins {
+          id 'org.openapi.generator'
+        }
+        openApiGenerate {
+            generatorName = "kotlin"
+            inputSpec = file("spec.yaml").absolutePath
+            outputDir = file("build/kotlin").absolutePath
+            apiPackage = "org.openapitools.example.api"
+            invokerPackage = "org.openapitools.example.invoker"
+            modelPackage = "org.openapitools.example.model"
+            configOptions = [
+                    dateLibrary: "java8"
+            ]
+            generateMetadata = false
+        }
+    """.trimIndent(),
+            projectFiles
+        )
+
+        // Act
+        val result = GradleRunner.create()
+            .withProjectDir(temp)
+            .withArguments("openApiGenerate", "--info")
+            .withPluginClasspath()
+            .build()
+
+        // Assert
+        assertTrue(
+            result.output.contains("Skipped by generateMetadata option supplied by user."),
+            "Skipped generateMetadata message is missing."
+        )
+    }
 }

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -107,7 +107,8 @@ mvn clean compile
 | `skipIfSpecIsUnchanged` |  `codegen.skipIfSpecIsUnchanged` | Skip the execution if the source file is older than the output folder (`false` by default. Can also be set globally through the `codegen.skipIfSpecIsUnchanged` property)
 | `addCompileSourceRoot` |  `openapi.generator.maven.plugin.addCompileSourceRoot` | Add the output directory to the project as a source root, so that the generated java types are compiled and included in the project artifact (`true` by default). Mutually exclusive with `addTestCompileSourceRoot`.
 | `addTestCompileSourceRoot` |  `openapi.generator.maven.plugin.addTestCompileSourceRoot` | Add the output directory to the project as a test source root, so that the generated java types are compiled only for the test classpath of the project (`false` by default). Mutually exclusive with `addCompileSourceRoot`.
-| `dryRun` | `openapi.generator.maven.plugin.dryRun` | Defines whether the generator should run in dry-run mode. In dry-run mode no files are written and a summary about file states is output ( `false` by default).
+| `dryRun` | `openapi.generator.maven.plugin.dryRun` | Defines whether the generator should run in dry-run mode. In dry-run mode no files are written and a summary about file states is output (`false` by default).
+| `generateMetadata` | `openapi.generator.maven.plugin.generateMetadata` | Defines whether the generator should output metadata files like FILES, VERSION, .openapi-generator-ignore (`true` by default).
 | `environmentVariables` | N/A | deprecated. Use globalProperties instead.
 | `globalProperties` | N/A | A **map** of items conceptually similar to "environment variables" or "system properties". These are available to all aspects of the generation flow. See [Global Properties](https://openapi-generator.tech/docs/globals/) for list of available properties.
 | `configHelp` |  `codegen.configHelp` | dumps the configuration help for the specified library (generates no sources)

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -52,11 +52,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.project.MavenProject;
 
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenConfig;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.auth.AuthParser;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.config.GlobalSettings;
@@ -462,6 +458,9 @@ public class CodeGenMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "false", property = "openapi.generator.maven.plugin.dryRun")
     private Boolean dryRun = false;
+
+    @Parameter(defaultValue = "true", property = "openapi.generator.maven.plugin.generateMetadata")
+    private Boolean generateMetadata = true;
 
     // TODO: Rename to global properties in version 5.1
     @Parameter
@@ -870,7 +869,9 @@ public class CodeGenMojo extends AbstractMojo {
                 return;
             }
             adjustAdditionalProperties(config);
-            new DefaultGenerator(dryRun).opts(input).generate();
+            Generator generator = new DefaultGenerator(dryRun).opts(input);
+            generator.setGenerateMetadata(generateMetadata);
+            generator.generate();
 
             if (buildContext != null) {
                 buildContext.refresh(new File(getCompileSourceRoot()));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -172,6 +172,7 @@ public class DefaultGenerator implements Generator {
      *
      * @param generateMetadata true: enable outputs, false: disable outputs
      */
+    @Override
     @SuppressWarnings("WeakerAccess")
     public void setGenerateMetadata(Boolean generateMetadata) {
         this.generateMetadata = generateMetadata;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/Generator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/Generator.java
@@ -24,4 +24,6 @@ public interface Generator {
     Generator opts(ClientOptInput opts);
 
     List<File> generate();
+
+    void setGenerateMetadata(Boolean generateMetadata);
 }


### PR DESCRIPTION
A different approach to #13699 not via global properties as I have found them to have a problematic interaction with the `setGenerateMetadata` method on the `DefaultGenerator` (global properties are set in the `generate` method and you have to be careful to not overwrite anything that would have been set by that method).

Also adds support to the CLI in the form of a `--skip-generate-metadata` option.
Adds tests for the Gradle plugin and the CLI.

Fixes #15731
Supersedes #13699 (unless going via global properties is the better architectural decision)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
