### PR TITLE
[BUG] [Java-Spring] Required-Fields-Constructor has wrong super call when using multiple inheritance layers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -1174,13 +1174,12 @@ public class SpringCodegen extends AbstractJavaCodegen
                                     codegenModel.getImports().add(imp);
                                 }
                             }
-
-                            if (property.required) {
-                                codegenModel.parentRequiredVars.add(parentVar.clone());
-                            }
                         }
                     }
                     parentCodegenModel = parentCodegenModel.getParentModel();
+                }
+                if (codegenModel.getParentModel() != null) {
+                    codegenModel.parentRequiredVars = new ArrayList<>(codegenModel.getParentModel().requiredVars);
                 }
                 // There must be a better way ...
                 for (String imp: inheritedImports) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -402,7 +402,7 @@ public class SpringCodegenTest {
                 .setAdditionalProperties(properties)
                 .setGeneratorName("spring")
                 .setLibrary(SPRING_BOOT)
-                .setInputSpec("src/test/resources/bugs/issue_required-values-with-multiple-inheritance.yaml")
+                .setInputSpec("src/test/resources/bugs/issue_constructor-required-values-with-multiple-inheritance.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -391,7 +391,7 @@ public class SpringCodegenTest {
     }
 
     @Test
-    public void testJavaClientCorrectConstructorOrderForRequiredFields_issueNoNumberYet() throws IOException {
+    public void testJavaClientCorrectConstructorOrderForRequiredFields_issue15825() throws IOException {
         Map<String, Object> properties = new HashMap<>();
         properties.put(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0");
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -26,9 +26,11 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.java.assertions.JavaFileAssert;
 import org.openapitools.codegen.languages.AbstractJavaCodegen;
+import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.languages.SpringCodegen;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.CXFServerFeatures;
@@ -386,6 +388,46 @@ public class SpringCodegenTest {
                 .assertParameterAnnotations()
                 .containsWithNameAndAttributes("RequestParam", ImmutableMap.of("value", "\"start\""))
                 .containsWithNameAndAttributes("DateTimeFormat", ImmutableMap.of("iso", "DateTimeFormat.ISO.DATE_TIME"));
+    }
+
+    @Test
+    public void testJavaClientCorrectConstructorOrderForRequiredFields_issueNoNumberYet() throws IOException {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setAdditionalProperties(properties)
+                .setGeneratorName("spring")
+                .setLibrary(SPRING_BOOT)
+                .setInputSpec("src/test/resources/bugs/issue_required-values-with-multiple-inheritance.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(clientOptInput).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("SubType.java"))
+                .assertConstructor("TypeEnum", "SchemaVersion", "UUID", "Boolean", "Boolean", "SomeEnum")
+                .bodyContainsLines("super(someBoolean, someEnum, schemaVersion, id, oneBoolean);",
+                        "this.type = type;");
+        JavaFileAssert.assertThat(files.get("IntermediateSubType.java"))
+                .assertConstructor("Boolean", "SomeEnum", "SchemaVersion", "UUID", "Boolean")
+                .bodyContainsLines("super(oneBoolean, schemaVersion, id);",
+                        "this.someBoolean = someBoolean;",
+                        "this.someEnum = someEnum");
+        JavaFileAssert.assertThat(files.get("IntermediateType.java"))
+                .assertConstructor("Boolean", "SchemaVersion", "UUID")
+                .bodyContainsLines("super(schemaVersion, id);",
+                        "this.oneBoolean = oneBoolean;");
+        JavaFileAssert.assertThat(files.get("BaseType.java"))
+                .assertConstructor("SchemaVersion", "UUID")
+                .bodyContainsLines(
+                        "this.schemaVersion = schemaVersion;",
+                        "this.id = id;");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/bugs/issue_constructor-required-values-with-multiple-inheritance.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_constructor-required-values-with-multiple-inheritance.yaml
@@ -1,0 +1,94 @@
+---
+openapi: 3.0.2
+info:
+  version: 0.0.0
+  title: Wrong Constructor
+
+paths: {}
+
+components:
+
+  schemas:
+    BaseType:
+      type: object
+      required:
+        - schemaVersion
+        - id
+      properties:
+        schemaVersion:
+          $ref: "#/components/schemas/SchemaVersion"
+        id:
+          type: string
+          format: "uuid"
+        freeTextField:
+          type: array
+          default: [ ]
+          minItems: 0
+          maxItems: 6
+          items:
+            type: string
+            maxLength: 255
+      discriminator:
+        propertyName: type
+        mapping:
+          SubType: "#/components/schemas/SubType"
+
+
+    IntermediateType:
+      allOf:
+        - $ref: "#/components/schemas/BaseType"
+        - type: object
+          required:
+            - OneBoolean
+          properties:
+            OneBoolean:
+              type: boolean
+              default: false
+            OneOptionalBoolean:
+              type: boolean
+              default: false
+
+    IntermediateSubType:
+      allOf:
+        - $ref: "#/components/schemas/IntermediateType"
+        - type: object
+          required:
+            - someBoolean
+            - someEnum
+          properties:
+            someBoolean:
+              type: boolean
+              default: false
+            someEnum:
+              $ref: "#/components/schemas/SomeEnum"
+
+    SubType:
+      allOf:
+        - $ref: "#/components/schemas/IntermediateSubType"
+        - type: object
+          properties:
+            type:
+              type: string
+              default: "SubType"
+              enum: [ "SubType" ]
+          required:
+            - type
+
+
+    SomeEnum:
+      type: string
+      enum:
+        - LIT1
+        - LIT2
+      x-enum-varnames:
+        - Literal1
+        - Literal2
+
+
+    SchemaVersion:
+      type: string
+      default: "1.0.0"
+      x-enum-varnames:
+        - CURRENT
+      enum:
+        - "1.0.0"


### PR DESCRIPTION
PR fixes Issue https://github.com/OpenAPITools/openapi-generator/issues/15825




### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09)



"Im Auftrag der DB Systel GmbH"