### PR TITLE
[C#] minor refactoring

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -863,8 +863,6 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     }
 
     private void patchParameter(CodegenParameter parameter, List<ModelMap> allModels) {
-        parameter.paramName = escapeReservedWord(parameter.paramName);
-
         patchVendorExtensionNullableValueType(parameter);
 
         if (this.getNullableReferencesTypes() || (parameter.vendorExtensions.get("x-nullable-value-type") != null)) {
@@ -1014,7 +1012,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         // pet_id => petId
         name = camelize(name, LOWERCASE_FIRST_LETTER);
 
-        return name;
+        return escapeReservedWord(name);
     }
 
     public String escapeReservedWord(CodegenModel model, String name) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -765,19 +765,6 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         }
                     }
 
-
-                    // check if the payload is json and set x-is-json accordingly
-                    if (operation.consumes != null) {
-                        for (Map<String, String> consume : operation.consumes) {
-                            if (consume.containsKey("mediaType")) {
-                                if (isJsonMimeType(consume.get("mediaType"))) {
-                                    operation.vendorExtensions.put("x-is-json", true);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
                     if (operation.examples != null) {
                         for (Map<String, String> example : operation.examples) {
                             for (Map.Entry<String, String> entry : example.entrySet()) {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/FakeApi.md
@@ -846,7 +846,7 @@ namespace Example
             var integer = 56;  // int | None (optional) 
             var int32 = 56;  // int | None (optional) 
             var int64 = 789L;  // long | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var password = "password_example";  // string | None (optional) 
             var callback = "callback_example";  // string | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/FakeApi.md
@@ -846,7 +846,7 @@ namespace Example
             var integer = 56;  // int | None (optional) 
             var int32 = 56;  // int | None (optional) 
             var int64 = 789L;  // long | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var password = "password_example";  // string | None (optional) 
             var callback = "callback_example";  // string | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/FakeApi.md
@@ -846,7 +846,7 @@ namespace Example
             var integer = 56;  // int | None (optional) 
             var int32 = 56;  // int | None (optional) 
             var int64 = 789L;  // long | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var password = "password_example";  // string | None (optional) 
             var callback = "callback_example";  // string | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FakeApi.md
@@ -884,7 +884,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // FileParameter | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string? | None (optional) 
+            var varString = "varString_example";  // string? | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream? | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string | None (optional) 
+            var varString = "varString_example";  // string | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FakeApi.md
@@ -844,7 +844,7 @@ namespace Example
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789L;  // long? | None (optional) 
             var varFloat = 3.4F;  // float? | None (optional) 
-            var varString = "string_example";  // string? | None (optional) 
+            var varString = "varString_example";  // string? | None (optional) 
             var binary = new System.IO.MemoryStream(System.IO.File.ReadAllBytes("/path/to/file.txt"));  // System.IO.Stream? | None (optional) 
             var date = DateTime.Parse("2013-10-20");  // DateTime? | None (optional) 
             var dateTime = DateTime.Parse(""2010-02-01T10:20:10.111110+01:00"");  // DateTime? | None (optional)  (default to "2010-02-01T10:20:10.111110+01:00")


### PR DESCRIPTION
- escape reserved words directly in `toParamName`
- remove code block to add `x-is-json` (not in used anywhere)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05)

cc @devhl-labs 