### PR TITLE
[Java][Client] remove model annotations from AbstractOpenApiSchema

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/AbstractOpenApiSchema.mustache
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}
+{{>generatedAnnotation}}
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/AbstractOpenApiSchema.mustache
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}
+{{>generatedAnnotation}}
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/AbstractOpenApiSchema.mustache
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}
+{{>generatedAnnotation}}
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/AbstractOpenApiSchema.mustache
@@ -13,7 +13,7 @@ import {{javaxPackage}}.ws.rs.core.GenericType;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}
+{{>generatedAnnotation}}
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -53,6 +53,7 @@ import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
@@ -2057,6 +2058,38 @@ public class JavaClientCodegenTest {
 
 
         output.deleteOnExit();
+    }
+
+    @DataProvider(name = "shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684")
+    public static Object[][] shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684_dataProvider() {
+        return new Object[][] {{"okhttp-gson"}, {"jersey2"}, {"jersey3"}, {"native"}};
+    }
+
+    @Test(dataProvider = "shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684")
+    public void shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684(String library) throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(library)
+            .addAdditionalProperty(AbstractJavaCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS, "@annotation1;@annotation2")
+            .setInputSpec("src/test/resources/3_0/deprecated-properties.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(clientOptInput).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("AbstractOpenApiSchema.java"))
+            .assertTypeAnnotations()
+            .doesNotContainsWithName("annotation1")
+            .doesNotContainsWithName("annotation2");
+        JavaFileAssert.assertThat(files.get("Animal.java"))
+            .assertTypeAnnotations()
+            .containsWithName("annotation1")
+            .containsWithName("annotation2");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/AbstractAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/AbstractAnnotationAssert.java
@@ -37,7 +37,7 @@ public abstract class AbstractAnnotationAssert<ACTUAL extends AbstractAnnotation
 
     public ACTUAL doesNotContainsWithName(final String name) {
         super
-            .withFailMessage("Should have annotation with name: " + name)
+            .withFailMessage("Shouldn't have annotation with name: " + name)
             .noneMatch(annotation -> annotation.getNameAsString().equals(name));
         return myself();
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fix https://github.com/OpenAPITools/openapi-generator/issues/15684
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
