### PR TITLE
[BUG][JAVA] Handling default values leads to wrong defaults or not compilable code fixed

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -974,6 +974,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                     _default.elements().forEachRemaining((element) -> {
                         final_values.add(element.asText());
                     });
+                } else if (schema.getDefault() instanceof Collection) {
+                    var _default = (Collection<String>) schema.getDefault();
+                    List<String> final_values = _values;
+                    _default.forEach((element) -> {
+                        final_values.add(element);
+                    });
                 } else { // single value
                     _values = java.util.Collections.singletonList(String.valueOf(schema.getDefault()));
                 }
@@ -986,7 +992,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                         defaultValues.add(cp.items.datatypeWithEnum + "." + toEnumVarName(_value, cp.items.dataType));
                     }
                     defaultValue = StringUtils.join(defaultValues, ", ");
-                } else {
+                } else if (_values.size() > 0) {
                     if (cp.items.isString) { // array item is string
                         defaultValue = String.format(Locale.ROOT, "\"%s\"", StringUtils.join(_values, "\", \""));
                     } else if (cp.items.isNumeric) {
@@ -1006,7 +1012,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                     } else { // array item is non-string, e.g. integer
                         defaultValue = StringUtils.join(_values, ", ");
                     }
+                } else {
+                    return "new ArrayList<>()";
                 }
+
                 return String.format(Locale.ROOT, "new ArrayList<>(Arrays.asList(%s))", defaultValue);
             } else if (cp.isArray && cp.getUniqueItems()) { // set
                 // TODO

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1617,6 +1617,37 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testJavaClientDefaultValues_issueNoNumber() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setAdditionalProperties(properties)
+                .setGeneratorName("java")
+                .setLibrary(JavaClientCodegen.WEBCLIENT)
+                .setInputSpec("src/test/resources/bugs/java-codegen-empty-array-as-default-value/issue_wrong-default.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(clientOptInput).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("DefaultValuesType.java"))
+                .hasProperty("stringDefault")
+                .asString().endsWith("= new ArrayList<>();");
+        JavaFileAssert.assertThat(files.get("DefaultValuesType.java"))
+                .hasProperty("stringDefault2")
+                .asString().endsWith("= new ArrayList<>(Arrays.asList(\"Hallo\", \"Huhu\"));");
+        JavaFileAssert.assertThat(files.get("DefaultValuesType.java"))
+                .hasProperty("objectDefault")
+                .asString().endsWith("= new ArrayList<>();");
+    }
+
+    @Test
     public void testWebClientJsonCreatorWithNullable_issue12790() throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put(AbstractJavaCodegen.OPENAPI_NULLABLE, "true");

--- a/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/baseType.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/baseType.yaml
@@ -1,0 +1,10 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: BaseType
+type: object
+required:
+ - property
+properties:
+  property1:
+    type: array
+    items:
+      $ref: 'defaultValuesType.yaml'

--- a/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/defaultValuesType.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/defaultValuesType.yaml
@@ -1,0 +1,29 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: DefaultValuesType
+type: object
+properties:
+  stringDefault:
+    type: array
+    default: []
+    items:
+      type: string
+  stringDefault2:
+    type: array
+    default:
+      - "Hallo"
+      - "Huhu"
+    items:
+      type: string
+  objectDefault:
+    type: array
+    default: []
+    items:
+      $ref: 'objectType.yaml'
+#  objectDefault2:
+#    type: array
+#    default:
+#    - someInt: 1
+#    - someInt: 3
+#    items:
+#      $ref: 'objectType.yaml'
+

--- a/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/defaultValuesType.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/defaultValuesType.yaml
@@ -19,11 +19,5 @@ properties:
     default: []
     items:
       $ref: 'objectType.yaml'
-#  objectDefault2:
-#    type: array
-#    default:
-#    - someInt: 1
-#    - someInt: 3
-#    items:
-#      $ref: 'objectType.yaml'
+
 

--- a/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/issue_wrong-default.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/issue_wrong-default.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Subfile-Defaults
+
+paths:
+  "/dummy":
+    post:
+      operationId: doSomething
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaseRequest'
+      responses:
+        "200":
+          description: Successful Operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+
+
+components:
+
+  schemas:
+    BaseRequest:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: './baseType.yaml'
+    BaseResponse:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'
+
+    Status:
+      type: string
+      enum:
+        - GOOD
+        - BAD

--- a/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/objectType.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/java-codegen-empty-array-as-default-value/objectType.yaml
@@ -1,0 +1,6 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: ObjectType
+type: object
+properties:
+  someInt:
+    type: integer


### PR DESCRIPTION
PR fixes Issue https://github.com/OpenAPITools/openapi-generator/issues/15835



### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)



"Im Auftrag der DB Systel GmbH"