### PR TITLE
FIX: Typo on swagger2 dependency

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -158,7 +158,7 @@ dependencies {
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
     {{/swagger1AnnotationLibrary}}
     {{#swagger2AnnotationLibrary}}
-    implementation "io.swagge.core.v3r:swagger-annotations:$swagger_annotations_version"
+    implementation "io.swagger.core.v3:swagger-annotations:$swagger_annotations_version"
     {{/swagger2AnnotationLibrary}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"

--- a/samples/client/petstore/java/webclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/webclient-swagger2/build.gradle
@@ -124,7 +124,7 @@ ext {
 }
 
 dependencies {
-    implementation "io.swagge.core.v3r:swagger-annotations:$swagger_annotations_version"
+    implementation "io.swagger.core.v3:swagger-annotations:$swagger_annotations_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"


### PR DESCRIPTION
Just fixes a misplaced insert for the swagger2 annotation library dependency.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.0) (breaking changes without fallbacks)
