### PR TITLE
fix c-libcurl generator for int and boolean required values

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -332,9 +332,13 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     // {{{classname}}}->{{{name}}}
     {{#required}}
     {{^isEnum}}
+    {{^isNumeric}}
+    {{^isBoolean}}
     if (!{{{classname}}}->{{{name}}}) {
         goto fail;
     }
+    {{/isBoolean}}
+    {{/isNumeric}}
     {{/isEnum}}
     {{#isEnum}}
     if ({{projectName}}_{{classVarName}}_{{enumName}}_NULL == {{{classname}}}->{{{name}}}) {
@@ -344,7 +348,11 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{/required}}
     {{^required}}
     {{^isEnum}}
+    {{^isNumeric}}
+    {{^isBoolean}}
     if({{{classname}}}->{{{name}}}) {
+    {{/isBoolean}}
+    {{/isNumeric}}
     {{/isEnum}}
     {{#isEnum}}
     if({{{classname}}}->{{{name}}} != {{projectName}}_{{classVarName}}_{{enumName}}_NULL) {
@@ -548,7 +556,11 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{/isMap}}
     {{/isContainer}}
     {{^required}}
+    {{^isNumeric}}
+    {{^isBoolean}}
     }
+    {{/isBoolean}}
+    {{/isNumeric}}
     {{/required}}
 
     {{/vars}}

--- a/samples/client/petstore/c/model/api_response.c
+++ b/samples/client/petstore/c/model/api_response.c
@@ -42,10 +42,8 @@ cJSON *api_response_convertToJSON(api_response_t *api_response) {
     cJSON *item = cJSON_CreateObject();
 
     // api_response->code
-    if(api_response->code) {
     if(cJSON_AddNumberToObject(item, "code", api_response->code) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 

--- a/samples/client/petstore/c/model/category.c
+++ b/samples/client/petstore/c/model/category.c
@@ -36,10 +36,8 @@ cJSON *category_convertToJSON(category_t *category) {
     cJSON *item = cJSON_CreateObject();
 
     // category->id
-    if(category->id) {
     if(cJSON_AddNumberToObject(item, "id", category->id) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -61,26 +61,20 @@ cJSON *order_convertToJSON(order_t *order) {
     cJSON *item = cJSON_CreateObject();
 
     // order->id
-    if(order->id) {
     if(cJSON_AddNumberToObject(item, "id", order->id) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 
     // order->pet_id
-    if(order->pet_id) {
     if(cJSON_AddNumberToObject(item, "petId", order->pet_id) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 
     // order->quantity
-    if(order->quantity) {
     if(cJSON_AddNumberToObject(item, "quantity", order->quantity) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 
@@ -102,10 +96,8 @@ cJSON *order_convertToJSON(order_t *order) {
 
 
     // order->complete
-    if(order->complete) {
     if(cJSON_AddBoolToObject(item, "complete", order->complete) == NULL) {
     goto fail; //Bool
-    }
     }
 
     return item;

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -79,10 +79,8 @@ cJSON *pet_convertToJSON(pet_t *pet) {
     cJSON *item = cJSON_CreateObject();
 
     // pet->id
-    if(pet->id) {
     if(cJSON_AddNumberToObject(item, "id", pet->id) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 

--- a/samples/client/petstore/c/model/tag.c
+++ b/samples/client/petstore/c/model/tag.c
@@ -36,10 +36,8 @@ cJSON *tag_convertToJSON(tag_t *tag) {
     cJSON *item = cJSON_CreateObject();
 
     // tag->id
-    if(tag->id) {
     if(cJSON_AddNumberToObject(item, "id", tag->id) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 

--- a/samples/client/petstore/c/model/user.c
+++ b/samples/client/petstore/c/model/user.c
@@ -68,10 +68,8 @@ cJSON *user_convertToJSON(user_t *user) {
     cJSON *item = cJSON_CreateObject();
 
     // user->id
-    if(user->id) {
     if(cJSON_AddNumberToObject(item, "id", user->id) == NULL) {
     goto fail; //Numeric
-    }
     }
 
 
@@ -124,10 +122,8 @@ cJSON *user_convertToJSON(user_t *user) {
 
 
     // user->user_status
-    if(user->user_status) {
     if(cJSON_AddNumberToObject(item, "userStatus", user->user_status) == NULL) {
     goto fail; //Numeric
-    }
     }
 
     return item;


### PR DESCRIPTION
Hello, while working with the kubernetes-c library that is generated with openai-generator, I had one case where I got a null CJSON object. More info here: https://github.com/kubernetes-client/c/issues/193

Basically for required int and boolean fields, there is a check that is made that has no logic. This is an example:

```
    // v1_daemon_set_status->number_misscheduled
    if (!v1_daemon_set_status->number_misscheduled) {
        goto fail;
    }
    if(cJSON_AddNumberToObject(item, "numberMisscheduled", v1_daemon_set_status->number_misscheduled) == NULL) {
    goto fail; //Numeric
    }
```
in this case `number_misscheduled` is a required int and if this value is 0, this conversion will fail.

The PR fix this issue for int and boolean values.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
