### PR TITLE
Update openapi-generator-online Dockerfile to use openjdk11 image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,13 +7,14 @@ on:
       - run-in-docker.sh
       - pom.xml
       - modules/openapi-generator-online/pom.xml
+      - modules/openapi-generator-online/Dockerfile
   pull_request:
     paths:
       - Dockerfile
       - run-in-docker.sh
       - pom.xml
       - modules/openapi-generator-online/pom.xml
-
+      - modules/openapi-generator-online/Dockerfile
 jobs:
   build:
     name: 'Build: Docker'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,4 +34,6 @@ jobs:
 
       - name: Build modules/openapi-generator-online
         shell: bash
-        run: docker build modules/openapi-generator-online/
+        run: |
+          docker build modules/openapi-generator-online/ -t test
+          docker run test

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,4 +37,3 @@ jobs:
         shell: bash
         run: |
           docker build modules/openapi-generator-online/ -t test
-          docker run test

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           sed -i 's/ -it / /g' run-in-docker.sh
-          ./run-in-docker.sh ./mvnw clean install
+          ./run-in-docker.sh mvn clean install
 
       - name: Build Dockerfile
         shell: bash

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
 WORKDIR /generator
 


### PR DESCRIPTION
Update openapi-generator-online Dockerfile to use openjdk11 image

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
