### PR TITLE
fix: NullPointerException in DefaultCodegen.mergeProperties when processing models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2825,7 +2825,7 @@ public class DefaultCodegen implements CodegenConfig {
             Schema existingType = existingProperties.get("type");
             Schema newType = newProperties.get("type");
             existingProperties.putAll(newProperties);
-            if (null != existingType && null != newType && !newType.getEnum().isEmpty()) {
+            if (null != existingType && null != newType && null != newType.getEnum() && !newType.getEnum().isEmpty()) {
                 for (Object e : newType.getEnum()) {
                     // ensure all interface enum types are added to schema
                     if (null != existingType.getEnum() && !existingType.getEnum().contains(e)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -671,6 +671,31 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testOneOfMergeProperties() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue15859.json");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        String modelName = "Pet";
+
+        final Schema schema = openAPI.getComponents().getSchemas().get(modelName);
+        codegen.setOpenAPI(openAPI);
+        CodegenModel pet = codegen.fromModel(modelName, schema);
+
+        Set<String> oneOf = new TreeSet<String>();
+        oneOf.add("Dog");
+        oneOf.add("Cat");
+        Assert.assertEquals(pet.oneOf, oneOf);
+        // make sure that animal has the property type
+        boolean typeSeen = false;
+        for (CodegenProperty cp : pet.vars) {
+            if ("type".equals(cp.name)) {
+                typeSeen = true;
+                break;
+            }
+        }
+        Assert.assertTrue(typeSeen);
+    }
+
+    @Test
     public void testComposedSchemaOneOfWithProperties() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOf.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/issue15859.json
+++ b/modules/openapi-generator/src/test/resources/3_0/issue15859.json
@@ -1,0 +1,77 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "version": "1.0.0",
+    "title": "OpenAPI Petstore"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "description": "get all pets in a household",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/Dog"
+        }, {
+          "$ref" : "#/components/schemas/Cat"
+        } ],
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "Animal": {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "type" ]
+      },
+      "Dog": {
+        "allOf": [ {
+          "$ref": "#/components/schemas/Animal"
+        }, {
+          "type" : "object",
+          "title": "Dog",
+          "properties" : {
+            "type" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "type" ]
+      },
+      "Cat": {
+        "allOf": [ {
+          "$ref": "#/components/schemas/Animal"
+        }, {
+          "type" : "object",
+          "title": "Cat",
+          "properties" : {
+            "type" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "required" : [ "type" ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
To fix the following exception:
```
Exception in thread \"main\" java.lang.RuntimeException: Could not process model 'ResourceMonitor'.Please make sure that your schema is correct!
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:535)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:956)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:487)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
Caused by: java.lang.NullPointerException
	at org.openapitools.codegen.DefaultCodegen.mergeProperties(DefaultCodegen.java:2828)
	at org.openapitools.codegen.DefaultCodegen.updateModelForComposedSchema(DefaultCodegen.java:2741)
	at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:3076)
	at org.openapitools.codegen.languages.AbstractJavaCodegen.fromModel(AbstractJavaCodegen.java:1412)
	at org.openapitools.codegen.languages.JavaClientCodegen.fromModel(JavaClientCodegen.java:998)
	at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1335)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:530)
	... 4 more
```

`ResourceMonitor` is something like this:
```
    ResourceMonitor:
      oneOf:
        - $ref: '#/components/schemas/AuthenticationMonitor'
        - $ref: '#/components/schemas/SelfCheckMonitor'
      discriminator:
        propertyName: type
```

Usually, null check is performed on `getEnum()` before checking `getEnum().isEmpty()`:

https://github.com/OpenAPITools/openapi-generator/blob/95cefaeecdae21a43a453f07ed510c420abaa461/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L3508

Added the same kind of null check to not blow out.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
