### PR TITLE
Use substring instead of substr in JavaScript and TypeScript generators

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -132,7 +132,7 @@ export class {{classname}} {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString(){{^isDateTime}}.substr(0, 10){{/isDateTime}});
+                    httpParams = httpParams.append(key, (value as Date).toISOString(){{^isDateTime}}.substring(0, 10){{/isDateTime}});
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -123,7 +123,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
                 {{^isDateTime}}
                 {{#isDate}}
                 localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any instanceof Date) ?
-                    ({{paramName}} as any).toISOString().substr(0,10) :
+                    ({{paramName}} as any).toISOString().substring(0,10) :
                     {{paramName}};
                 {{/isDate}}
                 {{^isDate}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -128,7 +128,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{/isDateTimeType}}
             {{^isDateTimeType}}
             {{#isDateType}}
-            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
+            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substring(0,10);
             {{/isDateType}}
             {{^isDateType}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -119,7 +119,7 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         {{^isReadOnly}}
         {{#isPrimitiveType}}
         {{#isDateType}}
-        '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString().substr(0,10)),
+        '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString().substring(0,10)),
         {{/isDateType}}
         {{#isDateTimeType}}
         '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString()),

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/apis.mustache
@@ -71,7 +71,7 @@ function {{nickname}}Raw<T>({{#allParams.0}}requestParameters: {{operationIdCame
         {{/isDateTime}}
         {{^isDateTime}}
         {{#isDate}}
-        queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
+        queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substring(0,10);
         {{/isDate}}
         {{^isDate}}
         queryParameters['{{baseName}}'] = requestParameters.{{paramName}};

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/modelGeneric.mustache
@@ -92,7 +92,7 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
         {{#vars}}
         {{^isReadOnly}}
         {{#isPrimitiveType}}
-        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString().substr(0,10){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString(){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
+        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString().substring(0,10){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString(){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api/user.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api/project.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api/project.service.ts
@@ -90,7 +90,7 @@ export class ProjectService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api/matrixParams.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api/matrixParams.service.ts
@@ -75,7 +75,7 @@ export class MatrixParamsService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/pet.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/store.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/user.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/api/default.service.ts
@@ -75,7 +75,7 @@ export class DefaultService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/api/default.service.ts
@@ -75,7 +75,7 @@ export class DefaultService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -86,7 +86,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/api/store.service.ts
@@ -71,7 +71,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/with-npm/api/user.service.ts
@@ -71,7 +71,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/api/pet.service.ts
@@ -90,7 +90,7 @@ export class PetService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/api/store.service.ts
@@ -75,7 +75,7 @@ export class StoreService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/api/user.service.ts
@@ -75,7 +75,7 @@ export class UserService {
                 (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
             } else if (value instanceof Date) {
                 if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
+                    httpParams = httpParams.append(key, (value as Date).toISOString().substring(0, 10));
                 } else {
                    throw Error("key may not be null if value is Date");
                 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -185,7 +185,7 @@ export function FormatTestToJSON(value?: FormatTest | null): any {
         'string': value.string,
         'byte': value._byte,
         'binary': value.binary,
-        'date': (value.date.toISOString().substr(0,10)),
+        'date': (value.date.toISOString().substring(0,10)),
         'dateTime': value.dateTime === undefined ? undefined : (value.dateTime.toISOString()),
         'uuid': value.uuid,
         'password': value.password,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/InlineObject3.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/InlineObject3.ts
@@ -151,7 +151,7 @@ export function InlineObject3ToJSON(value?: InlineObject3 | null): any {
         'pattern_without_delimiter': value.patternWithoutDelimiter,
         'byte': value._byte,
         'binary': value.binary,
-        'date': value.date === undefined ? undefined : (value.date.toISOString().substr(0,10)),
+        'date': value.date === undefined ? undefined : (value.date.toISOString().substring(0,10)),
         'dateTime': value.dateTime === undefined ? undefined : (value.dateTime.toISOString()),
         'password': value.password,
         'callback': value.callback,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -143,7 +143,7 @@ export function NullableClassToJSON(value?: NullableClass | null): any {
         'number_prop': value.numberProp,
         'boolean_prop': value.booleanProp,
         'string_prop': value.stringProp,
-        'date_prop': value.dateProp === undefined ? undefined : (value.dateProp === null ? null : value.dateProp.toISOString().substr(0,10)),
+        'date_prop': value.dateProp === undefined ? undefined : (value.dateProp === null ? null : value.dateProp.toISOString().substring(0,10)),
         'datetime_prop': value.datetimeProp === undefined ? undefined : (value.datetimeProp === null ? null : value.datetimeProp.toISOString()),
         'array_nullable_prop': value.arrayNullableProp,
         'array_and_items_nullable_prop': value.arrayAndItemsNullableProp,

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -185,7 +185,7 @@ export function FormatTestToJSON(value?: FormatTest | null): any {
         'string': value.string,
         'byte': value._byte,
         'binary': value.binary,
-        'date': (value.date.toISOString().substr(0,10)),
+        'date': (value.date.toISOString().substring(0,10)),
         'dateTime': value.dateTime === undefined ? undefined : (value.dateTime.toISOString()),
         'uuid': value.uuid,
         'password': value.password,

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -143,7 +143,7 @@ export function NullableClassToJSON(value?: NullableClass | null): any {
         'number_prop': value.numberProp,
         'boolean_prop': value.booleanProp,
         'string_prop': value.stringProp,
-        'date_prop': value.dateProp === undefined ? undefined : (value.dateProp === null ? null : value.dateProp.toISOString().substr(0,10)),
+        'date_prop': value.dateProp === undefined ? undefined : (value.dateProp === null ? null : value.dateProp.toISOString().substring(0,10)),
         'datetime_prop': value.datetimeProp === undefined ? undefined : (value.datetimeProp === null ? null : value.datetimeProp.toISOString()),
         'array_nullable_prop': value.arrayNullableProp,
         'array_and_items_nullable_prop': value.arrayAndItemsNullableProp,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
