### PR TITLE
chore: remove <any> from enum declaration

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
@@ -59,7 +59,7 @@ export namespace {{classname}} {
     export enum {{enumName}} {
         {{#allowableValues}}
         {{#enumVars}}
-        {{name}} = <any> {{{value}}}{{^-last}},{{/-last}}
+        {{name}} = {{{value}}}{{^-last}},{{/-last}}
         {{/enumVars}}
         {{/allowableValues}}
     }
@@ -72,7 +72,7 @@ export namespace {{classname}} {
 export enum {{classname}} {
     {{#allowableValues}}
     {{#enumVars}}
-    {{name}} = <any> {{{value}}}{{^-last}},{{/-last}}
+    {{name}} = {{{value}}}{{^-last}},{{/-last}}
     {{/enumVars}}
     {{/allowableValues}}
 }


### PR DESCRIPTION
Hi there!

Currently the enum values generated through the `typescript-node` generator are typed as <any>. They get outputted like so:

```typescript
export enum TestEnum {
    Something = <any> 'something'
}
```

But there seems to be no apparent reason as to why <any> is being used. Note that the last change to this line was 5 years ago, so there might have been a perfectly understandable reason why this was put in there at the time

However, with modern Typescript this leads to issues, as it isn't able to infer the enum value. For example, the following code leads to issues:

```typescript
export enum TestEnum {
    Something = <any> 'something'
}

const foo = 'something'

foo === TestEnum.Something 
```

Attached below is an illustration of what is going on:

![Screenshot 2023-07-24 at 10 51 20](https://github.com/OpenAPITools/openapi-generator/assets/10176709/6805f589-718c-4058-a79b-fb1d87ff45c7)


When the <any> typing is removed, the enum gets processed correctly and string/enum comparison works as expected.

![Screenshot 2023-07-24 at 10 53 51](https://github.com/OpenAPITools/openapi-generator/assets/10176709/f3c33700-affa-4a4f-bf79-65cc4e709a71)

Let me know if I'm missing something here. Please note that other typescript generators that I've checked don't have the <any> type in place. (typescript-axios for example)

