### PR TITLE
Fix epoch deserialization and parsing numbers

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -86,7 +86,7 @@ DateTime? mapDateTime(dynamic map, String key, [String? pattern]) {
     if (value is int) {
       millis = value;
     } else if (value is String) {
-      if (pattern == _dateEpochMarker) {
+      if (_isEpochMarker(pattern)) {
         millis = int.tryParse(value);
       } else {
         return DateTime.tryParse(value);

--- a/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
@@ -31,3 +31,5 @@ final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
 
 ApiClient defaultApiClient = ApiClient();
+
+bool _isEpochMarker(String? pattern) => pattern == _dateEpochMarker || pattern == '/$_dateEpochMarker/';

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -66,7 +66,7 @@ class {{{classname}}} {
     {{/isNullable}}
     {{#isDateTime}}
       {{#pattern}}
-      json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
+      json[r'{{{baseName}}}'] = _isEpochMarker(r'{{{pattern}}}')
         ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
         : this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
       {{/pattern}}
@@ -76,7 +76,7 @@ class {{{classname}}} {
     {{/isDateTime}}
     {{#isDate}}
       {{#pattern}}
-      json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
+      json[r'{{{baseName}}}'] = _isEpochMarker(r'{{{pattern}}}')
         ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
         : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
       {{/pattern}}
@@ -128,10 +128,10 @@ class {{{classname}}} {
       return {{{classname}}}(
   {{#vars}}
     {{#isDateTime}}
-        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', r'{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
     {{/isDateTime}}
     {{#isDate}}
-        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', r'{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
     {{/isDate}}
     {{^isDateTime}}
       {{^isDate}}
@@ -211,9 +211,9 @@ class {{{classname}}} {
             {{/isMap}}
             {{^isMap}}
               {{#isNumber}}
-        {{{name}}}: json[r'{{{baseName}}}'] == null
+        {{{name}}}: {{#isNullable}}json[r'{{{baseName}}}'] == null
             ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
-            : {{{datatypeWithEnum}}}.parse(json[r'{{{baseName}}}'].toString()),
+            : {{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
               {{/isNumber}}
               {{^isNumber}}
                 {{^isEnum}}

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
@@ -47,3 +47,5 @@ final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
 
 ApiClient defaultApiClient = ApiClient();
+
+bool _isEpochMarker(String? pattern) => pattern == _dateEpochMarker || pattern == '/$_dateEpochMarker/';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
@@ -87,7 +87,7 @@ DateTime? mapDateTime(dynamic map, String key, [String? pattern]) {
     if (value is int) {
       millis = value;
     } else if (value is String) {
-      if (pattern == _dateEpochMarker) {
+      if (_isEpochMarker(pattern)) {
         millis = int.tryParse(value);
       } else {
         return DateTime.tryParse(value);

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -133,7 +133,7 @@ class Order {
         id: mapValueOfType<int>(json, r'id'),
         petId: mapValueOfType<int>(json, r'petId'),
         quantity: mapValueOfType<int>(json, r'quantity'),
-        shipDate: mapDateTime(json, r'shipDate', ''),
+        shipDate: mapDateTime(json, r'shipDate', r''),
         status: OrderStatusEnum.fromJson(json[r'status']),
         complete: mapValueOfType<bool>(json, r'complete') ?? false,
       );

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
@@ -92,3 +92,5 @@ final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
 
 ApiClient defaultApiClient = ApiClient();
+
+bool _isEpochMarker(String? pattern) => pattern == _dateEpochMarker || pattern == '/$_dateEpochMarker/';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
@@ -105,7 +105,7 @@ DateTime? mapDateTime(dynamic map, String key, [String? pattern]) {
     if (value is int) {
       millis = value;
     } else if (value is String) {
-      if (pattern == _dateEpochMarker) {
+      if (_isEpochMarker(pattern)) {
         millis = int.tryParse(value);
       } else {
         return DateTime.tryParse(value);

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -71,9 +71,7 @@ class FakeBigDecimalMap200Response {
       }());
 
       return FakeBigDecimalMap200Response(
-        someId: json[r'someId'] == null
-            ? null
-            : num.parse(json[r'someId'].toString()),
+        someId: num.parse('${json[r'someId']}'),
         someMap: mapCastOfType<String, num>(json, r'someMap') ?? const {},
       );
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -280,17 +280,15 @@ class FormatTest {
         integer: mapValueOfType<int>(json, r'integer'),
         int32: mapValueOfType<int>(json, r'int32'),
         int64: mapValueOfType<int>(json, r'int64'),
-        number: json[r'number'] == null
-            ? null
-            : num.parse(json[r'number'].toString()),
+        number: num.parse('${json[r'number']}'),
         float: mapValueOfType<double>(json, r'float'),
         double_: mapValueOfType<double>(json, r'double'),
         decimal: mapValueOfType<double>(json, r'decimal'),
         string: mapValueOfType<String>(json, r'string'),
         byte: mapValueOfType<String>(json, r'byte')!,
         binary: null, // No support for decoding binary content from JSON
-        date: mapDateTime(json, r'date', '')!,
-        dateTime: mapDateTime(json, r'dateTime', ''),
+        date: mapDateTime(json, r'date', r'')!,
+        dateTime: mapDateTime(json, r'dateTime', r''),
         uuid: mapValueOfType<String>(json, r'uuid'),
         password: mapValueOfType<String>(json, r'password')!,
         patternWithDigits: mapValueOfType<String>(json, r'pattern_with_digits'),

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -88,7 +88,7 @@ class MixedPropertiesAndAdditionalPropertiesClass {
 
       return MixedPropertiesAndAdditionalPropertiesClass(
         uuid: mapValueOfType<String>(json, r'uuid'),
-        dateTime: mapDateTime(json, r'dateTime', ''),
+        dateTime: mapDateTime(json, r'dateTime', r''),
         map: Animal.mapFromJson(json[r'map']),
       );
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -164,11 +164,11 @@ class NullableClass {
         integerProp: mapValueOfType<int>(json, r'integer_prop'),
         numberProp: json[r'number_prop'] == null
             ? null
-            : num.parse(json[r'number_prop'].toString()),
+            : num.parse('${json[r'number_prop']}'),
         booleanProp: mapValueOfType<bool>(json, r'boolean_prop'),
         stringProp: mapValueOfType<String>(json, r'string_prop'),
-        dateProp: mapDateTime(json, r'date_prop', ''),
-        datetimeProp: mapDateTime(json, r'datetime_prop', ''),
+        dateProp: mapDateTime(json, r'date_prop', r''),
+        datetimeProp: mapDateTime(json, r'datetime_prop', r''),
         arrayNullableProp: Object.listFromJson(json[r'array_nullable_prop']),
         arrayAndItemsNullableProp: Object.listFromJson(json[r'array_and_items_nullable_prop']),
         arrayItemsNullable: Object.listFromJson(json[r'array_items_nullable']),

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -65,9 +65,7 @@ class NumberOnly {
       }());
 
       return NumberOnly(
-        justNumber: json[r'JustNumber'] == null
-            ? null
-            : num.parse(json[r'JustNumber'].toString()),
+        justNumber: num.parse('${json[r'JustNumber']}'),
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -104,9 +104,7 @@ class ObjectWithDeprecatedFields {
 
       return ObjectWithDeprecatedFields(
         uuid: mapValueOfType<String>(json, r'uuid'),
-        id: json[r'id'] == null
-            ? null
-            : num.parse(json[r'id'].toString()),
+        id: num.parse('${json[r'id']}'),
         deprecatedRef: DeprecatedObject.fromJson(json[r'deprecatedRef']),
         bars: json[r'bars'] is Iterable
             ? (json[r'bars'] as Iterable).cast<String>().toList(growable: false)

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -133,7 +133,7 @@ class Order {
         id: mapValueOfType<int>(json, r'id'),
         petId: mapValueOfType<int>(json, r'petId'),
         quantity: mapValueOfType<int>(json, r'quantity'),
-        shipDate: mapDateTime(json, r'shipDate', ''),
+        shipDate: mapDateTime(json, r'shipDate', r''),
         status: OrderStatusEnum.fromJson(json[r'status']),
         complete: mapValueOfType<bool>(json, r'complete') ?? false,
       );

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -97,9 +97,7 @@ class OuterComposite {
       }());
 
       return OuterComposite(
-        myNumber: json[r'my_number'] == null
-            ? null
-            : num.parse(json[r'my_number'].toString()),
+        myNumber: num.parse('${json[r'my_number']}'),
         myString: mapValueOfType<String>(json, r'my_string'),
         myBoolean: mapValueOfType<bool>(json, r'my_boolean'),
       );


### PR DESCRIPTION
During generation of a new code, I uncovered 2 bugs in the Dart template:

1. Deserializing a date-time field when `pattern: epoch` fails because the generated code outputs `/epoch/` instead of `epoch`, as it used to be before.
2. Having a non-nullable field of type `integer` without a default value produces code with syntax errors (assigning `null` to property).

This pr addresses both of these bugs.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)