### PR TITLE
[ruby] Add tests to operation servers in ruby client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ commands: # a reusable command with parameters
       - run:
           command: |
             sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       path1.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       path2.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.111     path3.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       operation1.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       operation2.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.111     operation3.test.openapi-generator.tech"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,15 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |
-            #sudo tee -a /etc/hosts \<<< "127.0.0.1       path1.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.1       path2.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.111     path3.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.1       operation1.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.1       operation2.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.111     operation3.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.1       server1.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.1       server2.test.openapi-generator.tech"
-            #sudo tee -a /etc/hosts \<<< "127.0.0.111     server3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       path.v1.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       path.v2.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.111     path.v3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation.v1.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation.v2.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.111     operation.v3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       server.v1.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       server.v2.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.111     server.v3.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
             cat /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,12 @@ commands: # a reusable command with parameters
       - run:
           command: |-
             printf '127.0.0.1       petstore.swagger.io
+                    127.0.0.1   operation1.test.openapi-generator.tech
+                    127.0.0.1   operation2.test.openapi-generator.tech
+                    127.0.0.111 operation3.test.openapi-generator.tech
+                    127.0.0.1   server1.test.openapi-generator.tech
+                    127.0.0.1   server2.test.openapi-generator.tech
+                    127.0.0.111 server3.test.openapi-generator.tech
             ' | sudo tee -a /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,15 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       path1.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       path2.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.111     path3.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation1.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation2.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.111     operation3.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       server1.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       server2.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.111     server3.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.1       path1.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.1       path2.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.111     path3.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.1       operation1.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.1       operation2.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.111     operation3.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.1       server1.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.1       server2.test.openapi-generator.tech"
+            #sudo tee -a /etc/hosts \<<< "127.0.0.111     server3.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
             cat /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       path1.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       path2.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.111     path3.test.openapi-generator.tech"
@@ -49,6 +48,7 @@ commands: # a reusable command with parameters
             sudo tee -a /etc/hosts \<<< "127.0.0.1       server1.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       server2.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.111     server3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
             cat /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ commands: # a reusable command with parameters
             sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       operation1.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       operation2.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.111     operation3.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       server1.test.openapi-generator.tech"
             sudo tee -a /etc/hosts \<<< "127.0.0.1       server2.test.openapi-generator.tech"
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       server3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.111     server3.test.openapi-generator.tech"
             cat /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,13 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |
-            #printf "127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech
-            sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation1.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation2.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       operation3.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       server1.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       server2.test.openapi-generator.tech"
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       server3.test.openapi-generator.tech"
             cat /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,14 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |-
-            printf '127.0.0.1       petstore.swagger.io
-                    127.0.0.1   operation1.test.openapi-generator.tech
-                    127.0.0.1   operation2.test.openapi-generator.tech
-                    127.0.0.111 operation3.test.openapi-generator.tech
-                    127.0.0.1   server1.test.openapi-generator.tech
-                    127.0.0.1   server2.test.openapi-generator.tech
-                    127.0.0.111 server3.test.openapi-generator.tech
+            printf '
+127.0.0.1       petstore.swagger.io
+127.0.0.1   operation1.test.openapi-generator.tech
+127.0.0.1   operation2.test.openapi-generator.tech
+127.0.0.111 operation3.test.openapi-generator.tech
+127.0.0.1   server1.test.openapi-generator.tech
+127.0.0.1   server2.test.openapi-generator.tech
+127.0.0.111 server3.test.openapi-generator.tech
             ' | sudo tee -a /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,14 +39,7 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |-
-            printf '
-127.0.0.1       petstore.swagger.io
-127.0.0.1   operation1.test.openapi-generator.tech
-127.0.0.1   operation2.test.openapi-generator.tech
-127.0.0.111 operation3.test.openapi-generator.tech
-127.0.0.1   server1.test.openapi-generator.tech
-127.0.0.1   server2.test.openapi-generator.tech
-127.0.0.111 server3.test.openapi-generator.tech
+            printf '127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech
             ' | sudo tee -a /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,10 @@ commands: # a reusable command with parameters
       - run:
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
-          command: |-
-            printf "127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech
-            " | sudo tee -a /etc/hosts
+          command: |
+            #printf "127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech
+            sudo tee -a /etc/hosts \<<< "127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech"
+            cat /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
       - run: docker pull swaggerapi/petstore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ commands: # a reusable command with parameters
           command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
       - run:
           command: |-
-            printf '127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech
-            ' | sudo tee -a /etc/hosts
+            printf "127.0.0.1       petstore.swagger.io\n127.0.0.1   operation1.test.openapi-generator.tech\n127.0.0.1   operation2.test.openapi-generator.tech\n127.0.0.111 operation3.test.openapi-generator.tech\n127.0.0.1   server1.test.openapi-generator.tech\n127.0.0.1   server2.test.openapi-generator.tech\n127.0.0.111 server3.test.openapi-generator.tech
+            " | sudo tee -a /etc/hosts
       #    - run: docker pull openapitools/openapi-petstore
       #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
       - run: docker pull swaggerapi/petstore

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_anyof_module.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_anyof_module.mustache
@@ -81,7 +81,7 @@
               # raise if data contains keys that are not known to the model
               raise unless (data.keys - const.acceptable_attributes).empty?
               model = const.build_from_hash(data)
-              return model if model && model.valid?
+              return model if model
             end
           end
         end

--- a/modules/openapi-generator/src/test/resources/3_0/ruby/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/ruby/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -189,7 +189,7 @@ paths:
   '/pet/{petId}':
     servers:
     - url: 'http://petstore.swagger.io/v2'
-    - url: 'http://path-server-test.petstore.local/'
+    - url: 'http://path-server-test.petstore.local/v2'
     - url: 'http://{server}.swagger.io:{port}/v2'
       description: test server with variables
       variables:

--- a/modules/openapi-generator/src/test/resources/3_0/ruby/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/ruby/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -48,6 +48,15 @@ paths:
             - 80
             - 8080
           default: 80
+    - url: 'http://path.{version}.test.openapi-generator.tech/v2'
+      description: test server with variables
+      variables:
+        version:
+          description: target server
+          enum:
+            - 'v1'
+            - 'v2'
+          default: 'v2'
     post:
       tags:
         - pet
@@ -178,6 +187,33 @@ paths:
             - 'read:pets'
       deprecated: true
   '/pet/{petId}':
+    servers:
+    - url: 'http://petstore.swagger.io/v2'
+    - url: 'http://path-server-test.petstore.local/'
+    - url: 'http://{server}.swagger.io:{port}/v2'
+      description: test server with variables
+      variables:
+        server:
+          description: target server
+          enum:
+            - 'petstore'
+            - 'qa-petstore'
+            - 'dev-petstore'
+          default: 'petstore'
+        port:
+          enum:
+            - 80
+            - 8080
+          default: 80
+    - url: 'http://path.{version}.test.openapi-generator.tech/v2'
+      description: test server with variables
+      variables:
+        version:
+          description: target server
+          enum:
+            - 'v1'
+            - 'v2'
+          default: 'v2'
     get:
       tags:
         - pet
@@ -1256,6 +1292,15 @@ servers:
         default: 'v2'
   - url: https://127.0.0.1/no_varaible
     description: The local server without variables
+  - url: http://server.{version}.openapi-generator.tech
+    description: The openapi-generator test server
+    variables:
+      version:
+        description: target server
+        enum:
+          - 'v1'
+          - 'v2'
+        default: 'v2'
 components:
   requestBodies:
     UserArray:

--- a/pom.xml
+++ b/pom.xml
@@ -1192,8 +1192,8 @@
                 </property>
             </activation>
             <modules>
-                <module>samples/client/petstore/ruby-faraday</module>
                 <module>samples/client/petstore/ruby</module>
+                <module>samples/client/petstore/ruby-faraday</module>
                 <module>samples/client/petstore/ruby-autoload</module>
             </modules>
         </profile>

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -316,6 +316,20 @@ module Petstore
         {
           url: "https://127.0.0.1/no_varaible",
           description: "The local server without variables",
+        },
+        {
+          url: "http://server.{version}.openapi-generator.tech",
+          description: "The openapi-generator test server",
+          variables: {
+            version: {
+                description: "target server",
+                default_value: "v2",
+                enum_values: [
+                  "v1",
+                  "v2"
+                ]
+              }
+            }
         }
       ]
     end
@@ -353,6 +367,114 @@ module Petstore
                 ]
               }
             }
+          },
+          {
+          url: "http://path.{version}.test.openapi-generator.tech/v2",
+          description: "test server with variables",
+          variables: {
+            version: {
+                description: "target server",
+                default_value: "v2",
+                enum_values: [
+                  "v1",
+                  "v2"
+                ]
+              }
+            }
+          }
+        ],
+        "PetApi.delete_pet": [
+          {
+          url: "http://petstore.swagger.io/v2",
+          description: "No description provided",
+          },
+          {
+          url: "http://path-server-test.petstore.local/v2",
+          description: "No description provided",
+          },
+          {
+          url: "http://{server}.swagger.io:{port}/v2",
+          description: "test server with variables",
+          variables: {
+            server: {
+                description: "target server",
+                default_value: "petstore",
+                enum_values: [
+                  "petstore",
+                  "qa-petstore",
+                  "dev-petstore"
+                ]
+              },
+            port: {
+                description: "No description provided",
+                default_value: "80",
+                enum_values: [
+                  "80",
+                  "8080"
+                ]
+              }
+            }
+          },
+          {
+          url: "http://path.{version}.test.openapi-generator.tech/v2",
+          description: "test server with variables",
+          variables: {
+            version: {
+                description: "target server",
+                default_value: "v2",
+                enum_values: [
+                  "v1",
+                  "v2"
+                ]
+              }
+            }
+          }
+        ],
+        "PetApi.get_pet_by_id": [
+          {
+          url: "http://petstore.swagger.io/v2",
+          description: "No description provided",
+          },
+          {
+          url: "http://path-server-test.petstore.local/v2",
+          description: "No description provided",
+          },
+          {
+          url: "http://{server}.swagger.io:{port}/v2",
+          description: "test server with variables",
+          variables: {
+            server: {
+                description: "target server",
+                default_value: "petstore",
+                enum_values: [
+                  "petstore",
+                  "qa-petstore",
+                  "dev-petstore"
+                ]
+              },
+            port: {
+                description: "No description provided",
+                default_value: "80",
+                enum_values: [
+                  "80",
+                  "8080"
+                ]
+              }
+            }
+          },
+          {
+          url: "http://path.{version}.test.openapi-generator.tech/v2",
+          description: "test server with variables",
+          variables: {
+            version: {
+                description: "target server",
+                default_value: "v2",
+                enum_values: [
+                  "v1",
+                  "v2"
+                ]
+              }
+            }
           }
         ],
         "PetApi.update_pet": [
@@ -383,6 +505,67 @@ module Petstore
                 enum_values: [
                   "80",
                   "8080"
+                ]
+              }
+            }
+          },
+          {
+          url: "http://path.{version}.test.openapi-generator.tech/v2",
+          description: "test server with variables",
+          variables: {
+            version: {
+                description: "target server",
+                default_value: "v2",
+                enum_values: [
+                  "v1",
+                  "v2"
+                ]
+              }
+            }
+          }
+        ],
+        "PetApi.update_pet_with_form": [
+          {
+          url: "http://petstore.swagger.io/v2",
+          description: "No description provided",
+          },
+          {
+          url: "http://path-server-test.petstore.local/v2",
+          description: "No description provided",
+          },
+          {
+          url: "http://{server}.swagger.io:{port}/v2",
+          description: "test server with variables",
+          variables: {
+            server: {
+                description: "target server",
+                default_value: "petstore",
+                enum_values: [
+                  "petstore",
+                  "qa-petstore",
+                  "dev-petstore"
+                ]
+              },
+            port: {
+                description: "No description provided",
+                default_value: "80",
+                enum_values: [
+                  "80",
+                  "8080"
+                ]
+              }
+            }
+          },
+          {
+          url: "http://path.{version}.test.openapi-generator.tech/v2",
+          description: "test server with variables",
+          variables: {
+            version: {
+                description: "target server",
+                default_value: "v2",
+                enum_values: [
+                  "v1",
+                  "v2"
                 ]
               }
             }

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -389,7 +389,7 @@ module Petstore
           description: "No description provided",
           },
           {
-          url: "http://path-server-test.petstore.local/",
+          url: "http://path-server-test.petstore.local/v2",
           description: "No description provided",
           },
           {
@@ -436,7 +436,7 @@ module Petstore
           description: "No description provided",
           },
           {
-          url: "http://path-server-test.petstore.local/",
+          url: "http://path-server-test.petstore.local/v2",
           description: "No description provided",
           },
           {
@@ -530,7 +530,7 @@ module Petstore
           description: "No description provided",
           },
           {
-          url: "http://path-server-test.petstore.local/",
+          url: "http://path-server-test.petstore.local/v2",
           description: "No description provided",
           },
           {

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -389,7 +389,7 @@ module Petstore
           description: "No description provided",
           },
           {
-          url: "http://path-server-test.petstore.local/v2",
+          url: "http://path-server-test.petstore.local/",
           description: "No description provided",
           },
           {
@@ -436,7 +436,7 @@ module Petstore
           description: "No description provided",
           },
           {
-          url: "http://path-server-test.petstore.local/v2",
+          url: "http://path-server-test.petstore.local/",
           description: "No description provided",
           },
           {
@@ -530,7 +530,7 @@ module Petstore
           description: "No description provided",
           },
           {
-          url: "http://path-server-test.petstore.local/v2",
+          url: "http://path-server-test.petstore.local/",
           description: "No description provided",
           },
           {

--- a/samples/client/petstore/ruby/lib/petstore/models/mammal_anyof.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mammal_anyof.rb
@@ -89,7 +89,7 @@ module Petstore
               # raise if data contains keys that are not known to the model
               raise unless (data.keys - const.acceptable_attributes).empty?
               model = const.build_from_hash(data)
-              return model if model && model.valid?
+              return model if model
             end
           end
         end

--- a/samples/client/petstore/ruby/spec/custom/configuration_spec.rb
+++ b/samples/client/petstore/ruby/spec/custom/configuration_spec.rb
@@ -61,7 +61,7 @@ describe Petstore::Configuration do
       }
       expect {
         config.base_url(:'PetApi.add_pet')
-      }.to raise_error(ArgumentError, 'Invalid index 10 when selecting the server. Must not be nil and must be less than 3')
+      }.to raise_error(ArgumentError, 'Invalid index 10 when selecting the server. Must not be nil and must be less than 4')
     end
 
     it 'should remove trailing slashes' do

--- a/samples/client/petstore/ruby/spec/custom/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/custom/pet_spec.rb
@@ -60,6 +60,49 @@ describe "Pet" do
       expect(pet.category.name).to eq("category test")
     end
 
+    it "should fetch a pet object using invalid operation path" do
+      # backup index
+      index_backup = @pet_api.api_client.config.server_operation_index
+      expect(index_backup).to eq({})
+      # test operation index 1 (invalid path)
+      @pet_api.api_client.config.server_operation_index = {
+        :'PetApi.get_pet_by_id' => 1
+      }
+
+      expect(@pet_api.api_client.config.base_url(:'PetApi.get_pet_by_id')).to eq('http://path-server-test.petstore.local/v2')
+
+      expect {
+        pet = @pet_api.get_pet_by_id(@pet_id)
+      }.to raise_error(Petstore::ApiError) # path-server-test.petstore.local is invalid (not defined in host table)
+
+      # restore index
+      @pet_api.api_client.config.server_operation_index = index_backup
+      expect(@pet_api.api_client.config.server_operation_index).to eq({})
+    end
+
+    it "should fetch a pet object using operation path" do
+      # backup index
+      index_backup = @pet_api.api_client.config.server_operation_index
+      expect(index_backup).to eq({})
+      # test operation index 3
+      @pet_api.api_client.config.server_operation_index = {
+        :'PetApi.get_pet_by_id' => 3
+      }
+
+      expect(@pet_api.api_client.config.base_url(:'PetApi.get_pet_by_id')).to eq('http://path.v2.test.openapi-generator.tech/v2')
+
+      pet = @pet_api.get_pet_by_id(@pet_id)
+      expect(pet).to be_a(Petstore::Pet)
+      expect(pet.id).to eq(@pet_id)
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+      expect(pet.tags[0].name).to eq("tag test")
+      expect(pet.category.name).to eq("category test")
+      # restore index
+      @pet_api.api_client.config.server_operation_index = index_backup
+      expect(@pet_api.api_client.config.server_operation_index).to eq({})
+      expect(@pet_api.api_client.config.base_url(:'PetApi.get_pet_by_id')).to eq('http://petstore.swagger.io/v2')
+    end
+
     it "should fetch a pet object with http info" do
       pet, status_code, headers = @pet_api.get_pet_by_id_with_http_info(@pet_id)
       expect(status_code).to eq(200)


### PR DESCRIPTION
- Add tests to operation servers in ruby client
- remove `valid?` (deprecated) from anyof model template

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
