### PR TITLE
Update php options for better customization of composer.json

### DIFF
--- a/docs/generators/php-dt.md
+++ b/docs/generators/php-dt.md
@@ -20,12 +20,17 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |modern|use modern language features (generated code will require PHP 8.0)| |false|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|

--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -20,12 +20,17 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -20,12 +20,17 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-mezzio-ph.md
+++ b/docs/generators/php-mezzio-ph.md
@@ -20,12 +20,17 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |modern|use modern language features (generated code will require PHP 8.0)| |false|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|

--- a/docs/generators/php-slim-deprecated.md
+++ b/docs/generators/php-slim-deprecated.md
@@ -20,12 +20,17 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-slim4.md
+++ b/docs/generators/php-slim4.md
@@ -20,12 +20,17 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -20,17 +20,22 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
 |bundleAlias|The alias of the Symfony bundle. The template uses {{aliasName}}| |null|
 |bundleName|The name of the Symfony bundle. The template uses {{bundleName}}| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
 |composerProjectName|The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client| |null|
 |composerVendorName|The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |phpLegacySupport|Should the generated code be compatible with PHP 5.x?| |true|

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -20,14 +20,18 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
+|artifactUrl|artifact URL in generated pom.xml| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
-|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`)| |null|
+|composerPackageName|The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).| |null|
+|developerOrganization|developer organization in generated pom.xml| |null|
+|developerOrganizationUrl|developer organization URL in generated pom.xml| |null|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |enumUnknownDefaultCase|If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.|<dl><dt>**false**</dt><dd>No changes to the enum's are made, this is the default option.</dd><dt>**true**</dt><dd>With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.</dd></dl>|false|
 |hideGenerationTimestamp|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |true|
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C# have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|licenseName|The name of the license| |null|
 |modelPackage|package for generated models| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -176,6 +176,8 @@ public class CodegenConstants {
     public static final String PACKAGE_AUTHORS_URL_DESC = "Specifies Authors URL property in the PHP composer.json file.";
     public static final String PACKAGE_COPYRIGHT = "packageCopyright";
     public static final String PACKAGE_COPYRIGHT_DESC = "Specifies an AssemblyCopyright for the .NET Framework global assembly attributes stored in the AssemblyInfo file.";
+    public static final String COMPOSER_PACKAGE_NAME = "composerPackageName";
+    public static final String COMPOSER_PACKAGE_NAME_DESC = "The name to use in the composer package name field. e.g. `vendor/project` (must be lowercase and consist of words separated by `-`, `.` or `_`).";
 
     public static final String POD_VERSION = "podVersion";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -155,6 +155,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         cliOptions.add(new CliOption(CodegenConstants.LICENSE_NAME, CodegenConstants.LICENSE_NAME_DESC));
         cliOptions.add(new CliOption(CodegenConstants.DEVELOPER_ORGANIZATION, CodegenConstants.DEVELOPER_ORGANIZATION_DESC));
         cliOptions.add(new CliOption(CodegenConstants.DEVELOPER_ORGANIZATION_URL, CodegenConstants.DEVELOPER_ORGANIZATION_URL_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.COMPOSER_PACKAGE_NAME, CodegenConstants.COMPOSER_PACKAGE_NAME_DESC));
     }
 
     @Override
@@ -415,6 +416,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
 
         return toModelName(type);
+    }
+
+    public String getInvokerPackage() {
+        return invokerPackage;
     }
 
     public void setInvokerPackage(String invokerPackage) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -201,7 +201,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
         additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
 
-         // {{artifactVersion}}
+        // {{artifactVersion}}
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {
             this.setArtifactVersion((String) additionalProperties.get(CodegenConstants.ARTIFACT_VERSION));
         } else {
@@ -295,9 +295,9 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
         // Trim prefix file separators from package path
         String packagePath = StringUtils.removeStart(
-            // Replace period, backslash, forward slash with file separator in package name
-            modifiedPackageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement("/")),
-            File.separator
+                // Replace period, backslash, forward slash with file separator in package name
+                modifiedPackageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement("/")),
+                File.separator
         );
 
         // Trim trailing file separators from the overall path
@@ -614,6 +614,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     /**
      * Return the default value of the property
+     *
      * @param p OpenAPI property object
      * @return string presentation of the default value of the property
      */
@@ -731,7 +732,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             return "EMPTY";
         }
 
-        if(name.trim().length() == 0) {
+        if (name.trim().length() == 0) {
             return "SPACE_" + name.length();
         }
 
@@ -811,7 +812,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
 
         // If the string contains only "trim-able" characters, don't trim it
-        if(input.trim().length() == 0) {
+        if (input.trim().length() == 0) {
             return input;
         }
 
@@ -881,9 +882,9 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     public String getComposerPackageName() {
         String packageName = this.getGitUserId() + "/" + this.getGitRepoId();
         if (
-            packageName.contentEquals("/")
-            || packageName.contentEquals("null/null")
-            || !Pattern.matches("^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$", packageName)
+                packageName.contentEquals("/")
+                        || packageName.contentEquals("null/null")
+                        || !Pattern.matches("^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$", packageName)
         ) {
             return "";
         }
@@ -897,5 +898,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.PHP; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.PHP;
+    }
 }

--- a/modules/openapi-generator/src/main/resources/php-dt-modern/composer.json.mustache
+++ b/modules/openapi-generator/src/main/resources/php-dt-modern/composer.json.mustache
@@ -1,9 +1,22 @@
 {
     "name": "{{#lambda.lowercase}}{{gitUserId}}/{{gitRepoId}}{{/lambda.lowercase}}",
     "description": "{{description}}",
-    "license": "unlicense",
     "version": "{{artifactVersion}}",
     "type": "library",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
+    "authors": [
+        {
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
+        }
+    ],
     "require": {
         "php": "^8.0",
         "articus/data-transfer": "^0.5",

--- a/modules/openapi-generator/src/main/resources/php-dt/composer.json.mustache
+++ b/modules/openapi-generator/src/main/resources/php-dt/composer.json.mustache
@@ -1,7 +1,20 @@
 {
     "name": "{{#lambda.lowercase}}{{gitUserId}}/{{gitRepoId}}{{/lambda.lowercase}}",
     "description": "{{description}}",
-    "license": "unlicense",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
+    "authors": [
+        {
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
+        }
+    ],
     "version": "{{artifactVersion}}",
     "type": "library",
     "require": {

--- a/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
@@ -5,7 +5,19 @@
   {{#artifactVersion}}
   "version": "{{.}}",
   {{/artifactVersion}}
-  "license": "MIT",
+  "keywords": [
+    "openapi",
+    "php",
+    "api"
+  ],
+  "homepage": "{{{artifactUrl}}}",
+  "license": "{{{licenseName}}}",
+  "authors": [
+    {
+        "name": "{{{developerOrganization}}}",
+        "homepage": "{{{developerOrganizationUrl}}}"
+    }
+  ],
   "type": "project",
   "require": {
     "php": "^7.2.5",

--- a/modules/openapi-generator/src/main/resources/php-lumen/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-lumen/composer.mustache
@@ -14,12 +14,12 @@
         "sdk",
         "api"
     ],
-    "homepage": "http://openapi-generator.tech",
-    "license": "unlicense",
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
     "authors": [
         {
-            "name": "OpenAPI-Generator contributors",
-            "homepage": "https://openapi-generator.tech"
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
         }
     ],
     "type": "project",

--- a/modules/openapi-generator/src/main/resources/php-mezzio-ph-modern/composer.json.mustache
+++ b/modules/openapi-generator/src/main/resources/php-mezzio-ph-modern/composer.json.mustache
@@ -1,7 +1,20 @@
 {
     "name": "{{#lambda.lowercase}}{{gitUserId}}/{{gitRepoId}}{{/lambda.lowercase}}",
     "description": "{{description}}",
-    "license": "unlicense",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
+    "authors": [
+        {
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
+        }
+    ],
     "version": "{{artifactVersion}}",
     "type": "project",
     "require": {

--- a/modules/openapi-generator/src/main/resources/php-mezzio-ph/composer.json.mustache
+++ b/modules/openapi-generator/src/main/resources/php-mezzio-ph/composer.json.mustache
@@ -1,9 +1,22 @@
 {
     "name": "{{#lambda.lowercase}}{{gitUserId}}/{{gitRepoId}}{{/lambda.lowercase}}",
     "description": "{{description}}",
-    "license": "unlicense",
     "version": "{{artifactVersion}}",
     "type": "project",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
+    "authors": [
+        {
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-yaml": "^2.0",

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
@@ -7,6 +7,20 @@
       "no-api": true
     }
   ],
+  "description": "{{description}}",
+  "keywords": [
+    "openapi",
+    "php",
+    "api"
+  ],
+  "homepage": "{{{artifactUrl}}}",
+  "license": "{{{licenseName}}}",
+  "authors": [
+    {
+      "name": "{{{developerOrganization}}}",
+      "homepage": "{{{developerOrganizationUrl}}}"
+    }
+  ],
   "require": {
     "php": "^7.4 || ^8.0",
     "dyorg/slim-token-authentication": "dev-slim4",

--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -1,5 +1,10 @@
 {
+    {{#composerPackageName}}
+    "name": "{{{.}}}",
+    {{/composerPackageName}}
+    {{^composerPackageName}}
     "name": "{{gitUserId}}/{{gitRepoId}}",
+    {{/composerPackageName}}
     {{#artifactVersion}}
     "version": "{{.}}",
     {{/artifactVersion}}
@@ -10,12 +15,12 @@
         "sdk",
         "api"
     ],
-    "homepage": "https://github.com/openapitools/openapi-generator",
-    "license": "unlicense",
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
     "authors": [
         {
-            "name": "openapi-generator contributors",
-            "homepage": "https://github.com/openapitools/openapi-generator"
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
         }
     ],
     "require": {

--- a/modules/openapi-generator/src/main/resources/php/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/composer.mustache
@@ -1,9 +1,9 @@
 {
     {{#composerPackageName}}
-    "name": "{{.}}",
+    "name": "{{{.}}}",
     {{/composerPackageName}}
     {{#artifactVersion}}
-    "version": "{{.}}",
+    "version": "{{{.}}}",
     {{/artifactVersion}}
     "description": "{{{appDescription}}}",
     "keywords": [
@@ -15,12 +15,12 @@
         "rest",
         "api"
     ],
-    "homepage": "{{artifactUrl}}",
-    "license": "{{licenseName}}",
+    "homepage": "{{{artifactUrl}}}",
+    "license": "{{{licenseName}}}",
     "authors": [
         {
-            "name": "{{developerOrganization}}",
-            "homepage": "{{developerOrganizationUrl}}"
+            "name": "{{{developerOrganization}}}",
+            "homepage": "{{{developerOrganizationUrl}}}"
         }
     ],
     "require": {
@@ -36,9 +36,9 @@
         "friendsofphp/php-cs-fixer": "^3.5"
     },
     "autoload": {
-        "psr-4": { "{{escapedInvokerPackage}}\\" : "{{srcBasePath}}/" }
+        "psr-4": { "{{{escapedInvokerPackage}}}\\" : "{{{srcBasePath}}}/" }
     },
     "autoload-dev": {
-        "psr-4": { "{{escapedInvokerPackage}}\\Test\\" : "{{testBasePath}}/" }
+        "psr-4": { "{{{escapedInvokerPackage}}}\\Test\\" : "{{{testBasePath}}}/" }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
@@ -49,5 +49,9 @@ public class PhpLumenServerOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setSrcBasePath(PhpLumenServerOptionsProvider.SRC_BASE_PATH_VALUE);
         verify(clientCodegen).setArtifactVersion(PhpLumenServerOptionsProvider.ARTIFACT_VERSION_VALUE);
         verify(clientCodegen).setEnumUnknownDefaultCase(Boolean.parseBoolean(PhpLumenServerOptionsProvider.ENUM_UNKNOWN_DEFAULT_CASE_VALUE));
+        verify(clientCodegen).setLicenseName(PhpLumenServerOptionsProvider.LICENSE_VALUE);
+        verify(clientCodegen).setDeveloperOrganizationUrl(PhpLumenServerOptionsProvider.DEVELOPER_ORGANIZATION_URL_VALUE);
+        verify(clientCodegen).setArtifactUrl(PhpLumenServerOptionsProvider.ARTIFACTURL_VALUE);
+        verify(clientCodegen).setDeveloperOrganization(PhpLumenServerOptionsProvider.DEVELOPER_ORGANIZATION_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
@@ -37,6 +37,11 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
     public static final String ENUM_UNKNOWN_DEFAULT_CASE_VALUE = "false";
+    public static final String LICENSE_VALUE = "mit";
+    public static final String DEVELOPER_ORGANIZATION_URL_VALUE = "http://github.com/openapitools/openapi-generator";
+    public static final String ARTIFACTURL_VALUE = "https://anotherUrl.com";
+    public static final String DEVELOPER_ORGANIZATION_VALUE = "openapi generator contributors";
+    public static final String COMPOSER_PACKAGE_NAME_VALUE = "package/name";
 
     @Override
     public String getLanguage() {
@@ -62,6 +67,11 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
+                .put(CodegenConstants.LICENSE_NAME, LICENSE_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION_URL, DEVELOPER_ORGANIZATION_URL_VALUE)
+                .put(CodegenConstants.ARTIFACT_URL, ARTIFACTURL_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION, DEVELOPER_ORGANIZATION_VALUE)
+                .put(CodegenConstants.COMPOSER_PACKAGE_NAME, COMPOSER_PACKAGE_NAME_VALUE)
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
@@ -37,6 +37,11 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
     public static final String ENUM_UNKNOWN_DEFAULT_CASE_VALUE = "false";
+    public static final String LICENSE_VALUE = "mit";
+    public static final String DEVELOPER_ORGANIZATION_URL_VALUE = "http://github.com/openapitools/openapi-generator";
+    public static final String ARTIFACTURL_VALUE = "https://anotherUrl.com";
+    public static final String DEVELOPER_ORGANIZATION_VALUE = "openapi generator contributors";
+    public static final String COMPOSER_PACKAGE_NAME_VALUE = "package/name";
 
     @Override
     public String getLanguage() {
@@ -61,6 +66,11 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
+                .put(CodegenConstants.LICENSE_NAME, LICENSE_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION_URL, DEVELOPER_ORGANIZATION_URL_VALUE)
+                .put(CodegenConstants.ARTIFACT_URL, ARTIFACTURL_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION, DEVELOPER_ORGANIZATION_VALUE)
+                .put(CodegenConstants.COMPOSER_PACKAGE_NAME, COMPOSER_PACKAGE_NAME_VALUE)
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlim4ServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlim4ServerOptionsProvider.java
@@ -39,6 +39,11 @@ public class PhpSlim4ServerOptionsProvider implements OptionsProvider {
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
     public static final String PSR7_IMPLEMENTATION_VALUE = "zend-diactoros";
     public static final String ENUM_UNKNOWN_DEFAULT_CASE_VALUE = "false";
+    public static final String LICENSE_VALUE = "mit";
+    public static final String DEVELOPER_ORGANIZATION_URL_VALUE = "http://github.com/openapitools/openapi-generator";
+    public static final String ARTIFACTURL_VALUE = "https://anotherUrl.com";
+    public static final String DEVELOPER_ORGANIZATION_VALUE = "openapi generator contributors";
+    public static final String COMPOSER_PACKAGE_NAME_VALUE = "package/name";
 
     @Override
     public String getLanguage() {
@@ -64,6 +69,11 @@ public class PhpSlim4ServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
+                .put(CodegenConstants.LICENSE_NAME, LICENSE_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION_URL, DEVELOPER_ORGANIZATION_URL_VALUE)
+                .put(CodegenConstants.ARTIFACT_URL, ARTIFACTURL_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION, DEVELOPER_ORGANIZATION_VALUE)
+                .put(CodegenConstants.COMPOSER_PACKAGE_NAME, COMPOSER_PACKAGE_NAME_VALUE)
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
@@ -37,6 +37,11 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
     public static final String ENUM_UNKNOWN_DEFAULT_CASE_VALUE = "false";
+    public static final String LICENSE_VALUE = "mit";
+    public static final String DEVELOPER_ORGANIZATION_URL_VALUE = "http://github.com/openapitools/openapi-generator";
+    public static final String ARTIFACTURL_VALUE = "https://anotherUrl.com";
+    public static final String DEVELOPER_ORGANIZATION_VALUE = "openapi generator contributors";
+    public static final String COMPOSER_PACKAGE_NAME_VALUE = "package/name";
 
     @Override
     public String getLanguage() {
@@ -61,6 +66,11 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
+                .put(CodegenConstants.LICENSE_NAME, LICENSE_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION_URL, DEVELOPER_ORGANIZATION_URL_VALUE)
+                .put(CodegenConstants.ARTIFACT_URL, ARTIFACTURL_VALUE)
+                .put(CodegenConstants.DEVELOPER_ORGANIZATION, DEVELOPER_ORGANIZATION_VALUE)
+                .put(CodegenConstants.COMPOSER_PACKAGE_NAME, COMPOSER_PACKAGE_NAME_VALUE)
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
@@ -21,6 +21,7 @@ import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpClientCodegen;
 import org.openapitools.codegen.options.PhpClientOptionsProvider;
+import org.openapitools.codegen.options.PhpLumenServerOptionsProvider;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,5 +50,9 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setSrcBasePath(PhpClientOptionsProvider.SRC_BASE_PATH_VALUE);
         verify(clientCodegen).setArtifactVersion(PhpClientOptionsProvider.ARTIFACT_VERSION_VALUE);
         verify(clientCodegen).setEnumUnknownDefaultCase(Boolean.parseBoolean(PhpClientOptionsProvider.ENUM_UNKNOWN_DEFAULT_CASE_VALUE));
+        verify(clientCodegen).setLicenseName(PhpClientOptionsProvider.LICENSE_VALUE);
+        verify(clientCodegen).setDeveloperOrganizationUrl(PhpClientOptionsProvider.DEVELOPER_ORGANIZATION_URL_VALUE);
+        verify(clientCodegen).setArtifactUrl(PhpClientOptionsProvider.ARTIFACTURL_VALUE);
+        verify(clientCodegen).setDeveloperOrganization(PhpClientOptionsProvider.DEVELOPER_ORGANIZATION_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim4/PhpSlim4ServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim4/PhpSlim4ServerOptionsTest.java
@@ -20,6 +20,7 @@ package org.openapitools.codegen.slim4;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.PhpSlim4ServerCodegen;
+import org.openapitools.codegen.options.PhpLumenServerOptionsProvider;
 import org.openapitools.codegen.options.PhpSlim4ServerOptionsProvider;
 
 import static org.mockito.Mockito.mock;
@@ -50,6 +51,10 @@ public class PhpSlim4ServerOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlim4ServerOptionsProvider.SORT_PARAMS_VALUE));
         verify(clientCodegen).setPsr7Implementation(PhpSlim4ServerOptionsProvider.PSR7_IMPLEMENTATION_VALUE);
         verify(clientCodegen).setEnumUnknownDefaultCase(Boolean.parseBoolean(PhpSlim4ServerOptionsProvider.ENUM_UNKNOWN_DEFAULT_CASE_VALUE));
+        verify(clientCodegen).setLicenseName(PhpSlim4ServerOptionsProvider.LICENSE_VALUE);
+        verify(clientCodegen).setDeveloperOrganizationUrl(PhpSlim4ServerOptionsProvider.DEVELOPER_ORGANIZATION_URL_VALUE);
+        verify(clientCodegen).setArtifactUrl(PhpLumenServerOptionsProvider.ARTIFACTURL_VALUE);
+        verify(clientCodegen).setDeveloperOrganization(PhpSlim4ServerOptionsProvider.DEVELOPER_ORGANIZATION_VALUE);
     }
 }
 

--- a/samples/client/petstore/php-dt-modern/composer.json
+++ b/samples/client/petstore/php-dt-modern/composer.json
@@ -1,9 +1,22 @@
 {
     "name": "git_user_id/git_repo_id",
     "description": "",
-    "license": "unlicense",
     "version": "1.0.0",
     "type": "library",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "https://openapi-generator.tech",
+    "license": "unlicense",
+    "authors": [
+        {
+            "name": "OpenAPI",
+            "homepage": "https://openapi-generator.tech"
+        }
+    ],
     "require": {
         "php": "^8.0",
         "articus/data-transfer": "^0.5",

--- a/samples/client/petstore/php-dt/composer.json
+++ b/samples/client/petstore/php-dt/composer.json
@@ -1,7 +1,20 @@
 {
     "name": "git_user_id/git_repo_id",
     "description": "",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "https://openapi-generator.tech",
     "license": "unlicense",
+    "authors": [
+        {
+            "name": "OpenAPI",
+            "homepage": "https://openapi-generator.tech"
+        }
+    ],
     "version": "1.0.0",
     "type": "library",
     "require": {

--- a/samples/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/client/petstore/php/OpenAPIClient-php/composer.json
@@ -13,7 +13,7 @@
     "license": "unlicense",
     "authors": [
         {
-            "name": "OpenAPI-Generator contributors",
+            "name": "OpenAPI",
             "homepage": "https://openapi-generator.tech"
         }
     ],

--- a/samples/server/petstore/php-laravel/lib/composer.json
+++ b/samples/server/petstore/php-laravel/lib/composer.json
@@ -2,7 +2,19 @@
   "name": "openapitools/petstore",
   "description": ".",
   "keywords": ["framework", "laravel"],
-  "license": "MIT",
+  "keywords": [
+    "openapi",
+    "php",
+    "api"
+  ],
+  "homepage": "https://openapi-generator.tech",
+  "license": "unlicense",
+  "authors": [
+    {
+        "name": "OpenAPI",
+        "homepage": "https://openapi-generator.tech"
+    }
+  ],
   "type": "project",
   "require": {
     "php": "^7.2.5",

--- a/samples/server/petstore/php-lumen/lib/composer.json
+++ b/samples/server/petstore/php-lumen/lib/composer.json
@@ -11,11 +11,11 @@
         "sdk",
         "api"
     ],
-    "homepage": "http://openapi-generator.tech",
+    "homepage": "https://openapi-generator.tech",
     "license": "unlicense",
     "authors": [
         {
-            "name": "OpenAPI-Generator contributors",
+            "name": "OpenAPI",
             "homepage": "https://openapi-generator.tech"
         }
     ],

--- a/samples/server/petstore/php-mezzio-ph-modern/composer.json
+++ b/samples/server/petstore/php-mezzio-ph-modern/composer.json
@@ -1,7 +1,20 @@
 {
     "name": "git_user_id/git_repo_id",
     "description": "",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "https://openapi-generator.tech",
     "license": "unlicense",
+    "authors": [
+        {
+            "name": "OpenAPI",
+            "homepage": "https://openapi-generator.tech"
+        }
+    ],
     "version": "1.0.0",
     "type": "project",
     "require": {

--- a/samples/server/petstore/php-mezzio-ph/composer.json
+++ b/samples/server/petstore/php-mezzio-ph/composer.json
@@ -1,9 +1,22 @@
 {
     "name": "git_user_id/git_repo_id",
     "description": "",
-    "license": "unlicense",
     "version": "1.0.0",
     "type": "project",
+    "keywords": [
+        "openapi",
+        "php",
+        "sdk",
+        "api"
+    ],
+    "homepage": "https://openapi-generator.tech",
+    "license": "unlicense",
+    "authors": [
+        {
+            "name": "OpenAPI",
+            "homepage": "https://openapi-generator.tech"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-yaml": "^2.0",

--- a/samples/server/petstore/php-slim4/composer.json
+++ b/samples/server/petstore/php-slim4/composer.json
@@ -7,6 +7,20 @@
       "no-api": true
     }
   ],
+  "description": "",
+  "keywords": [
+    "openapi",
+    "php",
+    "api"
+  ],
+  "homepage": "https://openapi-generator.tech",
+  "license": "unlicense",
+  "authors": [
+    {
+      "name": "OpenAPI",
+      "homepage": "https://openapi-generator.tech"
+    }
+  ],
   "require": {
     "php": "^7.4 || ^8.0",
     "dyorg/slim-token-authentication": "dev-slim4",

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -7,12 +7,12 @@
         "sdk",
         "api"
     ],
-    "homepage": "https://github.com/openapitools/openapi-generator",
+    "homepage": "https://openapi-generator.tech",
     "license": "unlicense",
     "authors": [
         {
-            "name": "openapi-generator contributors",
-            "homepage": "https://github.com/openapitools/openapi-generator"
+            "name": "OpenAPI",
+            "homepage": "https://openapi-generator.tech"
         }
     ],
     "require": {


### PR DESCRIPTION
update php options to allow better customization of composer.json

php client tests passed
```
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

...............................................................  63 / 207 ( 30%)
............................................................... 126 / 207 ( 60%)
............................................................... 189 / 207 ( 91%)
..................                                              207 / 207 (100%)

Time: 00:02.230, Memory: 12.00 MB

OK (207 tests, 357 assertions)

```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ybelenko (2018/07), @renepardon (2018/12)
