### PR TITLE
[csharp] Collect operation parameters to a list instead of set

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -836,7 +836,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         }
                     }
 
-                    Set<CodegenParameter> referenceTypes = operation.allParams.stream().filter(p -> p.vendorExtensions.get("x-is-value-type") == null && !p.isNullable).collect(Collectors.toSet());
+                    List<CodegenParameter> referenceTypes = operation.allParams.stream().filter(p -> p.vendorExtensions.get("x-is-value-type") == null && !p.isNullable).collect(Collectors.toList());
                     operation.vendorExtensions.put("x-not-nullable-reference-types", referenceTypes);
                     operation.vendorExtensions.put("x-has-not-nullable-reference-types", referenceTypes.size() > 0);
                     processOperation(operation);

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1736,31 +1736,31 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="varByte"></param>
-        /// <param name="callback"></param>
-        /// <param name="binary"></param>
-        /// <param name="password"></param>
         /// <param name="patternWithoutDelimiter"></param>
+        /// <param name="binary"></param>
         /// <param name="varString"></param>
+        /// <param name="password"></param>
+        /// <param name="callback"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(byte[] varByte, Option<string> callback, Option<System.IO.Stream> binary, Option<string> password, string patternWithoutDelimiter, Option<string> varString)
+        private void ValidateTestEndpointParameters(byte[] varByte, string patternWithoutDelimiter, Option<System.IO.Stream> binary, Option<string> varString, Option<string> password, Option<string> callback)
         {
             if (varByte == null)
                 throw new ArgumentNullException(nameof(varByte));
 
-            if (callback.IsSet && callback.Value == null)
-                throw new ArgumentNullException(nameof(callback));
+            if (patternWithoutDelimiter == null)
+                throw new ArgumentNullException(nameof(patternWithoutDelimiter));
 
             if (binary.IsSet && binary.Value == null)
                 throw new ArgumentNullException(nameof(binary));
 
+            if (varString.IsSet && varString.Value == null)
+                throw new ArgumentNullException(nameof(varString));
+
             if (password.IsSet && password.Value == null)
                 throw new ArgumentNullException(nameof(password));
 
-            if (patternWithoutDelimiter == null)
-                throw new ArgumentNullException(nameof(patternWithoutDelimiter));
-
-            if (varString.IsSet && varString.Value == null)
-                throw new ArgumentNullException(nameof(varString));
+            if (callback.IsSet && callback.Value == null)
+                throw new ArgumentNullException(nameof(callback));
         }
 
         /// <summary>
@@ -1915,7 +1915,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestEndpointParameters(varByte, callback, binary, password, patternWithoutDelimiter, varString);
+                ValidateTestEndpointParameters(varByte, patternWithoutDelimiter, binary, varString, password, callback);
 
                 FormatTestEndpointParameters(ref varByte, ref number, ref varDouble, ref patternWithoutDelimiter, ref date, ref binary, ref varFloat, ref integer, ref int32, ref int64, ref varString, ref password, ref callback, ref dateTime);
 
@@ -2026,11 +2026,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="enumHeaderStringArray"></param>
         /// <param name="enumQueryStringArray"></param>
         /// <param name="enumFormStringArray"></param>
-        /// <param name="enumQueryString"></param>
         /// <param name="enumHeaderString"></param>
+        /// <param name="enumQueryString"></param>
         /// <param name="enumFormString"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<List<string>> enumQueryStringArray, Option<List<string>> enumFormStringArray, Option<string> enumQueryString, Option<string> enumHeaderString, Option<string> enumFormString)
+        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<List<string>> enumQueryStringArray, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<string> enumQueryString, Option<string> enumFormString)
         {
             if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumHeaderStringArray));
@@ -2041,11 +2041,11 @@ namespace Org.OpenAPITools.Api
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
-            if (enumQueryString.IsSet && enumQueryString.Value == null)
-                throw new ArgumentNullException(nameof(enumQueryString));
-
             if (enumHeaderString.IsSet && enumHeaderString.Value == null)
                 throw new ArgumentNullException(nameof(enumHeaderString));
+
+            if (enumQueryString.IsSet && enumQueryString.Value == null)
+                throw new ArgumentNullException(nameof(enumQueryString));
 
             if (enumFormString.IsSet && enumFormString.Value == null)
                 throw new ArgumentNullException(nameof(enumFormString));
@@ -2167,7 +2167,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray, enumQueryString, enumHeaderString, enumFormString);
+                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
 
                 FormatTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, ref enumQueryDouble, ref enumQueryInteger, enumFormStringArray, ref enumHeaderString, ref enumQueryString, ref enumFormString);
 
@@ -2711,16 +2711,28 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
         /// <param name="context"></param>
         /// <param name="requiredNotNullable"></param>
         /// <param name="notRequiredNotNullable"></param>
-        /// <param name="pipe"></param>
-        /// <param name="ioutil"></param>
-        /// <param name="url"></param>
-        /// <param name="http"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable, List<string> pipe, List<string> ioutil, List<string> url, List<string> http)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
         {
+            if (pipe == null)
+                throw new ArgumentNullException(nameof(pipe));
+
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
+
+            if (http == null)
+                throw new ArgumentNullException(nameof(http));
+
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
+
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
@@ -2729,18 +2741,6 @@ namespace Org.OpenAPITools.Api
 
             if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
                 throw new ArgumentNullException(nameof(notRequiredNotNullable));
-
-            if (pipe == null)
-                throw new ArgumentNullException(nameof(pipe));
-
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
-
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
-
-            if (http == null)
-                throw new ArgumentNullException(nameof(http));
         }
 
         /// <summary>
@@ -2865,7 +2865,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(context, requiredNotNullable, notRequiredNotNullable, pipe, ioutil, url, http);
+                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
 
                 FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Api/PetApi.cs
@@ -1429,16 +1429,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="additionalMetadata"></param>
         /// <param name="file"></param>
+        /// <param name="additionalMetadata"></param>
         /// <returns></returns>
-        private void ValidateUploadFile(Option<string> additionalMetadata, Option<System.IO.Stream> file)
+        private void ValidateUploadFile(Option<System.IO.Stream> file, Option<string> additionalMetadata)
         {
-            if (additionalMetadata.IsSet && additionalMetadata.Value == null)
-                throw new ArgumentNullException(nameof(additionalMetadata));
-
             if (file.IsSet && file.Value == null)
                 throw new ArgumentNullException(nameof(file));
+
+            if (additionalMetadata.IsSet && additionalMetadata.Value == null)
+                throw new ArgumentNullException(nameof(additionalMetadata));
         }
 
         /// <summary>
@@ -1527,7 +1527,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateUploadFile(additionalMetadata, file);
+                ValidateUploadFile(file, additionalMetadata);
 
                 FormatUploadFile(ref petId, ref file, ref additionalMetadata);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1436,16 +1436,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="query"></param>
         /// <param name="user"></param>
+        /// <param name="query"></param>
         /// <returns></returns>
-        private void ValidateTestBodyWithQueryParams(string query, User user)
+        private void ValidateTestBodyWithQueryParams(User user, string query)
         {
-            if (query == null)
-                throw new ArgumentNullException(nameof(query));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (query == null)
+                throw new ArgumentNullException(nameof(query));
         }
 
         /// <summary>
@@ -1528,7 +1528,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestBodyWithQueryParams(query, user);
+                ValidateTestBodyWithQueryParams(user, query);
 
                 FormatTestBodyWithQueryParams(user, ref query);
 
@@ -1733,17 +1733,17 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="password"></param>
+        /// <param name="varByte"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="binary"></param>
         /// <param name="varString"></param>
+        /// <param name="password"></param>
         /// <param name="callback"></param>
-        /// <param name="varByte"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(Option<string> password, string patternWithoutDelimiter, Option<System.IO.Stream> binary, Option<string> varString, Option<string> callback, byte[] varByte)
+        private void ValidateTestEndpointParameters(byte[] varByte, string patternWithoutDelimiter, Option<System.IO.Stream> binary, Option<string> varString, Option<string> password, Option<string> callback)
         {
-            if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password));
+            if (varByte == null)
+                throw new ArgumentNullException(nameof(varByte));
 
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -1754,11 +1754,11 @@ namespace Org.OpenAPITools.Api
             if (varString.IsSet && varString.Value == null)
                 throw new ArgumentNullException(nameof(varString));
 
+            if (password.IsSet && password.Value == null)
+                throw new ArgumentNullException(nameof(password));
+
             if (callback.IsSet && callback.Value == null)
                 throw new ArgumentNullException(nameof(callback));
-
-            if (varByte == null)
-                throw new ArgumentNullException(nameof(varByte));
         }
 
         /// <summary>
@@ -1913,7 +1913,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestEndpointParameters(password, patternWithoutDelimiter, binary, varString, callback, varByte);
+                ValidateTestEndpointParameters(varByte, patternWithoutDelimiter, binary, varString, password, callback);
 
                 FormatTestEndpointParameters(ref varByte, ref number, ref varDouble, ref patternWithoutDelimiter, ref date, ref binary, ref varFloat, ref integer, ref int32, ref int64, ref varString, ref password, ref callback, ref dateTime);
 
@@ -2021,32 +2021,32 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
+        /// <param name="enumHeaderStringArray"></param>
         /// <param name="enumQueryStringArray"></param>
         /// <param name="enumFormStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumFormString"></param>
         /// <param name="enumHeaderString"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumFormString"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumQueryStringArray, Option<List<string>> enumFormStringArray, Option<string> enumQueryString, Option<List<string>> enumHeaderStringArray, Option<string> enumFormString, Option<string> enumHeaderString)
+        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<List<string>> enumQueryStringArray, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<string> enumQueryString, Option<string> enumFormString)
         {
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
             if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryStringArray));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
             if (enumQueryString.IsSet && enumQueryString.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryString));
 
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
             if (enumFormString.IsSet && enumFormString.Value == null)
                 throw new ArgumentNullException(nameof(enumFormString));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
         }
 
         /// <summary>
@@ -2165,7 +2165,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestEnumParameters(enumQueryStringArray, enumFormStringArray, enumQueryString, enumHeaderStringArray, enumFormString, enumHeaderString);
+                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
 
                 FormatTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, ref enumQueryDouble, ref enumQueryInteger, enumFormStringArray, ref enumHeaderString, ref enumQueryString, ref enumFormString);
 
@@ -2710,35 +2710,35 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="pipe"></param>
-        /// <param name="http"></param>
-        /// <param name="notRequiredNotNullable"></param>
-        /// <param name="context"></param>
         /// <param name="ioutil"></param>
-        /// <param name="requiredNotNullable"></param>
+        /// <param name="http"></param>
         /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <param name="requiredNotNullable"></param>
+        /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> http, Option<string> notRequiredNotNullable, List<string> context, List<string> ioutil, string requiredNotNullable, List<string> url)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
         {
             if (pipe == null)
                 throw new ArgumentNullException(nameof(pipe));
 
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
+
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotNullable));
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
-
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
+                throw new ArgumentNullException(nameof(notRequiredNotNullable));
         }
 
         /// <summary>
@@ -2863,7 +2863,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, http, notRequiredNotNullable, context, ioutil, requiredNotNullable, url);
+                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
 
                 FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -1254,16 +1254,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="status"></param>
         /// <param name="name"></param>
+        /// <param name="status"></param>
         /// <returns></returns>
-        private void ValidateUpdatePetWithForm(Option<string> status, Option<string> name)
+        private void ValidateUpdatePetWithForm(Option<string> name, Option<string> status)
         {
-            if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status));
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name));
+
+            if (status.IsSet && status.Value == null)
+                throw new ArgumentNullException(nameof(status));
         }
 
         /// <summary>
@@ -1352,7 +1352,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateUpdatePetWithForm(status, name);
+                ValidateUpdatePetWithForm(name, status);
 
                 FormatUpdatePetWithForm(ref petId, ref name, ref status);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -1201,16 +1201,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
@@ -1293,7 +1293,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
                 FormatUpdateUser(user, ref username);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -1430,16 +1430,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="query"></param>
         /// <param name="user"></param>
+        /// <param name="query"></param>
         /// <returns></returns>
-        private void ValidateTestBodyWithQueryParams(string query, User user)
+        private void ValidateTestBodyWithQueryParams(User user, string query)
         {
-            if (query == null)
-                throw new ArgumentNullException(nameof(query));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (query == null)
+                throw new ArgumentNullException(nameof(query));
         }
 
         /// <summary>
@@ -1522,7 +1522,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestBodyWithQueryParams(query, user);
+                ValidateTestBodyWithQueryParams(user, query);
 
                 FormatTestBodyWithQueryParams(user, ref query);
 
@@ -1726,17 +1726,17 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="password"></param>
+        /// <param name="varByte"></param>
         /// <param name="patternWithoutDelimiter"></param>
         /// <param name="binary"></param>
         /// <param name="varString"></param>
+        /// <param name="password"></param>
         /// <param name="callback"></param>
-        /// <param name="varByte"></param>
         /// <returns></returns>
-        private void ValidateTestEndpointParameters(Option<string> password, string patternWithoutDelimiter, Option<System.IO.Stream> binary, Option<string> varString, Option<string> callback, byte[] varByte)
+        private void ValidateTestEndpointParameters(byte[] varByte, string patternWithoutDelimiter, Option<System.IO.Stream> binary, Option<string> varString, Option<string> password, Option<string> callback)
         {
-            if (password.IsSet && password.Value == null)
-                throw new ArgumentNullException(nameof(password));
+            if (varByte == null)
+                throw new ArgumentNullException(nameof(varByte));
 
             if (patternWithoutDelimiter == null)
                 throw new ArgumentNullException(nameof(patternWithoutDelimiter));
@@ -1747,11 +1747,11 @@ namespace Org.OpenAPITools.Api
             if (varString.IsSet && varString.Value == null)
                 throw new ArgumentNullException(nameof(varString));
 
+            if (password.IsSet && password.Value == null)
+                throw new ArgumentNullException(nameof(password));
+
             if (callback.IsSet && callback.Value == null)
                 throw new ArgumentNullException(nameof(callback));
-
-            if (varByte == null)
-                throw new ArgumentNullException(nameof(varByte));
         }
 
         /// <summary>
@@ -1906,7 +1906,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestEndpointParameters(password, patternWithoutDelimiter, binary, varString, callback, varByte);
+                ValidateTestEndpointParameters(varByte, patternWithoutDelimiter, binary, varString, password, callback);
 
                 FormatTestEndpointParameters(ref varByte, ref number, ref varDouble, ref patternWithoutDelimiter, ref date, ref binary, ref varFloat, ref integer, ref int32, ref int64, ref varString, ref password, ref callback, ref dateTime);
 
@@ -2014,32 +2014,32 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
+        /// <param name="enumHeaderStringArray"></param>
         /// <param name="enumQueryStringArray"></param>
         /// <param name="enumFormStringArray"></param>
-        /// <param name="enumQueryString"></param>
-        /// <param name="enumHeaderStringArray"></param>
-        /// <param name="enumFormString"></param>
         /// <param name="enumHeaderString"></param>
+        /// <param name="enumQueryString"></param>
+        /// <param name="enumFormString"></param>
         /// <returns></returns>
-        private void ValidateTestEnumParameters(Option<List<string>> enumQueryStringArray, Option<List<string>> enumFormStringArray, Option<string> enumQueryString, Option<List<string>> enumHeaderStringArray, Option<string> enumFormString, Option<string> enumHeaderString)
+        private void ValidateTestEnumParameters(Option<List<string>> enumHeaderStringArray, Option<List<string>> enumQueryStringArray, Option<List<string>> enumFormStringArray, Option<string> enumHeaderString, Option<string> enumQueryString, Option<string> enumFormString)
         {
+            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderStringArray));
+
             if (enumQueryStringArray.IsSet && enumQueryStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryStringArray));
 
             if (enumFormStringArray.IsSet && enumFormStringArray.Value == null)
                 throw new ArgumentNullException(nameof(enumFormStringArray));
 
+            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
+                throw new ArgumentNullException(nameof(enumHeaderString));
+
             if (enumQueryString.IsSet && enumQueryString.Value == null)
                 throw new ArgumentNullException(nameof(enumQueryString));
 
-            if (enumHeaderStringArray.IsSet && enumHeaderStringArray.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderStringArray));
-
             if (enumFormString.IsSet && enumFormString.Value == null)
                 throw new ArgumentNullException(nameof(enumFormString));
-
-            if (enumHeaderString.IsSet && enumHeaderString.Value == null)
-                throw new ArgumentNullException(nameof(enumHeaderString));
         }
 
         /// <summary>
@@ -2158,7 +2158,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestEnumParameters(enumQueryStringArray, enumFormStringArray, enumQueryString, enumHeaderStringArray, enumFormString, enumHeaderString);
+                ValidateTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, enumFormStringArray, enumHeaderString, enumQueryString, enumFormString);
 
                 FormatTestEnumParameters(enumHeaderStringArray, enumQueryStringArray, ref enumQueryDouble, ref enumQueryInteger, enumFormStringArray, ref enumHeaderString, ref enumQueryString, ref enumFormString);
 
@@ -2702,35 +2702,35 @@ namespace Org.OpenAPITools.Api
         /// Validates the request parameters
         /// </summary>
         /// <param name="pipe"></param>
-        /// <param name="http"></param>
-        /// <param name="notRequiredNotNullable"></param>
-        /// <param name="context"></param>
         /// <param name="ioutil"></param>
-        /// <param name="requiredNotNullable"></param>
+        /// <param name="http"></param>
         /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <param name="requiredNotNullable"></param>
+        /// <param name="notRequiredNotNullable"></param>
         /// <returns></returns>
-        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> http, Option<string> notRequiredNotNullable, List<string> context, List<string> ioutil, string requiredNotNullable, List<string> url)
+        private void ValidateTestQueryParameterCollectionFormat(List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string requiredNotNullable, Option<string> notRequiredNotNullable)
         {
             if (pipe == null)
                 throw new ArgumentNullException(nameof(pipe));
 
+            if (ioutil == null)
+                throw new ArgumentNullException(nameof(ioutil));
+
             if (http == null)
                 throw new ArgumentNullException(nameof(http));
 
-            if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
-                throw new ArgumentNullException(nameof(notRequiredNotNullable));
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
 
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            if (ioutil == null)
-                throw new ArgumentNullException(nameof(ioutil));
-
             if (requiredNotNullable == null)
                 throw new ArgumentNullException(nameof(requiredNotNullable));
 
-            if (url == null)
-                throw new ArgumentNullException(nameof(url));
+            if (notRequiredNotNullable.IsSet && notRequiredNotNullable.Value == null)
+                throw new ArgumentNullException(nameof(notRequiredNotNullable));
         }
 
         /// <summary>
@@ -2855,7 +2855,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateTestQueryParameterCollectionFormat(pipe, http, notRequiredNotNullable, context, ioutil, requiredNotNullable, url);
+                ValidateTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, requiredNotNullable, notRequiredNotNullable);
 
                 FormatTestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, ref requiredNotNullable, ref requiredNullable, ref notRequiredNotNullable, ref notRequiredNullable);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -1250,16 +1250,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="status"></param>
         /// <param name="name"></param>
+        /// <param name="status"></param>
         /// <returns></returns>
-        private void ValidateUpdatePetWithForm(Option<string> status, Option<string> name)
+        private void ValidateUpdatePetWithForm(Option<string> name, Option<string> status)
         {
-            if (status.IsSet && status.Value == null)
-                throw new ArgumentNullException(nameof(status));
-
             if (name.IsSet && name.Value == null)
                 throw new ArgumentNullException(nameof(name));
+
+            if (status.IsSet && status.Value == null)
+                throw new ArgumentNullException(nameof(status));
         }
 
         /// <summary>
@@ -1348,7 +1348,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateUpdatePetWithForm(status, name);
+                ValidateUpdatePetWithForm(name, status);
 
                 FormatUpdatePetWithForm(ref petId, ref name, ref status);
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -1197,16 +1197,16 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// Validates the request parameters
         /// </summary>
-        /// <param name="username"></param>
         /// <param name="user"></param>
+        /// <param name="username"></param>
         /// <returns></returns>
-        private void ValidateUpdateUser(string username, User user)
+        private void ValidateUpdateUser(User user, string username)
         {
-            if (username == null)
-                throw new ArgumentNullException(nameof(username));
-
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
+
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
         }
 
         /// <summary>
@@ -1289,7 +1289,7 @@ namespace Org.OpenAPITools.Api
 
             try
             {
-                ValidateUpdateUser(username, user);
+                ValidateUpdateUser(user, username);
 
                 FormatUpdateUser(user, ref username);
 


### PR DESCRIPTION
Possible fix for the samples being wrong due to parameter sorting being inconsistent.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
