### PR TITLE
[Julia] Fix julia string type codegen

### DIFF
--- a/modules/openapi-generator/src/main/resources/julia-client/partial_model_single.mustache
+++ b/modules/openapi-generator/src/main/resources/julia-client/partial_model_single.mustache
@@ -3,7 +3,7 @@
 
     {{classname}}(;
 {{#allVars}}
-        {{{name}}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}nothing{{/defaultValue}},
+        {{{name}}}={{#defaultValue}}{{#isString}}{{{defaultValue}}}{{/isString}}{{^isString}}{{{defaultValue}}}{{/isString}}{{/defaultValue}}{{^defaultValue}}nothing{{/defaultValue}},
 {{/allVars}}
     )
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Before: For `String` type with default value, Julia codegen is missing double quotes 
![image](https://github.com/OpenAPITools/openapi-generator/assets/17470335/fb97f46b-102e-44bd-833d-5bf687c98316)
![image](https://github.com/OpenAPITools/openapi-generator/assets/17470335/92397568-50c5-4db9-8059-d3d111cfeeba)

After patch:
![image](https://github.com/OpenAPITools/openapi-generator/assets/17470335/c784b5e2-bdae-4405-8930-ba8973a195ed)

@tanmaykm Hi, is this the correct fix?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
