### PR TITLE
[C][Client] Add GitHub Action to test c client sample build

### DIFF
--- a/.github/workflows/samples-c-libcurl-client.yaml
+++ b/.github/workflows/samples-c-libcurl-client.yaml
@@ -1,0 +1,27 @@
+name: Samples c libcurl client
+
+on:
+  push:
+    paths:
+      - 'samples/client/petstore/c/**'
+  pull_request:
+    paths:
+      - 'samples/client/petstore/c/**'
+
+jobs:
+  build:
+    name: Build c libcurl client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev
+      - name: Build
+        working-directory: "samples/client/petstore/c"
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR adds a GitHub Action to test c client sample build to address https://github.com/OpenAPITools/openapi-generator/pull/15782#issuecomment-1581832821

@wing328 @zhemant (2018/11) @ityuhui (2019/12) @michelealbano (2020/03)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
