### PR TITLE
[python] install urllib3 < 2.1.0 only

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3
+urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11
 {{#asyncio}}

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = ">=3.7"
 {{#apis}}
 {{#-last}}
 REQUIRES = [
-    "urllib3 >= 1.25.3",
+    "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
 {{#asyncio}}
     "aiohttp >= 3.0.0",

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3
+urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -25,7 +25,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3",
+    "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
     "pydantic >= 1.10.5, < 2",
     "aenum"

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3
+urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11
 aiohttp >= 3.0.0

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -24,7 +24,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3",
+    "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
     "aiohttp >= 3.0.0",
     "pem>=19.3.0",

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3
+urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -24,7 +24,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3",
+    "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
     "pem>=19.3.0",
     "pycryptodome>=3.9.0",


### PR DESCRIPTION
Install urllib3 < 2.1.0, which contains breaking changes

https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11) @krjakbrjak (2023/02)