### PR TITLE
[Typescript-Node] Added TS typing to APIS variable

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/api-all.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-all.mustache
@@ -19,5 +19,5 @@ export class HttpError extends Error {
 
 export { RequestFile } from '../model/models';
 
-export const APIS = [{{#apis}}{{#operations}}{{ classname }}{{/operations}}{{^-last}}, {{/-last}}{{/apis}}];
+export const APIS:unknown[] = [{{#apis}}{{#operations}}{{ classname }}{{/operations}}{{^-last}}, {{/-last}}{{/apis}}];
 {{/apiInfo}}

--- a/samples/client/petstore/typescript-node/default/api/apis.ts
+++ b/samples/client/petstore/typescript-node/default/api/apis.ts
@@ -15,4 +15,4 @@ export class HttpError extends Error {
 
 export { RequestFile } from '../model/models';
 
-export const APIS = [PetApi, StoreApi, UserApi];
+export const APIS:unknown[] = [PetApi, StoreApi, UserApi];

--- a/samples/client/petstore/typescript-node/npm/api/apis.ts
+++ b/samples/client/petstore/typescript-node/npm/api/apis.ts
@@ -15,4 +15,4 @@ export class HttpError extends Error {
 
 export { RequestFile } from '../model/models';
 
-export const APIS = [PetApi, StoreApi, UserApi];
+export const APIS:unknown[] = [PetApi, StoreApi, UserApi];


### PR DESCRIPTION
Added `unknown[]` typing for APIS variable in the typescript-node mustache file. Allows generated files to compile when no APIs are generated. Verify the template change by generating files from any yaml. The api/apis.ts file will now contain the line: `export const APIS:unknown[] = ...`

Resolves #16098.  (references not making API files, but this PR covers all cases). 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu
@taxpon
@sebastianhaas 
@kenisteward 
@Vrolijkx 
@macjohnny 
@topce 
@akehir 
@petejohansonxo 
@amakhrov 
@davidgamero 
@mkusaka 
