### PR TITLE
Add parameter name mappings option

### DIFF
--- a/bin/configs/java-okhttp-gson.yaml
+++ b/bin/configs/java-okhttp-gson.yaml
@@ -6,6 +6,9 @@ templateDir: modules/openapi-generator/src/main/resources/Java
 nameMappings:
   _type: underscoreType
   type_: typeWithUnderscore
+parameterNameMappings:
+  _type: underscoreType
+  type_: typeWithUnderscore
 additionalProperties:
   artifactId: petstore-okhttp-gson
   hideGenerationTimestamp: "true"

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -397,7 +397,7 @@ or
 
 ## Name Mapping
 
-One can map the name of the property/parameter to something else. Consider the following schema:
+One can map the property name using `nameMappings` option and parameter name using `parameterNameMappings` option to something else. Consider the following schema:
 ```
     PropertyNameCollision:
       properties:
@@ -411,12 +411,12 @@ One can map the name of the property/parameter to something else. Consider the f
 ```
 `_type`, `type`, `type_` will result in property name collision in the Java client generator for example. We can resolve the issue using `nameMappings` by mapping `_type` to `underscoreType`, `type_` to `typeWithUnderscore`.
 
-Here is an example to use `nameMappings` in CLI:
+Here is an example to use `nameMappings` and `parameterNameMapping` in CLI:
 ```sh
-java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml  -o /tmp/java2/ --name-mappings _type=underscoreType, type_=typeWithUnderscore
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml  -o /tmp/java2/ --name-mappings _type=underscoreType, type_=typeWithUnderscore, --parameter-name-mappings _type=paramType, type_=typeParam
 ```
 
-(Not all generators support this feature yet. Please open an issue (ticket) to let us know which generators you would like to have this feature enabled and we'll prioritize accordingly.)
+(Not all generators support this feature yet. Please give it a try to confirm the behaviour and open an issue (ticket) to let us know which generators you would like to have this feature enabled and we'll prioritize accordingly.)
 
 ## Schema Mapping
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
@@ -80,8 +80,11 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
     @Option(name = {"--inline-schema-options"}, title = "inline schema options", description = "options for handling inline schemas in inline model resolver")
     private Boolean inlineSchemaOptions;
 
-    @Option(name = {"--name-mappings"}, title = "property/parameter name mappings", description = "displays the property/parameter name mappings (none)")
+    @Option(name = {"--name-mappings"}, title = "property name mappings", description = "displays the property name mappings (none)")
     private Boolean nameMappings;
+
+    @Option(name = {"--parameter-name-mappings"}, title = "parameter name mappings", description = "displays the parameter name mappings (none)")
+    private Boolean parameterNameMappings;
 
     @Option(name = {"--openapi-normalizer"}, title = "openapi normalizer rules", description = "displays the OpenAPI normalizer rules (none)")
     private Boolean openapiNormalizer;
@@ -501,14 +504,26 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
         }
 
         if (Boolean.TRUE.equals(nameMappings)) {
-            sb.append(newline).append("PROPERTY, PARAMETER NAME MAPPING").append(newline).append(newline);
+            sb.append(newline).append("PROPERTY NAME MAPPING").append(newline).append(newline);
             Map<String, String> map = config.nameMapping()
                     .entrySet()
                     .stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> {
                         throw new IllegalStateException(String.format(Locale.ROOT, "Duplicated options! %s and %s", a, b));
                     }, TreeMap::new));
-            writePlainTextFromMap(sb, map, optIndent, optNestedIndent, "property, parameter name", "Mapped to");
+            writePlainTextFromMap(sb, map, optIndent, optNestedIndent, "property name", "Mapped to");
+            sb.append(newline);
+        }
+
+        if (Boolean.TRUE.equals(parameterNameMappings)) {
+            sb.append(newline).append("PARAMETER NAME MAPPING").append(newline).append(newline);
+            Map<String, String> map = config.parameterNameMapping()
+                    .entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> {
+                        throw new IllegalStateException(String.format(Locale.ROOT, "Duplicated options! %s and %s", a, b));
+                    }, TreeMap::new));
+            writePlainTextFromMap(sb, map, optIndent, optNestedIndent, "parameter name", "Mapped to");
             sb.append(newline);
         }
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -190,10 +190,17 @@ public class Generate extends OpenApiGeneratorCommand {
 
     @Option(
             name = {"--name-mappings"},
-            title = "property, parameter name mappings",
-            description = "specifies mappings between the property, parameter name and the new name in the format of param_name=paramName,prop_name=PropName."
+            title = "property name mappings",
+            description = "specifies mappings between the property name and the new name in the format of prop_name=PropName,prop_name2=PropName2."
                     + " You can also have multiple occurrences of this option.")
     private List<String> nameMappings = new ArrayList<>();
+
+    @Option(
+            name = {"--parameter-name-mappings"},
+            title = "parameter name mappings",
+            description = "specifies mappings between the parameter name and the new name in the format of param_name=paramName,param_name2=paramName2."
+                    + " You can also have multiple occurrences of this option.")
+    private List<String> parameterNameMappings = new ArrayList<>();
 
     @Option(
             name = {"--openapi-normalizer"},
@@ -476,6 +483,7 @@ public class Generate extends OpenApiGeneratorCommand {
         applyInlineSchemaNameMappingsKvpList(inlineSchemaNameMappings, configurator);
         applyInlineSchemaOptionsKvpList(inlineSchemaOptions, configurator);
         applyNameMappingsKvpList(nameMappings, configurator);
+        applyParameterNameMappingsKvpList(parameterNameMappings, configurator);
         applyOpenAPINormalizerKvpList(openapiNormalizer, configurator);
         applyTypeMappingsKvpList(typeMappings, configurator);
         applyAdditionalPropertiesKvpList(additionalProperties, configurator);

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
@@ -54,6 +54,7 @@ public final class GeneratorSettings implements Serializable {
     private final Map<String, String> inlineSchemaNameMappings;
     private final Map<String, String> inlineSchemaOptions;
     private final Map<String, String> nameMappings;
+    private final Map<String, String> parameterNameMappings;
     private final Map<String, String> openapiNormalizer;
     private final Set<String> languageSpecificPrimitives;
     private final Map<String, String> reservedWordsMappings;
@@ -267,12 +268,21 @@ public final class GeneratorSettings implements Serializable {
     }
 
     /**
-     * Gets property, parameter name mappings between a property, parameter name and the new name.
+     * Gets property name mappings between a property name and the new name.
      *
-     * @return the property, parameter name mappings
+     * @return the property name mappings
      */
     public Map<String, String> getNameMappings() {
         return nameMappings;
+    }
+
+    /**
+     * Gets parameter name mappings between a parameter name and the new name.
+     *
+     * @return the parameter name mappings
+     */
+    public Map<String, String> getParameterNameMappings() {
+        return parameterNameMappings;
     }
 
     /**
@@ -403,6 +413,7 @@ public final class GeneratorSettings implements Serializable {
         inlineSchemaNameMappings = Collections.unmodifiableMap(builder.inlineSchemaNameMappings);
         inlineSchemaOptions = Collections.unmodifiableMap(builder.inlineSchemaOptions);
         nameMappings = Collections.unmodifiableMap(builder.nameMappings);
+        parameterNameMappings = Collections.unmodifiableMap(builder.parameterNameMappings);
         openapiNormalizer = Collections.unmodifiableMap(builder.openapiNormalizer);
         languageSpecificPrimitives = Collections.unmodifiableSet(builder.languageSpecificPrimitives);
         reservedWordsMappings = Collections.unmodifiableMap(builder.reservedWordsMappings);
@@ -478,6 +489,7 @@ public final class GeneratorSettings implements Serializable {
         inlineSchemaNameMappings = Collections.unmodifiableMap(new HashMap<>(0));
         inlineSchemaOptions = Collections.unmodifiableMap(new HashMap<>(0));
         nameMappings = Collections.unmodifiableMap(new HashMap<>(0));
+        parameterNameMappings = Collections.unmodifiableMap(new HashMap<>(0));
         openapiNormalizer = Collections.unmodifiableMap(new HashMap<>(0));
         languageSpecificPrimitives = Collections.unmodifiableSet(new HashSet<>(0));
         reservedWordsMappings = Collections.unmodifiableMap(new HashMap<>(0));
@@ -542,6 +554,9 @@ public final class GeneratorSettings implements Serializable {
         if (copy.getNameMappings() != null) {
             builder.nameMappings.putAll(copy.getNameMappings());
         }
+        if (copy.getParameterNameMappings() != null) {
+            builder.parameterNameMappings.putAll(copy.getParameterNameMappings());
+        }
         if (copy.getOpenAPINormalizer() != null) {
             builder.openapiNormalizer.putAll(copy.getOpenAPINormalizer());
         }
@@ -588,6 +603,7 @@ public final class GeneratorSettings implements Serializable {
         private Map<String, String> inlineSchemaNameMappings;
         private Map<String, String> inlineSchemaOptions;
         private Map<String, String> nameMappings;
+        private Map<String, String> parameterNameMappings;
         private Map<String, String> openapiNormalizer;
         private Set<String> languageSpecificPrimitives;
         private Map<String, String> reservedWordsMappings;
@@ -610,6 +626,7 @@ public final class GeneratorSettings implements Serializable {
             inlineSchemaNameMappings = new HashMap<>();
             inlineSchemaOptions = new HashMap<>();
             nameMappings = new HashMap<>();
+            parameterNameMappings = new HashMap<>();
             openapiNormalizer = new HashMap<>();
             languageSpecificPrimitives = new HashSet<>();
             reservedWordsMappings = new HashMap<>();
@@ -958,6 +975,32 @@ public final class GeneratorSettings implements Serializable {
         }
 
         /**
+         * Sets the {@code parameterNameMappings} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param parameterNameMappings the {@code parameterNameMappings} to set
+         * @return a reference to this Builder
+         */
+        public Builder withParameterNameMappings(Map<String, String> parameterNameMappings) {
+            this.parameterNameMappings = parameterNameMappings;
+            return this;
+        }
+
+        /**
+         * Sets a single {@code parameterNameMappings} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param key   A key for the name mapping
+         * @param value The value of name mapping
+         * @return a reference to this Builder
+         */
+        public Builder withParameterNameMapping(String key, String value) {
+            if (this.parameterNameMappings == null) {
+                this.parameterNameMappings = new HashMap<>();
+            }
+            this.parameterNameMappings.put(key, value);
+            return this;
+        }
+
+        /**
          * Sets the {@code openapiNormalizer} and returns a reference to this Builder so that the methods can be chained together.
          *
          * @param openapiNormalizer the {@code openapiNormalizer} to set
@@ -1172,6 +1215,7 @@ public final class GeneratorSettings implements Serializable {
                 Objects.equals(getInlineSchemaNameMappings(), that.getInlineSchemaNameMappings()) &&
                 Objects.equals(getInlineSchemaOptions(), that.getInlineSchemaOptions()) &&
                 Objects.equals(getNameMappings(), that.getNameMappings()) &&
+                Objects.equals(getParameterNameMappings(), that.getParameterNameMappings()) &&
                 Objects.equals(getOpenAPINormalizer(), that.getOpenAPINormalizer()) &&
                 Objects.equals(getLanguageSpecificPrimitives(), that.getLanguageSpecificPrimitives()) &&
                 Objects.equals(getReservedWordsMappings(), that.getReservedWordsMappings()) &&
@@ -1205,6 +1249,7 @@ public final class GeneratorSettings implements Serializable {
                 getInlineSchemaNameMappings(),
                 getInlineSchemaOptions(),
                 getNameMappings(),
+                getParameterNameMappings(),
                 getOpenAPINormalizer(),
                 getLanguageSpecificPrimitives(),
                 getReservedWordsMappings(),

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -168,9 +168,14 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val inlineSchemaOptions = project.objects.mapProperty<String, String>()
 
     /**
-     * Specifies mappings between a property, parameter name and the new name
+     * Specifies mappings between a property name and the new name
      */
     val nameMappings = project.objects.mapProperty<String, String>()
+
+    /**
+     * Specifies mappings between a parameter name and the new name
+     */
+    val parameterNameMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Specifies mappings (rules) in OpenAPI normalizer

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -273,11 +273,18 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
     val inlineSchemaOptions = project.objects.mapProperty<String, String>()
 
     /**
-     * Specifies mappings between the property, parameter name and the new name
+     * Specifies mappings between the property name and the new name
      */
     @Optional
     @Input
     val nameMappings = project.objects.mapProperty<String, String>()
+
+    /**
+     * Specifies mappings between the parameter name and the new name
+     */
+    @Optional
+    @Input
+    val parameterNameMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Specifies mappings (rules) in OpenAPI normalizer
@@ -817,6 +824,12 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
             if (nameMappings.isPresent) {
                 nameMappings.get().forEach { entry ->
                     configurator.addNameMapping(entry.key, entry.value)
+                }
+            }
+
+            if (parameterNameMappings.isPresent) {
+                parameterNameMappings.get().forEach { entry ->
+                    configurator.addParameterNameMapping(entry.key, entry.value)
                 }
             }
 

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -333,10 +333,16 @@ public class CodeGenMojo extends AbstractMojo {
     private List<String> inlineSchemaOptions;
 
     /**
-     * A map of property, parameter  names and the new names
+     * A map of property names and the new names
      */
     @Parameter(name = "nameMappings", property = "openapi.generator.maven.plugin.nameMappings")
     private List<String> nameMappings;
+
+    /**
+     * A map of parameter names and the new names
+     */
+    @Parameter(name = "parameterNameMappings", property = "openapi.generator.maven.plugin.parameterNameMappings")
+    private List<String> parameterNameMappings;
 
     /**
      * A set of rules for OpenAPI normalizer
@@ -805,6 +811,16 @@ public class CodeGenMojo extends AbstractMojo {
             // Apply Inline Schema Options
             if (inlineSchemaOptions != null && (configOptions == null || !configOptions.containsKey("inline-schema-options"))) {
                 applyInlineSchemaOptionsKvpList(inlineSchemaOptions, configurator);
+            }
+
+            // Apply Name Mappings
+            if (nameMappings != null && (configOptions == null || !configOptions.containsKey("name-mappings"))) {
+                applyNameMappingsKvpList(nameMappings, configurator);
+            }
+
+            // Apply Parameter Name Mappings
+            if (parameterNameMappings != null && (configOptions == null || !configOptions.containsKey("paramter-name-mappings"))) {
+                applyParameterNameMappingsKvpList(parameterNameMappings, configurator);
             }
 
             // Apply OpenAPI normalizer rules

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -149,6 +149,8 @@ public interface CodegenConfig {
 
     Map<String, String> nameMapping();
 
+    Map<String, String> parameterNameMapping();
+
     Map<String, String> openapiNormalizer();
 
     Map<String, String> apiTemplateFiles();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -164,8 +164,10 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> inlineSchemaNameMapping = new HashMap<>();
     // a map to store the inline schema naming conventions
     protected Map<String, String> inlineSchemaOption = new HashMap<>();
-    // a map to store the mapping between property, parameter name and the name provided by the user
+    // a map to store the mapping between property name and the name provided by the user
     protected Map<String, String> nameMapping = new HashMap<>();
+    // a map to store the mapping between parameter name and the name provided by the user
+    protected Map<String, String> parameterNameMapping = new HashMap<>();
     // a map to store the rules in OpenAPI Normalizer
     protected Map<String, String> openapiNormalizer = new HashMap<>();
     protected String modelPackage = "", apiPackage = "", fileSuffix;
@@ -1204,6 +1206,11 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public Map<String, String> nameMapping() {
         return nameMapping;
+    }
+
+    @Override
+    public Map<String, String> parameterNameMapping() {
+        return parameterNameMapping;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -72,6 +72,7 @@ public class CodegenConfigurator {
     private Map<String, String> inlineSchemaNameMappings = new HashMap<>();
     private Map<String, String> inlineSchemaOptions = new HashMap<>();
     private Map<String, String> nameMappings = new HashMap<>();
+    private Map<String, String> parameterNameMappings = new HashMap<>();
     private Map<String, String> openapiNormalizer = new HashMap<>();
     private Set<String> languageSpecificPrimitives = new HashSet<>();
     private Map<String, String> reservedWordsMappings = new HashMap<>();
@@ -127,6 +128,9 @@ public class CodegenConfigurator {
             }
             if(generatorSettings.getNameMappings() != null) {
                 configurator.nameMappings.putAll(generatorSettings.getNameMappings());
+            }
+            if(generatorSettings.getParameterNameMappings() != null) {
+                configurator.parameterNameMappings.putAll(generatorSettings.getParameterNameMappings());
             }
             if(generatorSettings.getOpenAPINormalizer() != null) {
                 configurator.openapiNormalizer.putAll(generatorSettings.getOpenAPINormalizer());
@@ -221,6 +225,12 @@ public class CodegenConfigurator {
     public CodegenConfigurator addNameMapping(String key, String value) {
         this.nameMappings.put(key, value);
         generatorSettingsBuilder.withNameMapping(key, value);
+        return this;
+    }
+
+    public CodegenConfigurator addParameterNameMapping(String key, String value) {
+        this.parameterNameMappings.put(key, value);
+        generatorSettingsBuilder.withParameterNameMapping(key, value);
         return this;
     }
 
@@ -405,6 +415,12 @@ public class CodegenConfigurator {
     public CodegenConfigurator setNameMappings(Map<String, String> nameMappings) {
         this.nameMappings = nameMappings;
         generatorSettingsBuilder.withNameMappings(nameMappings);
+        return this;
+    }
+
+    public CodegenConfigurator setParameterNameMappings(Map<String, String> parameterNameMappings) {
+        this.parameterNameMappings = parameterNameMappings;
+        generatorSettingsBuilder.withParameterNameMappings(parameterNameMappings);
         return this;
     }
 
@@ -694,6 +710,7 @@ public class CodegenConfigurator {
         config.inlineSchemaNameMapping().putAll(generatorSettings.getInlineSchemaNameMappings());
         config.inlineSchemaOption().putAll(generatorSettings.getInlineSchemaOptions());
         config.nameMapping().putAll(generatorSettings.getNameMappings());
+        config.parameterNameMapping().putAll(generatorSettings.getParameterNameMappings());
         config.openapiNormalizer().putAll(generatorSettings.getOpenAPINormalizer());
         config.languageSpecificPrimitives().addAll(generatorSettings.getLanguageSpecificPrimitives());
         config.reservedWordsMappings().putAll(generatorSettings.getReservedWordsMappings());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
@@ -133,6 +133,19 @@ public final class CodegenConfiguratorUtils {
         }
     }
 
+    public static void applyParameterNameMappingsKvpList(List<String> parameterNameMappings, CodegenConfigurator configurator) {
+        for (String propString : parameterNameMappings) {
+            applyParameterNameMappingsKvp(propString, configurator);
+        }
+    }
+
+    public static void applyParameterNameMappingsKvp(String parameterNameMappings, CodegenConfigurator configurator) {
+        final Map<String, String> map = createMapFromKeyValuePairs(parameterNameMappings);
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            configurator.addParameterNameMapping(entry.getKey().trim(), entry.getValue().trim());
+        }
+    }
+
     public static void applyOpenAPINormalizerKvpList(List<String> openapiNormalizer, CodegenConfigurator configurator) {
         for (String propString : openapiNormalizer) {
             applyOpenAPINormalizerKvp(propString, configurator);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -858,9 +858,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toParamName(String name) {
-        // obtain the name from nameMapping directly if provided
-        if (nameMapping.containsKey(name)) {
-            return nameMapping.get(name);
+        // obtain the name from paramterNameMapping directly if provided
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
         }
 
         // to avoid conflicts with 'callback' parameter for async call

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -223,9 +223,9 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toParamName(String name) {
-        // obtain the name from nameMapping directly if provided
-        if (nameMapping.containsKey(name)) {
-            return nameMapping.get(name);
+        // obtain the name from parameterNameMapping directly if provided
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
         }
 
         // to avoid conflicts with 'callback' parameter for async call

--- a/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml
@@ -1109,6 +1109,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArrayOfEnums'
+  /fake/parameter-name-mapping:
+    get:
+      tags:
+        - fake
+      summary: parameter name mapping test
+      operationId: getParameterNameMapping
+      parameters:
+        - name: _type
+          in: header 
+          description: _type
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: type
+          in: query
+          description: type
+          required: true
+          schema:
+            type: string
+        - name: type_
+          in: header 
+          description: type_
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
   /values:
     get:
       tags:

--- a/samples/client/petstore/java/okhttp-gson/README.md
+++ b/samples/client/petstore/java/okhttp-gson/README.md
@@ -121,6 +121,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**fakeOuterNumberSerialize**](docs/FakeApi.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 *FakeApi* | [**fakeOuterStringSerialize**](docs/FakeApi.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
 *FakeApi* | [**getArrayOfEnums**](docs/FakeApi.md#getArrayOfEnums) | **GET** /fake/array-of-enums | Array of Enums
+*FakeApi* | [**getParameterNameMapping**](docs/FakeApi.md#getParameterNameMapping) | **GET** /fake/parameter-name-mapping | parameter name mapping test
 *FakeApi* | [**testBodyWithFileSchema**](docs/FakeApi.md#testBodyWithFileSchema) | **PUT** /fake/body-with-file-schema | 
 *FakeApi* | [**testBodyWithQueryParams**](docs/FakeApi.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 *FakeApi* | [**testClientModel**](docs/FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model

--- a/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
@@ -1132,6 +1132,42 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+  /fake/parameter-name-mapping:
+    get:
+      operationId: getParameterNameMapping
+      parameters:
+      - description: _type
+        explode: false
+        in: header
+        name: _type
+        required: true
+        schema:
+          format: int64
+          type: integer
+        style: simple
+      - description: type
+        explode: true
+        in: query
+        name: type
+        required: true
+        schema:
+          type: string
+        style: form
+      - description: type_
+        explode: false
+        in: header
+        name: type_
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          description: OK
+      summary: parameter name mapping test
+      tags:
+      - fake
+      x-accepts: application/json
   /values:
     get:
       description: ""

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -10,6 +10,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**fakeOuterNumberSerialize**](FakeApi.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number |  |
 | [**fakeOuterStringSerialize**](FakeApi.md#fakeOuterStringSerialize) | **POST** /fake/outer/string |  |
 | [**getArrayOfEnums**](FakeApi.md#getArrayOfEnums) | **GET** /fake/array-of-enums | Array of Enums |
+| [**getParameterNameMapping**](FakeApi.md#getParameterNameMapping) | **GET** /fake/parameter-name-mapping | parameter name mapping test |
 | [**testBodyWithFileSchema**](FakeApi.md#testBodyWithFileSchema) | **PUT** /fake/body-with-file-schema |  |
 | [**testBodyWithQueryParams**](FakeApi.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params |  |
 | [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model |
@@ -380,6 +381,69 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | Got named array of enums |  -  |
+
+<a id="getParameterNameMapping"></a>
+# **getParameterNameMapping**
+> getParameterNameMapping(underscoreType, type, typeWithUnderscore)
+
+parameter name mapping test
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Long underscoreType = 56L; // Long | _type
+    String type = "type_example"; // String | type
+    String typeWithUnderscore = "typeWithUnderscore_example"; // String | type_
+    try {
+      apiInstance.getParameterNameMapping(underscoreType, type, typeWithUnderscore);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#getParameterNameMapping");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **underscoreType** | **Long**| _type | |
+| **type** | **String**| type | |
+| **typeWithUnderscore** | **String**| type_ | |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | OK |  -  |
 
 <a id="testBodyWithFileSchema"></a>
 # **testBodyWithFileSchema**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -780,6 +780,153 @@ public class FakeApi {
         return localVarCall;
     }
     /**
+     * Build call for getParameterNameMapping
+     * @param underscoreType _type (required)
+     * @param type type (required)
+     * @param typeWithUnderscore type_ (required)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call getParameterNameMappingCall(Long underscoreType, String type, String typeWithUnderscore, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/fake/parameter-name-mapping";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (type != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("type", type));
+        }
+
+        if (underscoreType != null) {
+            localVarHeaderParams.put("_type", localVarApiClient.parameterToString(underscoreType));
+        }
+
+        if (typeWithUnderscore != null) {
+            localVarHeaderParams.put("type_", localVarApiClient.parameterToString(typeWithUnderscore));
+        }
+
+        final String[] localVarAccepts = {
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call getParameterNameMappingValidateBeforeCall(Long underscoreType, String type, String typeWithUnderscore, final ApiCallback _callback) throws ApiException {
+        // verify the required parameter 'underscoreType' is set
+        if (underscoreType == null) {
+            throw new ApiException("Missing the required parameter 'underscoreType' when calling getParameterNameMapping(Async)");
+        }
+
+        // verify the required parameter 'type' is set
+        if (type == null) {
+            throw new ApiException("Missing the required parameter 'type' when calling getParameterNameMapping(Async)");
+        }
+
+        // verify the required parameter 'typeWithUnderscore' is set
+        if (typeWithUnderscore == null) {
+            throw new ApiException("Missing the required parameter 'typeWithUnderscore' when calling getParameterNameMapping(Async)");
+        }
+
+        return getParameterNameMappingCall(underscoreType, type, typeWithUnderscore, _callback);
+
+    }
+
+    /**
+     * parameter name mapping test
+     * 
+     * @param underscoreType _type (required)
+     * @param type type (required)
+     * @param typeWithUnderscore type_ (required)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public void getParameterNameMapping(Long underscoreType, String type, String typeWithUnderscore) throws ApiException {
+        getParameterNameMappingWithHttpInfo(underscoreType, type, typeWithUnderscore);
+    }
+
+    /**
+     * parameter name mapping test
+     * 
+     * @param underscoreType _type (required)
+     * @param type type (required)
+     * @param typeWithUnderscore type_ (required)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> getParameterNameMappingWithHttpInfo(Long underscoreType, String type, String typeWithUnderscore) throws ApiException {
+        okhttp3.Call localVarCall = getParameterNameMappingValidateBeforeCall(underscoreType, type, typeWithUnderscore, null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     * parameter name mapping test (asynchronously)
+     * 
+     * @param underscoreType _type (required)
+     * @param type type (required)
+     * @param typeWithUnderscore type_ (required)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call getParameterNameMappingAsync(Long underscoreType, String type, String typeWithUnderscore, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = getParameterNameMappingValidateBeforeCall(underscoreType, type, typeWithUnderscore, _callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
+    /**
      * Build call for testBodyWithFileSchema
      * @param fileSchemaTestClass  (required)
      * @param _callback Callback for upload/download progress


### PR DESCRIPTION
- Add parameter name mappings option to allow users map parameter name to whatever they want. (parameter naming can be different than the property naming so that's why we need another option)
- Add tests
- update doc
- update abstract java codegen to use the new option.

FYI @OpenAPITools/generator-core-team 



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @OpenAPITools/generator-core-team 