### PR TITLE
[BUG][typescript] add missing importFileExtension support

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -1,10 +1,10 @@
 {{#platforms}}
 {{#node}}
 // TODO: evaluate if we can easily get rid of this library
-import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data";
-import { URL, URLSearchParams } from 'url';
-import * as http from 'http';
-import * as https from 'https';
+import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data{{importFileExtension}}";
+import { URL, URLSearchParams } from 'url{{importFileExtension}}';
+import * as http from 'http{{importFileExtension}}';
+import * as https from 'https{{importFileExtension}}';
 {{/node}}
 {{/platforms}}
 import { Observable, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
@@ -13,10 +13,10 @@ import { Observable, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../r
 {{^deno}}
 {{#frameworks}}
 {{#fetch-api}}
-export * from './isomorphic-fetch';
+export * from './isomorphic-fetch{{importFileExtension}}';
 {{/fetch-api}}
 {{#jquery}}
-export * from './jquery';
+export * from './jquery{{importFileExtension}}';
 {{/jquery}}
 {{/frameworks}}
 {{/deno}}


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)