### PR TITLE
Dart deep-equals

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
@@ -24,15 +24,13 @@ part 'auth/http_bearer_auth.dart';
 {{#models}}{{#model}}part 'model/{{{classFilename}}}.dart';
 {{/model}}{{/models}}
 
-/// A handy comparison utility to deep-compare any arbitrary objects.
-const deepEquality = DeepCollectionEquality();
-
 /// An [ApiClient] instance that uses the default values obtained from
 /// the OpenAPI specification file.
 var defaultApiClient = ApiClient();
 
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
+const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');

--- a/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
@@ -29,6 +30,7 @@ final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
+final _deepEquality = DeepCollectionEquality();
 
 ApiClient defaultApiClient = ApiClient();
 

--- a/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
@@ -26,11 +26,11 @@ part 'auth/http_bearer_auth.dart';
 
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
+const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
-final _deepEquality = DeepCollectionEquality();
 
 ApiClient defaultApiClient = ApiClient();
 

--- a/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
@@ -24,14 +24,18 @@ part 'auth/http_bearer_auth.dart';
 {{#models}}{{#model}}part 'model/{{{classFilename}}}.dart';
 {{/model}}{{/models}}
 
+/// A handy comparison utility to deep-compare any arbitrary objects.
+const deepEquality = DeepCollectionEquality();
+
+/// An [ApiClient] instance that uses the default values obtained from
+/// the OpenAPI specification file.
+var defaultApiClient = ApiClient();
+
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
-const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
-
-ApiClient defaultApiClient = ApiClient();
 
 bool _isEpochMarker(String? pattern) => pattern == _dateEpochMarker || pattern == '/$_dateEpochMarker/';

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -15,7 +15,7 @@ publish_to: {{.}}
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  collection: '^1.17.1'
+  collection: '^1.17.0'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -15,7 +15,7 @@ publish_to: {{.}}
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  collection: '^1.18.0'
+  collection: '^1.17.1'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -15,6 +15,7 @@ publish_to: {{.}}
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
+  collection: '^1.18.0'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'
@@ -22,4 +23,5 @@ dev_dependencies:
   test: '>=1.16.0 <1.18.0'
 {{#json_serializable}}
   build_runner: '^1.10.9'
-  json_serializable: '^3.5.1'{{/json_serializable}}
+  json_serializable: '^3.5.1'
+{{/json_serializable}}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -38,7 +38,7 @@ class {{{classname}}} {
   @override
   bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
   {{#vars}}
-    {{#isMap}}deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isMap}}{{^isMap}}{{#isArray}}deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isArray}}{{^isArray}}other.{{{name}}} == {{{name}}}{{/isArray}}{{/isMap}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
+    {{#isMap}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isMap}}{{^isMap}}{{#isArray}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isArray}}{{^isArray}}other.{{{name}}} == {{{name}}}{{/isArray}}{{/isMap}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
   @override

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -38,7 +38,7 @@ class {{{classname}}} {
   @override
   bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
   {{#vars}}
-     other.{{{name}}} == {{{name}}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
+    {{#complexType}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/complexType}}{{^complexType}}other.{{{name}}} == {{{name}}}{{/complexType}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
   @override

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -38,7 +38,7 @@ class {{{classname}}} {
   @override
   bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
   {{#vars}}
-    {{#isMap}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isMap}}{{^isMap}}{{#isArray}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isArray}}{{^isArray}}other.{{{name}}} == {{{name}}}{{/isArray}}{{/isMap}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
+    {{#isMap}}deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isMap}}{{^isMap}}{{#isArray}}deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isArray}}{{^isArray}}other.{{{name}}} == {{{name}}}{{/isArray}}{{/isMap}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
   @override

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -38,7 +38,7 @@ class {{{classname}}} {
   @override
   bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
   {{#vars}}
-    {{#complexType}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/complexType}}{{^complexType}}other.{{{name}}} == {{{name}}}{{/complexType}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
+    {{#isMap}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isMap}}{{^isMap}}{{#isArray}}_deepEquality.equals(other.{{{name}}}, {{{name}}}){{/isArray}}{{^isArray}}other.{{{name}}} == {{{name}}}{{/isArray}}{{/isMap}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
   @override

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
@@ -14,6 +14,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
@@ -41,6 +42,7 @@ part 'model/user.dart';
 
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
+const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
@@ -40,14 +40,18 @@ part 'model/tag.dart';
 part 'model/user.dart';
 
 
+/// A handy comparison utility to deep-compare any arbitrary objects.
+const deepEquality = DeepCollectionEquality();
+
+/// An [ApiClient] instance that uses the default values obtained from
+/// the OpenAPI specification file.
+var defaultApiClient = ApiClient();
+
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
-const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
-
-ApiClient defaultApiClient = ApiClient();
 
 bool _isEpochMarker(String? pattern) => pattern == _dateEpochMarker || pattern == '/$_dateEpochMarker/';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
@@ -40,15 +40,13 @@ part 'model/tag.dart';
 part 'model/user.dart';
 
 
-/// A handy comparison utility to deep-compare any arbitrary objects.
-const deepEquality = DeepCollectionEquality();
-
 /// An [ApiClient] instance that uses the default values obtained from
 /// the OpenAPI specification file.
 var defaultApiClient = ApiClient();
 
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
+const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -44,9 +44,9 @@ class ApiResponse {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ApiResponse &&
-     other.code == code &&
-     other.type == type &&
-     other.message == message;
+    other.code == code &&
+    other.type == type &&
+    other.message == message;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -35,8 +35,8 @@ class Category {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Category &&
-     other.id == id &&
-     other.name == name;
+    other.id == id &&
+    other.name == name;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -60,12 +60,12 @@ class Order {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Order &&
-     other.id == id &&
-     other.petId == petId &&
-     other.quantity == quantity &&
-     other.shipDate == shipDate &&
-     other.status == status &&
-     other.complete == complete;
+    other.id == id &&
+    other.petId == petId &&
+    other.quantity == quantity &&
+    other.shipDate == shipDate &&
+    other.status == status &&
+    other.complete == complete;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -48,12 +48,12 @@ class Pet {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Pet &&
-     other.id == id &&
-     other.category == category &&
-     other.name == name &&
-     other.photoUrls == photoUrls &&
-     other.tags == tags &&
-     other.status == status;
+    other.id == id &&
+    other.category == category &&
+    other.name == name &&
+    _deepEquality.equals(other.photoUrls, photoUrls) &&
+    _deepEquality.equals(other.tags, tags) &&
+    other.status == status;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -51,8 +51,8 @@ class Pet {
     other.id == id &&
     other.category == category &&
     other.name == name &&
-    deepEquality.equals(other.photoUrls, photoUrls) &&
-    deepEquality.equals(other.tags, tags) &&
+    _deepEquality.equals(other.photoUrls, photoUrls) &&
+    _deepEquality.equals(other.tags, tags) &&
     other.status == status;
 
   @override

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -51,8 +51,8 @@ class Pet {
     other.id == id &&
     other.category == category &&
     other.name == name &&
-    _deepEquality.equals(other.photoUrls, photoUrls) &&
-    _deepEquality.equals(other.tags, tags) &&
+    deepEquality.equals(other.photoUrls, photoUrls) &&
+    deepEquality.equals(other.tags, tags) &&
     other.status == status;
 
   @override

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -35,8 +35,8 @@ class Tag {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Tag &&
-     other.id == id &&
-     other.name == name;
+    other.id == id &&
+    other.name == name;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -90,14 +90,14 @@ class User {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is User &&
-     other.id == id &&
-     other.username == username &&
-     other.firstName == firstName &&
-     other.lastName == lastName &&
-     other.email == email &&
-     other.password == password &&
-     other.phone == phone &&
-     other.userStatus == userStatus;
+    other.id == id &&
+    other.username == username &&
+    other.firstName == firstName &&
+    other.lastName == lastName &&
+    other.email == email &&
+    other.password == password &&
+    other.phone == phone &&
+    other.userStatus == userStatus;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  collection: '^1.17.1'
+  collection: '^1.17.0'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -9,9 +9,9 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
+  collection: '^1.17.1'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'
 dev_dependencies:
   test: '>=1.16.0 <1.18.0'
-

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
@@ -85,15 +85,13 @@ part 'model/tag.dart';
 part 'model/user.dart';
 
 
-/// A handy comparison utility to deep-compare any arbitrary objects.
-const deepEquality = DeepCollectionEquality();
-
 /// An [ApiClient] instance that uses the default values obtained from
 /// the OpenAPI specification file.
 var defaultApiClient = ApiClient();
 
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
+const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
@@ -14,6 +14,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
@@ -86,6 +87,7 @@ part 'model/user.dart';
 
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
+const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
@@ -85,14 +85,18 @@ part 'model/tag.dart';
 part 'model/user.dart';
 
 
+/// A handy comparison utility to deep-compare any arbitrary objects.
+const deepEquality = DeepCollectionEquality();
+
+/// An [ApiClient] instance that uses the default values obtained from
+/// the OpenAPI specification file.
+var defaultApiClient = ApiClient();
+
 const _delimiters = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'};
 const _dateEpochMarker = 'epoch';
-const _deepEquality = DeepCollectionEquality();
 final _dateFormatter = DateFormat('yyyy-MM-dd');
 final _regList = RegExp(r'^List<(.*)>$');
 final _regSet = RegExp(r'^Set<(.*)>$');
 final _regMap = RegExp(r'^Map<String,(.*)>$');
-
-ApiClient defaultApiClient = ApiClient();
 
 bool _isEpochMarker(String? pattern) => pattern == _dateEpochMarker || pattern == '/$_dateEpochMarker/';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -23,8 +23,8 @@ class AdditionalPropertiesClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is AdditionalPropertiesClass &&
-     other.mapProperty == mapProperty &&
-     other.mapOfMapProperty == mapOfMapProperty;
+    _deepEquality.equals(other.mapProperty, mapProperty) &&
+    _deepEquality.equals(other.mapOfMapProperty, mapOfMapProperty);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -23,8 +23,8 @@ class AdditionalPropertiesClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is AdditionalPropertiesClass &&
-    _deepEquality.equals(other.mapProperty, mapProperty) &&
-    _deepEquality.equals(other.mapOfMapProperty, mapOfMapProperty);
+    deepEquality.equals(other.mapProperty, mapProperty) &&
+    deepEquality.equals(other.mapOfMapProperty, mapOfMapProperty);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -23,8 +23,8 @@ class AdditionalPropertiesClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is AdditionalPropertiesClass &&
-    deepEquality.equals(other.mapProperty, mapProperty) &&
-    deepEquality.equals(other.mapOfMapProperty, mapOfMapProperty);
+    _deepEquality.equals(other.mapProperty, mapProperty) &&
+    _deepEquality.equals(other.mapOfMapProperty, mapOfMapProperty);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
@@ -35,8 +35,8 @@ class AllOfWithSingleRef {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is AllOfWithSingleRef &&
-     other.username == username &&
-     other.singleRefType == singleRefType;
+    other.username == username &&
+    other.singleRefType == singleRefType;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
@@ -23,8 +23,8 @@ class Animal {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Animal &&
-     other.className == className &&
-     other.color == color;
+    other.className == className &&
+    other.color == color;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -44,9 +44,9 @@ class ApiResponse {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ApiResponse &&
-     other.code == code &&
-     other.type == type &&
-     other.message == message;
+    other.code == code &&
+    other.type == type &&
+    other.message == message;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -20,7 +20,7 @@ class ArrayOfArrayOfNumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayOfArrayOfNumberOnly &&
-     other.arrayArrayNumber == arrayArrayNumber;
+    _deepEquality.equals(other.arrayArrayNumber, arrayArrayNumber);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -20,7 +20,7 @@ class ArrayOfArrayOfNumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayOfArrayOfNumberOnly &&
-    deepEquality.equals(other.arrayArrayNumber, arrayArrayNumber);
+    _deepEquality.equals(other.arrayArrayNumber, arrayArrayNumber);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -20,7 +20,7 @@ class ArrayOfArrayOfNumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayOfArrayOfNumberOnly &&
-    _deepEquality.equals(other.arrayArrayNumber, arrayArrayNumber);
+    deepEquality.equals(other.arrayArrayNumber, arrayArrayNumber);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -20,7 +20,7 @@ class ArrayOfNumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayOfNumberOnly &&
-     other.arrayNumber == arrayNumber;
+    _deepEquality.equals(other.arrayNumber, arrayNumber);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -20,7 +20,7 @@ class ArrayOfNumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayOfNumberOnly &&
-    _deepEquality.equals(other.arrayNumber, arrayNumber);
+    deepEquality.equals(other.arrayNumber, arrayNumber);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -20,7 +20,7 @@ class ArrayOfNumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayOfNumberOnly &&
-    deepEquality.equals(other.arrayNumber, arrayNumber);
+    _deepEquality.equals(other.arrayNumber, arrayNumber);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -26,9 +26,9 @@ class ArrayTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayTest &&
-     other.arrayOfString == arrayOfString &&
-     other.arrayArrayOfInteger == arrayArrayOfInteger &&
-     other.arrayArrayOfModel == arrayArrayOfModel;
+    _deepEquality.equals(other.arrayOfString, arrayOfString) &&
+    _deepEquality.equals(other.arrayArrayOfInteger, arrayArrayOfInteger) &&
+    _deepEquality.equals(other.arrayArrayOfModel, arrayArrayOfModel);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -26,9 +26,9 @@ class ArrayTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayTest &&
-    deepEquality.equals(other.arrayOfString, arrayOfString) &&
-    deepEquality.equals(other.arrayArrayOfInteger, arrayArrayOfInteger) &&
-    deepEquality.equals(other.arrayArrayOfModel, arrayArrayOfModel);
+    _deepEquality.equals(other.arrayOfString, arrayOfString) &&
+    _deepEquality.equals(other.arrayArrayOfInteger, arrayArrayOfInteger) &&
+    _deepEquality.equals(other.arrayArrayOfModel, arrayArrayOfModel);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -26,9 +26,9 @@ class ArrayTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ArrayTest &&
-    _deepEquality.equals(other.arrayOfString, arrayOfString) &&
-    _deepEquality.equals(other.arrayArrayOfInteger, arrayArrayOfInteger) &&
-    _deepEquality.equals(other.arrayArrayOfModel, arrayArrayOfModel);
+    deepEquality.equals(other.arrayOfString, arrayOfString) &&
+    deepEquality.equals(other.arrayArrayOfInteger, arrayArrayOfInteger) &&
+    deepEquality.equals(other.arrayArrayOfModel, arrayArrayOfModel);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -72,12 +72,12 @@ class Capitalization {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Capitalization &&
-     other.smallCamel == smallCamel &&
-     other.capitalCamel == capitalCamel &&
-     other.smallSnake == smallSnake &&
-     other.capitalSnake == capitalSnake &&
-     other.sCAETHFlowPoints == sCAETHFlowPoints &&
-     other.ATT_NAME == ATT_NAME;
+    other.smallCamel == smallCamel &&
+    other.capitalCamel == capitalCamel &&
+    other.smallSnake == smallSnake &&
+    other.capitalSnake == capitalSnake &&
+    other.sCAETHFlowPoints == sCAETHFlowPoints &&
+    other.ATT_NAME == ATT_NAME;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -32,9 +32,9 @@ class Cat {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Cat &&
-     other.className == className &&
-     other.color == color &&
-     other.declawed == declawed;
+    other.className == className &&
+    other.color == color &&
+    other.declawed == declawed;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -29,8 +29,8 @@ class Category {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Category &&
-     other.id == id &&
-     other.name == name;
+    other.id == id &&
+    other.name == name;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -26,7 +26,7 @@ class ClassModel {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ClassModel &&
-     other.class_ == class_;
+    other.class_ == class_;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
@@ -26,7 +26,7 @@ class DeprecatedObject {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is DeprecatedObject &&
-     other.name == name;
+    other.name == name;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -32,9 +32,9 @@ class Dog {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Dog &&
-     other.className == className &&
-     other.color == color &&
-     other.breed == breed;
+    other.className == className &&
+    other.color == color &&
+    other.breed == breed;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -23,8 +23,8 @@ class EnumArrays {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is EnumArrays &&
-     other.justSymbol == justSymbol &&
-     other.arrayEnum == arrayEnum;
+    other.justSymbol == justSymbol &&
+    _deepEquality.equals(other.arrayEnum, arrayEnum);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -24,7 +24,7 @@ class EnumArrays {
   @override
   bool operator ==(Object other) => identical(this, other) || other is EnumArrays &&
     other.justSymbol == justSymbol &&
-    deepEquality.equals(other.arrayEnum, arrayEnum);
+    _deepEquality.equals(other.arrayEnum, arrayEnum);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -24,7 +24,7 @@ class EnumArrays {
   @override
   bool operator ==(Object other) => identical(this, other) || other is EnumArrays &&
     other.justSymbol == justSymbol &&
-    _deepEquality.equals(other.arrayEnum, arrayEnum);
+    deepEquality.equals(other.arrayEnum, arrayEnum);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -59,14 +59,14 @@ class EnumTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is EnumTest &&
-     other.enumString == enumString &&
-     other.enumStringRequired == enumStringRequired &&
-     other.enumInteger == enumInteger &&
-     other.enumNumber == enumNumber &&
-     other.outerEnum == outerEnum &&
-     other.outerEnumInteger == outerEnumInteger &&
-     other.outerEnumDefaultValue == outerEnumDefaultValue &&
-     other.outerEnumIntegerDefaultValue == outerEnumIntegerDefaultValue;
+    other.enumString == enumString &&
+    other.enumStringRequired == enumStringRequired &&
+    other.enumInteger == enumInteger &&
+    other.enumNumber == enumNumber &&
+    other.outerEnum == outerEnum &&
+    other.outerEnumInteger == outerEnumInteger &&
+    other.outerEnumDefaultValue == outerEnumDefaultValue &&
+    other.outerEnumIntegerDefaultValue == outerEnumIntegerDefaultValue;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -29,8 +29,8 @@ class FakeBigDecimalMap200Response {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is FakeBigDecimalMap200Response &&
-     other.someId == someId &&
-     other.someMap == someMap;
+    other.someId == someId &&
+    _deepEquality.equals(other.someMap, someMap);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -30,7 +30,7 @@ class FakeBigDecimalMap200Response {
   @override
   bool operator ==(Object other) => identical(this, other) || other is FakeBigDecimalMap200Response &&
     other.someId == someId &&
-    _deepEquality.equals(other.someMap, someMap);
+    deepEquality.equals(other.someMap, someMap);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -30,7 +30,7 @@ class FakeBigDecimalMap200Response {
   @override
   bool operator ==(Object other) => identical(this, other) || other is FakeBigDecimalMap200Response &&
     other.someId == someId &&
-    deepEquality.equals(other.someMap, someMap);
+    _deepEquality.equals(other.someMap, someMap);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -29,8 +29,8 @@ class FileSchemaTestClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is FileSchemaTestClass &&
-     other.file == file &&
-     other.files == files;
+    other.file == file &&
+    _deepEquality.equals(other.files, files);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -30,7 +30,7 @@ class FileSchemaTestClass {
   @override
   bool operator ==(Object other) => identical(this, other) || other is FileSchemaTestClass &&
     other.file == file &&
-    deepEquality.equals(other.files, files);
+    _deepEquality.equals(other.files, files);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -30,7 +30,7 @@ class FileSchemaTestClass {
   @override
   bool operator ==(Object other) => identical(this, other) || other is FileSchemaTestClass &&
     other.file == file &&
-    _deepEquality.equals(other.files, files);
+    deepEquality.equals(other.files, files);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
@@ -20,7 +20,7 @@ class Foo {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Foo &&
-     other.bar == bar;
+    other.bar == bar;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
@@ -26,7 +26,7 @@ class FooGetDefaultResponse {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is FooGetDefaultResponse &&
-     other.string == string;
+    other.string == string;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -149,22 +149,22 @@ class FormatTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is FormatTest &&
-     other.integer == integer &&
-     other.int32 == int32 &&
-     other.int64 == int64 &&
-     other.number == number &&
-     other.float == float &&
-     other.double_ == double_ &&
-     other.decimal == decimal &&
-     other.string == string &&
-     other.byte == byte &&
-     other.binary == binary &&
-     other.date == date &&
-     other.dateTime == dateTime &&
-     other.uuid == uuid &&
-     other.password == password &&
-     other.patternWithDigits == patternWithDigits &&
-     other.patternWithDigitsAndDelimiter == patternWithDigitsAndDelimiter;
+    other.integer == integer &&
+    other.int32 == int32 &&
+    other.int64 == int64 &&
+    other.number == number &&
+    other.float == float &&
+    other.double_ == double_ &&
+    other.decimal == decimal &&
+    other.string == string &&
+    other.byte == byte &&
+    other.binary == binary &&
+    other.date == date &&
+    other.dateTime == dateTime &&
+    other.uuid == uuid &&
+    other.password == password &&
+    other.patternWithDigits == patternWithDigits &&
+    other.patternWithDigitsAndDelimiter == patternWithDigitsAndDelimiter;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -35,8 +35,8 @@ class HasOnlyReadOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is HasOnlyReadOnly &&
-     other.bar == bar &&
-     other.foo == foo;
+    other.bar == bar &&
+    other.foo == foo;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -20,7 +20,7 @@ class HealthCheckResult {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is HealthCheckResult &&
-     other.nullableMessage == nullableMessage;
+    other.nullableMessage == nullableMessage;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -29,10 +29,10 @@ class MapTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is MapTest &&
-     other.mapMapOfString == mapMapOfString &&
-     other.mapOfEnumString == mapOfEnumString &&
-     other.directMap == directMap &&
-     other.indirectMap == indirectMap;
+    _deepEquality.equals(other.mapMapOfString, mapMapOfString) &&
+    _deepEquality.equals(other.mapOfEnumString, mapOfEnumString) &&
+    _deepEquality.equals(other.directMap, directMap) &&
+    _deepEquality.equals(other.indirectMap, indirectMap);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -29,10 +29,10 @@ class MapTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is MapTest &&
-    deepEquality.equals(other.mapMapOfString, mapMapOfString) &&
-    deepEquality.equals(other.mapOfEnumString, mapOfEnumString) &&
-    deepEquality.equals(other.directMap, directMap) &&
-    deepEquality.equals(other.indirectMap, indirectMap);
+    _deepEquality.equals(other.mapMapOfString, mapMapOfString) &&
+    _deepEquality.equals(other.mapOfEnumString, mapOfEnumString) &&
+    _deepEquality.equals(other.directMap, directMap) &&
+    _deepEquality.equals(other.indirectMap, indirectMap);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -29,10 +29,10 @@ class MapTest {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is MapTest &&
-    _deepEquality.equals(other.mapMapOfString, mapMapOfString) &&
-    _deepEquality.equals(other.mapOfEnumString, mapOfEnumString) &&
-    _deepEquality.equals(other.directMap, directMap) &&
-    _deepEquality.equals(other.indirectMap, indirectMap);
+    deepEquality.equals(other.mapMapOfString, mapMapOfString) &&
+    deepEquality.equals(other.mapOfEnumString, mapOfEnumString) &&
+    deepEquality.equals(other.directMap, directMap) &&
+    deepEquality.equals(other.indirectMap, indirectMap);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -38,9 +38,9 @@ class MixedPropertiesAndAdditionalPropertiesClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is MixedPropertiesAndAdditionalPropertiesClass &&
-     other.uuid == uuid &&
-     other.dateTime == dateTime &&
-     other.map == map;
+    other.uuid == uuid &&
+    other.dateTime == dateTime &&
+    _deepEquality.equals(other.map, map);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -40,7 +40,7 @@ class MixedPropertiesAndAdditionalPropertiesClass {
   bool operator ==(Object other) => identical(this, other) || other is MixedPropertiesAndAdditionalPropertiesClass &&
     other.uuid == uuid &&
     other.dateTime == dateTime &&
-    deepEquality.equals(other.map, map);
+    _deepEquality.equals(other.map, map);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -40,7 +40,7 @@ class MixedPropertiesAndAdditionalPropertiesClass {
   bool operator ==(Object other) => identical(this, other) || other is MixedPropertiesAndAdditionalPropertiesClass &&
     other.uuid == uuid &&
     other.dateTime == dateTime &&
-    _deepEquality.equals(other.map, map);
+    deepEquality.equals(other.map, map);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -35,8 +35,8 @@ class Model200Response {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Model200Response &&
-     other.name == name &&
-     other.class_ == class_;
+    other.name == name &&
+    other.class_ == class_;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
@@ -26,7 +26,7 @@ class ModelClient {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ModelClient &&
-     other.client == client;
+    other.client == client;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
@@ -27,7 +27,7 @@ class ModelFile {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ModelFile &&
-     other.sourceURI == sourceURI;
+    other.sourceURI == sourceURI;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
@@ -26,7 +26,7 @@ class ModelList {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ModelList &&
-     other.n123list == n123list;
+    other.n123list == n123list;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -26,7 +26,7 @@ class ModelReturn {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ModelReturn &&
-     other.return_ == return_;
+    other.return_ == return_;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -47,10 +47,10 @@ class Name {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Name &&
-     other.name == name &&
-     other.snakeCase == snakeCase &&
-     other.property == property &&
-     other.n123number == n123number;
+    other.name == name &&
+    other.snakeCase == snakeCase &&
+    other.property == property &&
+    other.n123number == n123number;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -53,18 +53,18 @@ class NullableClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is NullableClass &&
-     other.integerProp == integerProp &&
-     other.numberProp == numberProp &&
-     other.booleanProp == booleanProp &&
-     other.stringProp == stringProp &&
-     other.dateProp == dateProp &&
-     other.datetimeProp == datetimeProp &&
-     other.arrayNullableProp == arrayNullableProp &&
-     other.arrayAndItemsNullableProp == arrayAndItemsNullableProp &&
-     other.arrayItemsNullable == arrayItemsNullable &&
-     other.objectNullableProp == objectNullableProp &&
-     other.objectAndItemsNullableProp == objectAndItemsNullableProp &&
-     other.objectItemsNullable == objectItemsNullable;
+    other.integerProp == integerProp &&
+    other.numberProp == numberProp &&
+    other.booleanProp == booleanProp &&
+    other.stringProp == stringProp &&
+    other.dateProp == dateProp &&
+    other.datetimeProp == datetimeProp &&
+    _deepEquality.equals(other.arrayNullableProp, arrayNullableProp) &&
+    _deepEquality.equals(other.arrayAndItemsNullableProp, arrayAndItemsNullableProp) &&
+    _deepEquality.equals(other.arrayItemsNullable, arrayItemsNullable) &&
+    _deepEquality.equals(other.objectNullableProp, objectNullableProp) &&
+    _deepEquality.equals(other.objectAndItemsNullableProp, objectAndItemsNullableProp) &&
+    _deepEquality.equals(other.objectItemsNullable, objectItemsNullable);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -59,12 +59,12 @@ class NullableClass {
     other.stringProp == stringProp &&
     other.dateProp == dateProp &&
     other.datetimeProp == datetimeProp &&
-    deepEquality.equals(other.arrayNullableProp, arrayNullableProp) &&
-    deepEquality.equals(other.arrayAndItemsNullableProp, arrayAndItemsNullableProp) &&
-    deepEquality.equals(other.arrayItemsNullable, arrayItemsNullable) &&
-    deepEquality.equals(other.objectNullableProp, objectNullableProp) &&
-    deepEquality.equals(other.objectAndItemsNullableProp, objectAndItemsNullableProp) &&
-    deepEquality.equals(other.objectItemsNullable, objectItemsNullable);
+    _deepEquality.equals(other.arrayNullableProp, arrayNullableProp) &&
+    _deepEquality.equals(other.arrayAndItemsNullableProp, arrayAndItemsNullableProp) &&
+    _deepEquality.equals(other.arrayItemsNullable, arrayItemsNullable) &&
+    _deepEquality.equals(other.objectNullableProp, objectNullableProp) &&
+    _deepEquality.equals(other.objectAndItemsNullableProp, objectAndItemsNullableProp) &&
+    _deepEquality.equals(other.objectItemsNullable, objectItemsNullable);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -59,12 +59,12 @@ class NullableClass {
     other.stringProp == stringProp &&
     other.dateProp == dateProp &&
     other.datetimeProp == datetimeProp &&
-    _deepEquality.equals(other.arrayNullableProp, arrayNullableProp) &&
-    _deepEquality.equals(other.arrayAndItemsNullableProp, arrayAndItemsNullableProp) &&
-    _deepEquality.equals(other.arrayItemsNullable, arrayItemsNullable) &&
-    _deepEquality.equals(other.objectNullableProp, objectNullableProp) &&
-    _deepEquality.equals(other.objectAndItemsNullableProp, objectAndItemsNullableProp) &&
-    _deepEquality.equals(other.objectItemsNullable, objectItemsNullable);
+    deepEquality.equals(other.arrayNullableProp, arrayNullableProp) &&
+    deepEquality.equals(other.arrayAndItemsNullableProp, arrayAndItemsNullableProp) &&
+    deepEquality.equals(other.arrayItemsNullable, arrayItemsNullable) &&
+    deepEquality.equals(other.objectNullableProp, objectNullableProp) &&
+    deepEquality.equals(other.objectAndItemsNullableProp, objectAndItemsNullableProp) &&
+    deepEquality.equals(other.objectItemsNullable, objectItemsNullable);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -26,7 +26,7 @@ class NumberOnly {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is NumberOnly &&
-     other.justNumber == justNumber;
+    other.justNumber == justNumber;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -47,10 +47,10 @@ class ObjectWithDeprecatedFields {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ObjectWithDeprecatedFields &&
-     other.uuid == uuid &&
-     other.id == id &&
-     other.deprecatedRef == deprecatedRef &&
-     other.bars == bars;
+    other.uuid == uuid &&
+    other.id == id &&
+    other.deprecatedRef == deprecatedRef &&
+    _deepEquality.equals(other.bars, bars);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -50,7 +50,7 @@ class ObjectWithDeprecatedFields {
     other.uuid == uuid &&
     other.id == id &&
     other.deprecatedRef == deprecatedRef &&
-    _deepEquality.equals(other.bars, bars);
+    deepEquality.equals(other.bars, bars);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -50,7 +50,7 @@ class ObjectWithDeprecatedFields {
     other.uuid == uuid &&
     other.id == id &&
     other.deprecatedRef == deprecatedRef &&
-    deepEquality.equals(other.bars, bars);
+    _deepEquality.equals(other.bars, bars);
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -60,12 +60,12 @@ class Order {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Order &&
-     other.id == id &&
-     other.petId == petId &&
-     other.quantity == quantity &&
-     other.shipDate == shipDate &&
-     other.status == status &&
-     other.complete == complete;
+    other.id == id &&
+    other.petId == petId &&
+    other.quantity == quantity &&
+    other.shipDate == shipDate &&
+    other.status == status &&
+    other.complete == complete;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -44,9 +44,9 @@ class OuterComposite {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is OuterComposite &&
-     other.myNumber == myNumber &&
-     other.myString == myString &&
-     other.myBoolean == myBoolean;
+    other.myNumber == myNumber &&
+    other.myString == myString &&
+    other.myBoolean == myBoolean;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
@@ -20,7 +20,7 @@ class OuterObjectWithEnumProperty {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is OuterObjectWithEnumProperty &&
-     other.value == value;
+    other.value == value;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -48,12 +48,12 @@ class Pet {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Pet &&
-     other.id == id &&
-     other.category == category &&
-     other.name == name &&
-     other.photoUrls == photoUrls &&
-     other.tags == tags &&
-     other.status == status;
+    other.id == id &&
+    other.category == category &&
+    other.name == name &&
+    _deepEquality.equals(other.photoUrls, photoUrls) &&
+    _deepEquality.equals(other.tags, tags) &&
+    other.status == status;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -51,8 +51,8 @@ class Pet {
     other.id == id &&
     other.category == category &&
     other.name == name &&
-    deepEquality.equals(other.photoUrls, photoUrls) &&
-    deepEquality.equals(other.tags, tags) &&
+    _deepEquality.equals(other.photoUrls, photoUrls) &&
+    _deepEquality.equals(other.tags, tags) &&
     other.status == status;
 
   @override

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -51,8 +51,8 @@ class Pet {
     other.id == id &&
     other.category == category &&
     other.name == name &&
-    _deepEquality.equals(other.photoUrls, photoUrls) &&
-    _deepEquality.equals(other.tags, tags) &&
+    deepEquality.equals(other.photoUrls, photoUrls) &&
+    deepEquality.equals(other.tags, tags) &&
     other.status == status;
 
   @override

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -35,8 +35,8 @@ class ReadOnlyFirst {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ReadOnlyFirst &&
-     other.bar == bar &&
-     other.baz == baz;
+    other.bar == bar &&
+    other.baz == baz;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -26,7 +26,7 @@ class SpecialModelName {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SpecialModelName &&
-     other.dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket == dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket;
+    other.dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket == dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -35,8 +35,8 @@ class Tag {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is Tag &&
-     other.id == id &&
-     other.name == name;
+    other.id == id &&
+    other.name == name;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -90,14 +90,14 @@ class User {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is User &&
-     other.id == id &&
-     other.username == username &&
-     other.firstName == firstName &&
-     other.lastName == lastName &&
-     other.email == email &&
-     other.password == password &&
-     other.phone == phone &&
-     other.userStatus == userStatus;
+    other.id == id &&
+    other.username == username &&
+    other.firstName == firstName &&
+    other.lastName == lastName &&
+    other.email == email &&
+    other.password == password &&
+    other.phone == phone &&
+    other.userStatus == userStatus;
 
   @override
   int get hashCode =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  collection: '^1.17.1'
+  collection: '^1.17.0'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -9,9 +9,9 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
+  collection: '^1.17.1'
   http: '>=0.13.0 <0.14.0'
   intl: '^0.18.0'
   meta: '^1.1.8'
 dev_dependencies:
   test: '>=1.16.0 <1.18.0'
-


### PR DESCRIPTION
The existing implementation of `operator ==` in models uses a simple equality for all properties, which may include Sets, Lists, Iterables, and Maps. But, Dart doesn't perform deep-equality checks on these complex types, so the implementation would always return `false`.

This PR addresses this problem by using the [collection](https://rdr.to/HrcSCSVtQHB) package to perform deep equality.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh bin/configs/dart*
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)