### PR TITLE
[PHP-Symfony] Fix Symfony warning on OpenAPIServerBundle

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/Bundle.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Bundle.mustache
@@ -33,7 +33,7 @@ use {{invokerPackage}}\DependencyInjection\Compiler\{{bundleName}}ApiPass;
  */
 class {{bundleClassName}} extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new {{bundleName}}ApiPass());
     }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/OpenAPIServerBundle.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/OpenAPIServerBundle.php
@@ -43,7 +43,7 @@ use OpenAPI\Server\DependencyInjection\Compiler\OpenAPIServerApiPass;
  */
 class OpenAPIServerBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new OpenAPIServerApiPass());
     }


### PR DESCRIPTION
This fixes the issue described on #15959 ; it: it fixes the Symfony warning:

`User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "OpenAPI\Server\OpenAPIServerBundle" now to avoid errors or add an explicit @return annotation to suppress this message`

I tested this PR by setting up a Symfony app with the bundle autogenerated with this patch, and observing that the warning goes away, and that the queries made against the symfony app are correctly handled.

It's PHP, so here is a ping: @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
