### PR TITLE
[Java][okhttp-gson] Refactor handling of 'number' types in oneOf

### DIFF
--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -149,7 +149,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## LANGUAGE PRIMITIVES
 
 <ul class="column-ul">
-<li>BigDecimal</li>
 <li>Boolean</li>
 <li>Double</li>
 <li>Float</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -191,8 +191,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         modelPackage = "org.openapitools.client.model";
         rootJavaEEPackage = MICROPROFILE_REST_CLIENT_DEFAULT_ROOT_PACKAGE;
 
-        languageSpecificPrimitives.add("BigDecimal");
-
         // cliOptions default redefinition need to be updated
         updateOption(CodegenConstants.INVOKER_PACKAGE, this.getInvokerPackage());
         updateOption(CodegenConstants.ARTIFACT_ID, this.getArtifactId());
@@ -1021,16 +1019,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         }
 
         return codegenModel;
-    }
-
-    @Override
-    protected boolean needToImport(String type) {
-        // add import for BigDecimal explicitly since it is a primitive type
-        if("BigDecimal".equals(type)) {
-            return true;
-        }
-
-        return super.needToImport(type) && !type.contains(".");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
@@ -135,6 +135,13 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     // deserialize {{{dataType}}}
                     try {
                       // validate the JSON object to see if any exception is thrown
+                    {{#isNumber}}
+                      if(!jsonElement.getAsJsonPrimitive().isNumber()) {
+                        throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
+                      }
+                      actualAdapter = adapter{{{dataType}}};
+                    {{/isNumber}}
+                    {{^isNumber}}
                     {{#isPrimitiveType}}
                       if(!jsonElement.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}()) {
                         throw new IllegalArgumentException(String.format("Expected json element to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString()));
@@ -147,6 +154,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                       actualAdapter = adapter{{{dataType}}};
                     {{/isArray}}
                     {{/isPrimitiveType}}
+                    {{/isNumber}}
                     {{#isArray}}
                       if (!jsonElement.isJsonArray()) {
                         throw new IllegalArgumentException(String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString()));
@@ -156,6 +164,13 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                       // validate array items
                       for(JsonElement element : array) {
                       {{#items}}
+                      {{#isNumber}}
+                        if(!jsonElement.getAsJsonPrimitive().isNumber()) {
+                          throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
+                        }
+                        actualAdapter = adapter{{{dataType}}};
+                      {{/isNumber}}
+                      {{^isNumber}}
                       {{#isPrimitiveType}}
                       if(!element.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}()) {
                         throw new IllegalArgumentException(String.format("Expected array items to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString()));
@@ -164,6 +179,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                       {{^isPrimitiveType}}
                         {{{dataType}}}.validateJsonElement(element);
                       {{/isPrimitiveType}}
+                      {{/isNumber}}
                       {{/items}}
                       }
                       actualAdapter = adapter{{{complexType}}}List;
@@ -311,6 +327,12 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     // validate the json string with {{{dataType}}}
     try {
     {{^hasVars}}
+    {{#isNumber}}
+      if(!jsonElement.getAsJsonPrimitive().isNumber()) {
+        throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
+      }
+    {{/isNumber}}
+    {{^isNumber}}
     {{#isPrimitiveType}}
       if(!jsonElement.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}()) {
         throw new IllegalArgumentException(String.format("Expected json element to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString()));
@@ -321,6 +343,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
       {{{dataType}}}.validateJsonElement(jsonElement);
     {{/isArray}}
     {{/isPrimitiveType}}
+    {{/isNumber}}
     {{#isArray}}
       if (!jsonElement.isJsonArray()) {
           throw new IllegalArgumentException(String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString()));
@@ -329,6 +352,12 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
       // validate array items
       for(JsonElement element : array) {
         {{#items}}
+        {{#isNumber}}
+          if(!jsonElement.getAsJsonPrimitive().isNumber()) {
+            throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
+          }
+        {{/isNumber}}
+        {{^isNumber}}
         {{#isPrimitiveType}}
         if(!element.getAsJsonPrimitive().is{{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}}()) {
           throw new IllegalArgumentException(String.format("Expected array items to be of type {{#isBoolean}}Boolean{{/isBoolean}}{{#isString}}String{{/isString}}{{^isString}}{{^isBoolean}}Number{{/isBoolean}}{{/isString}} in the JSON string but got `%s`", jsonElement.toString()));
@@ -337,6 +366,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         {{^isPrimitiveType}}
         {{{dataType}}}.validateJsonElement(element);
         {{/isPrimitiveType}}
+        {{/isNumber}}
         {{/items}}
       }
     {{/isArray}}

--- a/samples/client/petstore/java/apache-httpclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/apache-httpclient/docs/FakeApi.md
@@ -396,7 +396,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -148,13 +148,15 @@ public class ArrayOfArrayOfNumberOnly {
     // add `ArrayArrayNumber` to the URL query string
     if (getArrayArrayNumber() != null) {
       for (int i = 0; i < getArrayArrayNumber().size(); i++) {
-        try {
-          joiner.add(String.format("%sArrayArrayNumber%s%s=%s", prefix, suffix,
-              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
-              URLEncoder.encode(String.valueOf(getArrayArrayNumber().get(i)), "UTF-8").replaceAll("\\+", "%20")));
-        } catch (UnsupportedEncodingException e) {
-          // Should never happen, UTF-8 is always supported
-          throw new RuntimeException(e);
+        if (getArrayArrayNumber().get(i) != null) {
+          try {
+            joiner.add(String.format("%sArrayArrayNumber%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                URLEncoder.encode(String.valueOf(getArrayArrayNumber().get(i)), "UTF-8").replaceAll("\\+", "%20")));
+          } catch (UnsupportedEncodingException e) {
+            // Should never happen, UTF-8 is always supported
+            throw new RuntimeException(e);
+          }
         }
       }
     }

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -148,13 +148,15 @@ public class ArrayOfNumberOnly {
     // add `ArrayNumber` to the URL query string
     if (getArrayNumber() != null) {
       for (int i = 0; i < getArrayNumber().size(); i++) {
-        try {
-          joiner.add(String.format("%sArrayNumber%s%s=%s", prefix, suffix,
-              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
-              URLEncoder.encode(String.valueOf(getArrayNumber().get(i)), "UTF-8").replaceAll("\\+", "%20")));
-        } catch (UnsupportedEncodingException e) {
-          // Should never happen, UTF-8 is always supported
-          throw new RuntimeException(e);
+        if (getArrayNumber().get(i) != null) {
+          try {
+            joiner.add(String.format("%sArrayNumber%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                URLEncoder.encode(String.valueOf(getArrayNumber().get(i)), "UTF-8").replaceAll("\\+", "%20")));
+          } catch (UnsupportedEncodingException e) {
+            // Should never happen, UTF-8 is always supported
+            throw new RuntimeException(e);
+          }
         }
       }
     }

--- a/samples/client/petstore/java/google-api-client/docs/FakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/docs/FakeApi.md
@@ -264,7 +264,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -264,7 +264,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey3/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey3/docs/FakeApi.md
@@ -260,7 +260,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/native-async/docs/FakeApi.md
+++ b/samples/client/petstore/java/native-async/docs/FakeApi.md
@@ -640,7 +640,7 @@ public class Example {
 
 ### Return type
 
-CompletableFuture<**BigDecimal**>
+CompletableFuture<[**BigDecimal**](BigDecimal.md)>
 
 
 ### Authorization
@@ -716,7 +716,7 @@ public class Example {
 
 ### Return type
 
-CompletableFuture<ApiResponse<**BigDecimal**>>
+CompletableFuture<ApiResponse<[**BigDecimal**](BigDecimal.md)>>
 
 
 ### Authorization

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -153,9 +153,11 @@ public class ArrayOfArrayOfNumberOnly {
     // add `ArrayArrayNumber` to the URL query string
     if (getArrayArrayNumber() != null) {
       for (int i = 0; i < getArrayArrayNumber().size(); i++) {
-        joiner.add(String.format("%sArrayArrayNumber%s%s=%s", prefix, suffix,
-            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
-            URLEncoder.encode(String.valueOf(getArrayArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        if (getArrayArrayNumber().get(i) != null) {
+          joiner.add(String.format("%sArrayArrayNumber%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(getArrayArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        }
       }
     }
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -153,9 +153,11 @@ public class ArrayOfNumberOnly {
     // add `ArrayNumber` to the URL query string
     if (getArrayNumber() != null) {
       for (int i = 0; i < getArrayNumber().size(); i++) {
-        joiner.add(String.format("%sArrayNumber%s%s=%s", prefix, suffix,
-            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
-            URLEncoder.encode(String.valueOf(getArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        if (getArrayNumber().get(i) != null) {
+          joiner.add(String.format("%sArrayNumber%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(getArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        }
       }
     }
 

--- a/samples/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/client/petstore/java/native/docs/FakeApi.md
@@ -603,7 +603,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 
 ### Authorization
@@ -671,7 +671,7 @@ public class Example {
 
 ### Return type
 
-ApiResponse<**BigDecimal**>
+ApiResponse<[**BigDecimal**](BigDecimal.md)>
 
 
 ### Authorization

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -153,9 +153,11 @@ public class ArrayOfArrayOfNumberOnly {
     // add `ArrayArrayNumber` to the URL query string
     if (getArrayArrayNumber() != null) {
       for (int i = 0; i < getArrayArrayNumber().size(); i++) {
-        joiner.add(String.format("%sArrayArrayNumber%s%s=%s", prefix, suffix,
-            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
-            URLEncoder.encode(String.valueOf(getArrayArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        if (getArrayArrayNumber().get(i) != null) {
+          joiner.add(String.format("%sArrayArrayNumber%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(getArrayArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        }
       }
     }
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -153,9 +153,11 @@ public class ArrayOfNumberOnly {
     // add `ArrayNumber` to the URL query string
     if (getArrayNumber() != null) {
       for (int i = 0; i < getArrayNumber().size(); i++) {
-        joiner.add(String.format("%sArrayNumber%s%s=%s", prefix, suffix,
-            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
-            URLEncoder.encode(String.valueOf(getArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        if (getArrayNumber().get(i) != null) {
+          joiner.add(String.format("%sArrayNumber%s%s=%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(getArrayNumber().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+        }
       }
     }
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/docs/FakeApi.md
@@ -251,7 +251,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -251,7 +251,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -475,7 +475,7 @@ public class AdditionalPropertiesClass implements Parcelable {
 
   AdditionalPropertiesClass(Parcel in) {
     mapString = (Map<String, String>)in.readValue(null);
-    mapNumber = (Map<String, BigDecimal>)in.readValue(null);
+    mapNumber = (Map<String, BigDecimal>)in.readValue(BigDecimal.class.getClassLoader());
     mapInteger = (Map<String, Integer>)in.readValue(null);
     mapBoolean = (Map<String, Boolean>)in.readValue(null);
     mapArrayInteger = (Map<String, List<Integer>>)in.readValue(List.class.getClassLoader());

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -137,7 +137,7 @@ public class ArrayOfNumberOnly implements Parcelable {
   }
 
   ArrayOfNumberOnly(Parcel in) {
-    arrayNumber = (List<BigDecimal>)in.readValue(null);
+    arrayNumber = (List<BigDecimal>)in.readValue(BigDecimal.class.getClassLoader());
   }
 
   public int describeContents() {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -508,7 +508,7 @@ public class FormatTest implements Parcelable {
     integer = (Integer)in.readValue(null);
     int32 = (Integer)in.readValue(null);
     int64 = (Long)in.readValue(null);
-    number = (BigDecimal)in.readValue(null);
+    number = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     _float = (Float)in.readValue(null);
     _double = (Double)in.readValue(null);
     string = (String)in.readValue(null);
@@ -518,7 +518,7 @@ public class FormatTest implements Parcelable {
     dateTime = (OffsetDateTime)in.readValue(OffsetDateTime.class.getClassLoader());
     uuid = (UUID)in.readValue(UUID.class.getClassLoader());
     password = (String)in.readValue(null);
-    bigDecimal = (BigDecimal)in.readValue(null);
+    bigDecimal = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
   }
 
   public int describeContents() {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -127,7 +127,7 @@ public class NumberOnly implements Parcelable {
   }
 
   NumberOnly(Parcel in) {
-    justNumber = (BigDecimal)in.readValue(null);
+    justNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
   }
 
   public int describeContents() {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -183,7 +183,7 @@ public class OuterComposite implements Parcelable {
   }
 
   OuterComposite(Parcel in) {
-    myNumber = (BigDecimal)in.readValue(null);
+    myNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     myString = (String)in.readValue(null);
     myBoolean = (Boolean)in.readValue(null);
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -250,7 +250,7 @@ public class TypeHolderDefault implements Parcelable {
 
   TypeHolderDefault(Parcel in) {
     stringItem = (String)in.readValue(null);
-    numberItem = (BigDecimal)in.readValue(null);
+    numberItem = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     integerItem = (Integer)in.readValue(null);
     boolItem = (Boolean)in.readValue(null);
     arrayItem = (List<Integer>)in.readValue(null);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -278,7 +278,7 @@ public class TypeHolderExample implements Parcelable {
 
   TypeHolderExample(Parcel in) {
     stringItem = (String)in.readValue(null);
-    numberItem = (BigDecimal)in.readValue(null);
+    numberItem = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     floatItem = (Float)in.readValue(null);
     integerItem = (Integer)in.readValue(null);
     boolItem = (Boolean)in.readValue(null);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -986,30 +986,30 @@ public class XmlItem implements Parcelable {
 
   XmlItem(Parcel in) {
     attributeString = (String)in.readValue(null);
-    attributeNumber = (BigDecimal)in.readValue(null);
+    attributeNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     attributeInteger = (Integer)in.readValue(null);
     attributeBoolean = (Boolean)in.readValue(null);
     wrappedArray = (List<Integer>)in.readValue(null);
     nameString = (String)in.readValue(null);
-    nameNumber = (BigDecimal)in.readValue(null);
+    nameNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     nameInteger = (Integer)in.readValue(null);
     nameBoolean = (Boolean)in.readValue(null);
     nameArray = (List<Integer>)in.readValue(null);
     nameWrappedArray = (List<Integer>)in.readValue(null);
     prefixString = (String)in.readValue(null);
-    prefixNumber = (BigDecimal)in.readValue(null);
+    prefixNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     prefixInteger = (Integer)in.readValue(null);
     prefixBoolean = (Boolean)in.readValue(null);
     prefixArray = (List<Integer>)in.readValue(null);
     prefixWrappedArray = (List<Integer>)in.readValue(null);
     namespaceString = (String)in.readValue(null);
-    namespaceNumber = (BigDecimal)in.readValue(null);
+    namespaceNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     namespaceInteger = (Integer)in.readValue(null);
     namespaceBoolean = (Boolean)in.readValue(null);
     namespaceArray = (List<Integer>)in.readValue(null);
     namespaceWrappedArray = (List<Integer>)in.readValue(null);
     prefixNsString = (String)in.readValue(null);
-    prefixNsNumber = (BigDecimal)in.readValue(null);
+    prefixNsNumber = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
     prefixNsInteger = (Integer)in.readValue(null);
     prefixNsBoolean = (Boolean)in.readValue(null);
     prefixNsArray = (List<Integer>)in.readValue(null);

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -248,7 +248,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Scalar.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Scalar.java
@@ -84,8 +84,8 @@ public class Scalar extends AbstractOpenApiSchema {
                     }
                     // check if the actual instance is of the type `BigDecimal`
                     if (value.getActualInstance() instanceof BigDecimal) {
-                      JsonPrimitive primitive = adapterBigDecimal.toJsonTree((BigDecimal)value.getActualInstance()).getAsJsonPrimitive();
-                      elementAdapter.write(out, primitive);
+                      JsonElement element = adapterBigDecimal.toJsonTree((BigDecimal)value.getActualInstance());
+                      elementAdapter.write(out, element);
                       return;
                     }
                     // check if the actual instance is of the type `Boolean`

--- a/samples/client/petstore/java/rest-assured-jackson/docs/FakeApi.md
+++ b/samples/client/petstore/java/rest-assured-jackson/docs/FakeApi.md
@@ -174,7 +174,7 @@ api.fakeOuterNumberSerialize().execute(r -> r.prettyPeek());
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -138,6 +138,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -62,6 +62,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -197,6 +197,7 @@ public class FormatTest {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")
   @JsonProperty(JSON_PROPERTY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -478,6 +479,7 @@ public class FormatTest {
    * @return bigDecimal
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -52,6 +52,7 @@ public class NumberOnly {
    * @return justNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -60,6 +60,7 @@ public class OuterComposite {
    * @return myNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -99,6 +99,7 @@ public class TypeHolderDefault {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -103,6 +103,7 @@ public class TypeHolderExample {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -193,6 +193,7 @@ public class XmlItem {
    * @return attributeNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -336,6 +337,7 @@ public class XmlItem {
    * @return nameNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -514,6 +516,7 @@ public class XmlItem {
    * @return prefixNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -692,6 +695,7 @@ public class XmlItem {
    * @return namespaceNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -870,6 +874,7 @@ public class XmlItem {
    * @return prefixNsNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/rest-assured/docs/FakeApi.md
+++ b/samples/client/petstore/java/rest-assured/docs/FakeApi.md
@@ -174,7 +174,7 @@ api.fakeOuterNumberSerialize().execute(r -> r.prettyPeek());
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -131,6 +131,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public Map<String, BigDecimal> getMapNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -59,6 +59,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public List<BigDecimal> getArrayNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -181,6 +181,7 @@ public class FormatTest {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")
 
   public BigDecimal getNumber() {
@@ -422,6 +423,7 @@ public class FormatTest {
    * @return bigDecimal
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getBigDecimal() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -49,6 +49,7 @@ public class NumberOnly {
    * @return justNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getJustNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -57,6 +57,7 @@ public class OuterComposite {
    * @return myNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getMyNumber() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -92,6 +92,7 @@ public class TypeHolderDefault {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
 
 
   public BigDecimal getNumberItem() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -96,6 +96,7 @@ public class TypeHolderExample {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
 
 
   public BigDecimal getNumberItem() {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -186,6 +186,7 @@ public class XmlItem {
    * @return attributeNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getAttributeNumber() {
@@ -309,6 +310,7 @@ public class XmlItem {
    * @return nameNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getNameNumber() {
@@ -463,6 +465,7 @@ public class XmlItem {
    * @return prefixNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getPrefixNumber() {
@@ -617,6 +620,7 @@ public class XmlItem {
    * @return namespaceNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getNamespaceNumber() {
@@ -771,6 +775,7 @@ public class XmlItem {
    * @return prefixNsNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
 
   public BigDecimal getPrefixNsNumber() {

--- a/samples/client/petstore/java/resteasy/docs/FakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/resttemplate/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -137,6 +137,7 @@ public class AdditionalPropertiesClass {
    * @return mapNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -61,6 +61,7 @@ public class ArrayOfNumberOnly {
    * @return arrayNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -196,6 +196,7 @@ public class FormatTest {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")
   @JsonProperty(JSON_PROPERTY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -477,6 +478,7 @@ public class FormatTest {
    * @return bigDecimal
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -51,6 +51,7 @@ public class NumberOnly {
    * @return justNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -59,6 +59,7 @@ public class OuterComposite {
    * @return myNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -98,6 +98,7 @@ public class TypeHolderDefault {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -102,6 +102,7 @@ public class TypeHolderExample {
   **/
   @javax.annotation.Nonnull
   @NotNull
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -192,6 +192,7 @@ public class XmlItem {
    * @return attributeNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -335,6 +336,7 @@ public class XmlItem {
    * @return nameNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -513,6 +515,7 @@ public class XmlItem {
    * @return prefixNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -691,6 +694,7 @@ public class XmlItem {
    * @return namespaceNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -869,6 +873,7 @@ public class XmlItem {
    * @return prefixNsNumber
   **/
   @javax.annotation.Nullable
+  @Valid
 
   @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/samples/client/petstore/java/retrofit2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2rx3/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx3/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/vertx-no-nullable/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx-no-nullable/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/vertx/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx/docs/FakeApi.md
@@ -266,7 +266,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/webclient-jakarta/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient-jakarta/docs/FakeApi.md
@@ -396,7 +396,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/webclient-swagger2/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient-swagger2/docs/FakeApi.md
@@ -396,7 +396,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -396,7 +396,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -260,7 +260,7 @@ public class Example {
 
 ### Return type
 
-**BigDecimal**
+[**BigDecimal**](BigDecimal.md)
 
 ### Authorization
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR improves the handling of `number` datatypes used in `oneOf` by removing a previous workaround which treated `BigDecimal` as a `languagePrimitiveType`.

This PR fixes #16166 since treating `BigDecimal` as a primitive results in, the generator not adding any imports for it. Instead this change provides separate handling of `number` datatypes in the `oneof_model.mustache` template.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
