### PR TITLE
[Java][Native] Support sending json Object as Query-Parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -58,13 +58,31 @@ public class ApiClient {
   private Duration connectTimeout;
 
   private static String valueToString(Object value) {
-    if (value == null) {
-      return "";
-    }
-    if (value instanceof OffsetDateTime) {
-      return ((OffsetDateTime) value).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-    }
-    return value.toString();
+     if (value == null) {
+        return "";
+     }
+     if (value instanceof OffsetDateTime) {
+        return ((OffsetDateTime) value).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+     }
+     return value.toString();
+  }
+
+  private String valueToStringWithObjectMapper(Object value) {
+      if (value == null) {
+          return "";
+      }
+      if (value instanceof OffsetDateTime) {
+          return ((OffsetDateTime) value).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+      }
+
+      if (!value.getClass().isPrimitive()) {
+          try {
+              return mapper.writeValueAsString(value);
+          } catch (Exception e) {
+              return e.toString();
+          }
+      }
+      return value.toString();
   }
 
   /**
@@ -95,6 +113,13 @@ public class ApiClient {
       return Collections.emptyList();
     }
     return Collections.singletonList(new Pair(urlEncode(name), urlEncode(valueToString(value))));
+  }
+
+  public List<Pair> parameterToPairsWithObjectMapper(String name, Object value) {
+      if (name == null || name.isEmpty() || value == null) {
+          return Collections.emptyList();
+      }
+      return Collections.singletonList(new Pair(urlEncode(name), urlEncode(valueToStringWithObjectMapper(value))));
   }
 
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -57,6 +57,7 @@ public class {{classname}} {
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
   private final Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
+  private ApiClient apiClient;
 
   public {{classname}}() {
     this(new ApiClient());
@@ -70,6 +71,7 @@ public class {{classname}} {
     memberVarReadTimeout = apiClient.getReadTimeout();
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
     memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
+    this.apiClient = apiClient;
   }
   {{#asyncNative}}
 
@@ -393,7 +395,7 @@ public class {{classname}} {
                 {{/hasVars}}
             {{/isExplode}}
             {{^isExplode}}
-    localVarQueryParams.addAll(ApiClient.parameterToPairs("{{baseName}}", {{paramName}}));
+    localVarQueryParams.addAll(apiClient.parameterToPairsWithObjectMapper("{{baseName}}", {{paramName}}));
             {{/isExplode}}
         {{/isDeepObject}}
       {{/collectionFormat}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1393,6 +1393,37 @@ public class JavaClientCodegenTest {
         );
     }
 
+  /**
+   * See https://github.com/OpenAPITools/openapi-generator/issues/10806
+   */
+  @Test
+  public void testNativeClientJsonQueryParamObject() throws IOException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+
+    File output = Files.createTempDirectory("test").toFile();
+    output.deleteOnExit();
+
+    final CodegenConfigurator configurator = new CodegenConfigurator()
+        .setGeneratorName("java")
+        .setLibrary(JavaClientCodegen.NATIVE)
+        .setAdditionalProperties(properties)
+        .setInputSpec("src/test/resources/3_0/issue10806.yaml")
+        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+    final ClientOptInput clientOptInput = configurator.toClientOptInput();
+    DefaultGenerator generator = new DefaultGenerator();
+    List<File> files = generator.opts(clientOptInput).generate();
+
+    Assert.assertEquals(files.size(), 38);
+    validateJavaSourceFiles(files);
+
+    TestUtils.assertFileContains(Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
+        "localVarQueryParams.addAll(apiClient.parameterToPairsWithObjectMapper(\"QueryObject\", queryObject));"
+
+    );
+  }
+
     @Test
     public void testExtraAnnotationsNative() throws IOException {
         testExtraAnnotations(JavaClientCodegen.NATIVE);

--- a/modules/openapi-generator/src/test/resources/3_0/issue10806.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue10806.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: Issue 10806 - json query params
+  description: "json query params"
+  version: "1.0.0"
+servers:
+  - url: localhost:8080
+paths:
+  /api:
+    get:
+      operationId: GetSomeValue
+      parameters:
+        - in: query
+          name: QueryObject
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryObject'
+      responses:
+        '200':
+          description: Some return value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeReturnValue'
+components:
+  schemas:
+    QueryObject:
+      type: object
+      properties:
+        some-key:
+          type: string
+    SomeReturnValue:
+      type: object
+      required:
+        - someValue
+      properties:
+        someValue:
+          type: string


### PR DESCRIPTION
1. Added support for sending JSON Object as Query-Parameter with object-mapper instead of `object.toString()`
2. Modified the native `api.mustache` template
3. Added test for case of JSON object as query-param

Refer #10806

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
