### PR TITLE
[Julia] Fix error in server enum generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/julia-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/model.mustache
@@ -2,15 +2,14 @@
 {{#models}}
 {{#model}}
 {{#isAlias}}
-if !isdefined(@__MODULE__, :{{classname}})
-    const {{classname}} = {{dataType}}
-else
-    @warn("Skipping redefinition of {{classname}} to {{dataType}}")
-end
+{{>partial_model_alias}}
 {{/isAlias}}{{^isAlias}}{{#oneOf}}{{#-first}}
 {{>partial_model_oneof}}
 {{/-first}}{{/oneOf}}{{^oneOf}}{{#anyOf}}{{#-first}}
 {{>partial_model_anyof}}
-{{/-first}}{{/anyOf}}{{^anyOf}}
+{{/-first}}{{/anyOf}}{{^anyOf}}{{#hasVars}}
 {{>partial_model_single}}
+{{/hasVars}}{{^hasVars}}
+{{>partial_model_alias}}
+{{/hasVars}}
 {{/anyOf}}{{/oneOf}}{{/isAlias}}{{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/julia-server/partial_model_alias.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/partial_model_alias.mustache
@@ -1,0 +1,5 @@
+if !isdefined(@__MODULE__, :{{classname}})
+    const {{classname}} = {{dataType}}
+else
+    @warn("Skipping redefinition of {{classname}} to {{dataType}}")
+end

--- a/modules/openapi-generator/src/main/resources/julia-server/partial_model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/partial_model_anyof.mustache
@@ -1,6 +1,6 @@
 {{#anyOf}}{{#-first}}
-@doc raw"""{{#description}}{{description}}
-{{/description}}
+@doc raw"""{{name}}{{#description}}
+{{description}}{{/description}}
 
     {{classname}}(; value=nothing)
 """

--- a/modules/openapi-generator/src/main/resources/julia-server/partial_model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/partial_model_oneof.mustache
@@ -1,6 +1,6 @@
 {{#oneOf}}{{#-first}}
-@doc raw"""{{#description}}{{description}}
-{{/description}}
+@doc raw"""{{name}}{{#description}}
+{{description}}{{/description}}
 
     {{classname}}(; value=nothing)
 """

--- a/modules/openapi-generator/src/main/resources/julia-server/partial_model_single.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-server/partial_model_single.mustache
@@ -1,5 +1,5 @@
-@doc raw"""{{#description}}{{description}}
-{{/description}}
+@doc raw"""{{name}}{{#description}}
+{{description}}{{/description}}
 
     {{classname}}(;
 {{#allVars}}
@@ -40,7 +40,7 @@ function OpenAPI.validate_property(::Type{ {{classname}} }, name::Symbol, val)
 {{#allVars}}
 {{#isEnum}}
     if name === Symbol("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}")
-        OpenAPI.validate_param(name, "{{classname}}", :enum, val, [{{#allowableValues}}{{#values}}{{#isString}}"{{{this}}}"{{/isString}}{{^isString}}{{{this}}}{{/isString}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}])
+        OpenAPI.validate_param(name, "{{classname}}", :enum, val, [{{#_enum}}{{#isString}}"{{.}}"{{/isString}}{{^isString}}{{.}}{{/isString}}{{^-last}}, {{/-last}}{{/_enum}}])
     end
 {{/isEnum}}
 {{^isEnum}}

--- a/samples/server/petstore/julia/src/models/model_ApiResponse.jl
+++ b/samples/server/petstore/julia/src/models/model_ApiResponse.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""Describes the result of uploading an image resource
+@doc raw"""ApiResponse
+Describes the result of uploading an image resource
 
     ApiResponse(;
         code=nothing,

--- a/samples/server/petstore/julia/src/models/model_Category.jl
+++ b/samples/server/petstore/julia/src/models/model_Category.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A category for a pet
+@doc raw"""Category
+A category for a pet
 
     Category(;
         id=nothing,

--- a/samples/server/petstore/julia/src/models/model_Order.jl
+++ b/samples/server/petstore/julia/src/models/model_Order.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""An order for a pets from the pet store
+@doc raw"""Order
+An order for a pets from the pet store
 
     Order(;
         id=nothing,

--- a/samples/server/petstore/julia/src/models/model_Pet.jl
+++ b/samples/server/petstore/julia/src/models/model_Pet.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A pet for sale in the pet store
+@doc raw"""Pet
+A pet for sale in the pet store
 
     Pet(;
         id=nothing,

--- a/samples/server/petstore/julia/src/models/model_Tag.jl
+++ b/samples/server/petstore/julia/src/models/model_Tag.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A tag for a pet
+@doc raw"""Tag
+A tag for a pet
 
     Tag(;
         id=nothing,

--- a/samples/server/petstore/julia/src/models/model_User.jl
+++ b/samples/server/petstore/julia/src/models/model_User.jl
@@ -2,7 +2,8 @@
 # Do not modify this file directly. Modify the OpenAPI specification instead.
 
 
-@doc raw"""A User who is purchasing from the pet store
+@doc raw"""User
+A User who is purchasing from the pet store
 
     User(;
         id=nothing,


### PR DESCRIPTION
Fixed issue in enum generation for julia-server code. An empty struct was generated, where it should have generated a type alias.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @wing328 