### PR TITLE
[typescript-axios] Added functionalApisOnly flag for better tree-shaking (#12283)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -25,7 +25,12 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError } from './base';
 {{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}
 {{/models}}
 {{#apiInfo}}{{#apis}}
+{{^functionalApisOnly}}
 {{>apiInner}}
+{{/functionalApisOnly}}
+{{#functionalApisOnly}}
+{{>apiInnerFunctional}}
+{{/functionalApisOnly}}
 {{/apis}}{{/apiInfo}}
 {{/withSeparateModelsAndApi}}{{#withSeparateModelsAndApi}}
 {{#apiInfo}}{{#apis}}{{#operations}}export * from './{{tsApiPackage}}/{{classFilename}}';

--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInnerFunctional.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInnerFunctional.mustache
@@ -1,0 +1,301 @@
+{{#withSeparateModelsAndApi}}
+/* tslint:disable */
+/* eslint-disable */
+{{>licenseInfo}}
+
+import type { Configuration } from '{{apiRelativeToRoot}}configuration';
+import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios from 'axios';
+{{#withNodeImports}}
+// URLSearchParams not necessarily used
+// @ts-ignore
+import { URL, URLSearchParams } from 'url';
+{{#multipartFormData}}
+import FormData from 'form-data'
+{{/multipartFormData}}
+{{/withNodeImports}}
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '{{apiRelativeToRoot}}common';
+// @ts-ignore
+import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, {{^functionalApisOnly}}BaseAPI, {{/functionalApisOnly}}RequiredError } from '{{apiRelativeToRoot}}base';
+{{#imports}}
+// @ts-ignore
+import { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
+{{/imports}}
+{{/withSeparateModelsAndApi}}
+{{^withSeparateModelsAndApi}}
+{{/withSeparateModelsAndApi}}
+{{#operations}}
+{{#operation}}
+/**
+ * {{classname}}{{operationIdCamelCase}} - axios parameter creator{{#description}}
+ * {{&description}}{{/description}}
+ * {{&notes}}
+ {{#summary}}
+ * @summary {{&summary}}
+ {{/summary}}
+ {{#allParams}}
+ * @param {{=<% %>=}}{<%#isEnum%><%&datatypeWithEnum%><%/isEnum%><%^isEnum%><%&dataType%><%#isNullable%> | null<%/isNullable%><%/isEnum%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
+ {{/allParams}}
+ * @param {*} [options] Override http request option.{{#isDeprecated}}
+ * @deprecated{{/isDeprecated}}
+ * @throws {RequiredError}
+ */
+async function {{classname}}{{operationIdCamelCase}}AxiosParamCreator ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}options: AxiosRequestConfig = {}, configuration?: Configuration): Promise<RequestArgs> {
+{{#allParams}}
+{{#required}}
+    // verify required parameter '{{paramName}}' is not null or undefined
+    assertParamExists('{{nickname}}', '{{paramName}}', {{paramName}})
+{{/required}}
+{{/allParams}}
+    const localVarPath = `{{{path}}}`{{#pathParams}}
+        .replace(`{${"{{baseName}}"}}`, encodeURIComponent(String({{paramName}}))){{/pathParams}};
+    // use dummy base URL string because the URL constructor only accepts absolute URLs.
+    const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+    let baseOptions;
+    if (configuration) {
+        baseOptions = configuration.baseOptions;
+    }
+
+    const localVarRequestOptions = { method: '{{httpMethod}}', ...baseOptions, ...options};
+    const localVarHeaderParameter = {} as any;
+    const localVarQueryParameter = {} as any;{{#vendorExtensions}}{{#hasFormParams}}
+    const localVarFormParams = new {{^multipartFormData}}URLSearchParams(){{/multipartFormData}}{{#multipartFormData}}((configuration && configuration.formDataCtor) || FormData)(){{/multipartFormData}};{{/hasFormParams}}{{/vendorExtensions}}
+
+{{#authMethods}}
+    // authentication {{name}} required
+    {{#isApiKey}}
+    {{#isKeyInHeader}}
+    await setApiKeyToObject(localVarHeaderParameter, "{{keyParamName}}", configuration)
+    {{/isKeyInHeader}}
+    {{#isKeyInQuery}}
+    await setApiKeyToObject(localVarQueryParameter, "{{keyParamName}}", configuration)
+    {{/isKeyInQuery}}
+    {{/isApiKey}}
+    {{#isBasicBasic}}
+    // http basic authentication required
+    setBasicAuthToObject(localVarRequestOptions, configuration)
+    {{/isBasicBasic}}
+    {{#isBasicBearer}}
+    // http bearer authentication required
+    await setBearerAuthToObject(localVarHeaderParameter, configuration)
+    {{/isBasicBearer}}
+    {{#isOAuth}}
+    // oauth required
+    await setOAuthToObject(localVarHeaderParameter, "{{name}}", [{{#scopes}}"{{{scope}}}"{{^-last}}, {{/-last}}{{/scopes}}], configuration)
+    {{/isOAuth}}
+
+{{/authMethods}}
+{{#queryParams}}
+    {{#isArray}}
+    if ({{paramName}}) {
+    {{#isCollectionFormatMulti}}
+        {{#uniqueItems}}
+        localVarQueryParameter['{{baseName}}'] = Array.from({{paramName}});
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        localVarQueryParameter['{{baseName}}'] = {{paramName}};
+        {{/uniqueItems}}
+    {{/isCollectionFormatMulti}}
+    {{^isCollectionFormatMulti}}
+        {{#uniqueItems}}
+        localVarQueryParameter['{{baseName}}'] = Array.from({{paramName}}).join(COLLECTION_FORMATS.{{collectionFormat}});
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        localVarQueryParameter['{{baseName}}'] = {{paramName}}.join(COLLECTION_FORMATS.{{collectionFormat}});
+        {{/uniqueItems}}
+    {{/isCollectionFormatMulti}}
+    }
+    {{/isArray}}
+    {{^isArray}}
+    if ({{paramName}} !== undefined) {
+        {{#isDateTime}}
+        localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any instanceof Date) ?
+            ({{paramName}} as any).toISOString() :
+            {{paramName}};
+        {{/isDateTime}}
+        {{^isDateTime}}
+        {{#isDate}}
+        localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any instanceof Date) ?
+            ({{paramName}} as any).toISOString().substr(0,10) :
+            {{paramName}};
+        {{/isDate}}
+        {{^isDate}}
+        localVarQueryParameter['{{baseName}}'] = {{paramName}};
+        {{/isDate}}
+        {{/isDateTime}}
+    }
+    {{/isArray}}
+
+{{/queryParams}}
+{{#headerParams}}
+    {{#isArray}}
+    if ({{paramName}}) {
+        {{#uniqueItems}}
+        let mapped = Array.from({{paramName}}).map(value => (<any>"{{{dataType}}}" !== "Set<string>") ? JSON.stringify(value) : (value || ""));
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        let mapped = {{paramName}}.map(value => (<any>"{{{dataType}}}" !== "Array<string>") ? JSON.stringify(value) : (value || ""));
+        {{/uniqueItems}}
+        localVarHeaderParameter['{{baseName}}'] = mapped.join(COLLECTION_FORMATS["{{collectionFormat}}"]);
+    }
+    {{/isArray}}
+    {{^isArray}}
+    {{! `val == null` covers for both `null` and `undefined`}}
+    if ({{paramName}} != null) {
+        {{#isString}}
+        localVarHeaderParameter['{{baseName}}'] = String({{paramName}});
+        {{/isString}}
+        {{^isString}}
+        {{! isString is falsy also for $ref that defines a string or enum type}}
+        localVarHeaderParameter['{{baseName}}'] = typeof {{paramName}} === 'string'
+            ? {{paramName}}
+            : JSON.stringify({{paramName}});
+        {{/isString}}
+    }
+    {{/isArray}}
+
+{{/headerParams}}
+{{#vendorExtensions}}
+{{#formParams}}
+    {{#isArray}}
+    if ({{paramName}}) {
+    {{#isCollectionFormatMulti}}
+        {{paramName}}.forEach((element) => {
+            localVarFormParams.{{#multipartFormData}}append{{/multipartFormData}}{{^multipartFormData}}set{{/multipartFormData}}('{{baseName}}', element as any);
+        })
+    {{/isCollectionFormatMulti}}
+    {{^isCollectionFormatMulti}}
+        localVarFormParams.{{#multipartFormData}}append{{/multipartFormData}}{{^multipartFormData}}set{{/multipartFormData}}('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS.{{collectionFormat}}));
+    {{/isCollectionFormatMulti}}
+    }{{/isArray}}
+    {{^isArray}}
+    if ({{paramName}} !== undefined) { {{^multipartFormData}}
+        localVarFormParams.set('{{baseName}}', {{paramName}} as any);{{/multipartFormData}}{{#multipartFormData}}{{#isPrimitiveType}}
+        localVarFormParams.append('{{baseName}}', {{paramName}} as any);{{/isPrimitiveType}}{{^isPrimitiveType}}
+        localVarFormParams.append('{{baseName}}', new Blob([JSON.stringify({{paramName}})], { type: "application/json", }));{{/isPrimitiveType}}{{/multipartFormData}}
+    }{{/isArray}}
+{{/formParams}}{{/vendorExtensions}}
+{{#vendorExtensions}}{{#hasFormParams}}{{^multipartFormData}}
+    localVarHeaderParameter['Content-Type'] = 'application/x-www-form-urlencoded';{{/multipartFormData}}{{#multipartFormData}}
+    localVarHeaderParameter['Content-Type'] = 'multipart/form-data';{{/multipartFormData}}
+{{/hasFormParams}}{{/vendorExtensions}}
+{{#bodyParam}}
+    {{^consumes}}
+    localVarHeaderParameter['Content-Type'] = 'application/json';
+    {{/consumes}}
+    {{#consumes.0}}
+    localVarHeaderParameter['Content-Type'] = '{{{mediaType}}}';
+    {{/consumes.0}}
+
+{{/bodyParam}}
+    setSearchParams(localVarUrlObj, localVarQueryParameter);
+    let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+    localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions,{{#hasFormParams}}{{#multipartFormData}} ...(localVarFormParams as any).getHeaders?.(),{{/multipartFormData}}{{/hasFormParams}} ...options.headers};
+{{#hasFormParams}}
+    localVarRequestOptions.data = localVarFormParams{{#vendorExtensions}}{{^multipartFormData}}.toString(){{/multipartFormData}}{{/vendorExtensions}};
+{{/hasFormParams}}
+{{#bodyParam}}
+    localVarRequestOptions.data = serializeDataIfNeeded({{paramName}}, localVarRequestOptions, configuration)
+{{/bodyParam}}
+
+    return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+    };
+}
+{{/operation}}
+
+{{#useSingleRequestParameter}}
+{{#operation}}
+{{#allParams.0}}
+/**
+ * Request parameters for {{nickname}} operation in {{classname}}.
+ * @export
+ * @interface {{classname}}{{operationIdCamelCase}}Request
+ */
+export interface {{classname}}{{operationIdCamelCase}}Request {
+    {{#allParams}}
+    /**
+     * {{description}}
+     * @type {{=<% %>=}}{<%&dataType%>}<%={{ }}=%>
+     * @memberof {{classname}}{{operationIdCamelCase}}
+     */
+    readonly {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}
+    {{^-last}}
+
+    {{/-last}}
+    {{/allParams}}
+}
+
+{{/allParams.0}}
+{{/operation}}
+{{/useSingleRequestParameter}}
+{{#operation}}
+/**
+* {{&notes}}
+{{#summary}}
+* @summary {{&summary}}
+{{/summary}}
+{{#useSingleRequestParameter}}
+    {{#allParams.0}}
+* @param {{=<% %>=}}{<%& classname %><%& operationIdCamelCase %>Request}<%={{ }}=%> requestParameters Request parameters.
+    {{/allParams.0}}
+{{/useSingleRequestParameter}}
+{{^useSingleRequestParameter}}
+    {{#allParams}}
+* @param {{=<% %>=}}{<%#isEnum%><%&datatypeWithEnum%><%/isEnum%><%^isEnum%><%&dataType%><%#isNullable%> | null<%/isNullable%><%/isEnum%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
+    {{/allParams}}
+{{/useSingleRequestParameter}}
+* @param {*} [options] Override http request option.{{#isDeprecated}}
+* @deprecated{{/isDeprecated}}
+* @throws {RequiredError}
+*/
+export async function {{classname}}{{operationIdCamelCase}}{{#useSingleRequestParameter}}({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}options?: AxiosRequestConfig, configuration?: Configuration) {
+    const localVarAxiosArgs = await {{classname}}{{operationIdCamelCase}}AxiosParamCreator({{#allParams.0}}{{#allParams}}requestParameters.{{paramName}}, {{/allParams}}{{/allParams.0}}options, configuration);
+    const request: () => AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}> = createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    return request();
+}
+{{/useSingleRequestParameter}}{{^useSingleRequestParameter}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}options?: AxiosRequestConfig, configuration?: Configuration) {
+    const localVarAxiosArgs = await {{classname}}{{operationIdCamelCase}}AxiosParamCreator({{#allParams}}{{paramName}}, {{/allParams}}options, configuration);
+    const request: () => AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}> = createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    return request();
+}
+{{/useSingleRequestParameter}}
+{{/operation}}
+{{/operations}}
+{{#operations}}
+{{#operation}}
+{{#allParams}}
+{{#isEnum}}
+{{#stringEnums}}
+/**
+  * @export
+  * @enum {string}
+  */
+export enum {{operationIdCamelCase}}{{enumName}} {
+{{#allowableValues}}
+    {{#enumVars}}
+    {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+{{/allowableValues}}
+}
+{{/stringEnums}}
+{{^stringEnums}}
+/**
+ * @export
+ */
+export const {{operationIdCamelCase}}{{enumName}} = {
+{{#allowableValues}}
+    {{#enumVars}}
+    {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+{{/allowableValues}}
+} as const;
+export type {{operationIdCamelCase}}{{enumName}} = typeof {{operationIdCamelCase}}{{enumName}}[keyof typeof {{operationIdCamelCase}}{{enumName}}];
+{{/stringEnums}}
+{{/isEnum}}
+{{/allParams}}
+{{/operation}}
+{{/operations}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
@@ -30,7 +30,7 @@ export interface RequestArgs {
     url: string;
     options: AxiosRequestConfig;
 }
-
+{{^functionalApisOnly}}
 /**
  *
  * @export
@@ -46,7 +46,7 @@ export class BaseAPI {
         }
     }
 };
-
+{{/functionalApisOnly}}
 /**
  *
  * @export

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -135,8 +135,9 @@ export const toPathString = function (url: URL) {
  * @export
  */
 export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
-    return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-        const axiosRequestArgs = {...axiosArgs.options, url: (configuration?.basePath || basePath) + axiosArgs.url};
+    return <T = unknown, R = AxiosResponse<T>>({{^functionalApisOnly}}axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH{{/functionalApisOnly}}) => {
+        const axiosRequestArgs = {...axiosArgs.options, url: (configuration?.basePath || {{#functionalApisOnly}}BASE_PATH{{/functionalApisOnly}}{{^functionalApisOnly}}basePath{{/functionalApisOnly}}) + axiosArgs.url};
+        {{#functionalApisOnly}}const axios = configuration?.axios || globalAxios;{{/functionalApisOnly}}
         return axios.request<T, R>(axiosRequestArgs);
     };
 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
@@ -2,6 +2,8 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
+{{#functionalApisOnly}}import globalAxios, { AxiosInstance } from 'axios';{{/functionalApisOnly}}
+
 export interface ConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
     username?: string;
@@ -10,6 +12,7 @@ export interface ConfigurationParameters {
     basePath?: string;
     baseOptions?: any;
     formDataCtor?: new () => any;
+    {{#functionalApisOnly}}axios?: AxiosInstance;{{/functionalApisOnly}}
 }
 
 export class Configuration {
@@ -62,6 +65,7 @@ export class Configuration {
      * @type {new () => FormData}
      */
     formDataCtor?: new () => any;
+    {{#functionalApisOnly}}axios?: AxiosInstance;{{/functionalApisOnly}}
 
     constructor(param: ConfigurationParameters = {}) {
         this.apiKey = param.apiKey;
@@ -71,6 +75,7 @@ export class Configuration {
         this.basePath = param.basePath;
         this.baseOptions = param.baseOptions;
         this.formDataCtor = param.formDataCtor;
+        {{#functionalApisOnly}}this.axios = param.axios || globalAxios;{{/functionalApisOnly}}
     }
 
     /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Added a flag to typescript-axios generator to avoid generating classes for better tree-shaking in large projects, This is related to #12283 issue but the issue is more generic than the problem this pr solves.
<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
