### PR TITLE
[Java] Array default value requires import of java.util.Arrays

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1473,6 +1473,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         if ("array".equals(property.containerType)) {
             model.imports.add("ArrayList");
+            model.imports.add("Arrays");
         } else if ("set".equals(property.containerType)) {
             model.imports.add("LinkedHashSet");
             boolean canNotBeWrappedToNullable = !openApiNullable || !property.isNullable;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -252,6 +252,33 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
     }
 
     @Test
+    public void testGeneratePingDefaultArrayValue() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+
+        File output = Files.createTempDirectory("test").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("jaxrs-spec")
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/ping-array-default.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        validateJavaSourceFiles(files);
+
+        TestUtils.ensureContainsFile(files, output, "src/main/openapi/openapi.yaml");
+
+        Path path = Paths.get(output.toPath() + "/src/gen/java/org/openapitools/model/AnArrayOfString.java");
+
+        assertFileContains(path , "\nimport java.util.Arrays;\n");
+
+        output.deleteOnExit();
+    }
+
+    @Test
     public void testGeneratePingNoSpecFile() throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put(JavaJAXRSSpecServerCodegen.OPEN_API_SPEC_FILE_LOCATION, "");

--- a/modules/openapi-generator/src/test/resources/3_0/ping-array-default.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/ping-array-default.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: ping test
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000/'
+paths:
+  /ping:
+    get:
+      operationId: pingGet
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnArrayOfString"
+components:
+  schemas:
+    AnArrayOfString:
+      type: object
+      properties:
+        arrayWithADefaultValue:
+          default:
+            - aString
+          items:
+            type: string
+          type: array


### PR DESCRIPTION
Likely since 6.3.0 and introduction of default value for arrays in Java. https://github.com/OpenAPITools/openapi-generator/pull/14130 

In Java codegen a default value for the container type `array` will use `java.util.Arrays` to set the default value, however the required import is not added automatically. 
Issue reproduced at least with jaxrs-spec, jaxrs-jersey and spring generators.

https://github.com/OpenAPITools/openapi-generator/blob/dbb80de3cbd9b72da97d90be25c360f025f59567/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java#L1028-L1032

This PR contains:
- Test reproducing the issue.
- ⚠️ Possible fix by importing required class whenever array container type is found. With this approach the import could be superfluous when the array container doesn't specify a default value.  There are as well a lot of changes in samples and introduce duplicate imports in some cases (maybe because some template as well specify this import).

⚠️ The samples were not added yet to the PR as better approach for the resolution should be found from review by someone with a better understanding of the code base.

Handling of duplicates relates maybe to:
https://github.com/OpenAPITools/openapi-generator/blob/dbb80de3cbd9b72da97d90be25c360f025f59567/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java#L1547-L1550

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] ⚠️  See comment above. Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
