### PR TITLE
Add name mappings support to JS client

### DIFF
--- a/bin/configs/javascript-es6.yaml
+++ b/bin/configs/javascript-es6.yaml
@@ -5,3 +5,10 @@ inputSpec: modules/openapi-generator/src/test/resources/3_0/javascript/petstore-
 templateDir: modules/openapi-generator/src/main/resources/Javascript
 additionalProperties:
   appName: PetstoreClient
+modelNameMappings:
+  HealthCheckResult: HealthCheckStatus
+parameterNameMappings:
+  query_1: queryOne
+# the following has no effect as js client gen use baseName directly
+nameMappings:
+  NullableMessage: nullable_field

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -422,9 +422,7 @@ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generat
 ```
 will rename the Tag schema to Label instead.
 
-(Not all generators support thess features yet. Please give it a try to confirm the behaviour and open an issue (ticket) to let us know which generators you would like to have this feature enabled and we'll prioritize accordingly.)
-
-Related PRs: #16209 (modelNameMappings), #16194, #16206 (nameMappings, parameterNameMappings)
+Not all generators support thess features yet. Please give it a try to confirm the behaviour and open an issue (ticket) to let us know which generators you would like to have this feature enabled and we'll prioritize accordingly. We also welcome PRs to add these features to generators. Related PRs for reference: #16209, #16234 (modelNameMappings), #16194, #16206 (nameMappings, parameterNameMappings).
 
 NOTE: some generators use `baseName` (original name obtained direclty from OpenAPI spec, e.g. `shipping-date`) mustache tag in the templates so the mapping feature won't work.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -422,10 +422,11 @@ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generat
 ```
 will rename the Tag schema to Label instead.
 
-
 (Not all generators support thess features yet. Please give it a try to confirm the behaviour and open an issue (ticket) to let us know which generators you would like to have this feature enabled and we'll prioritize accordingly.)
 
 Related PRs: #16209 (modelNameMappings), #16194, #16206 (nameMappings, parameterNameMappings)
+
+NOTE: some generators use `baseName` (original name obtained direclty from OpenAPI spec, e.g. `shipping-date`) mustache tag in the templates so the mapping feature won't work.
 
 ## Schema Mapping
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -413,14 +413,14 @@ One can map the property name using `nameMappings` option and parameter name usi
 
 Here is an example to use `nameMappings` and `parameterNameMapping` in CLI:
 ```sh
-java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml  -o /tmp/java2/ --name-mappings _type=underscoreType, type_=typeWithUnderscore, --parameter-name-mappings _type=paramType, type_=typeParam
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml  -o /tmp/java2/ --name-mappings _type=underscoreType,type_=typeWithUnderscore, --parameter-name-mappings _type=paramType,type_=typeParam
 ```
 
 To map model names, use `modelNameMappings` option, e.g.
 ```sh
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g csharp -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml  -o /tmp/csharp/ --model-name-mappings Tag=Label
 ```
-will rename the Tag schema to Label instead.
+will rename the `Tag` schema to `Label` instead.
 
 Not all generators support thess features yet. Please give it a try to confirm the behaviour and open an issue (ticket) to let us know which generators you would like to have this feature enabled and we'll prioritize accordingly. We also welcome PRs to add these features to generators. Related PRs for reference: #16209, #16234 (modelNameMappings), #16194, #16206 (nameMappings, parameterNameMappings).
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -507,6 +507,11 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     @Override
     public String toVarName(String name) {
+        // obtain the name from nameMapping directly if provided
+        if (nameMapping.containsKey(name)) {
+            return nameMapping.get(name);
+        }
+
         // sanitize name
         name = sanitizeName(name);  // FIXME parameter should not be assigned. Also declare it as "final"
 
@@ -538,12 +543,22 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     @Override
     public String toParamName(String name) {
+        // obtain the name from parameterNameMapping directly if provided
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
+        }
+
         // should be the same as variable name
         return toVarName(name);
     }
 
     @Override
     public String toModelName(String name) {
+        // obtain the name from modelNameMapping directly if provided
+        if (modelNameMapping.containsKey(name)) {
+            return modelNameMapping.get(name);
+        }
+
         name = sanitizeName(name);  // FIXME parameter should not be assigned. Also declare it as "final"
 
         if (!StringUtils.isEmpty(modelNamePrefix)) {

--- a/samples/client/petstore/javascript-es6/.openapi-generator/FILES
+++ b/samples/client/petstore/javascript-es6/.openapi-generator/FILES
@@ -31,7 +31,7 @@ docs/Foo.md
 docs/FooGetDefaultResponse.md
 docs/FormatTest.md
 docs/HasOnlyReadOnly.md
-docs/HealthCheckResult.md
+docs/HealthCheckStatus.md
 docs/List.md
 docs/MapTest.md
 docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -97,7 +97,7 @@ src/model/Foo.js
 src/model/FooGetDefaultResponse.js
 src/model/FormatTest.js
 src/model/HasOnlyReadOnly.js
-src/model/HealthCheckResult.js
+src/model/HealthCheckStatus.js
 src/model/List.js
 src/model/MapTest.js
 src/model/MixedPropertiesAndAdditionalPropertiesClass.js

--- a/samples/client/petstore/javascript-es6/README.md
+++ b/samples/client/petstore/javascript-es6/README.md
@@ -190,7 +190,7 @@ Class | Method | HTTP request | Description
  - [OpenApiPetstore.FooGetDefaultResponse](docs/FooGetDefaultResponse.md)
  - [OpenApiPetstore.FormatTest](docs/FormatTest.md)
  - [OpenApiPetstore.HasOnlyReadOnly](docs/HasOnlyReadOnly.md)
- - [OpenApiPetstore.HealthCheckResult](docs/HealthCheckResult.md)
+ - [OpenApiPetstore.HealthCheckStatus](docs/HealthCheckStatus.md)
  - [OpenApiPetstore.List](docs/List.md)
  - [OpenApiPetstore.MapTest](docs/MapTest.md)
  - [OpenApiPetstore.MixedPropertiesAndAdditionalPropertiesClass](docs/MixedPropertiesAndAdditionalPropertiesClass.md)

--- a/samples/client/petstore/javascript-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-es6/docs/FakeApi.md
@@ -26,7 +26,7 @@ Method | HTTP request | Description
 
 ## fakeHealthGet
 
-> HealthCheckResult fakeHealthGet()
+> HealthCheckStatus fakeHealthGet()
 
 Health check endpoint
 
@@ -51,7 +51,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**HealthCheckStatus**](HealthCheckStatus.md)
 
 ### Authorization
 
@@ -78,7 +78,7 @@ let defaultClient = OpenApiPetstore.ApiClient.instance;
 let apiInstance = new OpenApiPetstore.FakeApi();
 let pet = new OpenApiPetstore.Pet(); // Pet | Pet object that needs to be added to the store
 let opts = {
-  'query1': "query1_example", // String | query parameter
+  'queryOne': "queryOne_example", // String | query parameter
   'header1': "header1_example" // String | header parameter
 };
 apiInstance.fakeHttpSignatureTest(pet, opts, (error, data, response) => {
@@ -96,7 +96,7 @@ apiInstance.fakeHttpSignatureTest(pet, opts, (error, data, response) => {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
- **query1** | **String**| query parameter | [optional] 
+ **queryOne** | **String**| query parameter | [optional] 
  **header1** | **String**| header parameter | [optional] 
 
 ### Return type

--- a/samples/client/petstore/javascript-es6/docs/HealthCheckStatus.md
+++ b/samples/client/petstore/javascript-es6/docs/HealthCheckStatus.md
@@ -1,9 +1,9 @@
-# OpenApiPetstore.HealthCheckResult
+# OpenApiPetstore.HealthCheckStatus
 
 ## Properties
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**nullableMessage** | **String** |  | [optional] 
+**nullable_field** | **String** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -16,7 +16,7 @@ import ApiClient from "../ApiClient";
 import Client from '../model/Client';
 import EnumClass from '../model/EnumClass';
 import FileSchemaTestClass from '../model/FileSchemaTestClass';
-import HealthCheckResult from '../model/HealthCheckResult';
+import HealthCheckStatus from '../model/HealthCheckStatus';
 import OuterComposite from '../model/OuterComposite';
 import OuterObjectWithEnumProperty from '../model/OuterObjectWithEnumProperty';
 import Pet from '../model/Pet';
@@ -45,14 +45,14 @@ export default class FakeApi {
      * Callback function to receive the result of the fakeHealthGet operation.
      * @callback module:api/FakeApi~fakeHealthGetCallback
      * @param {String} error Error message, if any.
-     * @param {module:model/HealthCheckResult} data The data returned by the service call.
+     * @param {module:model/HealthCheckStatus} data The data returned by the service call.
      * @param {String} response The complete HTTP response.
      */
 
     /**
      * Health check endpoint
      * @param {module:api/FakeApi~fakeHealthGetCallback} callback The callback function, accepting three arguments: error, data, response
-     * data is of type: {@link module:model/HealthCheckResult}
+     * data is of type: {@link module:model/HealthCheckStatus}
      */
     fakeHealthGet(callback) {
       let postBody = null;
@@ -69,7 +69,7 @@ export default class FakeApi {
       let authNames = [];
       let contentTypes = [];
       let accepts = ['application/json'];
-      let returnType = HealthCheckResult;
+      let returnType = HealthCheckStatus;
       return this.apiClient.callApi(
         '/fake/health', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
@@ -89,7 +89,7 @@ export default class FakeApi {
      * test http signature authentication
      * @param {module:model/Pet} pet Pet object that needs to be added to the store
      * @param {Object} opts Optional parameters
-     * @param {String} [query1] query parameter
+     * @param {String} [queryOne] query parameter
      * @param {String} [header1] header parameter
      * @param {module:api/FakeApi~fakeHttpSignatureTestCallback} callback The callback function, accepting three arguments: error, data, response
      */
@@ -104,7 +104,7 @@ export default class FakeApi {
       let pathParams = {
       };
       let queryParams = {
-        'query_1': opts['query1']
+        'query_1': opts['queryOne']
       };
       let headerParams = {
         'header_1': opts['header1']

--- a/samples/client/petstore/javascript-es6/src/index.js
+++ b/samples/client/petstore/javascript-es6/src/index.js
@@ -38,7 +38,7 @@ import Foo from './model/Foo';
 import FooGetDefaultResponse from './model/FooGetDefaultResponse';
 import FormatTest from './model/FormatTest';
 import HasOnlyReadOnly from './model/HasOnlyReadOnly';
-import HealthCheckResult from './model/HealthCheckResult';
+import HealthCheckStatus from './model/HealthCheckStatus';
 import List from './model/List';
 import MapTest from './model/MapTest';
 import MixedPropertiesAndAdditionalPropertiesClass from './model/MixedPropertiesAndAdditionalPropertiesClass';
@@ -262,10 +262,10 @@ export {
     HasOnlyReadOnly,
 
     /**
-     * The HealthCheckResult model constructor.
-     * @property {module:model/HealthCheckResult}
+     * The HealthCheckStatus model constructor.
+     * @property {module:model/HealthCheckStatus}
      */
-    HealthCheckResult,
+    HealthCheckStatus,
 
     /**
      * The List model constructor.

--- a/samples/client/petstore/javascript-es6/src/model/HealthCheckStatus.js
+++ b/samples/client/petstore/javascript-es6/src/model/HealthCheckStatus.js
@@ -14,19 +14,19 @@
 import ApiClient from '../ApiClient';
 
 /**
- * The HealthCheckResult model module.
- * @module model/HealthCheckResult
+ * The HealthCheckStatus model module.
+ * @module model/HealthCheckStatus
  * @version 1.0.0
  */
-class HealthCheckResult {
+class HealthCheckStatus {
     /**
-     * Constructs a new <code>HealthCheckResult</code>.
+     * Constructs a new <code>HealthCheckStatus</code>.
      * Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
-     * @alias module:model/HealthCheckResult
+     * @alias module:model/HealthCheckStatus
      */
     constructor() { 
         
-        HealthCheckResult.initialize(this);
+        HealthCheckStatus.initialize(this);
     }
 
     /**
@@ -38,15 +38,15 @@ class HealthCheckResult {
     }
 
     /**
-     * Constructs a <code>HealthCheckResult</code> from a plain JavaScript object, optionally creating a new instance.
+     * Constructs a <code>HealthCheckStatus</code> from a plain JavaScript object, optionally creating a new instance.
      * Copies all relevant properties from <code>data</code> to <code>obj</code> if supplied or a new instance if not.
      * @param {Object} data The plain JavaScript object bearing properties of interest.
-     * @param {module:model/HealthCheckResult} obj Optional instance to populate.
-     * @return {module:model/HealthCheckResult} The populated <code>HealthCheckResult</code> instance.
+     * @param {module:model/HealthCheckStatus} obj Optional instance to populate.
+     * @return {module:model/HealthCheckStatus} The populated <code>HealthCheckStatus</code> instance.
      */
     static constructFromObject(data, obj) {
         if (data) {
-            obj = obj || new HealthCheckResult();
+            obj = obj || new HealthCheckStatus();
 
             if (data.hasOwnProperty('NullableMessage')) {
                 obj['NullableMessage'] = ApiClient.convertToType(data['NullableMessage'], 'String');
@@ -56,9 +56,9 @@ class HealthCheckResult {
     }
 
     /**
-     * Validates the JSON data with respect to <code>HealthCheckResult</code>.
+     * Validates the JSON data with respect to <code>HealthCheckStatus</code>.
      * @param {Object} data The plain JavaScript object bearing properties of interest.
-     * @return {boolean} to indicate whether the JSON data is valid with respect to <code>HealthCheckResult</code>.
+     * @return {boolean} to indicate whether the JSON data is valid with respect to <code>HealthCheckStatus</code>.
      */
     static validateJSON(data) {
         // ensure the json data is a string
@@ -77,12 +77,12 @@ class HealthCheckResult {
 /**
  * @member {String} NullableMessage
  */
-HealthCheckResult.prototype['NullableMessage'] = undefined;
+HealthCheckStatus.prototype['NullableMessage'] = undefined;
 
 
 
 
 
 
-export default HealthCheckResult;
+export default HealthCheckStatus;
 

--- a/samples/client/petstore/javascript-es6/test/model/HealthCheckStatus.spec.js
+++ b/samples/client/petstore/javascript-es6/test/model/HealthCheckStatus.spec.js
@@ -28,7 +28,7 @@
   var instance;
 
   beforeEach(function() {
-    instance = new OpenApiPetstore.HealthCheckResult();
+    instance = new OpenApiPetstore.HealthCheckStatus();
   });
 
   var getProperty = function(object, getter, property) {
@@ -47,16 +47,16 @@
       object[property] = value;
   }
 
-  describe('HealthCheckResult', function() {
-    it('should create an instance of HealthCheckResult', function() {
-      // uncomment below and update the code to test HealthCheckResult
-      //var instance = new OpenApiPetstore.HealthCheckResult();
-      //expect(instance).to.be.a(OpenApiPetstore.HealthCheckResult);
+  describe('HealthCheckStatus', function() {
+    it('should create an instance of HealthCheckStatus', function() {
+      // uncomment below and update the code to test HealthCheckStatus
+      //var instance = new OpenApiPetstore.HealthCheckStatus();
+      //expect(instance).to.be.a(OpenApiPetstore.HealthCheckStatus);
     });
 
-    it('should have the property nullableMessage (base name: "NullableMessage")', function() {
-      // uncomment below and update the code to test the property nullableMessage
-      //var instance = new OpenApiPetstore.HealthCheckResult();
+    it('should have the property nullable_field (base name: "NullableMessage")', function() {
+      // uncomment below and update the code to test the property nullable_field
+      //var instance = new OpenApiPetstore.HealthCheckStatus();
       //expect(instance).to.be();
     });
 


### PR DESCRIPTION
Add name mappings (parameter, property, model) support to JS client

e.g.
```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g javascript -i modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-okhttp-gson.yaml  -o /tmp/javascript2/ --name-mappings _type=underscoreType,type_=typeWithUnderscore --parameter-name-mappings _type=paramType,type_=typeParam --model-mappings Tag=MyTag
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)
