### PR TITLE
Fix parsing of Accept header like '*/*;q=0.8'

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -183,6 +183,9 @@ class Controller extends AbstractController
         // Figure out what the client accepts
         $accept = preg_split("/[\s,]+/", $accept);
 
+        // Remove q-factor weighting. E.g. "application/json;q=0.8" becomes "application/json"
+        $accept = array_map(function ($type) {return explode(';', $type)[0];}, $accept);
+
         if (in_array('*/*', $accept) || in_array('application/*', $accept)) {
             // Prefer JSON if the client has no preference
             if (in_array('application/json', $produced)) {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -193,6 +193,9 @@ class Controller extends AbstractController
         // Figure out what the client accepts
         $accept = preg_split("/[\s,]+/", $accept);
 
+        // Remove q-factor weighting. E.g. "application/json;q=0.8" becomes "application/json"
+        $accept = array_map(function ($type) {return explode(';', $type)[0];}, $accept);
+
         if (in_array('*/*', $accept) || in_array('application/*', $accept)) {
             // Prefer JSON if the client has no preference
             if (in_array('application/json', $produced)) {


### PR DESCRIPTION
This fixes #15043

The issue is that browsers like "text/html,...,*/*;q=0.8" (see for instance https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values )

Without this commit we end up with an array of accepted type like `("text/html", "*/*;q=0.8)` so when we then check if the array contains `*/*` the check fails, and we return a 406 even though the client is able to get the response.

This commit fixes it by removing the `;q=0.8` part.

(Ideally we should not just discard that part, we should extract that
 value, and order by it. See
 https://developer.mozilla.org/en-US/docs/Glossary/Quality_values for
 more info about that. However this could be done in a subsequent PR:
 this already fixes the 406 error, which is pretty blocking)

To test this patch I:

* created an openapi generator file which defines a route like

```
/myRoute:
    get:
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema: ...
```

* create a symfony app with the generated code. The app could just return eg an empty json object for that endpoint
* query this route with either firefox or chrom

Expected behavior: the browser gets a 200 response
Actual behavior: without this commit we get a 406 error. With this commit we get a 200 response


Ping @jebentier, @dkarlovi, @mandrean , @jfastnacht, @ybelenko, @renepardon

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
