### PR TITLE
author command: replace \ by /, fix #9528

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,6 +47,11 @@ jobs:
         run: mvn clean --no-snapshot-updates --batch-mode --quiet install
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      - name: Test Template Retrieval
+        run: |
+          cd modules/openapi-generator-cli/target
+          # generator names containing "-" caused problems in the past, see https://github.com/OpenAPITools/openapi-generator/issues/9528
+          java -jar ./openapi-generator-cli.jar author template --verbose  -g jaxrs-spec --library quarkus
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Gradle tests

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/AuthorTemplate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/AuthorTemplate.java
@@ -45,7 +45,7 @@ public class AuthorTemplate extends OpenApiGeneratorCommand {
     @Override
     void execute() {
         CodegenConfig config = CodegenConfigLoader.forName(generatorName);
-        String templateDirectory = config.templateDir();
+        String templateDirectory = config.templateDir().replace('\\', '/');
 
         log("Requesting '{}' from embedded resource directory '{}'", generatorName, templateDirectory);
 


### PR DESCRIPTION
fix https://github.com/OpenAPITools/openapi-generator/issues/9528

On Windows, some generators use `\` in the template directory path. But for the author cli command, this is not interpreted as file separator.

run `java -jar .\openapi-generator-cli.jar author template --verbose  -g jaxrs-spec --library quarkus` on Windows to verify.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
