### PR TITLE
[POSTMAN] Mark request header as disabled

### DIFF
--- a/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
@@ -11,7 +11,8 @@
                                     {{#headerParams}}
                                         {
                                             "key": "{{baseName}}",
-                                            "value": "{{schema.defaultValue}}"
+                                            "value": "{{schema.defaultValue}}",
+                                            "disabled": {{#schema.defaultValue}}false{{/schema.defaultValue}}{{^schema.defaultValue}}true{{/schema.defaultValue}}
                                         }{{^-last}},{{/-last}}
                                     {{/headerParams}}
                                     ],

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -485,10 +485,11 @@ public class PostmanCollectionCodegenTest {
         TestUtils.assertFileExists(path);
         TestUtils.assertFileContains(path, "{ \"key\": \"Content-Type\", \"value\": \"application/json\"");
         TestUtils.assertFileContains(path, "{ \"key\": \"Accept\", \"value\": \"application/json\"");
-        // header without default value
-        TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\"");
-        // header with default value
-        TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\"");
+        // header without default value (disabled: true)
+        TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\", \"disabled\": true");
+        // header with default value (disabled: false)
+        TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\", \"disabled\": false");
+
     }
 
 

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -23,19 +23,23 @@
                                     "header": [
                                         {
                                             "key": "Content-Type",
-                                            "value": "application/json"
+                                            "value": "application/json",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "Accept",
-                                            "value": "application/json"
+                                            "value": "application/json",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "strCode",
-                                            "value": "code_one"
+                                            "value": "code_one",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "strCode2",
-                                            "value": ""
+                                            "value": "",
+                                            "disabled": true
                                         }
                                     ],
                                     "body": {
@@ -87,15 +91,18 @@
                                     "header": [
                                         {
                                             "key": "Accept",
-                                            "value": "application/json"
+                                            "value": "application/json",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "strCode",
-                                            "value": "code_one"
+                                            "value": "code_one",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "strCode2",
-                                            "value": ""
+                                            "value": "",
+                                            "disabled": true
                                         }
                                     ],
                                     "body": {
@@ -147,15 +154,18 @@
                                     "header": [
                                         {
                                             "key": "Accept",
-                                            "value": "application/json"
+                                            "value": "application/json",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "Custom-Header",
-                                            "value": ""
+                                            "value": "",
+                                            "disabled": true
                                         },
                                         {
                                             "key": "Another-Custom-Header",
-                                            "value": "abc"
+                                            "value": "abc",
+                                            "disabled": false
                                         }
                                     ],
                                     "body": {
@@ -200,11 +210,13 @@
                                     "header": [
                                         {
                                             "key": "Content-Type",
-                                            "value": "application/json"
+                                            "value": "application/json",
+                                            "disabled": false
                                         },
                                         {
                                             "key": "Accept",
-                                            "value": "application/json"
+                                            "value": "application/json",
+                                            "disabled": false
                                         }
                                     ],
                                     "body": {


### PR DESCRIPTION
This PR marks the Postman request header as disabled when it does not have a value.
The header is still created and included in the generated collection, but it will not be sent (by default) with the request.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 