### PR TITLE
[PHP-Symfony] fix name mismatch in generated README (#15961)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/README.mustache
@@ -78,7 +78,7 @@ Step 4: Implement the API calls:
 
 ```php
 <?php{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}
-// src/Acme/MyBundle/Api/{{classname}}.php
+// src/Acme/MyBundle/Api/{{baseName}}Api.php
 
 namespace Acme\MyBundle\Api;
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
@@ -67,7 +67,7 @@ Step 4: Implement the API calls:
 
 ```php
 <?php
-// src/Acme/MyBundle/Api/PetApiInterface.php
+// src/Acme/MyBundle/Api/PetApi.php
 
 namespace Acme\MyBundle\Api;
 


### PR DESCRIPTION
This fixes the issue described in on #15961. Ie: with this PR, the generated README suggests to implement the `class DefaultApi` in a file named DefaultApi.php instead of DefaultApiInterface.php

(I've tested this PR by running the php-symfony generator on an arbitrary openapi file and checking the content of the generated README)

It's PHP, so here is a ping: @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
