### PR TITLE
[Postman Collections] Keep original header name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -226,6 +226,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
                 // produces mediaType as `Accept` header (use first mediaType only)
                 String mediaType = codegenOperation.produces.get(0).get("mediaType");
                 CodegenParameter acceptHeader = new CodegenParameter();
+                acceptHeader.baseName = "Accept";
                 acceptHeader.paramName = "Accept";
                 CodegenProperty schema = new CodegenProperty();
                 schema.defaultValue = mediaType;
@@ -237,6 +238,8 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
                 // consumes mediaType as `Content-Type` header (use first mediaType only)
                 String mediaType = codegenOperation.consumes.get(0).get("mediaType");
                 CodegenParameter contentTypeHeader = new CodegenParameter();
+
+                contentTypeHeader.baseName = "Content-Type";
                 contentTypeHeader.paramName = "Content-Type";
                 CodegenProperty schema = new CodegenProperty();
                 schema.defaultValue = mediaType;

--- a/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
@@ -10,7 +10,7 @@
                                     "header": [
                                     {{#headerParams}}
                                         {
-                                            "key": "{{paramName}}",
+                                            "key": "{{baseName}}",
                                             "value": "{{schema.defaultValue}}"
                                         }{{^-last}},{{/-last}}
                                     {{/headerParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -6,10 +6,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Assert;
 import org.junit.Test;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenParameter;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PostmanCollectionCodegen;
 
@@ -465,6 +462,32 @@ public class PostmanCollectionCodegenTest {
         assertFileNotContains(path, "\\\"dateOfBirth\\\" : \\\"{{$isoTimestamp}}\\\"");
 
     }
+
+    @Test
+    public void testHeaderParameters() throws IOException {
+
+        File output = Files.createTempDirectory("postmantest_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("postman-collection")
+                .setInputSpec("./src/test/resources/SampleProject.yaml")
+                .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        files.forEach(File::deleteOnExit);
+
+        Path path = Paths.get(output + "/postman.json");
+        TestUtils.assertFileExists(path);
+        TestUtils.assertFileContains(path, "{ \"key\": \"Content-Type\", \"value\": \"application/json\"");
+        TestUtils.assertFileContains(path, "{ \"key\": \"Accept\", \"value\": \"application/json\"");
+        TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"null\"");
+    }
+
 
     @Test
     public void testFormatDescription() {

--- a/modules/openapi-generator/src/test/resources/3_0/postman-collection/SampleProject.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/postman-collection/SampleProject.yaml
@@ -47,6 +47,11 @@ paths:
           schema:
             type: string
             example: 888
+        - description: Custom HTTP header
+          name: Custom-Header
+          in: header
+          schema:
+            type: string
 
       responses:
         '200':

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -148,6 +148,10 @@
                                         {
                                             "key": "Accept",
                                             "value": "application/json"
+                                        },
+                                        {
+                                            "key": "Custom-Header",
+                                            "value": "null"
                                         }
                                     ],
                                     "body": {


### PR DESCRIPTION
PR to keep the original name of the header (`baseName`) in the generated Postman collection

Fix #15904 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 