### PR TITLE
[POSTMAN] Use parameter default value

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -135,7 +135,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             variables.add(new PostmanVariable()
                     .addName(parameter.paramName)
                     .addType(mapToPostmanType(parameter.dataType))
-                    .addExample(parameter.example));
+                    .addeDefaultValue(parameter.defaultValue));
         }
     }
 
@@ -152,7 +152,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             variables.entrySet().stream().forEach(serverVariableEntry -> this.variables.add(new PostmanVariable()
                     .addName(serverVariableEntry.getKey())
                     .addType("string")
-                    .addExample(serverVariableEntry.getValue().getDefault())));
+                    .addeDefaultValue(serverVariableEntry.getValue().getDefault())));
         }
 
         return super.fromServerVariables(variables);
@@ -402,7 +402,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
                 variables.add(new PostmanVariable()
                         .addName(var)
                         .addType("string")
-                        .addExample(""));
+                        .addeDefaultValue(""));
             }
         }
 
@@ -799,7 +799,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
 
         private String name;
         private String type;
-        private String example;
+        private String defaultValue;
 
         public PostmanVariable addName(String name) {
             this.name = name;
@@ -811,8 +811,8 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             return this;
         }
 
-        public PostmanVariable addExample(String example) {
-            this.example = example;
+        public PostmanVariable addeDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
             return this;
         }
 
@@ -832,12 +832,12 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             this.type = type;
         }
 
-        public String getExample() {
-            return example;
+        public String getDefaultValue() {
+            return defaultValue;
         }
 
-        public void setExample(String example) {
-            this.example = example;
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
         }
 
         @Override
@@ -858,7 +858,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             return "PostmanVariable{" +
                     "name='" + name + '\'' +
                     ", type='" + type + '\'' +
-                    ", example='" + example + '\'' +
+                    ", defaultValue='" + defaultValue + '\'' +
                     '}';
         }
     }

--- a/modules/openapi-generator/src/main/resources/postman-collection/postman.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/postman.mustache
@@ -66,7 +66,7 @@
 		{
 	        {{! use first element in vendorExtensions }}
 			"key": "{{name}}",
-			"value": "{{example}}",
+			"value": "{{defaultValue}}",
 			"type": "{{type}}"
 		}{{^-last}},{{/-last}}{{/variables}}{{/-first}}{{/vendorExtensions}}{{/apis}}{{/apiInfo}}
 	]

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -138,13 +138,22 @@ public class PostmanCollectionCodegenTest {
 
         files.forEach(File::deleteOnExit);
 
-        assertFileExists(Paths.get(output + "/postman.json"));
+        Path path = Paths.get(output + "/postman.json");
+        assertFileExists(path);
 
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonNode = objectMapper.readTree(new File(output + "/postman.json"));
         // verify json has variables
         assertTrue(jsonNode.get("variable") instanceof ArrayNode);
-        assertEquals(5, ((ArrayNode) jsonNode.get("variable")).size());
+        assertEquals(6, (jsonNode.get("variable")).size());
+
+        // verify param userId (without default value)
+        TestUtils.assertFileContains(path,
+                "key\": \"userId\", \"value\": \"\", \"type\": \"number\"");
+        // verify param groupId (with default value)
+        TestUtils.assertFileContains(path,
+                "key\": \"groupId\", \"value\": \"1\", \"type\": \"number\"");
+
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/postman-collection/SampleProject.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/postman-collection/SampleProject.yaml
@@ -244,6 +244,31 @@ paths:
       description: Create a new user.
       tags:
         - basic
+  '/groups/{groupId}':
+    get:
+      summary: Get group by ID
+      tags:
+        - advanced
+      parameters:
+        - description: group Id
+          name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            default: 1
+      responses:
+        '200':
+          description: Group Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '404':
+          description: Group Not Found
+      operationId: get-groups-groupId
+      description: Get group of users
+
 components:
   securitySchemes:
     BasicAuth:
@@ -303,6 +328,20 @@ components:
         - lastName
         - email
         - emailVerified
+    Group:
+      title: Group
+      type: object
+      description: ''
+      properties:
+        id:
+          type: integer
+          description: Unique identifier for the given group.
+        name:
+          type: string
+          example: admin
+      required:
+        - id
+        - name
   examples:
     get-user-basic:
       summary: Example request for Get User

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -77,6 +77,53 @@
 	            "name": "advanced",
 	            "item": [
 	                        {
+    "name": "/groups/{{groupId}}",
+                "description": "Get group of users",
+                 "item": [
+                            {
+                                "name": "Get group by ID",
+                                "request": {
+                                    "method": "GET",
+                                    "header": [
+                                        {
+                                            "key": "Accept",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": {
+                                        "mode": "raw",
+                                        "raw": "",
+                                        "options": {
+                                            "raw": {
+                                                "language": "json"
+                                            }
+                                        }
+                                    },
+                                    "url": {
+                                        "raw": "{{baseUrl}}/groups/{{groupId}}",
+                                        "host": [
+                                            "{{baseUrl}}"
+                                        ],
+                                        "path": [
+                                            "groups",
+                                            "{{groupId}}"
+                                        ],
+                                        "variable": [
+                                            {
+                                                "key": "groupId",
+                                                "value": "",
+                                                "description": "group Id"
+                                            }
+                                        ],
+                                        "query": [
+                                        ]
+                                    },
+                                    "description": "Get group of users"
+                                }
+                            }
+                            ]
+                        },
+	                        {
     "name": "/users/{{userId}}",
                 "description": "Retrieve the information of the user with the matching user ID.",
                  "item": [
@@ -269,13 +316,18 @@
 			"type": "string"
 		},
 		{
+			"key": "groupId",
+			"value": "1",
+			"type": "number"
+		},
+		{
 			"key": "port",
 			"value": "5000",
 			"type": "string"
 		},
 		{
 			"key": "userId",
-			"value": "a",
+			"value": "",
 			"type": "number"
 		}
 	]


### PR DESCRIPTION
This PR changes the value set for  the generated Postman variables:
- before this PR: the `example` would be used to define the value of the variable
- after this PR: the `defaultValue` is used to define the value of the variable

When there is no default value set for a OpenAPI parameter then the corresponding Postman variable will be generated without setting the initial value.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 