### PR TITLE
[haskell-servant][haskell-yesod] Use table-based conversion for field name conversion 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -658,6 +658,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         String prefix = camelize(model.classname, LOWERCASE_FIRST_LETTER);
         for (CodegenProperty prop : model.vars) {
             prop.name = toVarName(prefix + camelize(prop.name));
+            prop.vendorExtensions.put("x-base-name-string-literal", "\"" + escapeText(prop.getBaseName()) + "\"");
         }
 
         // Create newtypes for things with non-object types
@@ -668,8 +669,6 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
             model.vendorExtensions.put("x-custom-newtype", newtype);
         }
 
-        // Provide the prefix as a vendor extension, so that it can be used in the ToJSON and FromJSON instances.
-        model.vendorExtensions.put("x-prefix", prefix);
         model.vendorExtensions.put("x-data", dataOrNewtype);
 
         return model;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
@@ -552,6 +552,7 @@ public class HaskellYesodServerCodegen extends DefaultCodegen implements Codegen
         String prefix = camelize(model.classname, LOWERCASE_FIRST_LETTER);
         for (CodegenProperty prop : model.vars) {
             prop.name = toVarName(prefix + camelize(prop.name));
+            prop.vendorExtensions.put("x-base-name-string-literal", "\"" + escapeText(prop.getBaseName()) + "\"");
         }
 
         // Create newtypes for things with non-object types
@@ -562,8 +563,6 @@ public class HaskellYesodServerCodegen extends DefaultCodegen implements Codegen
             model.vendorExtensions.put("x-custom-newtype", newtype);
         }
 
-        // Provide the prefix as a vendor extension, so that it can be used in the ToJSON and FromJSON instances.
-        model.vendorExtensions.put("x-prefix", prefix);
         model.vendorExtensions.put("x-data", dataOrNewtype);
 
         return model;

--- a/modules/openapi-generator/src/main/resources/haskell-servant/Types.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/Types.mustache
@@ -13,7 +13,7 @@ module {{title}}.Types (
 
 import Data.Data (Data)
 import Data.UUID (UUID)
-import Data.List (stripPrefix)
+import Data.List (lookup)
 import Data.Maybe (fromMaybe)
 import Data.Aeson (Value, FromJSON(..), ToJSON(..), genericToJSON, genericParseJSON)
 import Data.Aeson.Types (Options(..), defaultOptions)
@@ -26,7 +26,6 @@ import qualified Data.Char as Char
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
-import Data.Function ((&))
 {{#imports}}import {{import}}
 {{/imports}}
 
@@ -42,15 +41,27 @@ import Data.Function ((&))
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON {{classname}} where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "{{vendorExtensions.x-prefix}}")
+  parseJSON = genericParseJSON options{{classname}}
 instance ToJSON {{classname}} where
-  toJSON = genericToJSON (removeFieldLabelPrefix "{{vendorExtensions.x-prefix}}")
+  toJSON = genericToJSON options{{classname}}
 {{#generateToSchema}}
 instance ToSchema {{classname}} where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "{{vendorExtensions.x-prefix}}"
+    $ options{{classname}}
 {{/generateToSchema}}
+
+options{{classname}} :: Options
+options{{classname}} =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
+    }
+  where
+    table =
+      [ {{#vars}}("{{& name}}", {{& vendorExtensions.x-base-name-string-literal}}){{^-last}}
+      , {{/-last}}{{/vars}}
+      ]
 
 {{/parent}}
 {{#parent}}
@@ -63,23 +74,3 @@ newtype {{classname}} = {{classname}} {{vendorExtensions.x-custom-newtype}} deri
 {{/vendorExtensions.x-custom-newtype}}
 {{/model}}
 {{/models}}
-
-uncapitalize :: String -> String
-uncapitalize (first:rest) = Char.toLower first : rest
-uncapitalize [] = []
-
--- | Remove a field label prefix during JSON parsing.
---   Also perform any replacements for special characters.
-removeFieldLabelPrefix :: String -> Options
-removeFieldLabelPrefix prefix =
-  defaultOptions
-    { omitNothingFields  = True
-    , fieldLabelModifier = uncapitalize . replaceSpecialChars . fromMaybe (error ("did not find prefix " ++ prefix)) . stripPrefix prefix
-    }
-  where
-    replaceSpecialChars field = foldl (&) field (map mkCharReplacement specialChars)
-    specialChars =
-      [ {{#specialCharReplacements}}("{{&char}}", "{{&replacement}}"){{^-last}}
-      , {{/-last}}{{/specialCharReplacements}}
-      ]
-    mkCharReplacement (replaceStr, searchStr) = T.unpack . T.replace (T.pack searchStr) (T.pack replaceStr) . T.pack

--- a/modules/openapi-generator/src/main/resources/haskell-yesod/src/API/Types.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-yesod/src/API/Types.mustache
@@ -13,6 +13,7 @@ module {{apiModuleName}}.Types (
 
 import ClassyPrelude.Yesod
 import Data.Foldable (foldl)
+import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 import Data.Aeson (Value, FromJSON(..), ToJSON(..), genericToJSON, genericParseJSON)
 import Data.Aeson.Types (Options(..), defaultOptions)
@@ -20,7 +21,6 @@ import qualified Data.Char as Char
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
-import Data.Function ((&))
 {{#imports}}import {{import}}
 {{/imports}}
 
@@ -36,9 +36,21 @@ import Data.Function ((&))
   } deriving (Show, Eq, Generic)
 
 instance FromJSON {{classname}} where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "{{vendorExtensions.x-prefix}}")
+  parseJSON = genericParseJSON options{{classname}}
 instance ToJSON {{classname}} where
-  toJSON = genericToJSON (removeFieldLabelPrefix "{{vendorExtensions.x-prefix}}")
+  toJSON = genericToJSON options{{classname}}
+
+options{{classname}} :: Options
+options{{classname}} =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
+    }
+  where
+    table =
+      [ {{#vars}}("{{& name}}", {{& vendorExtensions.x-base-name-string-literal}}){{^-last}}
+      , {{/-last}}{{/vars}}
+      ]
 
 {{/parent}}
 {{#parent}}
@@ -51,23 +63,3 @@ newtype {{classname}} = {{classname}} {{vendorExtensions.x-custom-newtype}} deri
 {{/vendorExtensions.x-custom-newtype}}
 {{/model}}
 {{/models}}
-
-uncapitalize :: String -> String
-uncapitalize (c : cs) = Char.toLower c : cs
-uncapitalize [] = []
-
--- | Remove a field label prefix during JSON parsing.
---   Also perform any replacements for special characters.
-removeFieldLabelPrefix :: String -> Options
-removeFieldLabelPrefix prefix =
-  defaultOptions
-    { omitNothingFields  = True
-    , fieldLabelModifier = uncapitalize . replaceSpecialChars . fromMaybe (error ("did not find prefix " ++ prefix)) . stripPrefix prefix
-    }
-  where
-    replaceSpecialChars field = foldl (&) field (map mkCharReplacement specialChars)
-    specialChars =
-      [ {{#specialCharReplacements}}("{{&char}}", "{{&replacement}}"){{^-last}}
-      , {{/-last}}{{/specialCharReplacements}}
-      ]
-    mkCharReplacement (replaceStr, searchStr) = T.unpack . T.replace (T.pack searchStr) (T.pack replaceStr) . T.pack

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/Types.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/Types.hs
@@ -14,7 +14,7 @@ module OpenAPIPetstore.Types (
 
 import Data.Data (Data)
 import Data.UUID (UUID)
-import Data.List (stripPrefix)
+import Data.List (lookup)
 import Data.Maybe (fromMaybe)
 import Data.Aeson (Value, FromJSON(..), ToJSON(..), genericToJSON, genericParseJSON)
 import Data.Aeson.Types (Options(..), defaultOptions)
@@ -27,7 +27,6 @@ import qualified Data.Char as Char
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
-import Data.Function ((&))
 
 
 -- | Describes the result of uploading an image resource
@@ -38,13 +37,26 @@ data ApiResponse = ApiResponse
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON ApiResponse where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "apiResponse")
+  parseJSON = genericParseJSON optionsApiResponse
 instance ToJSON ApiResponse where
-  toJSON = genericToJSON (removeFieldLabelPrefix "apiResponse")
+  toJSON = genericToJSON optionsApiResponse
 instance ToSchema ApiResponse where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "apiResponse"
+    $ optionsApiResponse
+
+optionsApiResponse :: Options
+optionsApiResponse =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
+    }
+  where
+    table =
+      [ ("apiResponseCode", "code")
+      , ("apiResponseType", "type")
+      , ("apiResponseMessage", "message")
+      ]
 
 
 -- | A category for a pet
@@ -54,13 +66,25 @@ data Category = Category
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON Category where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "category")
+  parseJSON = genericParseJSON optionsCategory
 instance ToJSON Category where
-  toJSON = genericToJSON (removeFieldLabelPrefix "category")
+  toJSON = genericToJSON optionsCategory
 instance ToSchema Category where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "category"
+    $ optionsCategory
+
+optionsCategory :: Options
+optionsCategory =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
+    }
+  where
+    table =
+      [ ("categoryId", "id")
+      , ("categoryName", "name")
+      ]
 
 
 -- | An order for a pets from the pet store
@@ -74,13 +98,29 @@ data Order = Order
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON Order where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "order")
+  parseJSON = genericParseJSON optionsOrder
 instance ToJSON Order where
-  toJSON = genericToJSON (removeFieldLabelPrefix "order")
+  toJSON = genericToJSON optionsOrder
 instance ToSchema Order where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "order"
+    $ optionsOrder
+
+optionsOrder :: Options
+optionsOrder =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
+    }
+  where
+    table =
+      [ ("orderId", "id")
+      , ("orderPetId", "petId")
+      , ("orderQuantity", "quantity")
+      , ("orderShipDate", "shipDate")
+      , ("orderStatus", "status")
+      , ("orderComplete", "complete")
+      ]
 
 
 -- | A pet for sale in the pet store
@@ -94,13 +134,29 @@ data Pet = Pet
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON Pet where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "pet")
+  parseJSON = genericParseJSON optionsPet
 instance ToJSON Pet where
-  toJSON = genericToJSON (removeFieldLabelPrefix "pet")
+  toJSON = genericToJSON optionsPet
 instance ToSchema Pet where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "pet"
+    $ optionsPet
+
+optionsPet :: Options
+optionsPet =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
+    }
+  where
+    table =
+      [ ("petId", "id")
+      , ("petCategory", "category")
+      , ("petName", "name")
+      , ("petPhotoUrls", "photoUrls")
+      , ("petTags", "tags")
+      , ("petStatus", "status")
+      ]
 
 
 -- | A tag for a pet
@@ -110,13 +166,25 @@ data Tag = Tag
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON Tag where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "tag")
+  parseJSON = genericParseJSON optionsTag
 instance ToJSON Tag where
-  toJSON = genericToJSON (removeFieldLabelPrefix "tag")
+  toJSON = genericToJSON optionsTag
 instance ToSchema Tag where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "tag"
+    $ optionsTag
+
+optionsTag :: Options
+optionsTag =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
+    }
+  where
+    table =
+      [ ("tagId", "id")
+      , ("tagName", "name")
+      ]
 
 
 -- | A User who is purchasing from the pet store
@@ -132,66 +200,29 @@ data User = User
   } deriving (Show, Eq, Generic, Data)
 
 instance FromJSON User where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "user")
+  parseJSON = genericParseJSON optionsUser
 instance ToJSON User where
-  toJSON = genericToJSON (removeFieldLabelPrefix "user")
+  toJSON = genericToJSON optionsUser
 instance ToSchema User where
   declareNamedSchema = Swagger.genericDeclareNamedSchema
     $ Swagger.fromAesonOptions
-    $ removeFieldLabelPrefix "user"
+    $ optionsUser
 
-
-uncapitalize :: String -> String
-uncapitalize (first:rest) = Char.toLower first : rest
-uncapitalize [] = []
-
--- | Remove a field label prefix during JSON parsing.
---   Also perform any replacements for special characters.
-removeFieldLabelPrefix :: String -> Options
-removeFieldLabelPrefix prefix =
+optionsUser :: Options
+optionsUser =
   defaultOptions
     { omitNothingFields  = True
-    , fieldLabelModifier = uncapitalize . replaceSpecialChars . fromMaybe (error ("did not find prefix " ++ prefix)) . stripPrefix prefix
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
     }
   where
-    replaceSpecialChars field = foldl (&) field (map mkCharReplacement specialChars)
-    specialChars =
-      [ ("$", "Dollar")
-      , ("^", "Caret")
-      , ("|", "Pipe")
-      , ("=", "Equal")
-      , ("*", "Star")
-      , ("-", "Dash")
-      , ("&", "Ampersand")
-      , ("%", "Percent")
-      , ("#", "Hash")
-      , ("@", "At")
-      , ("!", "Exclamation")
-      , ("+", "Plus")
-      , (":", "Colon")
-      , (";", "Semicolon")
-      , (">", "GreaterThan")
-      , ("<", "LessThan")
-      , (".", "Period")
-      , ("_", "Underscore")
-      , ("?", "Question_Mark")
-      , (",", "Comma")
-      , ("'", "Quote")
-      , ("/", "Slash")
-      , ("(", "Left_Parenthesis")
-      , (")", "Right_Parenthesis")
-      , ("{", "Left_Curly_Bracket")
-      , ("}", "Right_Curly_Bracket")
-      , ("[", "Left_Square_Bracket")
-      , ("]", "Right_Square_Bracket")
-      , ("~", "Tilde")
-      , ("`", "Backtick")
-      , ("<=", "Less_Than_Or_Equal_To")
-      , (">=", "Greater_Than_Or_Equal_To")
-      , ("!=", "Not_Equal")
-      , ("<>", "Not_Equal")
-      , ("~=", "Tilde_Equal")
-      , ("\\", "Back_Slash")
-      , ("\"", "Double_Quote")
+    table =
+      [ ("userId", "id")
+      , ("userUsername", "username")
+      , ("userFirstName", "firstName")
+      , ("userLastName", "lastName")
+      , ("userEmail", "email")
+      , ("userPassword", "password")
+      , ("userPhone", "phone")
+      , ("userUserStatus", "userStatus")
       ]
-    mkCharReplacement (replaceStr, searchStr) = T.unpack . T.replace (T.pack searchStr) (T.pack replaceStr) . T.pack
+

--- a/samples/server/petstore/haskell-yesod/src/OpenAPIPetstore/Types.hs
+++ b/samples/server/petstore/haskell-yesod/src/OpenAPIPetstore/Types.hs
@@ -14,6 +14,7 @@ module OpenAPIPetstore.Types (
 
 import ClassyPrelude.Yesod
 import Data.Foldable (foldl)
+import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 import Data.Aeson (Value, FromJSON(..), ToJSON(..), genericToJSON, genericParseJSON)
 import Data.Aeson.Types (Options(..), defaultOptions)
@@ -21,7 +22,6 @@ import qualified Data.Char as Char
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
-import Data.Function ((&))
 
 
 -- | Describes the result of uploading an image resource
@@ -32,9 +32,22 @@ data ApiResponse = ApiResponse
   } deriving (Show, Eq, Generic)
 
 instance FromJSON ApiResponse where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "apiResponse")
+  parseJSON = genericParseJSON optionsApiResponse
 instance ToJSON ApiResponse where
-  toJSON = genericToJSON (removeFieldLabelPrefix "apiResponse")
+  toJSON = genericToJSON optionsApiResponse
+
+optionsApiResponse :: Options
+optionsApiResponse =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
+    }
+  where
+    table =
+      [ ("apiResponseCode", "code")
+      , ("apiResponseType", "type")
+      , ("apiResponseMessage", "message")
+      ]
 
 
 -- | A category for a pet
@@ -44,9 +57,21 @@ data Category = Category
   } deriving (Show, Eq, Generic)
 
 instance FromJSON Category where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "category")
+  parseJSON = genericParseJSON optionsCategory
 instance ToJSON Category where
-  toJSON = genericToJSON (removeFieldLabelPrefix "category")
+  toJSON = genericToJSON optionsCategory
+
+optionsCategory :: Options
+optionsCategory =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
+    }
+  where
+    table =
+      [ ("categoryId", "id")
+      , ("categoryName", "name")
+      ]
 
 
 -- | An order for a pets from the pet store
@@ -60,9 +85,25 @@ data Order = Order
   } deriving (Show, Eq, Generic)
 
 instance FromJSON Order where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "order")
+  parseJSON = genericParseJSON optionsOrder
 instance ToJSON Order where
-  toJSON = genericToJSON (removeFieldLabelPrefix "order")
+  toJSON = genericToJSON optionsOrder
+
+optionsOrder :: Options
+optionsOrder =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
+    }
+  where
+    table =
+      [ ("orderId", "id")
+      , ("orderPetId", "petId")
+      , ("orderQuantity", "quantity")
+      , ("orderShipDate", "shipDate")
+      , ("orderStatus", "status")
+      , ("orderComplete", "complete")
+      ]
 
 
 -- | A pet for sale in the pet store
@@ -76,9 +117,25 @@ data Pet = Pet
   } deriving (Show, Eq, Generic)
 
 instance FromJSON Pet where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "pet")
+  parseJSON = genericParseJSON optionsPet
 instance ToJSON Pet where
-  toJSON = genericToJSON (removeFieldLabelPrefix "pet")
+  toJSON = genericToJSON optionsPet
+
+optionsPet :: Options
+optionsPet =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
+    }
+  where
+    table =
+      [ ("petId", "id")
+      , ("petCategory", "category")
+      , ("petName", "name")
+      , ("petPhotoUrls", "photoUrls")
+      , ("petTags", "tags")
+      , ("petStatus", "status")
+      ]
 
 
 -- | A tag for a pet
@@ -88,9 +145,21 @@ data Tag = Tag
   } deriving (Show, Eq, Generic)
 
 instance FromJSON Tag where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "tag")
+  parseJSON = genericParseJSON optionsTag
 instance ToJSON Tag where
-  toJSON = genericToJSON (removeFieldLabelPrefix "tag")
+  toJSON = genericToJSON optionsTag
+
+optionsTag :: Options
+optionsTag =
+  defaultOptions
+    { omitNothingFields  = True
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
+    }
+  where
+    table =
+      [ ("tagId", "id")
+      , ("tagName", "name")
+      ]
 
 
 -- | A User who is purchasing from the pet store
@@ -106,62 +175,25 @@ data User = User
   } deriving (Show, Eq, Generic)
 
 instance FromJSON User where
-  parseJSON = genericParseJSON (removeFieldLabelPrefix "user")
+  parseJSON = genericParseJSON optionsUser
 instance ToJSON User where
-  toJSON = genericToJSON (removeFieldLabelPrefix "user")
+  toJSON = genericToJSON optionsUser
 
-
-uncapitalize :: String -> String
-uncapitalize (c : cs) = Char.toLower c : cs
-uncapitalize [] = []
-
--- | Remove a field label prefix during JSON parsing.
---   Also perform any replacements for special characters.
-removeFieldLabelPrefix :: String -> Options
-removeFieldLabelPrefix prefix =
+optionsUser :: Options
+optionsUser =
   defaultOptions
     { omitNothingFields  = True
-    , fieldLabelModifier = uncapitalize . replaceSpecialChars . fromMaybe (error ("did not find prefix " ++ prefix)) . stripPrefix prefix
+    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ List.lookup s table
     }
   where
-    replaceSpecialChars field = foldl (&) field (map mkCharReplacement specialChars)
-    specialChars =
-      [ ("$", "Dollar")
-      , ("^", "Caret")
-      , ("|", "Pipe")
-      , ("=", "Equal")
-      , ("*", "Star")
-      , ("-", "Dash")
-      , ("&", "Ampersand")
-      , ("%", "Percent")
-      , ("#", "Hash")
-      , ("@", "At")
-      , ("!", "Exclamation")
-      , ("+", "Plus")
-      , (":", "Colon")
-      , (";", "Semicolon")
-      , (">", "GreaterThan")
-      , ("<", "LessThan")
-      , (".", "Period")
-      , ("_", "Underscore")
-      , ("?", "Question_Mark")
-      , (",", "Comma")
-      , ("'", "Quote")
-      , ("/", "Slash")
-      , ("(", "Left_Parenthesis")
-      , (")", "Right_Parenthesis")
-      , ("{", "Left_Curly_Bracket")
-      , ("}", "Right_Curly_Bracket")
-      , ("[", "Left_Square_Bracket")
-      , ("]", "Right_Square_Bracket")
-      , ("~", "Tilde")
-      , ("`", "Backtick")
-      , ("<=", "Less_Than_Or_Equal_To")
-      , (">=", "Greater_Than_Or_Equal_To")
-      , ("!=", "Not_Equal")
-      , ("<>", "Not_Equal")
-      , ("~=", "Tilde_Equal")
-      , ("\\", "Back_Slash")
-      , ("\"", "Double_Quote")
+    table =
+      [ ("userId", "id")
+      , ("userUsername", "username")
+      , ("userFirstName", "firstName")
+      , ("userLastName", "lastName")
+      , ("userEmail", "email")
+      , ("userPassword", "password")
+      , ("userPhone", "phone")
+      , ("userUserStatus", "userStatus")
       ]
-    mkCharReplacement (replaceStr, searchStr) = T.unpack . T.replace (T.pack searchStr) (T.pack replaceStr) . T.pack
+


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I noticed that `haskell` (haskell-servant) and `haskell-yesod` generators cannot handle field names starting with upper case characters. For example, the following spec contains the `Message` field, and the generated   `ToJSON`/`FromJSON`  instances of `HelloResponse` do not work.

```yaml
openapi: 3.0.0
info:
  title: Test
  description: Test API
  version: 1.0.0
servers:
  - url: https://api.example.com/
    description: the server

paths:
  /hello:
    get:
      operationId: hello
      summary: "summary"
      description: "description."
      responses:
        "200":
          description: foo
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HelloResponse'

components:
  schemas:
    HelloResponse:
      type: object
      properties:
        id:
          type: string
          description: id
        Message:
          type: string
          description: text
      required:
        - id
        - Message
      description: description
```

For example, the following test program failed to convert JSON string into `HelloResponse` value.

```haskell
module Main where

import qualified Data.Aeson as J
import qualified Data.ByteString.Lazy.Char8 as BL
import Test.Types

main :: IO ()
main = do
  let s = BL.pack "{\"Message\":\"bar\",\"id\":\"foo\"}"
  BL.putStrLn s
  let val :: HelloResponse
      Just val = J.decode s
  print val
  BL.putStrLn $ J.encode val
  print $ J.encode val == s
```

The problem is that those instances call the `uncapitalize` function even when the JSON field name starts with an upper-case letter.

```haskell
uncapitalize :: String -> String
uncapitalize (first:rest) = Char.toLower first : rest
uncapitalize [] = []
```

To resolve this problem, this PR proposes to change the field name conversion to the one based on the conversion table. 
(However, I'm curious if there is a better way or how other generators handle this issue.)

With the changes in this PR, generated code looks like this:

```haskell
-- | description
data HelloResponse = HelloResponse
  { helloResponseId :: Text -- ^ id
  , helloResponseMessage :: Text -- ^ text
  } deriving (Show, Eq, Generic, Data)

instance FromJSON HelloResponse where
  parseJSON = genericParseJSON optionsHelloResponse
instance ToJSON HelloResponse where
  toJSON = genericToJSON optionsHelloResponse
instance ToSchema HelloResponse where
  declareNamedSchema = Swagger.genericDeclareNamedSchema
    $ Swagger.fromAesonOptions
    $ optionsHelloResponse

optionsHelloResponse :: Options
optionsHelloResponse =
  defaultOptions
    { omitNothingFields  = True
    , fieldLabelModifier = \s -> fromMaybe ("did not find JSON field name for " ++ show s) $ lookup s table
    }
  where
    table =
      [ ("helloResponseId", "id")
      , ("helloResponseMessage", "Message")
      ]
```

and, the above-mentioned test program succeeds to convert JSON string and `HelloResponse` value:

```
{"Message":"bar","id":"foo"}
HelloResponse {helloResponseId = "foo", helloResponseMessage = "bar"}
{"Message":"bar","id":"foo"}
True
```

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @f-f @Drezil