### PR TITLE
[csharp][generichost] Fixed bug in http signing config

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HttpSigningConfiguration.mustache
@@ -268,10 +268,9 @@ namespace {{packageName}}.{{clientPackage}}
         /// <returns></returns>
         private string GetECDSASignature(byte[] dataToSign)
         {
+            {{#net60OrLater}}
             if (!File.Exists(KeyFilePath))
-            {
                 throw new Exception("key file path does not exist.");
-            }
 
             var ecKeyHeader = "-----BEGIN EC PRIVATE KEY-----";
             var ecKeyFooter = "-----END EC PRIVATE KEY-----";
@@ -280,7 +279,6 @@ namespace {{packageName}}.{{clientPackage}}
             var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
             var ecdsa = ECDsa.Create();
 
-#if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
             var byteCount = 0;
             if (KeyPassPhrase != null)
             {
@@ -301,18 +299,17 @@ namespace {{packageName}}.{{clientPackage}}
                 }
             }
             else
-            {
                 ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
-            }
+
             var signedBytes = ecdsa.SignHash(dataToSign);
             var derBytes = ConvertToECDSAANS1Format(signedBytes);
             var signedString = System.Convert.ToBase64String(derBytes);
 
             return signedString;
-#else
+            {{/net60OrLater}}
+            {{^net60OrLater}}
             throw new Exception("ECDSA signing is supported only on NETCOREAPP3_0 and above");
-#endif
-
+            {{/net60OrLater}}
         }
 
         private  byte[] ConvertToECDSAANS1Format(byte[] signedBytes)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -275,9 +275,7 @@ namespace Org.OpenAPITools.Client
         private string GetECDSASignature(byte[] dataToSign)
         {
             if (!File.Exists(KeyFilePath))
-            {
                 throw new Exception("key file path does not exist.");
-            }
 
             var ecKeyHeader = "-----BEGIN EC PRIVATE KEY-----";
             var ecKeyFooter = "-----END EC PRIVATE KEY-----";
@@ -286,7 +284,6 @@ namespace Org.OpenAPITools.Client
             var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
             var ecdsa = ECDsa.Create();
 
-#if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
             var byteCount = 0;
             if (KeyPassPhrase != null)
             {
@@ -307,18 +304,13 @@ namespace Org.OpenAPITools.Client
                 }
             }
             else
-            {
                 ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
-            }
+
             var signedBytes = ecdsa.SignHash(dataToSign);
             var derBytes = ConvertToECDSAANS1Format(signedBytes);
             var signedString = System.Convert.ToBase64String(derBytes);
 
             return signedString;
-#else
-            throw new Exception("ECDSA signing is supported only on NETCOREAPP3_0 and above");
-#endif
-
         }
 
         private  byte[] ConvertToECDSAANS1Format(byte[] signedBytes)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -273,9 +273,7 @@ namespace Org.OpenAPITools.Client
         private string GetECDSASignature(byte[] dataToSign)
         {
             if (!File.Exists(KeyFilePath))
-            {
                 throw new Exception("key file path does not exist.");
-            }
 
             var ecKeyHeader = "-----BEGIN EC PRIVATE KEY-----";
             var ecKeyFooter = "-----END EC PRIVATE KEY-----";
@@ -284,7 +282,6 @@ namespace Org.OpenAPITools.Client
             var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
             var ecdsa = ECDsa.Create();
 
-#if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
             var byteCount = 0;
             if (KeyPassPhrase != null)
             {
@@ -305,18 +302,13 @@ namespace Org.OpenAPITools.Client
                 }
             }
             else
-            {
                 ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
-            }
+
             var signedBytes = ecdsa.SignHash(dataToSign);
             var derBytes = ConvertToECDSAANS1Format(signedBytes);
             var signedString = System.Convert.ToBase64String(derBytes);
 
             return signedString;
-#else
-            throw new Exception("ECDSA signing is supported only on NETCOREAPP3_0 and above");
-#endif
-
         }
 
         private  byte[] ConvertToECDSAANS1Format(byte[] signedBytes)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -272,51 +272,7 @@ namespace Org.OpenAPITools.Client
         /// <returns></returns>
         private string GetECDSASignature(byte[] dataToSign)
         {
-            if (!File.Exists(KeyFilePath))
-            {
-                throw new Exception("key file path does not exist.");
-            }
-
-            var ecKeyHeader = "-----BEGIN EC PRIVATE KEY-----";
-            var ecKeyFooter = "-----END EC PRIVATE KEY-----";
-            var keyStr = File.ReadAllText(KeyFilePath);
-            var ecKeyBase64String = keyStr.Replace(ecKeyHeader, "").Replace(ecKeyFooter, "").Trim();
-            var keyBytes = System.Convert.FromBase64String(ecKeyBase64String);
-            var ecdsa = ECDsa.Create();
-
-#if (NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0)
-            var byteCount = 0;
-            if (KeyPassPhrase != null)
-            {
-                IntPtr unmanagedString = IntPtr.Zero;
-                try
-                {
-                    // convert secure string to byte array
-                    unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(KeyPassPhrase);
-
-                    string ptrToStringUni = Marshal.PtrToStringUni(unmanagedString) ?? throw new NullReferenceException();
-
-                    ecdsa.ImportEncryptedPkcs8PrivateKey(Encoding.UTF8.GetBytes(ptrToStringUni), keyBytes, out byteCount);
-                }
-                finally
-                {
-                    if (unmanagedString != IntPtr.Zero)
-                        Marshal.ZeroFreeBSTR(unmanagedString);
-                }
-            }
-            else
-            {
-                ecdsa.ImportPkcs8PrivateKey(keyBytes, out byteCount);
-            }
-            var signedBytes = ecdsa.SignHash(dataToSign);
-            var derBytes = ConvertToECDSAANS1Format(signedBytes);
-            var signedString = System.Convert.ToBase64String(derBytes);
-
-            return signedString;
-#else
             throw new Exception("ECDSA signing is supported only on NETCOREAPP3_0 and above");
-#endif
-
         }
 
         private  byte[] ConvertToECDSAANS1Format(byte[] signedBytes)


### PR DESCRIPTION
Used net60OrLater instead of hard coding the framework types. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
