### PR TITLE
[C++][Pistache] Serialize integer enums if possible

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -101,11 +101,11 @@ void to_json(nlohmann::json& j, const {{classname}}& o)
         {{#enumVars}}
         {{#-first}}
         case {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED:
-            j = "INVALID_VALUE_OPENAPI_GENERATED";
+            j = {{#isInteger}}0{{/isInteger}}{{^isInteger}}"INVALID_VALUE_OPENAPI_GENERATED"{{/isInteger}};
             break;
         {{/-first}}
         case {{classname}}::e{{classname}}::{{name}}:
-            j = "{{value}}";
+            j = {{#isInteger}}{{value}}{{/isInteger}}{{^isInteger}}"{{value}}"{{/isInteger}};
             break;
         {{/enumVars}}
     }{{/allowableValues}}{{/isEnum}}{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}to_json(j, o.m_value);{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
@@ -121,9 +121,9 @@ void from_json(const nlohmann::json& j, {{classname}}& o)
     } {{/required}}
     {{/vars}}
     {{#isEnum}}{{#allowableValues}}
-    auto s = j.get<std::string>();
+    auto s = j.get<{{#isInteger}}{{dataType}}{{/isInteger}}{{^isInteger}}std::string{{/isInteger}}>();
     {{#enumVars}}
-    {{#-first}}if{{/-first}}{{^-first}}else if{{/-first}} (s == "{{value}}") {
+    {{#-first}}if{{/-first}}{{^-first}}else if{{/-first}} (s == {{#isInteger}}{{value}}{{/isInteger}}{{^isInteger}}"{{value}}"{{/isInteger}}) {
      o.setValue({{classname}}::e{{classname}}::{{name}});
     } {{#-last}} else {
      std::stringstream ss;

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -96,12 +96,12 @@ void to_json(nlohmann::json& j, const {{classname}}& o)
     {{#enumVars}}
     {{#-first}}
     case {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED:
-         j = "INVALID_VALUE_OPENAPI_GENERATED";
-         break;
+        j = {{#isInteger}}0{{/isInteger}}{{^isInteger}}"INVALID_VALUE_OPENAPI_GENERATED"{{/isInteger}};
+        break;
     {{/-first}}
     case {{classname}}::e{{classname}}::{{name}}:
-         j = "{{value}}";
-         break;
+        j = {{#isInteger}}{{value}}{{/isInteger}}{{^isInteger}}"{{value}}"{{/isInteger}};
+        break;
     {{/enumVars}}
     }{{/allowableValues}}{{/isEnum}}{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}to_json(j, o.m_value);{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
 }
@@ -117,10 +117,10 @@ void from_json(const nlohmann::json& j, {{classname}}& o)
     }{{/required}}
     {{/vars}}
     {{#isEnum}}{{#allowableValues}}
-    auto s = j.get<std::string>();
+    auto s = j.get<{{#isInteger}}{{dataType}}{{/isInteger}}{{^isInteger}}std::string{{/isInteger}}>();
     {{#enumVars}}
     {{#-first}}
-    if{{/-first}}{{^-first}}else if{{/-first}}(s == "{{value}}") {
+    if{{/-first}}{{^-first}}else if{{/-first}}(s == {{#isInteger}}{{value}}{{/isInteger}}{{^isInteger}}"{{value}}"{{/isInteger}}) {
         o.value = {{classname}}::e{{classname}}::{{name}};
     } {{#-last}} else {
         std::stringstream ss;


### PR DESCRIPTION
In OpenAPI it is possible to define an enum schema containing integers only.

Similar to the following JSON snippet:
```
...
  "components": {
    "schemas": {
      "size": {
        "type": "integer",
        "description": "Container size",
        "enum": [
          10000,
          20000,
          100000,
          200000,
          300000,
          1000000,
          1200000,
          2500000,
          5000000,
          10000000
        ]
      }
    }
  }
...
```

To correctly serialize this we need to convert to JSON integers. We can achieve this by feeding nlohmann JSON objects directly with integers instead of strings.

For the C++ pistache server adapt the enum models to serialize integer values if possible.

C++ committee:  @ravinikam, @stkrwork, @etherealjoy, @martindelille, @muttleyxd

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
