### PR TITLE
Bugfix #15982 :  Use 'orElse' instead of 'get' toi avoir problem with optional header

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiController.mustache
@@ -196,7 +196,7 @@ public class {{classname}}Controller extends Controller {
         }
         {{/collectionFormat}}
         {{^collectionFormat}}
-        String value{{paramName}} = request.header("{{baseName}}").get();
+        String value{{paramName}} = request.header("{{baseName}}").orElse(null);
         {{{dataType}}} {{paramName}};
         if (value{{paramName}} != null) {
             {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};

--- a/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/PetApiController.java
@@ -55,7 +55,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-async/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-async/app/controllers/PetApiController.java
@@ -58,7 +58,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public CompletionStage<Result> deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-controller-only/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/controllers/PetApiController.java
@@ -53,7 +53,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
@@ -327,7 +327,7 @@ public class FakeApiController extends Controller {
                 enumHeaderStringArray.add(curParam);
             }
         }
-        String valueenumHeaderString = request.header("enum_header_string").get();
+        String valueenumHeaderString = request.header("enum_header_string").orElse(null);
         String enumHeaderString;
         if (valueenumHeaderString != null) {
             enumHeaderString = valueenumHeaderString;
@@ -367,14 +367,14 @@ public class FakeApiController extends Controller {
         } else {
             int64Group = null;
         }
-        String valuerequiredBooleanGroup = request.header("required_boolean_group").get();
+        String valuerequiredBooleanGroup = request.header("required_boolean_group").orElse(null);
         Boolean requiredBooleanGroup;
         if (valuerequiredBooleanGroup != null) {
             requiredBooleanGroup = Boolean.valueOf(valuerequiredBooleanGroup);
         } else {
             throw new IllegalArgumentException("'required_boolean_group' parameter is required");
         }
-        String valuebooleanGroup = request.header("boolean_group").get();
+        String valuebooleanGroup = request.header("boolean_group").orElse(null);
         Boolean booleanGroup;
         if (valuebooleanGroup != null) {
             booleanGroup = Boolean.valueOf(valuebooleanGroup);

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/PetApiController.java
@@ -56,7 +56,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/PetApiController.java
@@ -48,7 +48,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/PetApiController.java
@@ -56,7 +56,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId)  {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/PetApiController.java
@@ -64,7 +64,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-no-nullable/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-nullable/app/controllers/PetApiController.java
@@ -55,7 +55,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/PetApiController.java
@@ -55,7 +55,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/PetApiController.java
@@ -54,7 +54,7 @@ public class PetApiController extends Controller {
 
     
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;

--- a/samples/server/petstore/java-play-framework/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/PetApiController.java
@@ -55,7 +55,7 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result deletePet(Http.Request request, Long petId) throws Exception {
-        String valueapiKey = request.header("api_key").get();
+        String valueapiKey = request.header("api_key").orElse(null);
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;


### PR DESCRIPTION
This PR aims ot fix the bug listed here : https://github.com/OpenAPITools/openapi-generator/issues/15982

- Use 'orElse' instead of 'get' to avoid Exception for non required headers
- Update samples

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ X ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ X ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ X ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
