### PR TITLE
Add mapping option to Ada client/server codegen

### DIFF
--- a/bin/configs/ada.yaml
+++ b/bin/configs/ada.yaml
@@ -1,0 +1,15 @@
+generatorName: ada
+outputDir: samples/client/petstore/ada
+inputSpec: modules/openapi-generator/src/test/resources/3_0/ada/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/Ada
+nameMappings:
+  _type: P_UnderscoreType
+  type_: P_TypeWithUnderscore
+  http_debug_operation: P_HTTPDebugOperation
+parameterNameMappings:
+  _type: UnderscoreType
+  type_: TypeWithUnderscore
+  http_debug_operation: HttpDebugOperation 
+additionalProperties:
+  modelPackage: Samples.Petstore
+  projectName: Petstore

--- a/bin/configs/unmaintained/ada.yaml
+++ b/bin/configs/unmaintained/ada.yaml
@@ -1,7 +1,0 @@
-generatorName: ada
-outputDir: samples/client/petstore/ada
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
-templateDir: modules/openapi-generator/src/main/resources/Ada
-additionalProperties:
-  modelPackage: Samples.Petstore
-  projectName: Petstore

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
@@ -364,11 +364,21 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toVarName(String name) {
+        // obtain the name from nameMapping directly if provided
+        if (nameMapping.containsKey(name)) {
+            return nameMapping.get(name);
+        }
+
         return toAdaIdentifier(sanitizeName(name), "P_");
     }
 
     @Override
     public String toParamName(String name) {
+        // obtain the name from parameterNameMapping directly if provided
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
+        }
+
         return toAdaIdentifier(super.toParamName(name), "P_");
     }
 
@@ -833,7 +843,6 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public ModelsMap postProcessModels(ModelsMap objs) {
-
         // This is run first, before the operations.
         // remove model imports to avoid error
         List<Map<String, String>> imports = objs.getImports();

--- a/modules/openapi-generator/src/test/resources/3_0/ada/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/ada/petstore.yaml
@@ -1,0 +1,786 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server. For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      externalDocs:
+        url: "http://petstore.swagger.io/v2/doc/updatePet"
+        description: "API documentation for the updatePet operation"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          style: form
+          explode: false
+          deprecated: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'read:pets'
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: >-
+        Multiple tags can be provided with comma separated strings. Use tag1,
+        tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - 'read:pets'
+      deprecated: true
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  '/pet/{petId}/uploadImage':
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+                file:
+                  description: file to upload
+                  type: string
+                  format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ''
+      operationId: placeOrder
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+        description: order placed for purchasing the pet
+        required: true
+  '/store/order/{orderId}':
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: >-
+        For valid response try integer IDs with value <= 5 or > 10. Other values
+        will generate exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 5
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: >-
+        For valid response try integer IDs with value < 1000. Anything above
+        1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            Set-Cookie:
+              description: >-
+                Cookie authentication key for use with the `api_key`
+                apiKey authentication.
+              schema:
+                type: string
+                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+  '/user/{username}':
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid user supplied
+        '404':
+          description: User not found
+      security:
+        - api_key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      security:
+        - api_key: []
+  /fake/parameter-name-mapping:
+    get:
+      tags:
+        - fake
+      summary: parameter name mapping test
+      operationId: getParameterNameMapping
+      parameters:
+        - name: _type
+          in: header 
+          description: _type
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: type
+          in: query
+          description: type
+          required: true
+          schema:
+            type: string
+        - name: type_
+          in: header 
+          description: type_
+          required: true
+          schema:
+            type: string
+        - name: http_debug_option
+          in: query
+          description: http debug option (to test parameter naming option)
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  requestBodies:
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+      required: true
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'http://petstore.swagger.io/api/oauth/dialog'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      title: Pet Order
+      description: An order for a pets from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      title: Pet category
+      description: A category for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+      xml:
+        name: Category
+    User:
+      title: a User
+      description: A User who is purchasing from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      title: Pet Tag
+      description: A tag for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          deprecated: true
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      title: An uploaded response
+      description: Describes the result of uploading an image resource
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    PropertyNameMapping:
+      properties: 
+        http_debug_operation: 
+          type: string
+        _type:
+          type: string
+        type:
+          type: string
+        type_:
+          type: string

--- a/samples/client/petstore/ada/src/client/samples-petstore-clients.adb
+++ b/samples/client/petstore/ada/src/client/samples-petstore-clients.adb
@@ -26,18 +26,39 @@ package body Samples.Petstore.Clients is
      1 => Mime_1'Access   );
 
 
+   --  parameter name mapping test
+   procedure Get_Parameter_Name_Mapping
+      (Client : in out Client_Type;
+       UnderscoreType : in Swagger.Long;
+       P_Type : in Swagger.UString;
+       TypeWithUnderscore : in Swagger.UString;
+       Http_Debug_Option : in Swagger.UString) is
+      URI   : Swagger.Clients.URI_Type;
+   begin
+
+
+      URI.Add_Param ("type", P_Type);
+      URI.Add_Param ("http_debug_option", Http_Debug_Option);
+      URI.Set_Path ("/fake/parameter-name-mapping");
+      Client.Call (Swagger.Clients.GET, URI);
+   end Get_Parameter_Name_Mapping;
+
    --  Add a new pet to the store
    procedure Add_Pet
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.Pet_Type) is
+       Pet_Type : in Samples.Petstore.Models.Pet_Type;
+       Result : out Samples.Petstore.Models.Pet_Type) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
+      Reply : Swagger.Value_Type;
    begin
+      Client.Set_Accept (Media_List_1);
       Client.Initialize (Req, Media_List_1);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", Pet_Type);
 
       URI.Set_Path ("/pet");
-      Client.Call (Swagger.Clients.POST, URI, Req);
+      Client.Call (Swagger.Clients.POST, URI, Req, Reply);
+      Samples.Petstore.Models.Deserialize (Reply, "", Result);
    end Add_Pet;
 
    --  Deletes a pet
@@ -111,15 +132,19 @@ package body Samples.Petstore.Clients is
    --  Update an existing pet
    procedure Update_Pet
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.Pet_Type) is
+       Pet_Type : in Samples.Petstore.Models.Pet_Type;
+       Result : out Samples.Petstore.Models.Pet_Type) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
+      Reply : Swagger.Value_Type;
    begin
+      Client.Set_Accept (Media_List_1);
       Client.Initialize (Req, Media_List_1);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", Pet_Type);
 
       URI.Set_Path ("/pet");
-      Client.Call (Swagger.Clients.PUT, URI, Req);
+      Client.Call (Swagger.Clients.PUT, URI, Req, Reply);
+      Samples.Petstore.Models.Deserialize (Reply, "", Result);
    end Update_Pet;
 
    --  Updates a pet in the store with form data
@@ -156,7 +181,7 @@ package body Samples.Petstore.Clients is
 
       Client.Initialize (Req, Media_List_4);
       Req.Stream.Write_Entity ("additionalMetadata", Additional_Metadata);
---      Req.Stream.Write_Entity ("file", File);
+      Req.Stream.Write_Entity ("file", File);
 
       URI.Set_Path ("/pet/{petId}/uploadImage");
       URI.Set_Path_Param ("petId", Swagger.To_String (Pet_Id));
@@ -215,15 +240,15 @@ package body Samples.Petstore.Clients is
    --  Place an order for a pet
    procedure Place_Order
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.Order_Type;
+       Order_Type : in Samples.Petstore.Models.Order_Type;
        Result : out Samples.Petstore.Models.Order_Type) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
       Reply : Swagger.Value_Type;
    begin
       Client.Set_Accept (Media_List_1);
-      Client.Initialize (Req);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Client.Initialize (Req, Media_List_2);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", Order_Type);
 
       URI.Set_Path ("/store/order");
       Client.Call (Swagger.Clients.POST, URI, Req, Reply);
@@ -234,12 +259,12 @@ package body Samples.Petstore.Clients is
    --  This can only be done by the logged in user.
    procedure Create_User
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.User_Type) is
+       User_Type : in Samples.Petstore.Models.User_Type) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
    begin
-      Client.Initialize (Req);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Client.Initialize (Req, Media_List_2);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", User_Type);
 
       URI.Set_Path ("/user");
       Client.Call (Swagger.Clients.POST, URI, Req);
@@ -248,12 +273,12 @@ package body Samples.Petstore.Clients is
    --  Creates list of users with given input array
    procedure Create_Users_With_Array_Input
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.User_Type_Vectors.Vector) is
+       User : in Samples.Petstore.Models.User_Type_Vectors.Vector) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
    begin
-      Client.Initialize (Req);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Client.Initialize (Req, Media_List_2);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", User);
 
       URI.Set_Path ("/user/createWithArray");
       Client.Call (Swagger.Clients.POST, URI, Req);
@@ -262,12 +287,12 @@ package body Samples.Petstore.Clients is
    --  Creates list of users with given input array
    procedure Create_Users_With_List_Input
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.User_Type_Vectors.Vector) is
+       User : in Samples.Petstore.Models.User_Type_Vectors.Vector) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
    begin
-      Client.Initialize (Req);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Client.Initialize (Req, Media_List_2);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", User);
 
       URI.Set_Path ("/user/createWithList");
       Client.Call (Swagger.Clients.POST, URI, Req);
@@ -339,12 +364,12 @@ package body Samples.Petstore.Clients is
    procedure Update_User
       (Client : in out Client_Type;
        Username : in Swagger.UString;
-       P_Body : in Samples.Petstore.Models.User_Type) is
+       User_Type : in Samples.Petstore.Models.User_Type) is
       URI   : Swagger.Clients.URI_Type;
       Req   : Swagger.Clients.Request_Type;
    begin
-      Client.Initialize (Req);
-      Samples.Petstore.Models.Serialize (Req.Stream, "", P_Body);
+      Client.Initialize (Req, Media_List_2);
+      Samples.Petstore.Models.Serialize (Req.Stream, "", User_Type);
 
       URI.Set_Path ("/user/{username}");
       URI.Set_Path_Param ("username", Username);

--- a/samples/client/petstore/ada/src/client/samples-petstore-clients.ads
+++ b/samples/client/petstore/ada/src/client/samples-petstore-clients.ads
@@ -15,10 +15,19 @@ package Samples.Petstore.Clients is
 
    type Client_Type is new Swagger.Clients.Client_Type with null record;
 
+   --  parameter name mapping test
+   procedure Get_Parameter_Name_Mapping
+      (Client : in out Client_Type;
+       UnderscoreType : in Swagger.Long;
+       P_Type : in Swagger.UString;
+       TypeWithUnderscore : in Swagger.UString;
+       Http_Debug_Option : in Swagger.UString);
+
    --  Add a new pet to the store
    procedure Add_Pet
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.Pet_Type);
+       Pet_Type : in Samples.Petstore.Models.Pet_Type;
+       Result : out Samples.Petstore.Models.Pet_Type);
 
    --  Deletes a pet
    procedure Delete_Pet
@@ -50,7 +59,8 @@ package Samples.Petstore.Clients is
    --  Update an existing pet
    procedure Update_Pet
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.Pet_Type);
+       Pet_Type : in Samples.Petstore.Models.Pet_Type;
+       Result : out Samples.Petstore.Models.Pet_Type);
 
    --  Updates a pet in the store with form data
    procedure Update_Pet_With_Form
@@ -89,24 +99,24 @@ package Samples.Petstore.Clients is
    --  Place an order for a pet
    procedure Place_Order
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.Order_Type;
+       Order_Type : in Samples.Petstore.Models.Order_Type;
        Result : out Samples.Petstore.Models.Order_Type);
 
    --  Create user
    --  This can only be done by the logged in user.
    procedure Create_User
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.User_Type);
+       User_Type : in Samples.Petstore.Models.User_Type);
 
    --  Creates list of users with given input array
    procedure Create_Users_With_Array_Input
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.User_Type_Vectors.Vector);
+       User : in Samples.Petstore.Models.User_Type_Vectors.Vector);
 
    --  Creates list of users with given input array
    procedure Create_Users_With_List_Input
       (Client : in out Client_Type;
-       P_Body : in Samples.Petstore.Models.User_Type_Vectors.Vector);
+       User : in Samples.Petstore.Models.User_Type_Vectors.Vector);
 
    --  Delete user
    --  This can only be done by the logged in user.
@@ -136,6 +146,6 @@ package Samples.Petstore.Clients is
    procedure Update_User
       (Client : in out Client_Type;
        Username : in Swagger.UString;
-       P_Body : in Samples.Petstore.Models.User_Type);
+       User_Type : in Samples.Petstore.Models.User_Type);
 
 end Samples.Petstore.Clients;

--- a/samples/client/petstore/ada/src/model/samples-petstore-models.adb
+++ b/samples/client/petstore/ada/src/model/samples-petstore-models.adb
@@ -184,6 +184,63 @@ package body Samples.Petstore.Models is
 
    procedure Serialize (Into  : in out Swagger.Streams.Output_Stream'Class;
                         Name  : in String;
+                        Value : in Samples.Petstore.Models.PropertyNameMapping_Type) is
+   begin
+      Into.Start_Entity (Name);
+      if not Value.P_HTTPDebugOperation.Is_Null then
+         Into.Write_Entity ("http_debug_operation", Value.P_HTTPDebugOperation);
+      end if;
+      if not Value.P_UnderscoreType.Is_Null then
+         Into.Write_Entity ("_type", Value.P_UnderscoreType);
+      end if;
+      if not Value.P_Type.Is_Null then
+         Into.Write_Entity ("type", Value.P_Type);
+      end if;
+      if not Value.P_TypeWithUnderscore.Is_Null then
+         Into.Write_Entity ("type_", Value.P_TypeWithUnderscore);
+      end if;
+      Into.End_Entity (Name);
+   end Serialize;
+
+   procedure Serialize (Into  : in out Swagger.Streams.Output_Stream'Class;
+                        Name  : in String;
+                        Value : in PropertyNameMapping_Type_Vectors.Vector) is
+   begin
+      Into.Start_Array (Name);
+      for Item of Value loop
+         Serialize (Into, "", Item);
+      end loop;
+      Into.End_Array (Name);
+   end Serialize;
+
+   procedure Deserialize (From  : in Swagger.Value_Type;
+                          Name  : in String;
+                          Value : out Samples.Petstore.Models.PropertyNameMapping_Type) is
+      Object : Swagger.Value_Type;
+   begin
+      Swagger.Streams.Deserialize (From, Name, Object);
+      Swagger.Streams.Deserialize (Object, "http_debug_operation", Value.P_HTTPDebugOperation);
+      Swagger.Streams.Deserialize (Object, "_type", Value.P_UnderscoreType);
+      Swagger.Streams.Deserialize (Object, "type", Value.P_Type);
+      Swagger.Streams.Deserialize (Object, "type_", Value.P_TypeWithUnderscore);
+   end Deserialize;
+
+   procedure Deserialize (From  : in Swagger.Value_Type;
+                          Name  : in String;
+                          Value : in out PropertyNameMapping_Type_Vectors.Vector) is
+      List : Swagger.Value_Array_Type;
+      Item : Samples.Petstore.Models.PropertyNameMapping_Type;
+   begin
+      Value.Clear;
+      Swagger.Streams.Deserialize (From, Name, List);
+      for Data of List loop
+         Deserialize (Data, "", Item);
+         Value.Append (Item);
+      end loop;
+   end Deserialize;
+
+   procedure Serialize (Into  : in out Swagger.Streams.Output_Stream'Class;
+                        Name  : in String;
                         Value : in Samples.Petstore.Models.Tag_Type) is
    begin
       Into.Start_Entity (Name);

--- a/samples/client/petstore/ada/src/model/samples-petstore-models.ads
+++ b/samples/client/petstore/ada/src/model/samples-petstore-models.ads
@@ -106,6 +106,34 @@ package Samples.Petstore.Models is
                           Value : in out Order_Type_Vectors.Vector);
 
 
+
+   type PropertyNameMapping_Type is
+     record
+       P_HTTPDebugOperation : Swagger.Nullable_UString;
+       P_UnderscoreType : Swagger.Nullable_UString;
+       P_Type : Swagger.Nullable_UString;
+       P_TypeWithUnderscore : Swagger.Nullable_UString;
+     end record;
+
+
+   package PropertyNameMapping_Type_Vectors is
+      new Ada.Containers.Vectors (Index_Type   => Positive,
+                                  Element_Type => Samples.Petstore.Models.PropertyNameMapping_Type);
+
+   procedure Serialize (Into  : in out Swagger.Streams.Output_Stream'Class;
+                        Name  : in String;
+                        Value : in Samples.Petstore.Models.PropertyNameMapping_Type);
+   procedure Serialize (Into  : in out Swagger.Streams.Output_Stream'Class;
+                        Name  : in String;
+                        Value : in PropertyNameMapping_Type_Vectors.Vector);
+   procedure Deserialize (From  : in Swagger.Value_Type;
+                          Name  : in String;
+                          Value : out Samples.Petstore.Models.PropertyNameMapping_Type);
+   procedure Deserialize (From  : in Swagger.Value_Type;
+                          Name  : in String;
+                          Value : in out PropertyNameMapping_Type_Vectors.Vector);
+
+
    --  ------------------------------
    --  Pet Tag
    --  A tag for a pet


### PR DESCRIPTION
- Add mapping option to Ada client/server codegen
- add tests (new 3.0 petstore spec for ada)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @stcarrez (2018/02) @michelealbano (2018/02)
