### PR TITLE
Use openjdk official docker image in openapi-generator-online

### DIFF
--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM openjdk:11
 
 WORKDIR /generator
 


### PR DESCRIPTION
Use openjdk official docker image in openapi-generator-online as travis failed with adoptjdk in publishing docker images

a follow-up PR to https://github.com/OpenAPITools/openapi-generator/pull/15947/


```
docker build modules/openapi-generator-online/ -t test3

[+] Building 6.8s (9/9) FINISHED                                                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                                                   0.1s
 => => transferring dockerfile: 539B                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/openjdk:11                                                                                                                                                                          3.7s
 => [auth] library/openjdk:pull token for registry-1.docker.io                                                                                                                                                                         0.0s
 => [1/3] FROM docker.io/library/openjdk:11@sha256:99bac5bf83633e3c7399aed725c8415e7b569b54e03e4599e580fc9cdb7c21ab                                                                                                                    0.5s
 => => resolve docker.io/library/openjdk:11@sha256:99bac5bf83633e3c7399aed725c8415e7b569b54e03e4599e580fc9cdb7c21ab                                                                                                                    0.0s
 => => sha256:99bac5bf83633e3c7399aed725c8415e7b569b54e03e4599e580fc9cdb7c21ab 1.04kB / 1.04kB                                                                                                                                         0.0s
 => => sha256:e81b7f317654b0f26d3993e014b04bcb29250339b11b9de41e130feecd4cd43c 1.79kB / 1.79kB                                                                                                                                         0.0s
 => => sha256:47a932d998b743b9b0bcce55aa8ede77de94a6a183c8a67dec9d5e3b8ce0faa7 6.26kB / 6.26kB                                                                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                                                      2.2s
 => => transferring context: 43.92MB                                                                                                                                                                                                   2.2s
 => [2/3] WORKDIR /generator                                                                                                                                                                                                           0.1s
 => [3/3] COPY target/openapi-generator-online.jar /generator/openapi-generator-online.jar                                                                                                                                             0.4s
 => exporting to image                                                                                                                                                                                                                 0.2s
 => => exporting layers                                                                                                                                                                                                                0.2s
 => => writing image sha256:60dcee6b793701cab9ad1f00b0d75d930834d7653ca499ab2aa3310b8b3d7edb                                                                                                                                           0.0s
 => => naming to docker.io/library/test3                                                                                                                                                                                               0.0s
➜  openapi-generator7 git:(fix-docker-travis) ✗ docker run test3                                       
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/generator/openapi-generator-online.jar!/BOOT-INF/lib/logback-classic-1.2.11.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/generator/openapi-generator-online.jar!/BOOT-INF/lib/slf4j-simple-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::               (v2.5.14)

2023-06-30 11:15:24.237  INFO 1 --- [           main] o.o.codegen.online.OpenAPI2SpringBoot    : Starting OpenAPI2SpringBoot v7.0.0-SNAPSHOT using Java 11.0.16 on d1dc90f91fbe with PID 1 (/generator/openapi-generator-online.jar started by root in /generator)
2023-06-30 11:15:24.246  INFO 1 --- [           main] o.o.codegen.online.OpenAPI2SpringBoot    : No active profile set, falling back to 1 default profile: "default"
2023-06-30 11:15:42.472  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
2023-06-30 11:15:42.669  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2023-06-30 11:15:42.679  INFO 1 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.63]
2023-06-30 11:15:43.768  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2023-06-30 11:15:43.780  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 19135 ms
^C2023-06-30 11:16:07.794  INFO 1 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page: class path resource [static/index.html]
2023-06-30 11:16:08.868  WARN 1 --- [           main] o.s.b.a.m.MustacheAutoConfiguration      : Cannot find template location: classpath:/templates/ (please add some templates, check your Mustache configuration, or set spring.mustache.check-template-location=false)
2023-06-30 11:16:10.372  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
2023-06-30 11:16:16.739  INFO 1 --- [           main] o.o.codegen.online.OpenAPI2SpringBoot    : Started OpenAPI2SpringBoot in 56.799 seconds (JVM running for 63.113)

```

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
