### PR TITLE
[spring] Fix invalid swagger2 annotation library version in pom.xml

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -22,7 +22,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>
         {{/swagger1AnnotationLibrary}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
+        <swagger-annotations.version>2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{/springFoxDocumentationProvider}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
@@ -15,7 +15,7 @@
         {{/springDocDocumentationProvider}}
         {{^springDocDocumentationProvider}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
+        <swagger-annotations.version>2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
     </properties>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -22,7 +22,7 @@
         <swagger-annotations.version>1.6.6</swagger-annotations.version>
         {{/swagger1AnnotationLibrary}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.2.7</swagger-annotations.version>
+        <swagger-annotations.version>2.2.7</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{/springFoxDocumentationProvider}}


### PR DESCRIPTION
This fixes https://github.com/OpenAPITools/openapi-generator/issues/15828

There was additional char before version number which cause dependency not found error

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [ ] In case you are adding a new generator, run the following additional script : 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber @welshm @MelleD