### PR TITLE
support 32bit in postdata

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -236,7 +236,7 @@ char *assembleHeaderField(char *key, char *value) {
 void postData(CURL *handle, const char *bodyParameters) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     strlen(bodyParameters));
+                     (curl_off_t)strlen(bodyParameters));
 }
 
 int lengthOfKeyPair(keyValuePair_t *keyPair) {

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -190,7 +190,7 @@ char *assembleHeaderField(char *key, char *value) {
 void postData(CURL *handle, const char *bodyParameters) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     strlen(bodyParameters));
+                     (curl_off_t)strlen(bodyParameters));
 }
 
 int lengthOfKeyPair(keyValuePair_t *keyPair) {


### PR DESCRIPTION
 libcurl API curl_easy_setopt requires the third parameter has to be passed with correct type depending on specific option.
 For CURLOPT_POSTFIELDSIZE_LARGE option, it has to be type curl_off_t which is expected to be 64bit whether on 32bit or 64bit platform.
     
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
