### PR TITLE
[typescript-nestjs] allow configuration with forRootAsync (#15269)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/README.mustache
@@ -105,6 +105,31 @@ import { BASE_PATH } from '{{npmName}}';
 export class AppModule {}
 ```
 
+### Configuring the module with `forRootAsync`
+
+You can also use the Nestjs Config Module/Service to configure your app with `forRootAsync`.
+
+```
+@Module({
+    imports: [
+      ApiModule.forRootAsync({
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (config: ConfigService): Configuration => {
+          const params: ConfigurationParameters = {
+            // set configuration parameters here.
+            basePath: config.get('API_URL'),
+          };
+          return new Configuration(params);
+        },
+      })
+    ],
+    declarations: [ AppComponent ],
+    providers: [],
+    bootstrap: [ AppComponent ]
+})
+export class AppModule {}
+```
 
 #### Using @nestjs/cli
 First extend your `src/environments/*.ts` files by adding the corresponding base path:

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
@@ -5,7 +5,7 @@ import { HttpModule, HttpService } from '@nestjs/axios';
 {{^useAxiosHttpModule}}
 import { DynamicModule, HttpService, HttpModule, Module, Global } from '@nestjs/common';
 {{/useAxiosHttpModule}}
-import { Configuration } from './configuration';
+import { AsyncConfiguration, Configuration, ConfigurationFactory } from './configuration';
 
 {{#apiInfo}}
 {{#apis}}
@@ -30,6 +30,50 @@ export class ApiModule {
         return {
             module: ApiModule,
             providers: [ { provide: Configuration, useFactory: configurationFactory } ]
+        };
+    }
+
+    /**
+     * Register the module asynchronously.
+     */
+    static forRootAsync(options: AsyncConfiguration): DynamicModule {
+        const providers = [...this.createAsyncProviders(options)];
+        return {
+            module: ApiModule,
+            imports: options.imports || [],
+            providers,
+            exports: providers,
+        };
+    }
+
+    private static createAsyncProviders(options: AsyncConfiguration): Provider[] {
+        if (options.useExisting || options.useFactory) {
+            return [this.createAsyncConfigurationProvider(options)];
+        }
+        return [
+            this.createAsyncConfigurationProvider(options),
+            {
+                provide: options.useClass,
+                useClass: options.useClass,
+            },
+        ];
+    }
+
+    private static createAsyncConfigurationProvider(
+        options: AsyncConfiguration,
+    ): Provider {
+        if (options.useFactory) {
+            return {
+                provide: Configuration,
+                useFactory: options.useFactory,
+                inject: options.inject || [],
+            };
+        }
+        return {
+            provide: Configuration,
+            useFactory: async (optionsFactory: ConfigurationFactory) =>
+                await optionsFactory.createConfiguration(),
+            inject: [options.useExisting || options.useClass],
         };
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/configuration.mustache
@@ -1,3 +1,5 @@
+import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;
@@ -76,4 +78,28 @@ export class Configuration {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime != null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
     }
+}
+
+export interface ConfigurationFactory {
+  createConfiguration(): Promise<Configuration> | Configuration;
+}
+
+export interface AsyncConfiguration extends Pick<ModuleMetadata, 'imports'> {
+  /**
+   * The `useExisting` syntax allows you to create aliases for existing providers.
+   */
+  useExisting?: Type<ConfigurationFactory>;
+  /**
+   * The `useClass` syntax allows you to dynamically determine a class
+   * that a token should resolve to.
+   */
+  useClass?: Type<ConfigurationFactory>;
+  /**
+   * The `useFactory` syntax allows for creating providers dynamically.
+   */
+  useFactory?: (...args: any[]) => Promise<Configuration> | Configuration;
+  /**
+   * Optional list of providers to be injected into the context of the Factory function.
+   */
+  inject?: any[];
 }

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/README.md
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/README.md
@@ -105,6 +105,31 @@ import { BASE_PATH } from '@openapitools/typescript-nestjs-petstore';
 export class AppModule {}
 ```
 
+### Configuring the module with `forRootAsync`
+
+You can also use the Nestjs Config Module/Service to configure your app with `forRootAsync`.
+
+```
+@Module({
+    imports: [
+      ApiModule.forRootAsync({
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (config: ConfigService): Configuration => {
+          const params: ConfigurationParameters = {
+            // set configuration parameters here.
+            basePath: config.get('API_URL'),
+          };
+          return new Configuration(params);
+        },
+      })
+    ],
+    declarations: [ AppComponent ],
+    providers: [],
+    bootstrap: [ AppComponent ]
+})
+export class AppModule {}
+```
 
 #### Using @nestjs/cli
 First extend your `src/environments/*.ts` files by adding the corresponding base path:

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api.module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, HttpService, HttpModule, Module, Global } from '@nestjs/common';
-import { Configuration } from './configuration';
+import { AsyncConfiguration, Configuration, ConfigurationFactory } from './configuration';
 
 import { PetService } from './api/pet.service';
 import { StoreService } from './api/store.service';
@@ -24,6 +24,50 @@ export class ApiModule {
         return {
             module: ApiModule,
             providers: [ { provide: Configuration, useFactory: configurationFactory } ]
+        };
+    }
+
+    /**
+     * Register the module asynchronously.
+     */
+    static forRootAsync(options: AsyncConfiguration): DynamicModule {
+        const providers = [...this.createAsyncProviders(options)];
+        return {
+            module: ApiModule,
+            imports: options.imports || [],
+            providers,
+            exports: providers,
+        };
+    }
+
+    private static createAsyncProviders(options: AsyncConfiguration): Provider[] {
+        if (options.useExisting || options.useFactory) {
+            return [this.createAsyncConfigurationProvider(options)];
+        }
+        return [
+            this.createAsyncConfigurationProvider(options),
+            {
+                provide: options.useClass,
+                useClass: options.useClass,
+            },
+        ];
+    }
+
+    private static createAsyncConfigurationProvider(
+        options: AsyncConfiguration,
+    ): Provider {
+        if (options.useFactory) {
+            return {
+                provide: Configuration,
+                useFactory: options.useFactory,
+                inject: options.inject || [],
+            };
+        }
+        return {
+            provide: Configuration,
+            useFactory: async (optionsFactory: ConfigurationFactory) =>
+                await optionsFactory.createConfiguration(),
+            inject: [options.useExisting || options.useClass],
         };
     }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/configuration.ts
@@ -1,3 +1,5 @@
+import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;
@@ -76,4 +78,28 @@ export class Configuration {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime != null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
     }
+}
+
+export interface ConfigurationFactory {
+  createConfiguration(): Promise<Configuration> | Configuration;
+}
+
+export interface AsyncConfiguration extends Pick<ModuleMetadata, 'imports'> {
+  /**
+   * The `useExisting` syntax allows you to create aliases for existing providers.
+   */
+  useExisting?: Type<ConfigurationFactory>;
+  /**
+   * The `useClass` syntax allows you to dynamically determine a class
+   * that a token should resolve to.
+   */
+  useClass?: Type<ConfigurationFactory>;
+  /**
+   * The `useFactory` syntax allows for creating providers dynamically.
+   */
+  useFactory?: (...args: any[]) => Promise<Configuration> | Configuration;
+  /**
+   * Optional list of providers to be injected into the context of the Factory function.
+   */
+  inject?: any[];
 }

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/README.md
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/README.md
@@ -105,6 +105,31 @@ import { BASE_PATH } from '@openapitools/typescript-nestjs-petstore';
 export class AppModule {}
 ```
 
+### Configuring the module with `forRootAsync`
+
+You can also use the Nestjs Config Module/Service to configure your app with `forRootAsync`.
+
+```
+@Module({
+    imports: [
+      ApiModule.forRootAsync({
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (config: ConfigService): Configuration => {
+          const params: ConfigurationParameters = {
+            // set configuration parameters here.
+            basePath: config.get('API_URL'),
+          };
+          return new Configuration(params);
+        },
+      })
+    ],
+    declarations: [ AppComponent ],
+    providers: [],
+    bootstrap: [ AppComponent ]
+})
+export class AppModule {}
+```
 
 #### Using @nestjs/cli
 First extend your `src/environments/*.ts` files by adding the corresponding base path:

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api.module.ts
@@ -1,6 +1,6 @@
 import { DynamicModule, Module, Global } from '@nestjs/common';
 import { HttpModule, HttpService } from '@nestjs/axios';
-import { Configuration } from './configuration';
+import { AsyncConfiguration, Configuration, ConfigurationFactory } from './configuration';
 
 import { PetService } from './api/pet.service';
 import { StoreService } from './api/store.service';
@@ -25,6 +25,50 @@ export class ApiModule {
         return {
             module: ApiModule,
             providers: [ { provide: Configuration, useFactory: configurationFactory } ]
+        };
+    }
+
+    /**
+     * Register the module asynchronously.
+     */
+    static forRootAsync(options: AsyncConfiguration): DynamicModule {
+        const providers = [...this.createAsyncProviders(options)];
+        return {
+            module: ApiModule,
+            imports: options.imports || [],
+            providers,
+            exports: providers,
+        };
+    }
+
+    private static createAsyncProviders(options: AsyncConfiguration): Provider[] {
+        if (options.useExisting || options.useFactory) {
+            return [this.createAsyncConfigurationProvider(options)];
+        }
+        return [
+            this.createAsyncConfigurationProvider(options),
+            {
+                provide: options.useClass,
+                useClass: options.useClass,
+            },
+        ];
+    }
+
+    private static createAsyncConfigurationProvider(
+        options: AsyncConfiguration,
+    ): Provider {
+        if (options.useFactory) {
+            return {
+                provide: Configuration,
+                useFactory: options.useFactory,
+                inject: options.inject || [],
+            };
+        }
+        return {
+            provide: Configuration,
+            useFactory: async (optionsFactory: ConfigurationFactory) =>
+                await optionsFactory.createConfiguration(),
+            inject: [options.useExisting || options.useClass],
         };
     }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/configuration.ts
@@ -1,3 +1,5 @@
+import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;
@@ -76,4 +78,28 @@ export class Configuration {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime != null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
     }
+}
+
+export interface ConfigurationFactory {
+  createConfiguration(): Promise<Configuration> | Configuration;
+}
+
+export interface AsyncConfiguration extends Pick<ModuleMetadata, 'imports'> {
+  /**
+   * The `useExisting` syntax allows you to create aliases for existing providers.
+   */
+  useExisting?: Type<ConfigurationFactory>;
+  /**
+   * The `useClass` syntax allows you to dynamically determine a class
+   * that a token should resolve to.
+   */
+  useClass?: Type<ConfigurationFactory>;
+  /**
+   * The `useFactory` syntax allows for creating providers dynamically.
+   */
+  useFactory?: (...args: any[]) => Promise<Configuration> | Configuration;
+  /**
+   * Optional list of providers to be injected into the context of the Factory function.
+   */
+  inject?: any[];
 }


### PR DESCRIPTION
Allow the configuration of the nestjs module with different providers via `forRootAsync`. This will RESOLVE #15269. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
