### PR TITLE
Support vendor extensions on more objects as per the OAS spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
@@ -37,6 +37,8 @@ public class CodegenDiscriminator {
     // see the method createDiscriminator in DefaultCodegen.java
 
     private Set<MappedModel> mappedModels = new TreeSet<>();
+    private Map<String, Object> vendorExtensions = new HashMap<>();
+
 
     public String getPropertyName() {
         return propertyName;
@@ -92,6 +94,14 @@ public class CodegenDiscriminator {
 
     public void setIsEnum(boolean isEnum) {
         this.isEnum = isEnum;
+    }
+
+    public Map<String, Object> getVendorExtensions() {
+        return vendorExtensions;
+    }
+
+    public void setVendorExtensions(Map<String, Object> vendorExtensions) {
+        this.vendorExtensions = vendorExtensions;
     }
 
     /**
@@ -173,13 +183,14 @@ public class CodegenDiscriminator {
         return Objects.equals(propertyName, that.propertyName) &&
                 Objects.equals(propertyBaseName, that.propertyBaseName) &&
                 Objects.equals(mapping, that.mapping) &&
-                Objects.equals(mappedModels, that.mappedModels);
+                Objects.equals(mappedModels, that.mappedModels) &&
+                Objects.equals(vendorExtensions, that.vendorExtensions);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(propertyName, propertyBaseName, mapping, mappedModels);
+        return Objects.hash(propertyName, propertyBaseName, mapping, mappedModels, vendorExtensions);
     }
 
     @Override
@@ -189,6 +200,7 @@ public class CodegenDiscriminator {
         sb.append(", propertyBaseName='").append(propertyBaseName).append('\'');
         sb.append(", mapping=").append(mapping);
         sb.append(", mappedModels=").append(mappedModels);
+        sb.append(", vendorExtensions=").append(vendorExtensions);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenEncoding.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenEncoding.java
@@ -1,6 +1,8 @@
 package org.openapitools.codegen;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class CodegenEncoding {
@@ -9,6 +11,7 @@ public class CodegenEncoding {
     private String style;
     private boolean explode;
     private boolean allowReserved;
+    public Map<String, Object> vendorExtensions = new HashMap<>();
 
     public CodegenEncoding(String contentType, List<CodegenParameter> headers, String style, boolean explode, boolean allowReserved) {
         this.contentType = contentType;
@@ -38,6 +41,10 @@ public class CodegenEncoding {
         return allowReserved;
     }
 
+    public Map<String, Object> getVendorExtensions() {
+        return vendorExtensions;
+    }
+
     public String toString() {
         final StringBuilder sb = new StringBuilder("CodegenEncoding{");
         sb.append("contentType=").append(contentType);
@@ -45,6 +52,7 @@ public class CodegenEncoding {
         sb.append(", style=").append(style);
         sb.append(", explode=").append(explode);
         sb.append(", allowReserved=").append(allowReserved);
+        sb.append(", vendorExtensions=").append(vendorExtensions);
         sb.append('}');
         return sb.toString();
     }
@@ -57,11 +65,12 @@ public class CodegenEncoding {
                 Objects.equals(headers, that.getHeaders()) &&
                 style == that.getStyle() &&
                 explode == that.getExplode() &&
-                allowReserved == that.getAllowReserved();
+                allowReserved == that.getAllowReserved() &&
+                Objects.equals(vendorExtensions, that.vendorExtensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contentType, headers, style, explode, allowReserved);
+        return Objects.hash(contentType, headers, style, explode, allowReserved, vendorExtensions);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenMediaType.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenMediaType.java
@@ -13,6 +13,7 @@ public class CodegenMediaType {
     private HashMap<String, SchemaTestCase> testCases = new HashMap<>();
     private Map<String, Example> examples = null;
     private Object example = null;
+    public Map<String, Object> vendorExtensions = new HashMap<>();
 
     public CodegenMediaType(CodegenProperty schema, LinkedHashMap<String, CodegenEncoding> encoding, HashMap<String, SchemaTestCase> testCases) {
         this.schema = schema;
@@ -50,10 +51,15 @@ public class CodegenMediaType {
         return example;
     }
 
+    public Map<String, Object> getVendorExtensions() {
+        return vendorExtensions;
+    }
+
     public String toString() {
         final StringBuilder sb = new StringBuilder("CodegenMediaType{");
         sb.append("schema=").append(schema);
         sb.append(", encoding=").append(encoding);
+        sb.append(", vendorExtensions=").append(vendorExtensions);
         sb.append('}');
         return sb.toString();
     }
@@ -63,12 +69,13 @@ public class CodegenMediaType {
         if (o == null || getClass() != o.getClass()) return false;
         CodegenMediaType that = (CodegenMediaType) o;
         return Objects.equals(schema,that.getSchema()) &&
-                Objects.equals(encoding, that.getEncoding());
+                Objects.equals(encoding, that.getEncoding()) &&
+                Objects.equals(vendorExtensions, that.vendorExtensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schema, encoding);
+        return Objects.hash(schema, encoding, vendorExtensions);
     }
 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServer.java
@@ -1,12 +1,15 @@
 package org.openapitools.codegen;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class CodegenServer {
     public String url;
     public String description;
     public List<CodegenServerVariable> variables;
+    public Map<String, Object> vendorExtensions = new HashMap<>();
 
     @Override
     public boolean equals(Object o) {
@@ -15,13 +18,14 @@ public class CodegenServer {
         CodegenServer that = (CodegenServer) o;
         return Objects.equals(url, that.url) &&
                 Objects.equals(description, that.description) &&
-                Objects.equals(variables, that.variables);
+                Objects.equals(variables, that.variables) &&
+                Objects.equals(vendorExtensions, that.vendorExtensions);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(url, description, variables);
+        return Objects.hash(url, description, variables, vendorExtensions);
     }
 
     @Override
@@ -30,6 +34,7 @@ public class CodegenServer {
         sb.append("url='").append(url).append('\'');
         sb.append(", description='").append(description).append('\'');
         sb.append(", variables=").append(variables);
+        sb.append(", vendorExtensions=").append(vendorExtensions);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServerVariable.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServerVariable.java
@@ -1,6 +1,8 @@
 package org.openapitools.codegen;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class CodegenServerVariable {
@@ -9,6 +11,7 @@ public class CodegenServerVariable {
     public String description;
     public List<String> enumValues;
     public String value;
+    public Map<String, Object> vendorExtensions = new HashMap<>();
 
     @Override
     public boolean equals(Object o) {
@@ -19,13 +22,14 @@ public class CodegenServerVariable {
                 Objects.equals(defaultValue, that.defaultValue) &&
                 Objects.equals(description, that.description) &&
                 Objects.equals(enumValues, that.enumValues) &&
-                Objects.equals(value, that.value);
+                Objects.equals(value, that.value) &&
+                Objects.equals(vendorExtensions, that.vendorExtensions);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(name, defaultValue, description, enumValues, value);
+        return Objects.hash(name, defaultValue, description, enumValues, value, vendorExtensions);
     }
 
     @Override
@@ -36,6 +40,7 @@ public class CodegenServerVariable {
         sb.append(", description='").append(description).append('\'');
         sb.append(", enumValues=").append(enumValues);
         sb.append(", value='").append(value).append('\'');
+        sb.append(", vendorExtensions=").append(vendorExtensions);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3531,6 +3531,10 @@ public class DefaultCodegen implements CodegenConfig {
         discriminator.setPropertyBaseName(sourceDiscriminator.getPropertyName());
         discriminator.setPropertyGetter(toGetter(discriminator.getPropertyName()));
 
+        if (sourceDiscriminator.getExtensions() != null) {
+            discriminator.setVendorExtensions(sourceDiscriminator.getExtensions());
+        }
+
         // FIXME: for now, we assume that the discriminator property is String
         discriminator.setPropertyType(typeMapping.get("string"));
 
@@ -7381,6 +7385,11 @@ public class DefaultCodegen implements CodegenConfig {
                             enc.getExplode() == null ? false : enc.getExplode().booleanValue(),
                             enc.getAllowReserved() == null ? false : enc.getAllowReserved().booleanValue()
                     );
+
+                    if (enc.getExtensions() != null) {
+                        ce.vendorExtensions = enc.getExtensions();
+                    }
+
                     String propName = encodingEntry.getKey();
                     ceMap.put(propName, ce);
                 }
@@ -7410,6 +7419,10 @@ public class DefaultCodegen implements CodegenConfig {
                 codegenMt = new CodegenMediaType(schemaProp, ceMap, schemaTestCases, mt.getExample());
             } else {
                 codegenMt = new CodegenMediaType(schemaProp, ceMap, schemaTestCases);
+            }
+
+            if (mt.getExtensions() != null) {
+                codegenMt.vendorExtensions = mt.getExtensions();
             }
 
             cmtContent.put(contentType, codegenMt);
@@ -7683,6 +7696,11 @@ public class DefaultCodegen implements CodegenConfig {
             cs.description = escapeText(server.getDescription());
             cs.url = server.getUrl();
             cs.variables = this.fromServerVariables(server.getVariables());
+
+            if (server.getExtensions() != null) {
+                cs.vendorExtensions = server.getExtensions();
+            }
+
             codegenServers.add(cs);
         }
         return codegenServers;
@@ -7706,6 +7724,10 @@ public class DefaultCodegen implements CodegenConfig {
             codegenServerVariable.description = escapeText(variable.getDescription());
             codegenServerVariable.enumValues = enums;
             codegenServerVariable.name = variableEntry.getKey();
+
+            if (variable.getExtensions() != null) {
+                codegenServerVariable.vendorExtensions = variable.getExtensions();
+            }
 
             // Sets the override value for a server variable pattern.
             // NOTE: OpenAPI Specification doesn't prevent multiple server URLs with variables. If multiple objects have the same


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Per the OAS spec, discriminators, encodings, media types, servers, and server variables are supposed to support vendor extensions. This PR adds that.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
