### PR TITLE
fix(typescript-fetch): Fix bug with optional, nullable fields that were always set to undefined.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -60,36 +60,36 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#vars}}
         {{#isPrimitiveType}}
         {{#isDateType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDateTimeType}}
         {{^isDateType}}
         {{^isDateTimeType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}json['{{baseName}}'],
         {{/isDateTimeType}}
         {{/isDateType}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}
         {{^isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}'{{#isNullable}}, true{{/isNullable}}) ? undefined : {{/required}}json['{{baseName}}'],
         {{/isFreeFormObject}}
         {{/isMap}}
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -60,36 +60,36 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#vars}}
         {{#isPrimitiveType}}
         {{#isDateType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDateTimeType}}
         {{^isDateType}}
         {{^isDateTimeType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}json['{{baseName}}'],
         {{/isDateTimeType}}
         {{/isDateType}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}
         {{^isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}', {{#isNullable}}true{{/isNullable}}) ? undefined : {{/required}}json['{{baseName}}'],
         {{/isFreeFormObject}}
         {{/isMap}}
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -300,9 +300,9 @@ export interface RequestOpts {
 }
 
 {{^withoutRuntimeChecks}}
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 {{/withoutRuntimeChecks}}
 

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/nullable_property.json
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/nullable_property.json
@@ -1,0 +1,30 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Optional Nullable Property Test",
+        "version": "1.0.0"
+    },
+    "paths": {},
+    "components": {
+        "schemas": {
+            "TestSchema": {
+                "title": "TestSchema",
+                "required": [
+                    "required_property"
+                ],
+                "type": "object",
+                "properties": {
+                    "required_property": {
+                        "title": "Required property",
+                        "type": "string"
+                    },
+                    "nullable_property": {
+                        "title": "Optional Nullable property",
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -53,7 +53,7 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     }
     return {
         
-        'owner': !exists(json, 'owner') ? undefined : OwnerFromJSON(json['owner']),
+        'owner': !exists(json, 'owner', true) ? undefined : OwnerFromJSON(json['owner']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -158,7 +158,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': !exists(json, 'enum_integer') ? undefined : json['enum_integer'],
         'enumNumber': !exists(json, 'enum_number') ? undefined : json['enum_number'],
-        'outerEnum': !exists(json, 'outerEnum') ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': !exists(json, 'outerEnum', true) ? undefined : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': !exists(json, 'outerEnumInteger') ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': !exists(json, 'outerEnumDefaultValue') ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': !exists(json, 'outerEnumIntegerDefaultValue') ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -46,7 +46,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': !exists(json, 'NullableMessage') ? undefined : json['NullableMessage'],
+        'nullableMessage': !exists(json, 'NullableMessage', true) ? undefined : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -114,17 +114,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': !exists(json, 'integer_prop') ? undefined : json['integer_prop'],
-        'numberProp': !exists(json, 'number_prop') ? undefined : json['number_prop'],
-        'booleanProp': !exists(json, 'boolean_prop') ? undefined : json['boolean_prop'],
-        'stringProp': !exists(json, 'string_prop') ? undefined : json['string_prop'],
-        'dateProp': !exists(json, 'date_prop') ? undefined : (json['date_prop'] === null ? null : new Date(json['date_prop'])),
-        'datetimeProp': !exists(json, 'datetime_prop') ? undefined : (json['datetime_prop'] === null ? null : new Date(json['datetime_prop'])),
-        'arrayNullableProp': !exists(json, 'array_nullable_prop') ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': !exists(json, 'array_and_items_nullable_prop') ? undefined : json['array_and_items_nullable_prop'],
+        'integerProp': !exists(json, 'integer_prop', true) ? undefined : json['integer_prop'],
+        'numberProp': !exists(json, 'number_prop', true) ? undefined : json['number_prop'],
+        'booleanProp': !exists(json, 'boolean_prop', true) ? undefined : json['boolean_prop'],
+        'stringProp': !exists(json, 'string_prop', true) ? undefined : json['string_prop'],
+        'dateProp': !exists(json, 'date_prop', true) ? undefined : (json['date_prop'] === null ? null : new Date(json['date_prop'])),
+        'datetimeProp': !exists(json, 'datetime_prop', true) ? undefined : (json['datetime_prop'] === null ? null : new Date(json['datetime_prop'])),
+        'arrayNullableProp': !exists(json, 'array_nullable_prop', true) ? undefined : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': !exists(json, 'array_and_items_nullable_prop', true) ? undefined : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': !exists(json, 'array_items_nullable') ? undefined : json['array_items_nullable'],
-        'objectNullableProp': !exists(json, 'object_nullable_prop') ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': !exists(json, 'object_and_items_nullable_prop') ? undefined : json['object_and_items_nullable_prop'],
+        'objectNullableProp': !exists(json, 'object_nullable_prop', true) ? undefined : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': !exists(json, 'object_and_items_nullable_prop', true) ? undefined : json['object_and_items_nullable_prop'],
         'objectItemsNullable': !exists(json, 'object_items_nullable') ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -78,9 +78,9 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'stringEnum': !exists(json, 'string-enum') ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': !exists(json, 'nullable-string-enum') ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
+        'nullableStringEnum': !exists(json, 'nullable-string-enum', true) ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
         'numberEnum': !exists(json, 'number-enum') ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': !exists(json, 'nullable-number-enum') ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
+        'nullableNumberEnum': !exists(json, 'nullable-number-enum', true) ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -158,7 +158,7 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'enumStringRequired': json['enum_string_required'],
         'enumInteger': !exists(json, 'enum_integer') ? undefined : json['enum_integer'],
         'enumNumber': !exists(json, 'enum_number') ? undefined : json['enum_number'],
-        'outerEnum': !exists(json, 'outerEnum') ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnum': !exists(json, 'outerEnum', true) ? undefined : OuterEnumFromJSON(json['outerEnum']),
         'outerEnumInteger': !exists(json, 'outerEnumInteger') ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
         'outerEnumDefaultValue': !exists(json, 'outerEnumDefaultValue') ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
         'outerEnumIntegerDefaultValue': !exists(json, 'outerEnumIntegerDefaultValue') ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -46,7 +46,7 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'nullableMessage': !exists(json, 'NullableMessage') ? undefined : json['NullableMessage'],
+        'nullableMessage': !exists(json, 'NullableMessage', true) ? undefined : json['NullableMessage'],
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -114,17 +114,17 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
             ...json,
-        'integerProp': !exists(json, 'integer_prop') ? undefined : json['integer_prop'],
-        'numberProp': !exists(json, 'number_prop') ? undefined : json['number_prop'],
-        'booleanProp': !exists(json, 'boolean_prop') ? undefined : json['boolean_prop'],
-        'stringProp': !exists(json, 'string_prop') ? undefined : json['string_prop'],
-        'dateProp': !exists(json, 'date_prop') ? undefined : (json['date_prop'] === null ? null : new Date(json['date_prop'])),
-        'datetimeProp': !exists(json, 'datetime_prop') ? undefined : (json['datetime_prop'] === null ? null : new Date(json['datetime_prop'])),
-        'arrayNullableProp': !exists(json, 'array_nullable_prop') ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': !exists(json, 'array_and_items_nullable_prop') ? undefined : json['array_and_items_nullable_prop'],
+        'integerProp': !exists(json, 'integer_prop', true) ? undefined : json['integer_prop'],
+        'numberProp': !exists(json, 'number_prop', true) ? undefined : json['number_prop'],
+        'booleanProp': !exists(json, 'boolean_prop', true) ? undefined : json['boolean_prop'],
+        'stringProp': !exists(json, 'string_prop', true) ? undefined : json['string_prop'],
+        'dateProp': !exists(json, 'date_prop', true) ? undefined : (json['date_prop'] === null ? null : new Date(json['date_prop'])),
+        'datetimeProp': !exists(json, 'datetime_prop', true) ? undefined : (json['datetime_prop'] === null ? null : new Date(json['datetime_prop'])),
+        'arrayNullableProp': !exists(json, 'array_nullable_prop', true) ? undefined : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': !exists(json, 'array_and_items_nullable_prop', true) ? undefined : json['array_and_items_nullable_prop'],
         'arrayItemsNullable': !exists(json, 'array_items_nullable') ? undefined : json['array_items_nullable'],
-        'objectNullableProp': !exists(json, 'object_nullable_prop') ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': !exists(json, 'object_and_items_nullable_prop') ? undefined : json['object_and_items_nullable_prop'],
+        'objectNullableProp': !exists(json, 'object_nullable_prop', true) ? undefined : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': !exists(json, 'object_and_items_nullable_prop', true) ? undefined : json['object_and_items_nullable_prop'],
         'objectItemsNullable': !exists(json, 'object_items_nullable') ? undefined : json['object_items_nullable'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -78,9 +78,9 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'stringEnum': !exists(json, 'string-enum') ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': !exists(json, 'nullable-string-enum') ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
+        'nullableStringEnum': !exists(json, 'nullable-string-enum', true) ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
         'numberEnum': !exists(json, 'number-enum') ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': !exists(json, 'nullable-number-enum') ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
+        'nullableNumberEnum': !exists(json, 'nullable-number-enum', true) ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -310,9 +310,9 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: any, key: string, nullable: boolean = false) {
     const value = json[key];
-    return value !== null && value !== undefined;
+    return nullable ? value !== undefined : value !== null && value !== undefined;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {


### PR DESCRIPTION
### Details
This PR fixes #5670, where optional, nullable fields were inferred to be missing by the `exists` runtime function in `typescript-fetch`. Adding an additional `nullable` parameter to the `typescript-fetch` runtime function and setting it to true whenever the parameter is nullable should solve this issue.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
