### PR TITLE
Add Revved up by Gradle Enterprise badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Follow OpenAPI Generator Twitter account to get the latest update](https://img.shields.io/twitter/follow/oas_generator.svg?style=social&label=Follow)](https://twitter.com/oas_generator)
 [![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/OpenAPITools/openapi-generator)
 [![Conan Center](https://shields.io/conan/v/openapi-generator)](https://conan.io/center/openapi-generator)
-
+[![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.openapi-generator.tech/scans)
 </div>
 
 <div align="center">


### PR DESCRIPTION
Add Revved Up by Gradle Enterprise badge with a link to https://ge.openapi-generator.tech/scans

See rendering in the original branch:
https://github.com/jprinet/openapi-generator/tree/chore/add-revved-up-badge