### PR TITLE
[csharp] Removed a warning when deserializing json

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -538,6 +538,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 if (allOf != null) {
                     for(CodegenProperty property : allOf) {
                         property.name = patchPropertyName(model, property.baseType);
+                        patchPropertyVendorExtensinos(property);
                     }
                 }
 
@@ -547,6 +548,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                     for(CodegenProperty property : anyOf) {
                         property.name = patchPropertyName(model, property.baseType);
                         property.isNullable = true;
+                        patchPropertyVendorExtensinos(property);
                     }
                 }
 
@@ -556,6 +558,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                     for(CodegenProperty property : oneOf) {
                         property.name = patchPropertyName(model, property.baseType);
                         property.isNullable = true;
+                        patchPropertyVendorExtensinos(property);
                     }
                 }
             }
@@ -630,6 +633,13 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         return value;
     }
 
+    private void patchPropertyVendorExtensinos(CodegenProperty property) {
+        Boolean isValueType = isValueType(property);
+        property.vendorExtensions.put("x-is-value-type", isValueType);
+        property.vendorExtensions.put("x-is-reference-type", !isValueType);
+        property.vendorExtensions.put("x-is-nullable-type", this.getNullableReferencesTypes() || isValueType);
+    }
+
     protected void patchProperty(Map<String, CodegenModel> enumRefs, CodegenModel model, CodegenProperty property) {
         if (enumRefs.containsKey(property.dataType)) {
             // Handle any enum properties referred to by $ref.
@@ -643,17 +653,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
             property.isPrimitiveType = true;
         }
 
-        Boolean isValueType = isValueType(property);
-
-        property.vendorExtensions.put("x-is-value-type", isValueType);
-
-        if (property.isNullable && !property.isContainer && isValueType) {
-            property.vendorExtensions.put("x-nullable-value-type", true);
-        }
-
-        if (this.getNullableReferencesTypes() || isValueType) {
-            property.vendorExtensions.put("x-nullable-type", true);
-        }
+        patchPropertyVendorExtensinos(property);
 
         String tmpPropertyName = escapeReservedWord(model, property.name);
         property.name = patchPropertyName(model, property.name);

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -38,7 +38,7 @@
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
             {{#allVars}}
-            {{#isInnerEnum}}{{^isMap}}{{classname}}.{{/isMap}}{{/isInnerEnum}}{{#nrt}}{{#lambda.optional}}{{{datatypeWithEnum}}}{{/lambda.optional}}{{/nrt}}{{^nrt}}{{{datatypeWithEnum}}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = default;
+            {{#isInnerEnum}}{{^isMap}}{{classname}}.{{/isMap}}{{/isInnerEnum}}{{{datatypeWithEnum}}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} = default;
             {{#-last}}
 
             {{/-last}}

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets VarBool
         /// </summary>
-        public bool VarBool { get; set; }
+        public bool? VarBool { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            bool varBool = default;
+            bool? varBool = default;
             string varString = default;
             Object varObject = default;
             List<string> list = default;
@@ -163,7 +163,7 @@ namespace Org.OpenAPITools.Model
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
                     Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    OpenAPIClientUtils.TryDeserialize<bool>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    OpenAPIClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
 
                     Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
                     OpenAPIClientUtils.TryDeserialize<string>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets VarBool
         /// </summary>
-        public bool VarBool { get; set; }
+        public bool? VarBool { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -146,7 +146,7 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
-            bool varBool = default;
+            bool? varBool = default;
             string varString = default;
             Object varObject = default;
             List<string> list = default;
@@ -163,7 +163,7 @@ namespace Org.OpenAPITools.Model
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
                     Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    OpenAPIClientUtils.TryDeserialize<bool>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    OpenAPIClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
 
                     Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
                     OpenAPIClientUtils.TryDeserialize<string>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);


### PR DESCRIPTION
The mustache change is just a little simpler, no change in logic. The change in abstract removes the warning.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
