### PR TITLE
[typescript] add http info calls to access headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -213,7 +213,7 @@ export class {{classname}}ResponseProcessor {
             {{/dataType}}
             {{^dataType}}
             {{#is2xx}}
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
             {{/is2xx}}
             {{^is2xx}}
             throw new ApiException<undefined>(response.httpStatusCode, "{{message}}", undefined, response.headers);
@@ -237,7 +237,7 @@ export class {{classname}}ResponseProcessor {
             return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
             {{/returnType}}
             {{^returnType}}
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
             {{/returnType}}
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi{{importFileExtension}}';
 import {Configuration} from '../configuration{{importFileExtension}}';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http{{importFileExtension}}';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http{{importFileExtension}}';
 {{#platforms}}
 {{#node}}
 import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data";
@@ -190,7 +190,7 @@ export class {{classname}}ResponseProcessor {
      * @params response Response returned by the server for a request to {{nickname}}
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async {{nickname}}WithHttpInfo(response: ResponseContext): Promise<ApiResponse<{{{returnType}}} {{^returnType}}void{{/returnType}}>> {
+     public async {{nickname}}WithHttpInfo(response: ResponseContext): Promise<HttpInfo<{{{returnType}}} {{^returnType}}void{{/returnType}}>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
@@ -205,7 +205,7 @@ export class {{classname}}ResponseProcessor {
             ) as {{{dataType}}};
             {{/isBinary}}
             {{#is2xx}}
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
             {{/is2xx}}
             {{^is2xx}}
             throw new ApiException<{{{dataType}}}>(response.httpStatusCode, "{{message}}", body, response.headers);
@@ -213,7 +213,7 @@ export class {{classname}}ResponseProcessor {
             {{/dataType}}
             {{^dataType}}
             {{#is2xx}}
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
             {{/is2xx}}
             {{^is2xx}}
             throw new ApiException<undefined>(response.httpStatusCode, "{{message}}", undefined, response.headers);
@@ -234,10 +234,10 @@ export class {{classname}}ResponseProcessor {
                 "{{{returnType}}}", "{{returnFormat}}"
             ) as {{{returnType}}};
             {{/isBinary}}
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
             {{/returnType}}
             {{^returnType}}
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
             {{/returnType}}
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi{{importFileExtension}}';
 import {Configuration} from '../configuration{{importFileExtension}}';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http{{importFileExtension}}';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http{{importFileExtension}}';
 {{#platforms}}
 {{#node}}
 import {{^supportsES6}}* as{{/supportsES6}} FormData from "form-data";
@@ -190,7 +190,7 @@ export class {{classname}}ResponseProcessor {
      * @params response Response returned by the server for a request to {{nickname}}
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async {{nickname}}(response: ResponseContext): Promise<{{{returnType}}} {{^returnType}}void{{/returnType}}> {
+     public async {{nickname}}WithHttpInfo(response: ResponseContext): Promise<ApiResponse<{{{returnType}}} {{^returnType}}void{{/returnType}}>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
@@ -205,7 +205,7 @@ export class {{classname}}ResponseProcessor {
             ) as {{{dataType}}};
             {{/isBinary}}
             {{#is2xx}}
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
             {{/is2xx}}
             {{^is2xx}}
             throw new ApiException<{{{dataType}}}>(response.httpStatusCode, "{{message}}", body, response.headers);
@@ -234,7 +234,7 @@ export class {{classname}}ResponseProcessor {
                 "{{{returnType}}}", "{{returnFormat}}"
             ) as {{{returnType}}};
             {{/isBinary}}
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
             {{/returnType}}
             {{^returnType}}
             return;

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -309,7 +309,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -308,3 +308,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/modules/openapi-generator/src/main/resources/typescript/services/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/services/api.mustache
@@ -18,8 +18,6 @@ export abstract class Abstract{{classname}}ResponseProcessor {
     {{#operation}}
      public abstract {{nickname}}WithHttpInfo(response: ResponseContext): Promise<HttpInfo<{{{returnType}}} {{^returnType}}void{{/returnType}}>>;
 
-     public abstract {{nickname}}(response: ResponseContext): Promise<{{{returnType}}} {{^returnType}}void{{/returnType}}>;
-
     {{/operation}}
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/typescript/services/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/services/api.mustache
@@ -1,5 +1,5 @@
 import type { Configuration } from "../configuration";
-import type { HttpFile, RequestContext, ResponseContext } from "../http/http";
+import type { HttpFile, RequestContext, ResponseContext, HttpInfo } from "../http/http";
 
 {{#imports}}
 import { {{classname}} } from "{{filename}}";
@@ -16,6 +16,8 @@ export abstract class Abstract{{classname}}RequestFactory {
 
 export abstract class Abstract{{classname}}ResponseProcessor {
     {{#operation}}
+     public abstract {{nickname}}WithHttpInfo(response: ResponseContext): Promise<HttpInfo<{{{returnType}}} {{^returnType}}void{{/returnType}}>>;
+
      public abstract {{nickname}}(response: ResponseContext): Promise<{{{returnType}}} {{^returnType}}void{{/returnType}}>;
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObjectParamAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObjectParamAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http{{importFileExtension}}';
 import { Configuration} from '../configuration{{importFileExtension}}'
 {{#useRxJS}}
 import { Observable } from 'rxjs';
@@ -37,6 +37,19 @@ export class Object{{classname}} {
     }
 
 {{#operation}}
+    /**
+     {{#notes}}
+     * {{&notes}}
+     {{/notes}}
+     {{#summary}}
+     * {{&summary}}
+     {{/summary}}
+     * @param param the request object
+     */
+    public {{nickname}}WithHttpInfo(param: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, options?: Configuration): {{#useRxJS}}Observable{{/useRxJS}}{{^useRxJS}}Promise{{/useRxJS}}<ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+        return this.api.{{nickname}}WithHttpInfo({{#allParams}}param.{{paramName}}, {{/allParams}} options){{^useRxJS}}.toPromise(){{/useRxJS}};
+    }
+
     /**
      {{#notes}}
      * {{&notes}}

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObjectParamAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObjectParamAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http{{importFileExtension}}';
 import { Configuration} from '../configuration{{importFileExtension}}'
 {{#useRxJS}}
 import { Observable } from 'rxjs';
@@ -46,7 +46,7 @@ export class Object{{classname}} {
      {{/summary}}
      * @param param the request object
      */
-    public {{nickname}}WithHttpInfo(param: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, options?: Configuration): {{#useRxJS}}Observable{{/useRxJS}}{{^useRxJS}}Promise{{/useRxJS}}<ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}WithHttpInfo(param: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, options?: Configuration): {{#useRxJS}}Observable{{/useRxJS}}{{^useRxJS}}Promise{{/useRxJS}}<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         return this.api.{{nickname}}WithHttpInfo({{#allParams}}param.{{paramName}}, {{/allParams}} options){{^useRxJS}}.toPromise(){{/useRxJS}};
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http{{importFileExtension}}';
 import { Configuration} from '../configuration{{importFileExtension}}'
 import { Observable, of, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
 import {mergeMap, map} from  {{#useRxJS}}'rxjs/operators'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
@@ -61,7 +61,7 @@ export class Observable{{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
+    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}_options);
 
         // build promise chain
@@ -76,8 +76,23 @@ export class Observable{{classname}} {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.{{nickname}}(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.{{nickname}}WithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     {{#notes}}
+     * {{&notes}}
+     {{/notes}}
+     {{#summary}}
+     * {{&summary}}
+     {{/summary}}
+     {{#allParams}}
+     * @param {{paramName}} {{description}}
+     {{/allParams}}
+     */
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
+        return this.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}_options).pipe(map((apiResponse: ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>) => apiResponse.data));
     }
 
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http{{importFileExtension}}';
 import { Configuration} from '../configuration{{importFileExtension}}'
 import { Observable, of, from } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
 import {mergeMap, map} from  {{#useRxJS}}'rxjs/operators'{{/useRxJS}}{{^useRxJS}}'../rxjsStub{{importFileExtension}}'{{/useRxJS}};
@@ -61,7 +61,7 @@ export class Observable{{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}_options);
 
         // build promise chain
@@ -92,7 +92,7 @@ export class Observable{{classname}} {
      {{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
-        return this.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}_options).pipe(map((apiResponse: ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>) => apiResponse.data));
+        return this.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}_options).pipe(map((apiResponse: HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>) => apiResponse.data));
     }
 
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http{{importFileExtension}}';
 import { Configuration} from '../configuration{{importFileExtension}}'
 {{#useInversify}}
 import { injectable, inject, optional } from "inversify";
@@ -40,6 +40,22 @@ export class Promise{{classname}} {
     }
 
 {{#operation}}
+    /**
+     {{#notes}}
+     * {{&notes}}
+     {{/notes}}
+     {{#summary}}
+     * {{&summary}}
+     {{/summary}}
+     {{#allParams}}
+     * @param {{paramName}} {{description}}
+     {{/allParams}}
+     */
+    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+        const result = this.api.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}_options);
+        return result.toPromise();
+    }
+
     /**
      {{#notes}}
      * {{&notes}}

--- a/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http{{importFileExtension}}';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http{{importFileExtension}}';
 import { Configuration} from '../configuration{{importFileExtension}}'
 {{#useInversify}}
 import { injectable, inject, optional } from "inversify";
@@ -51,7 +51,7 @@ export class Promise{{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         const result = this.api.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}_options);
         return result.toPromise();
     }

--- a/samples/client/others/typescript/builds/with-unique-items/apis/DefaultApi.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/apis/DefaultApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -48,14 +48,14 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to uniqueItems
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uniqueItems(response: ResponseContext): Promise<Response > {
+     public async uniqueItemsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Response >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Response = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Response", ""
             ) as Response;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -64,7 +64,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Response", ""
             ) as Response;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/client/others/typescript/builds/with-unique-items/apis/DefaultApi.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/apis/DefaultApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -48,14 +48,14 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to uniqueItems
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uniqueItemsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Response >> {
+     public async uniqueItemsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Response >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Response = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Response", ""
             ) as Response;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -64,7 +64,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Response", ""
             ) as Response;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/client/others/typescript/builds/with-unique-items/http/http.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/http/http.ts
@@ -238,7 +238,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/client/others/typescript/builds/with-unique-items/http/http.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/http/http.ts
@@ -237,3 +237,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/client/others/typescript/builds/with-unique-items/types/ObjectParamAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Response } from '../models/Response';
@@ -14,6 +14,13 @@ export class ObjectDefaultApi {
 
     public constructor(configuration: Configuration, requestFactory?: DefaultApiRequestFactory, responseProcessor?: DefaultApiResponseProcessor) {
         this.api = new ObservableDefaultApi(configuration, requestFactory, responseProcessor);
+    }
+
+    /**
+     * @param param the request object
+     */
+    public uniqueItemsWithHttpInfo(param: DefaultApiUniqueItemsRequest = {}, options?: Configuration): Promise<ApiResponse<Response>> {
+        return this.api.uniqueItemsWithHttpInfo( options).toPromise();
     }
 
     /**

--- a/samples/client/others/typescript/builds/with-unique-items/types/ObjectParamAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Response } from '../models/Response';
@@ -19,7 +19,7 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
-    public uniqueItemsWithHttpInfo(param: DefaultApiUniqueItemsRequest = {}, options?: Configuration): Promise<ApiResponse<Response>> {
+    public uniqueItemsWithHttpInfo(param: DefaultApiUniqueItemsRequest = {}, options?: Configuration): Promise<HttpInfo<Response>> {
         return this.api.uniqueItemsWithHttpInfo( options).toPromise();
     }
 

--- a/samples/client/others/typescript/builds/with-unique-items/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -22,7 +22,7 @@ export class ObservableDefaultApi {
 
     /**
      */
-    public uniqueItemsWithHttpInfo(_options?: Configuration): Observable<ApiResponse<Response>> {
+    public uniqueItemsWithHttpInfo(_options?: Configuration): Observable<HttpInfo<Response>> {
         const requestContextPromise = this.requestFactory.uniqueItems(_options);
 
         // build promise chain
@@ -44,7 +44,7 @@ export class ObservableDefaultApi {
     /**
      */
     public uniqueItems(_options?: Configuration): Observable<Response> {
-        return this.uniqueItemsWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<Response>) => apiResponse.data));
+        return this.uniqueItemsWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<Response>) => apiResponse.data));
     }
 
 }

--- a/samples/client/others/typescript/builds/with-unique-items/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -22,7 +22,7 @@ export class ObservableDefaultApi {
 
     /**
      */
-    public uniqueItems(_options?: Configuration): Observable<Response> {
+    public uniqueItemsWithHttpInfo(_options?: Configuration): Observable<ApiResponse<Response>> {
         const requestContextPromise = this.requestFactory.uniqueItems(_options);
 
         // build promise chain
@@ -37,8 +37,14 @@ export class ObservableDefaultApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uniqueItems(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uniqueItemsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     */
+    public uniqueItems(_options?: Configuration): Observable<Response> {
+        return this.uniqueItemsWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<Response>) => apiResponse.data));
     }
 
 }

--- a/samples/client/others/typescript/builds/with-unique-items/types/PromiseAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Response } from '../models/Response';
@@ -18,7 +18,7 @@ export class PromiseDefaultApi {
 
     /**
      */
-    public uniqueItemsWithHttpInfo(_options?: Configuration): Promise<ApiResponse<Response>> {
+    public uniqueItemsWithHttpInfo(_options?: Configuration): Promise<HttpInfo<Response>> {
         const result = this.api.uniqueItemsWithHttpInfo(_options);
         return result.toPromise();
     }

--- a/samples/client/others/typescript/builds/with-unique-items/types/PromiseAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Response } from '../models/Response';
@@ -14,6 +14,13 @@ export class PromiseDefaultApi {
         responseProcessor?: DefaultApiResponseProcessor
     ) {
         this.api = new ObservableDefaultApi(configuration, requestFactory, responseProcessor);
+    }
+
+    /**
+     */
+    public uniqueItemsWithHttpInfo(_options?: Configuration): Promise<ApiResponse<Response>> {
+        const result = this.api.uniqueItemsWithHttpInfo(_options);
+        return result.toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -436,14 +436,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPet(response: ResponseContext): Promise<Pet > {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -455,7 +455,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -468,7 +468,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePet(response: ResponseContext): Promise< void> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -476,7 +476,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -489,14 +489,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -508,7 +508,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -521,14 +521,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -540,7 +540,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -553,14 +553,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetById(response: ResponseContext): Promise<Pet > {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -588,14 +588,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePet(response: ResponseContext): Promise<Pet > {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -613,7 +613,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -626,7 +626,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithForm(response: ResponseContext): Promise< void> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -634,7 +634,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -647,14 +647,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,7 +663,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -436,14 +436,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -455,7 +455,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -468,7 +468,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -476,7 +476,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -489,14 +489,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -508,7 +508,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -521,14 +521,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -540,7 +540,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -553,14 +553,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -588,14 +588,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -613,7 +613,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -626,7 +626,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -634,7 +634,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -647,14 +647,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,7 +663,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrder(response: ResponseContext): Promise< void> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -186,14 +186,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -202,7 +202,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -215,14 +215,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderById(response: ResponseContext): Promise<Order > {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -237,7 +237,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -250,14 +250,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrder(response: ResponseContext): Promise<Order > {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -269,7 +269,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -186,14 +186,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -202,7 +202,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -215,14 +215,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -237,7 +237,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -250,14 +250,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -269,7 +269,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUser(response: ResponseContext): Promise< void> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -382,7 +382,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -403,7 +403,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -416,7 +416,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -424,7 +424,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -437,7 +437,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUser(response: ResponseContext): Promise< void> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -448,7 +448,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -461,14 +461,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByName(response: ResponseContext): Promise<User > {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -483,7 +483,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -496,14 +496,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUser(response: ResponseContext): Promise<string > {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -515,7 +515,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -528,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUser(response: ResponseContext): Promise< void> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -536,7 +536,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -549,7 +549,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUser(response: ResponseContext): Promise< void> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -560,7 +560,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -382,7 +382,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -403,7 +403,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -416,7 +416,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -424,7 +424,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -437,7 +437,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -448,7 +448,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -461,14 +461,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -483,7 +483,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -496,14 +496,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -515,7 +515,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -528,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -536,7 +536,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -549,7 +549,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -560,7 +560,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
@@ -238,7 +238,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/http/http.ts
@@ -237,3 +237,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,8 +125,26 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param param the request object
+     */
     public addPet(param: PetApiAddPetRequest, options?: Configuration): Promise<Pet> {
         return this.api.addPet(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param param the request object
+     */
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
     /**
@@ -143,8 +161,26 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param param the request object
+     */
     public findPetsByStatus(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<Array<Pet>> {
         return this.api.findPetsByStatus(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param param the request object
+     */
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
     /**
@@ -161,8 +197,26 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param param the request object
+     */
     public getPetById(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<Pet> {
         return this.api.getPetById(param.petId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param param the request object
+     */
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
     /**
@@ -179,8 +233,26 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param param the request object
+     */
     public updatePetWithForm(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<void> {
         return this.api.updatePetWithForm(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param param the request object
+     */
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
     /**
@@ -239,8 +311,26 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param param the request object
+     */
     public deleteOrder(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<void> {
         return this.api.deleteOrder(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     * @param param the request object
+     */
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
     /**
@@ -257,8 +347,26 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param param the request object
+     */
     public getOrderById(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<Order> {
         return this.api.getOrderById(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param param the request object
+     */
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
     /**
@@ -365,8 +473,26 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param param the request object
+     */
     public createUser(param: UserApiCreateUserRequest, options?: Configuration): Promise<void> {
         return this.api.createUser(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
     /**
@@ -383,8 +509,26 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
     public createUsersWithListInput(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<void> {
         return this.api.createUsersWithListInput(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param param the request object
+     */
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
     /**
@@ -401,8 +545,26 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+        return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param param the request object
+     */
     public getUserByName(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<User> {
         return this.api.getUserByName(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param param the request object
+     */
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+        return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
     /**
@@ -419,8 +581,26 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.logoutUserWithHttpInfo( options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     * @param param the request object
+     */
     public logoutUser(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<void> {
         return this.api.logoutUser( options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param param the request object
+     */
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,7 +125,7 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
-    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -143,7 +143,7 @@ export class ObjectPetApi {
      * Deletes a pet
      * @param param the request object
      */
-    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
@@ -161,7 +161,7 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
-    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
     }
 
@@ -179,7 +179,7 @@ export class ObjectPetApi {
      * Finds Pets by tags
      * @param param the request object
      */
-    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
@@ -197,7 +197,7 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
-    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
     }
 
@@ -215,7 +215,7 @@ export class ObjectPetApi {
      * Update an existing pet
      * @param param the request object
      */
-    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -233,7 +233,7 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
-    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
     }
 
@@ -251,7 +251,7 @@ export class ObjectPetApi {
      * uploads an image
      * @param param the request object
      */
-    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
@@ -311,7 +311,7 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
-    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -329,7 +329,7 @@ export class ObjectStoreApi {
      * Returns pet inventories by status
      * @param param the request object
      */
-    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
@@ -347,7 +347,7 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
-    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -365,7 +365,7 @@ export class ObjectStoreApi {
      * Place an order for a pet
      * @param param the request object
      */
-    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
@@ -473,7 +473,7 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
-    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -491,7 +491,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -509,7 +509,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -527,7 +527,7 @@ export class ObjectUserApi {
      * Delete user
      * @param param the request object
      */
-    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -545,7 +545,7 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
-    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<HttpInfo<User>> {
         return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -563,7 +563,7 @@ export class ObjectUserApi {
      * Logs user into the system
      * @param param the request object
      */
-    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<HttpInfo<string>> {
         return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
@@ -581,7 +581,7 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
-    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.logoutUserWithHttpInfo( options).toPromise();
     }
 
@@ -599,7 +599,7 @@ export class ObjectUserApi {
      * Updated user
      * @param param the request object
      */
-    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -55,7 +55,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -64,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -90,7 +90,7 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -98,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -123,7 +123,7 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -131,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -156,7 +156,7 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -164,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -189,7 +189,7 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
-        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -197,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -222,7 +222,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -232,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -259,7 +259,7 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
-        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -269,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -296,7 +296,7 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
-        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -322,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -347,14 +347,14 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
-        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -378,7 +378,7 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
-        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -386,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -411,7 +411,7 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
-        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
     /**
@@ -419,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -444,7 +444,7 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
-        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
 }
@@ -470,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -495,7 +495,7 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, _options?: Configuration): Observable<void> {
-        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -503,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -528,7 +528,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -536,7 +536,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -561,7 +561,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -569,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -594,7 +594,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, _options?: Configuration): Observable<void> {
-        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -602,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -627,7 +627,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, _options?: Configuration): Observable<User> {
-        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<User>) => apiResponse.data));
     }
 
     /**
@@ -636,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -662,14 +662,14 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
-        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -693,7 +693,7 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(_options?: Configuration): Observable<void> {
-        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -702,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -728,7 +728,7 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
-        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -45,8 +45,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -55,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -70,8 +79,18 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -79,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -94,8 +113,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatus(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatusWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -103,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -118,8 +146,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTags(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTagsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -127,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -142,8 +179,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -151,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -166,8 +212,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -177,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -192,8 +247,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithForm(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithFormWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -203,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -218,8 +284,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFile(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFileWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -245,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -260,15 +337,24 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -283,8 +369,16 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventory(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventoryWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -292,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -307,8 +401,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
     /**
@@ -316,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -331,8 +434,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
 }
@@ -358,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, _options?: Configuration): Observable<void> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -373,8 +485,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -382,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -397,7 +518,7 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInputWithHttpInfo(rsp)));
             }));
     }
 
@@ -406,7 +527,16 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -421,8 +551,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInputWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -430,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -445,8 +584,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -454,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -469,8 +617,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByName(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByNameWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
     }
 
     /**
@@ -479,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -494,15 +651,25 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUser(_options?: Configuration): Observable<void> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -517,8 +684,16 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
+    public logoutUser(_options?: Configuration): Observable<void> {
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -527,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -542,8 +717,18 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,8 +26,29 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.addPetWithHttpInfo(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
     public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
         const result = this.api.addPet(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -47,8 +68,28 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
         const result = this.api.findPetsByStatus(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
 
@@ -67,8 +108,28 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.getPetByIdWithHttpInfo(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
     public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
         const result = this.api.getPetById(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
 
@@ -89,8 +150,32 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -130,8 +215,27 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
     public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteOrder(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
 
@@ -149,8 +253,28 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
     public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
         const result = this.api.getOrderById(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
 
@@ -188,8 +312,28 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUserWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
     public createUser(user: User, _options?: Configuration): Promise<void> {
         const result = this.api.createUser(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
 
@@ -208,6 +352,16 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
         const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
@@ -218,8 +372,28 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteUserWithHttpInfo(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
     public deleteUser(username: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteUser(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+        const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
 
@@ -239,6 +413,17 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+        const result = this.api.loginUserWithHttpInfo(username, password, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
     public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
         const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
@@ -248,8 +433,28 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.logoutUserWithHttpInfo(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
     public logoutUser(_options?: Configuration): Promise<void> {
         const result = this.api.logoutUser(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,7 +26,7 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.addPetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -47,7 +47,7 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
@@ -68,7 +68,7 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
         return result.toPromise();
     }
@@ -88,7 +88,7 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
@@ -108,7 +108,7 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.getPetByIdWithHttpInfo(petId, _options);
         return result.toPromise();
     }
@@ -128,7 +128,7 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -150,7 +150,7 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
         return result.toPromise();
     }
@@ -174,7 +174,7 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
@@ -215,7 +215,7 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -234,7 +234,7 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -253,7 +253,7 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -273,7 +273,7 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
@@ -312,7 +312,7 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUserWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -332,7 +332,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -352,7 +352,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -372,7 +372,7 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteUserWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -392,7 +392,7 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<User>> {
         const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -413,7 +413,7 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.loginUserWithHttpInfo(username, password, _options);
         return result.toPromise();
     }
@@ -433,7 +433,7 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.logoutUserWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -453,7 +453,7 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -133,10 +133,10 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to filePost
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async filePostWithHttpInfo(response: ResponseContext): Promise<ApiResponse<void >> {
+     public async filePostWithHttpInfo(response: ResponseContext): Promise<HttpInfo<void >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -145,7 +145,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "void", ""
             ) as void;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -158,10 +158,10 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to petsFilteredPatch
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async petsFilteredPatchWithHttpInfo(response: ResponseContext): Promise<ApiResponse<void >> {
+     public async petsFilteredPatchWithHttpInfo(response: ResponseContext): Promise<HttpInfo<void >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -170,7 +170,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "void", ""
             ) as void;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -183,10 +183,10 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to petsPatch
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async petsPatchWithHttpInfo(response: ResponseContext): Promise<ApiResponse<void >> {
+     public async petsPatchWithHttpInfo(response: ResponseContext): Promise<HttpInfo<void >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -195,7 +195,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "void", ""
             ) as void;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -133,10 +133,10 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to filePost
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async filePost(response: ResponseContext): Promise<void > {
+     public async filePostWithHttpInfo(response: ResponseContext): Promise<ApiResponse<void >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -145,7 +145,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "void", ""
             ) as void;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -158,10 +158,10 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to petsFilteredPatch
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async petsFilteredPatch(response: ResponseContext): Promise<void > {
+     public async petsFilteredPatchWithHttpInfo(response: ResponseContext): Promise<ApiResponse<void >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -170,7 +170,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "void", ""
             ) as void;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -183,10 +183,10 @@ export class DefaultApiResponseProcessor {
      * @params response Response returned by the server for a request to petsPatch
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async petsPatch(response: ResponseContext): Promise<void > {
+     public async petsPatchWithHttpInfo(response: ResponseContext): Promise<ApiResponse<void >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -195,7 +195,7 @@ export class DefaultApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "void", ""
             ) as void;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -238,7 +238,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -237,3 +237,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Cat } from '../models/Cat';
@@ -49,6 +49,13 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
+    public filePostWithHttpInfo(param: DefaultApiFilePostRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.filePostWithHttpInfo(param.filePostRequest,  options).toPromise();
+    }
+
+    /**
+     * @param param the request object
+     */
     public filePost(param: DefaultApiFilePostRequest = {}, options?: Configuration): Promise<void> {
         return this.api.filePost(param.filePostRequest,  options).toPromise();
     }
@@ -56,8 +63,22 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
+    public petsFilteredPatchWithHttpInfo(param: DefaultApiPetsFilteredPatchRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.petsFilteredPatchWithHttpInfo(param.petsFilteredPatchRequest,  options).toPromise();
+    }
+
+    /**
+     * @param param the request object
+     */
     public petsFilteredPatch(param: DefaultApiPetsFilteredPatchRequest = {}, options?: Configuration): Promise<void> {
         return this.api.petsFilteredPatch(param.petsFilteredPatchRequest,  options).toPromise();
+    }
+
+    /**
+     * @param param the request object
+     */
+    public petsPatchWithHttpInfo(param: DefaultApiPetsPatchRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.petsPatchWithHttpInfo(param.petsPatchRequest,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Cat } from '../models/Cat';
@@ -49,7 +49,7 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
-    public filePostWithHttpInfo(param: DefaultApiFilePostRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public filePostWithHttpInfo(param: DefaultApiFilePostRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.filePostWithHttpInfo(param.filePostRequest,  options).toPromise();
     }
 
@@ -63,7 +63,7 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
-    public petsFilteredPatchWithHttpInfo(param: DefaultApiPetsFilteredPatchRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public petsFilteredPatchWithHttpInfo(param: DefaultApiPetsFilteredPatchRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.petsFilteredPatchWithHttpInfo(param.petsFilteredPatchRequest,  options).toPromise();
     }
 
@@ -77,7 +77,7 @@ export class ObjectDefaultApi {
     /**
      * @param param the request object
      */
-    public petsPatchWithHttpInfo(param: DefaultApiPetsPatchRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public petsPatchWithHttpInfo(param: DefaultApiPetsPatchRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.petsPatchWithHttpInfo(param.petsPatchRequest,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -29,7 +29,7 @@ export class ObservableDefaultApi {
     /**
      * @param filePostRequest 
      */
-    public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<ApiResponse<void>> {
+    public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.filePost(filePostRequest, _options);
 
         // build promise chain
@@ -52,13 +52,13 @@ export class ObservableDefaultApi {
      * @param filePostRequest 
      */
     public filePost(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<void> {
-        return this.filePostWithHttpInfo(filePostRequest, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.filePostWithHttpInfo(filePostRequest, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * @param petsFilteredPatchRequest 
      */
-    public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<ApiResponse<void>> {
+    public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.petsFilteredPatch(petsFilteredPatchRequest, _options);
 
         // build promise chain
@@ -81,13 +81,13 @@ export class ObservableDefaultApi {
      * @param petsFilteredPatchRequest 
      */
     public petsFilteredPatch(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<void> {
-        return this.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * @param petsPatchRequest 
      */
-    public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<ApiResponse<void>> {
+    public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.petsPatch(petsPatchRequest, _options);
 
         // build promise chain
@@ -110,7 +110,7 @@ export class ObservableDefaultApi {
      * @param petsPatchRequest 
      */
     public petsPatch(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<void> {
-        return this.petsPatchWithHttpInfo(petsPatchRequest, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.petsPatchWithHttpInfo(petsPatchRequest, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -29,7 +29,7 @@ export class ObservableDefaultApi {
     /**
      * @param filePostRequest 
      */
-    public filePost(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<void> {
+    public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.filePost(filePostRequest, _options);
 
         // build promise chain
@@ -44,14 +44,21 @@ export class ObservableDefaultApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.filePost(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.filePostWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * @param filePostRequest 
+     */
+    public filePost(filePostRequest?: FilePostRequest, _options?: Configuration): Observable<void> {
+        return this.filePostWithHttpInfo(filePostRequest, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * @param petsFilteredPatchRequest 
      */
-    public petsFilteredPatch(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<void> {
+    public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.petsFilteredPatch(petsFilteredPatchRequest, _options);
 
         // build promise chain
@@ -66,14 +73,21 @@ export class ObservableDefaultApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.petsFilteredPatch(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.petsFilteredPatchWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * @param petsFilteredPatchRequest 
+     */
+    public petsFilteredPatch(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Observable<void> {
+        return this.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * @param petsPatchRequest 
      */
-    public petsPatch(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<void> {
+    public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.petsPatch(petsPatchRequest, _options);
 
         // build promise chain
@@ -88,8 +102,15 @@ export class ObservableDefaultApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.petsPatch(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.petsPatchWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * @param petsPatchRequest 
+     */
+    public petsPatch(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Observable<void> {
+        return this.petsPatchWithHttpInfo(petsPatchRequest, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Cat } from '../models/Cat';
@@ -25,6 +25,14 @@ export class PromiseDefaultApi {
     /**
      * @param filePostRequest 
      */
+    public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.filePostWithHttpInfo(filePostRequest, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * @param filePostRequest 
+     */
     public filePost(filePostRequest?: FilePostRequest, _options?: Configuration): Promise<void> {
         const result = this.api.filePost(filePostRequest, _options);
         return result.toPromise();
@@ -33,8 +41,24 @@ export class PromiseDefaultApi {
     /**
      * @param petsFilteredPatchRequest 
      */
+    public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * @param petsFilteredPatchRequest 
+     */
     public petsFilteredPatch(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Promise<void> {
         const result = this.api.petsFilteredPatch(petsFilteredPatchRequest, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * @param petsPatchRequest 
+     */
+    public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.petsPatchWithHttpInfo(petsPatchRequest, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { Cat } from '../models/Cat';
@@ -25,7 +25,7 @@ export class PromiseDefaultApi {
     /**
      * @param filePostRequest 
      */
-    public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Promise<ApiResponse<void>> {
+    public filePostWithHttpInfo(filePostRequest?: FilePostRequest, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.filePostWithHttpInfo(filePostRequest, _options);
         return result.toPromise();
     }
@@ -41,7 +41,7 @@ export class PromiseDefaultApi {
     /**
      * @param petsFilteredPatchRequest 
      */
-    public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Promise<ApiResponse<void>> {
+    public petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest?: PetsFilteredPatchRequest, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.petsFilteredPatchWithHttpInfo(petsFilteredPatchRequest, _options);
         return result.toPromise();
     }
@@ -57,7 +57,7 @@ export class PromiseDefaultApi {
     /**
      * @param petsPatchRequest 
      */
-    public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Promise<ApiResponse<void>> {
+    public petsPatchWithHttpInfo(petsPatchRequest?: PetsPatchRequest, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.petsPatchWithHttpInfo(petsPatchRequest, _options);
         return result.toPromise();
     }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -438,14 +438,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -457,7 +457,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -470,7 +470,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -478,7 +478,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -491,14 +491,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -510,7 +510,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -523,14 +523,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -542,7 +542,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -555,14 +555,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -577,7 +577,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -590,14 +590,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -615,7 +615,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -628,7 +628,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -636,7 +636,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -649,14 +649,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -665,7 +665,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -438,14 +438,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPet(response: ResponseContext): Promise<Pet > {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -457,7 +457,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -470,7 +470,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePet(response: ResponseContext): Promise< void> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -478,7 +478,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -491,14 +491,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -510,7 +510,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -523,14 +523,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -542,7 +542,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -555,14 +555,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetById(response: ResponseContext): Promise<Pet > {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -577,7 +577,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -590,14 +590,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePet(response: ResponseContext): Promise<Pet > {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -615,7 +615,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -628,7 +628,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithForm(response: ResponseContext): Promise< void> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -636,7 +636,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -649,14 +649,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -665,7 +665,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -164,7 +164,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -175,7 +175,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -188,14 +188,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -204,7 +204,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -217,14 +217,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -239,7 +239,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -252,14 +252,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -271,7 +271,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -164,7 +164,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrder(response: ResponseContext): Promise< void> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -175,7 +175,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -188,14 +188,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -204,7 +204,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -217,14 +217,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderById(response: ResponseContext): Promise<Order > {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -239,7 +239,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -252,14 +252,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrder(response: ResponseContext): Promise<Order > {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -271,7 +271,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -376,7 +376,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -384,7 +384,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -397,7 +397,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -405,7 +405,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -418,7 +418,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -426,7 +426,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -439,7 +439,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -450,7 +450,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -463,14 +463,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -485,7 +485,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -498,14 +498,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -517,7 +517,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -530,7 +530,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -538,7 +538,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -551,7 +551,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -562,7 +562,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -376,7 +376,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUser(response: ResponseContext): Promise< void> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -384,7 +384,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -397,7 +397,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -405,7 +405,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -418,7 +418,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -426,7 +426,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -439,7 +439,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUser(response: ResponseContext): Promise< void> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -450,7 +450,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -463,14 +463,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByName(response: ResponseContext): Promise<User > {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -485,7 +485,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -498,14 +498,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUser(response: ResponseContext): Promise<string > {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -517,7 +517,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -530,7 +530,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUser(response: ResponseContext): Promise< void> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -538,7 +538,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -551,7 +551,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUser(response: ResponseContext): Promise< void> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -562,7 +562,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -234,3 +234,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -235,7 +235,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,8 +125,26 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param param the request object
+     */
     public addPet(param: PetApiAddPetRequest, options?: Configuration): Promise<Pet> {
         return this.api.addPet(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param param the request object
+     */
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
     /**
@@ -143,8 +161,26 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param param the request object
+     */
     public findPetsByStatus(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<Array<Pet>> {
         return this.api.findPetsByStatus(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param param the request object
+     */
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
     /**
@@ -161,8 +197,26 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param param the request object
+     */
     public getPetById(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<Pet> {
         return this.api.getPetById(param.petId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param param the request object
+     */
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
     /**
@@ -179,8 +233,26 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param param the request object
+     */
     public updatePetWithForm(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<void> {
         return this.api.updatePetWithForm(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param param the request object
+     */
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
     /**
@@ -239,8 +311,26 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param param the request object
+     */
     public deleteOrder(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<void> {
         return this.api.deleteOrder(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     * @param param the request object
+     */
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
     /**
@@ -257,8 +347,26 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param param the request object
+     */
     public getOrderById(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<Order> {
         return this.api.getOrderById(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param param the request object
+     */
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
     /**
@@ -365,8 +473,26 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param param the request object
+     */
     public createUser(param: UserApiCreateUserRequest, options?: Configuration): Promise<void> {
         return this.api.createUser(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
     /**
@@ -383,8 +509,26 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
     public createUsersWithListInput(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<void> {
         return this.api.createUsersWithListInput(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param param the request object
+     */
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
     /**
@@ -401,8 +545,26 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+        return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param param the request object
+     */
     public getUserByName(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<User> {
         return this.api.getUserByName(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param param the request object
+     */
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+        return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
     /**
@@ -419,8 +581,26 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.logoutUserWithHttpInfo( options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     * @param param the request object
+     */
     public logoutUser(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<void> {
         return this.api.logoutUser( options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param param the request object
+     */
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,7 +125,7 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
-    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -143,7 +143,7 @@ export class ObjectPetApi {
      * Deletes a pet
      * @param param the request object
      */
-    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
@@ -161,7 +161,7 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
-    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
     }
 
@@ -179,7 +179,7 @@ export class ObjectPetApi {
      * Finds Pets by tags
      * @param param the request object
      */
-    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
@@ -197,7 +197,7 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
-    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
     }
 
@@ -215,7 +215,7 @@ export class ObjectPetApi {
      * Update an existing pet
      * @param param the request object
      */
-    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -233,7 +233,7 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
-    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
     }
 
@@ -251,7 +251,7 @@ export class ObjectPetApi {
      * uploads an image
      * @param param the request object
      */
-    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
@@ -311,7 +311,7 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
-    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -329,7 +329,7 @@ export class ObjectStoreApi {
      * Returns pet inventories by status
      * @param param the request object
      */
-    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
@@ -347,7 +347,7 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
-    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -365,7 +365,7 @@ export class ObjectStoreApi {
      * Place an order for a pet
      * @param param the request object
      */
-    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
@@ -473,7 +473,7 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
-    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -491,7 +491,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -509,7 +509,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -527,7 +527,7 @@ export class ObjectUserApi {
      * Delete user
      * @param param the request object
      */
-    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -545,7 +545,7 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
-    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<HttpInfo<User>> {
         return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -563,7 +563,7 @@ export class ObjectUserApi {
      * Logs user into the system
      * @param param the request object
      */
-    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<HttpInfo<string>> {
         return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
@@ -581,7 +581,7 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
-    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.logoutUserWithHttpInfo( options).toPromise();
     }
 
@@ -599,7 +599,7 @@ export class ObjectUserApi {
      * Updated user
      * @param param the request object
      */
-    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -55,7 +55,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -64,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -90,7 +90,7 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -98,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -123,7 +123,7 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -131,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -156,7 +156,7 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -164,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -189,7 +189,7 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
-        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -197,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -222,7 +222,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -232,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -259,7 +259,7 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
-        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -269,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -296,7 +296,7 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
-        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -322,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -347,14 +347,14 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
-        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -378,7 +378,7 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
-        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -386,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -411,7 +411,7 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
-        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
     /**
@@ -419,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -444,7 +444,7 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
-        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
 }
@@ -470,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -495,7 +495,7 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, _options?: Configuration): Observable<void> {
-        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -503,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -528,7 +528,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -536,7 +536,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -561,7 +561,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -569,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -594,7 +594,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, _options?: Configuration): Observable<void> {
-        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -602,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -627,7 +627,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, _options?: Configuration): Observable<User> {
-        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<User>) => apiResponse.data));
     }
 
     /**
@@ -636,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -662,14 +662,14 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
-        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -693,7 +693,7 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(_options?: Configuration): Observable<void> {
-        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -702,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -728,7 +728,7 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
-        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -45,8 +45,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -55,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -70,8 +79,18 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -79,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -94,8 +113,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatus(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatusWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -103,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -118,8 +146,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTags(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTagsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -127,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -142,8 +179,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -151,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -166,8 +212,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -177,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -192,8 +247,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithForm(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithFormWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -203,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -218,8 +284,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFile(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFileWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -245,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -260,15 +337,24 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -283,8 +369,16 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventory(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventoryWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -292,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -307,8 +401,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
     /**
@@ -316,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -331,8 +434,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
 }
@@ -358,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, _options?: Configuration): Observable<void> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -373,8 +485,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -382,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -397,7 +518,7 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInputWithHttpInfo(rsp)));
             }));
     }
 
@@ -406,7 +527,16 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -421,8 +551,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInputWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -430,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -445,8 +584,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -454,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -469,8 +617,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByName(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByNameWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
     }
 
     /**
@@ -479,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -494,15 +651,25 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUser(_options?: Configuration): Observable<void> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -517,8 +684,16 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
+    public logoutUser(_options?: Configuration): Observable<void> {
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -527,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -542,8 +717,18 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,8 +26,29 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.addPetWithHttpInfo(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
     public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
         const result = this.api.addPet(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -47,8 +68,28 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
         const result = this.api.findPetsByStatus(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
 
@@ -67,8 +108,28 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.getPetByIdWithHttpInfo(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
     public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
         const result = this.api.getPetById(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
 
@@ -89,8 +150,32 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -130,8 +215,27 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
     public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteOrder(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
 
@@ -149,8 +253,28 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
     public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
         const result = this.api.getOrderById(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
 
@@ -188,8 +312,28 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUserWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
     public createUser(user: User, _options?: Configuration): Promise<void> {
         const result = this.api.createUser(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
 
@@ -208,6 +352,16 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
         const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
@@ -218,8 +372,28 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteUserWithHttpInfo(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
     public deleteUser(username: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteUser(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+        const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
 
@@ -239,6 +413,17 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+        const result = this.api.loginUserWithHttpInfo(username, password, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
     public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
         const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
@@ -248,8 +433,28 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.logoutUserWithHttpInfo(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
     public logoutUser(_options?: Configuration): Promise<void> {
         const result = this.api.logoutUser(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,7 +26,7 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.addPetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -47,7 +47,7 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
@@ -68,7 +68,7 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
         return result.toPromise();
     }
@@ -88,7 +88,7 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
@@ -108,7 +108,7 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.getPetByIdWithHttpInfo(petId, _options);
         return result.toPromise();
     }
@@ -128,7 +128,7 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -150,7 +150,7 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
         return result.toPromise();
     }
@@ -174,7 +174,7 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
@@ -215,7 +215,7 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -234,7 +234,7 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -253,7 +253,7 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -273,7 +273,7 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
@@ -312,7 +312,7 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUserWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -332,7 +332,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -352,7 +352,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -372,7 +372,7 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteUserWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -392,7 +392,7 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<User>> {
         const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -413,7 +413,7 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.loginUserWithHttpInfo(username, password, _options);
         return result.toPromise();
     }
@@ -433,7 +433,7 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.logoutUserWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -453,7 +453,7 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi.ts';
 import {Configuration} from '../configuration.ts';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http.ts';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http.ts';
 import {ObjectSerializer} from '../models/ObjectSerializer.ts';
 import {ApiException} from './exception.ts';
 import {canConsumeForm, isCodeInRange} from '../util.ts';
@@ -436,14 +436,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPet(response: ResponseContext): Promise<Pet > {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -455,7 +455,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -468,7 +468,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePet(response: ResponseContext): Promise< void> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -476,7 +476,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -489,14 +489,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -508,7 +508,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -521,14 +521,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -540,7 +540,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -553,14 +553,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetById(response: ResponseContext): Promise<Pet > {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -588,14 +588,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePet(response: ResponseContext): Promise<Pet > {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -613,7 +613,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -626,7 +626,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithForm(response: ResponseContext): Promise< void> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -634,7 +634,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -647,14 +647,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,7 +663,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi.ts';
 import {Configuration} from '../configuration.ts';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http.ts';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http.ts';
 import {ObjectSerializer} from '../models/ObjectSerializer.ts';
 import {ApiException} from './exception.ts';
 import {canConsumeForm, isCodeInRange} from '../util.ts';
@@ -436,14 +436,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -455,7 +455,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -468,7 +468,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -476,7 +476,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -489,14 +489,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -508,7 +508,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -521,14 +521,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -540,7 +540,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -553,14 +553,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -588,14 +588,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -613,7 +613,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -626,7 +626,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -634,7 +634,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -647,14 +647,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,7 +663,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi.ts';
 import {Configuration} from '../configuration.ts';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http.ts';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http.ts';
 import {ObjectSerializer} from '../models/ObjectSerializer.ts';
 import {ApiException} from './exception.ts';
 import {canConsumeForm, isCodeInRange} from '../util.ts';
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrder(response: ResponseContext): Promise< void> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -186,14 +186,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -202,7 +202,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -215,14 +215,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderById(response: ResponseContext): Promise<Order > {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -237,7 +237,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -250,14 +250,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrder(response: ResponseContext): Promise<Order > {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -269,7 +269,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi.ts';
 import {Configuration} from '../configuration.ts';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http.ts';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http.ts';
 import {ObjectSerializer} from '../models/ObjectSerializer.ts';
 import {ApiException} from './exception.ts';
 import {canConsumeForm, isCodeInRange} from '../util.ts';
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -186,14 +186,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -202,7 +202,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -215,14 +215,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -237,7 +237,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -250,14 +250,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -269,7 +269,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi.ts';
 import {Configuration} from '../configuration.ts';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http.ts';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http.ts';
 import {ObjectSerializer} from '../models/ObjectSerializer.ts';
 import {ApiException} from './exception.ts';
 import {canConsumeForm, isCodeInRange} from '../util.ts';
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUser(response: ResponseContext): Promise< void> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -382,7 +382,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -403,7 +403,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -416,7 +416,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -424,7 +424,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -437,7 +437,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUser(response: ResponseContext): Promise< void> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -448,7 +448,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -461,14 +461,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByName(response: ResponseContext): Promise<User > {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -483,7 +483,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -496,14 +496,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUser(response: ResponseContext): Promise<string > {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -515,7 +515,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -528,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUser(response: ResponseContext): Promise< void> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -536,7 +536,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -549,7 +549,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUser(response: ResponseContext): Promise< void> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -560,7 +560,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi.ts';
 import {Configuration} from '../configuration.ts';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http.ts';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http.ts';
 import {ObjectSerializer} from '../models/ObjectSerializer.ts';
 import {ApiException} from './exception.ts';
 import {canConsumeForm, isCodeInRange} from '../util.ts';
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -382,7 +382,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -403,7 +403,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -416,7 +416,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -424,7 +424,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -437,7 +437,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -448,7 +448,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -461,14 +461,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -483,7 +483,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -496,14 +496,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -515,7 +515,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -528,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -536,7 +536,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -549,7 +549,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -560,7 +560,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -225,3 +225,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -226,7 +226,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http.ts';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http.ts';
 import { Configuration} from '../configuration.ts'
 
 import { ApiResponse } from '../models/ApiResponse.ts';
@@ -125,7 +125,7 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
-    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -143,7 +143,7 @@ export class ObjectPetApi {
      * Deletes a pet
      * @param param the request object
      */
-    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
@@ -161,7 +161,7 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
-    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
     }
 
@@ -179,7 +179,7 @@ export class ObjectPetApi {
      * Finds Pets by tags
      * @param param the request object
      */
-    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
@@ -197,7 +197,7 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
-    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
     }
 
@@ -215,7 +215,7 @@ export class ObjectPetApi {
      * Update an existing pet
      * @param param the request object
      */
-    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -233,7 +233,7 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
-    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
     }
 
@@ -251,7 +251,7 @@ export class ObjectPetApi {
      * uploads an image
      * @param param the request object
      */
-    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
@@ -311,7 +311,7 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
-    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -329,7 +329,7 @@ export class ObjectStoreApi {
      * Returns pet inventories by status
      * @param param the request object
      */
-    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
@@ -347,7 +347,7 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
-    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -365,7 +365,7 @@ export class ObjectStoreApi {
      * Place an order for a pet
      * @param param the request object
      */
-    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
@@ -473,7 +473,7 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
-    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -491,7 +491,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -509,7 +509,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -527,7 +527,7 @@ export class ObjectUserApi {
      * Delete user
      * @param param the request object
      */
-    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -545,7 +545,7 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
-    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<HttpInfo<User>> {
         return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -563,7 +563,7 @@ export class ObjectUserApi {
      * Logs user into the system
      * @param param the request object
      */
-    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<HttpInfo<string>> {
         return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
@@ -581,7 +581,7 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
-    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.logoutUserWithHttpInfo( options).toPromise();
     }
 
@@ -599,7 +599,7 @@ export class ObjectUserApi {
      * Updated user
      * @param param the request object
      */
-    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http.ts';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http.ts';
 import { Configuration} from '../configuration.ts'
 
 import { ApiResponse } from '../models/ApiResponse.ts';
@@ -125,8 +125,26 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param param the request object
+     */
     public addPet(param: PetApiAddPetRequest, options?: Configuration): Promise<Pet> {
         return this.api.addPet(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param param the request object
+     */
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
     /**
@@ -143,8 +161,26 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param param the request object
+     */
     public findPetsByStatus(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<Array<Pet>> {
         return this.api.findPetsByStatus(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param param the request object
+     */
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
     /**
@@ -161,8 +197,26 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param param the request object
+     */
     public getPetById(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<Pet> {
         return this.api.getPetById(param.petId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param param the request object
+     */
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
     /**
@@ -179,8 +233,26 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param param the request object
+     */
     public updatePetWithForm(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<void> {
         return this.api.updatePetWithForm(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param param the request object
+     */
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
     /**
@@ -239,8 +311,26 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param param the request object
+     */
     public deleteOrder(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<void> {
         return this.api.deleteOrder(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     * @param param the request object
+     */
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
     /**
@@ -257,8 +347,26 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param param the request object
+     */
     public getOrderById(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<Order> {
         return this.api.getOrderById(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param param the request object
+     */
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
     /**
@@ -365,8 +473,26 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param param the request object
+     */
     public createUser(param: UserApiCreateUserRequest, options?: Configuration): Promise<void> {
         return this.api.createUser(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
     /**
@@ -383,8 +509,26 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
     public createUsersWithListInput(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<void> {
         return this.api.createUsersWithListInput(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param param the request object
+     */
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
     /**
@@ -401,8 +545,26 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+        return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param param the request object
+     */
     public getUserByName(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<User> {
         return this.api.getUserByName(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param param the request object
+     */
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+        return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
     /**
@@ -419,8 +581,26 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.logoutUserWithHttpInfo( options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     * @param param the request object
+     */
     public logoutUser(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<void> {
         return this.api.logoutUser( options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param param the request object
+     */
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http.ts';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http.ts';
 import { Configuration} from '../configuration.ts'
 import { Observable, of, from } from '../rxjsStub.ts';
 import {mergeMap, map} from  '../rxjsStub.ts';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -45,8 +45,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -55,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -70,8 +79,18 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -79,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -94,8 +113,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatus(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatusWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -103,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -118,8 +146,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTags(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTagsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -127,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -142,8 +179,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -151,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -166,8 +212,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -177,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -192,8 +247,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithForm(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithFormWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -203,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -218,8 +284,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFile(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFileWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -245,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -260,15 +337,24 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -283,8 +369,16 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventory(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventoryWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -292,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -307,8 +401,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
     /**
@@ -316,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -331,8 +434,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
 }
@@ -358,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, _options?: Configuration): Observable<void> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -373,8 +485,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -382,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -397,7 +518,7 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInputWithHttpInfo(rsp)));
             }));
     }
 
@@ -406,7 +527,16 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -421,8 +551,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInputWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -430,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -445,8 +584,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -454,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -469,8 +617,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByName(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByNameWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
     }
 
     /**
@@ -479,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -494,15 +651,25 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUser(_options?: Configuration): Observable<void> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -517,8 +684,16 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
+    public logoutUser(_options?: Configuration): Observable<void> {
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -527,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -542,8 +717,18 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http.ts';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http.ts';
 import { Configuration} from '../configuration.ts'
 import { Observable, of, from } from '../rxjsStub.ts';
 import {mergeMap, map} from  '../rxjsStub.ts';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -55,7 +55,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -64,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -90,7 +90,7 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -98,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -123,7 +123,7 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -131,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -156,7 +156,7 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -164,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -189,7 +189,7 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
-        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -197,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -222,7 +222,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -232,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -259,7 +259,7 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
-        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -269,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -296,7 +296,7 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
-        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -322,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -347,14 +347,14 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
-        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -378,7 +378,7 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
-        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -386,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -411,7 +411,7 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
-        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
     /**
@@ -419,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -444,7 +444,7 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
-        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
 }
@@ -470,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -495,7 +495,7 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, _options?: Configuration): Observable<void> {
-        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -503,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -528,7 +528,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -536,7 +536,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -561,7 +561,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -569,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -594,7 +594,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, _options?: Configuration): Observable<void> {
-        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -602,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -627,7 +627,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, _options?: Configuration): Observable<User> {
-        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<User>) => apiResponse.data));
     }
 
     /**
@@ -636,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -662,14 +662,14 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
-        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -693,7 +693,7 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(_options?: Configuration): Observable<void> {
-        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -702,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -728,7 +728,7 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
-        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http.ts';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http.ts';
 import { Configuration} from '../configuration.ts'
 
 import { ApiResponse } from '../models/ApiResponse.ts';
@@ -26,8 +26,29 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.addPetWithHttpInfo(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
     public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
         const result = this.api.addPet(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -47,8 +68,28 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
         const result = this.api.findPetsByStatus(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
 
@@ -67,8 +108,28 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.getPetByIdWithHttpInfo(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
     public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
         const result = this.api.getPetById(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
 
@@ -89,8 +150,32 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -130,8 +215,27 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
     public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteOrder(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
 
@@ -149,8 +253,28 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
     public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
         const result = this.api.getOrderById(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
 
@@ -188,8 +312,28 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUserWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
     public createUser(user: User, _options?: Configuration): Promise<void> {
         const result = this.api.createUser(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
 
@@ -208,6 +352,16 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
         const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
@@ -218,8 +372,28 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteUserWithHttpInfo(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
     public deleteUser(username: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteUser(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+        const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
 
@@ -239,6 +413,17 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+        const result = this.api.loginUserWithHttpInfo(username, password, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
     public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
         const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
@@ -248,8 +433,28 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.logoutUserWithHttpInfo(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
     public logoutUser(_options?: Configuration): Promise<void> {
         const result = this.api.logoutUser(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http.ts';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http.ts';
 import { Configuration} from '../configuration.ts'
 
 import { ApiResponse } from '../models/ApiResponse.ts';
@@ -26,7 +26,7 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.addPetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -47,7 +47,7 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
@@ -68,7 +68,7 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
         return result.toPromise();
     }
@@ -88,7 +88,7 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
@@ -108,7 +108,7 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.getPetByIdWithHttpInfo(petId, _options);
         return result.toPromise();
     }
@@ -128,7 +128,7 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -150,7 +150,7 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
         return result.toPromise();
     }
@@ -174,7 +174,7 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
@@ -215,7 +215,7 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -234,7 +234,7 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -253,7 +253,7 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -273,7 +273,7 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
@@ -312,7 +312,7 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUserWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -332,7 +332,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -352,7 +352,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -372,7 +372,7 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteUserWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -392,7 +392,7 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<User>> {
         const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -413,7 +413,7 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.loginUserWithHttpInfo(username, password, _options);
         return result.toPromise();
     }
@@ -433,7 +433,7 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.logoutUserWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -453,7 +453,7 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.service.ts
@@ -1,5 +1,5 @@
 import type { Configuration } from "../configuration";
-import type { HttpFile, RequestContext, ResponseContext } from "../http/http";
+import type { HttpFile, RequestContext, ResponseContext, HttpInfo } from "../http/http";
 
 import { ApiResponse } from "../models/ApiResponse";
 import { Pet } from "../models/Pet";
@@ -25,19 +25,35 @@ export abstract class AbstractPetApiRequestFactory {
 
 
 export abstract class AbstractPetApiResponseProcessor {
+     public abstract addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >>;
+
      public abstract addPet(response: ResponseContext): Promise<Pet >;
+
+     public abstract deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
      public abstract deletePet(response: ResponseContext): Promise< void>;
 
+     public abstract findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >>;
+
      public abstract findPetsByStatus(response: ResponseContext): Promise<Array<Pet> >;
+
+     public abstract findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >>;
 
      public abstract findPetsByTags(response: ResponseContext): Promise<Array<Pet> >;
 
+     public abstract getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >>;
+
      public abstract getPetById(response: ResponseContext): Promise<Pet >;
+
+     public abstract updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >>;
 
      public abstract updatePet(response: ResponseContext): Promise<Pet >;
 
+     public abstract updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
+
      public abstract updatePetWithForm(response: ResponseContext): Promise< void>;
+
+     public abstract uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >>;
 
      public abstract uploadFile(response: ResponseContext): Promise<ApiResponse >;
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.service.ts
@@ -27,34 +27,18 @@ export abstract class AbstractPetApiRequestFactory {
 export abstract class AbstractPetApiResponseProcessor {
      public abstract addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >>;
 
-     public abstract addPet(response: ResponseContext): Promise<Pet >;
-
      public abstract deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
-
-     public abstract deletePet(response: ResponseContext): Promise< void>;
 
      public abstract findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >>;
 
-     public abstract findPetsByStatus(response: ResponseContext): Promise<Array<Pet> >;
-
      public abstract findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >>;
-
-     public abstract findPetsByTags(response: ResponseContext): Promise<Array<Pet> >;
 
      public abstract getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >>;
 
-     public abstract getPetById(response: ResponseContext): Promise<Pet >;
-
      public abstract updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >>;
-
-     public abstract updatePet(response: ResponseContext): Promise<Pet >;
 
      public abstract updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
-     public abstract updatePetWithForm(response: ResponseContext): Promise< void>;
-
      public abstract uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >>;
-
-     public abstract uploadFile(response: ResponseContext): Promise<ApiResponse >;
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -409,14 +409,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPet(response: ResponseContext): Promise<Pet > {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -428,7 +428,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -441,7 +441,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePet(response: ResponseContext): Promise< void> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -449,7 +449,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -462,14 +462,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -481,7 +481,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -494,14 +494,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -513,7 +513,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -526,14 +526,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetById(response: ResponseContext): Promise<Pet > {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -548,7 +548,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -561,14 +561,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePet(response: ResponseContext): Promise<Pet > {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -586,7 +586,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -599,7 +599,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithForm(response: ResponseContext): Promise< void> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -607,7 +607,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -620,14 +620,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -636,7 +636,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -409,14 +409,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -428,7 +428,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -441,7 +441,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -449,7 +449,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -462,14 +462,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -481,7 +481,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -494,14 +494,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -513,7 +513,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -526,14 +526,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -548,7 +548,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -561,14 +561,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -586,7 +586,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -599,7 +599,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -607,7 +607,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -620,14 +620,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -636,7 +636,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.service.ts
@@ -18,18 +18,10 @@ export abstract class AbstractStoreApiRequestFactory {
 export abstract class AbstractStoreApiResponseProcessor {
      public abstract deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
-     public abstract deleteOrder(response: ResponseContext): Promise< void>;
-
      public abstract getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >>;
-
-     public abstract getInventory(response: ResponseContext): Promise<{ [key: string]: number; } >;
 
      public abstract getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >>;
 
-     public abstract getOrderById(response: ResponseContext): Promise<Order >;
-
      public abstract placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >>;
-
-     public abstract placeOrder(response: ResponseContext): Promise<Order >;
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.service.ts
@@ -1,5 +1,5 @@
 import type { Configuration } from "../configuration";
-import type { HttpFile, RequestContext, ResponseContext } from "../http/http";
+import type { HttpFile, RequestContext, ResponseContext, HttpInfo } from "../http/http";
 
 import { Order } from "../models/Order";
 
@@ -16,11 +16,19 @@ export abstract class AbstractStoreApiRequestFactory {
 
 
 export abstract class AbstractStoreApiResponseProcessor {
+     public abstract deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
+
      public abstract deleteOrder(response: ResponseContext): Promise< void>;
+
+     public abstract getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >>;
 
      public abstract getInventory(response: ResponseContext): Promise<{ [key: string]: number; } >;
 
+     public abstract getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >>;
+
      public abstract getOrderById(response: ResponseContext): Promise<Order >;
+
+     public abstract placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >>;
 
      public abstract placeOrder(response: ResponseContext): Promise<Order >;
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -151,7 +151,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrder(response: ResponseContext): Promise< void> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -175,14 +175,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -191,7 +191,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -204,14 +204,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderById(response: ResponseContext): Promise<Order > {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -226,7 +226,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -239,14 +239,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrder(response: ResponseContext): Promise<Order > {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -258,7 +258,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -151,7 +151,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -175,14 +175,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -191,7 +191,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -204,14 +204,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -226,7 +226,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -239,14 +239,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -258,7 +258,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.service.ts
@@ -1,5 +1,5 @@
 import type { Configuration } from "../configuration";
-import type { HttpFile, RequestContext, ResponseContext } from "../http/http";
+import type { HttpFile, RequestContext, ResponseContext, HttpInfo } from "../http/http";
 
 import { User } from "../models/User";
 
@@ -24,19 +24,35 @@ export abstract class AbstractUserApiRequestFactory {
 
 
 export abstract class AbstractUserApiResponseProcessor {
+     public abstract createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
+
      public abstract createUser(response: ResponseContext): Promise< void>;
+
+     public abstract createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
      public abstract createUsersWithArrayInput(response: ResponseContext): Promise< void>;
 
+     public abstract createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
+
      public abstract createUsersWithListInput(response: ResponseContext): Promise< void>;
+
+     public abstract deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
      public abstract deleteUser(response: ResponseContext): Promise< void>;
 
+     public abstract getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >>;
+
      public abstract getUserByName(response: ResponseContext): Promise<User >;
+
+     public abstract loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >>;
 
      public abstract loginUser(response: ResponseContext): Promise<string >;
 
+     public abstract logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
+
      public abstract logoutUser(response: ResponseContext): Promise< void>;
+
+     public abstract updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
      public abstract updateUser(response: ResponseContext): Promise< void>;
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.service.ts
@@ -26,34 +26,18 @@ export abstract class AbstractUserApiRequestFactory {
 export abstract class AbstractUserApiResponseProcessor {
      public abstract createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
-     public abstract createUser(response: ResponseContext): Promise< void>;
-
      public abstract createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
-
-     public abstract createUsersWithArrayInput(response: ResponseContext): Promise< void>;
 
      public abstract createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
-     public abstract createUsersWithListInput(response: ResponseContext): Promise< void>;
-
      public abstract deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
-
-     public abstract deleteUser(response: ResponseContext): Promise< void>;
 
      public abstract getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >>;
 
-     public abstract getUserByName(response: ResponseContext): Promise<User >;
-
      public abstract loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >>;
-
-     public abstract loginUser(response: ResponseContext): Promise<string >;
 
      public abstract logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
 
-     public abstract logoutUser(response: ResponseContext): Promise< void>;
-
      public abstract updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>>;
-
-     public abstract updateUser(response: ResponseContext): Promise< void>;
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -347,7 +347,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUser(response: ResponseContext): Promise< void> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -355,7 +355,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -368,7 +368,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -376,7 +376,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -389,7 +389,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -397,7 +397,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -410,7 +410,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUser(response: ResponseContext): Promise< void> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -421,7 +421,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -434,14 +434,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByName(response: ResponseContext): Promise<User > {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -456,7 +456,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -469,14 +469,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUser(response: ResponseContext): Promise<string > {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -488,7 +488,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -501,7 +501,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUser(response: ResponseContext): Promise< void> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -509,7 +509,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -522,7 +522,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUser(response: ResponseContext): Promise< void> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -533,7 +533,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -347,7 +347,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -355,7 +355,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -368,7 +368,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -376,7 +376,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -389,7 +389,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -397,7 +397,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -410,7 +410,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -421,7 +421,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -434,14 +434,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -456,7 +456,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -469,14 +469,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -488,7 +488,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -501,7 +501,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -509,7 +509,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -522,7 +522,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -533,7 +533,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -234,3 +234,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -235,7 +235,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,8 +125,26 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param param the request object
+     */
     public addPet(param: PetApiAddPetRequest, options?: Configuration): Promise<Pet> {
         return this.api.addPet(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param param the request object
+     */
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
     /**
@@ -143,8 +161,26 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param param the request object
+     */
     public findPetsByStatus(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<Array<Pet>> {
         return this.api.findPetsByStatus(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param param the request object
+     */
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
     /**
@@ -161,8 +197,26 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param param the request object
+     */
     public getPetById(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<Pet> {
         return this.api.getPetById(param.petId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param param the request object
+     */
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
     /**
@@ -179,8 +233,26 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param param the request object
+     */
     public updatePetWithForm(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<void> {
         return this.api.updatePetWithForm(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param param the request object
+     */
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
     /**
@@ -239,8 +311,26 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param param the request object
+     */
     public deleteOrder(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<void> {
         return this.api.deleteOrder(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     * @param param the request object
+     */
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
     /**
@@ -257,8 +347,26 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param param the request object
+     */
     public getOrderById(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<Order> {
         return this.api.getOrderById(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param param the request object
+     */
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
     /**
@@ -365,8 +473,26 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param param the request object
+     */
     public createUser(param: UserApiCreateUserRequest, options?: Configuration): Promise<void> {
         return this.api.createUser(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
     /**
@@ -383,8 +509,26 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
     public createUsersWithListInput(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<void> {
         return this.api.createUsersWithListInput(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param param the request object
+     */
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
     /**
@@ -401,8 +545,26 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+        return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param param the request object
+     */
     public getUserByName(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<User> {
         return this.api.getUserByName(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param param the request object
+     */
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+        return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
     /**
@@ -419,8 +581,26 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.logoutUserWithHttpInfo( options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     * @param param the request object
+     */
     public logoutUser(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<void> {
         return this.api.logoutUser( options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param param the request object
+     */
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,7 +125,7 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
-    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -143,7 +143,7 @@ export class ObjectPetApi {
      * Deletes a pet
      * @param param the request object
      */
-    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
@@ -161,7 +161,7 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
-    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
     }
 
@@ -179,7 +179,7 @@ export class ObjectPetApi {
      * Finds Pets by tags
      * @param param the request object
      */
-    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
@@ -197,7 +197,7 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
-    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
     }
 
@@ -215,7 +215,7 @@ export class ObjectPetApi {
      * Update an existing pet
      * @param param the request object
      */
-    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -233,7 +233,7 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
-    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
     }
 
@@ -251,7 +251,7 @@ export class ObjectPetApi {
      * uploads an image
      * @param param the request object
      */
-    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
@@ -311,7 +311,7 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
-    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -329,7 +329,7 @@ export class ObjectStoreApi {
      * Returns pet inventories by status
      * @param param the request object
      */
-    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
@@ -347,7 +347,7 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
-    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -365,7 +365,7 @@ export class ObjectStoreApi {
      * Place an order for a pet
      * @param param the request object
      */
-    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
@@ -473,7 +473,7 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
-    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -491,7 +491,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -509,7 +509,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -527,7 +527,7 @@ export class ObjectUserApi {
      * Delete user
      * @param param the request object
      */
-    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -545,7 +545,7 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
-    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<HttpInfo<User>> {
         return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -563,7 +563,7 @@ export class ObjectUserApi {
      * Logs user into the system
      * @param param the request object
      */
-    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<HttpInfo<string>> {
         return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
@@ -581,7 +581,7 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
-    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.logoutUserWithHttpInfo( options).toPromise();
     }
 
@@ -599,7 +599,7 @@ export class ObjectUserApi {
      * Updated user
      * @param param the request object
      */
-    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -35,7 +35,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -50,8 +50,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -60,7 +69,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -75,8 +84,18 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -84,7 +103,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -99,8 +118,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatus(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatusWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -108,7 +136,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -123,8 +151,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTags(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTagsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -132,7 +169,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -147,8 +184,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -156,7 +202,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -171,8 +217,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -182,7 +237,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -197,8 +252,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithForm(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithFormWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -208,7 +274,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -223,8 +289,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFile(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFileWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -253,7 +330,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -268,15 +345,24 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -291,8 +377,16 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventory(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventoryWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -300,7 +394,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -315,8 +409,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
     /**
@@ -324,7 +427,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -339,8 +442,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
 }
@@ -369,7 +481,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, _options?: Configuration): Observable<void> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -384,8 +496,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -393,7 +514,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -408,7 +529,7 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInputWithHttpInfo(rsp)));
             }));
     }
 
@@ -417,7 +538,16 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -432,8 +562,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInputWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -441,7 +580,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -456,8 +595,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -465,7 +613,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -480,8 +628,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByName(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByNameWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
     }
 
     /**
@@ -490,7 +647,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -505,15 +662,25 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUser(_options?: Configuration): Observable<void> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -528,8 +695,16 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
+    public logoutUser(_options?: Configuration): Observable<void> {
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -538,7 +713,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -553,8 +728,18 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -35,7 +35,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -60,7 +60,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -69,7 +69,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -95,7 +95,7 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -103,7 +103,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -128,7 +128,7 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -136,7 +136,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -161,7 +161,7 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -169,7 +169,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -194,7 +194,7 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
-        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -202,7 +202,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -227,7 +227,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -237,7 +237,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -264,7 +264,7 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
-        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -274,7 +274,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -301,7 +301,7 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
-        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -330,7 +330,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -355,14 +355,14 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
-        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -386,7 +386,7 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
-        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -394,7 +394,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -419,7 +419,7 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
-        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
     /**
@@ -427,7 +427,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -452,7 +452,7 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
-        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
 }
@@ -481,7 +481,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -506,7 +506,7 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, _options?: Configuration): Observable<void> {
-        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -514,7 +514,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -539,7 +539,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -547,7 +547,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -572,7 +572,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -580,7 +580,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -605,7 +605,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, _options?: Configuration): Observable<void> {
-        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -613,7 +613,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -638,7 +638,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, _options?: Configuration): Observable<User> {
-        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<User>) => apiResponse.data));
     }
 
     /**
@@ -647,7 +647,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -673,14 +673,14 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
-        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -704,7 +704,7 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(_options?: Configuration): Observable<void> {
-        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -713,7 +713,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -739,7 +739,7 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
-        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { injectable, inject, optional } from "inversify";
 import { AbstractConfiguration } from "../services/configuration";
@@ -31,7 +31,7 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.addPetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -52,7 +52,7 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
@@ -73,7 +73,7 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
         return result.toPromise();
     }
@@ -93,7 +93,7 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
@@ -113,7 +113,7 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.getPetByIdWithHttpInfo(petId, _options);
         return result.toPromise();
     }
@@ -133,7 +133,7 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -155,7 +155,7 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
         return result.toPromise();
     }
@@ -179,7 +179,7 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
@@ -223,7 +223,7 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -242,7 +242,7 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -261,7 +261,7 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -281,7 +281,7 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
@@ -323,7 +323,7 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUserWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -343,7 +343,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -363,7 +363,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -383,7 +383,7 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteUserWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -403,7 +403,7 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<User>> {
         const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -424,7 +424,7 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.loginUserWithHttpInfo(username, password, _options);
         return result.toPromise();
     }
@@ -444,7 +444,7 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.logoutUserWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -464,7 +464,7 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { injectable, inject, optional } from "inversify";
 import { AbstractConfiguration } from "../services/configuration";
@@ -31,8 +31,29 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.addPetWithHttpInfo(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
     public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
         const result = this.api.addPet(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -52,8 +73,28 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
         const result = this.api.findPetsByStatus(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
 
@@ -72,8 +113,28 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.getPetByIdWithHttpInfo(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
     public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
         const result = this.api.getPetById(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
 
@@ -94,8 +155,32 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -138,8 +223,27 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
     public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteOrder(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
 
@@ -157,8 +261,28 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
     public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
         const result = this.api.getOrderById(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
 
@@ -199,8 +323,28 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUserWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
     public createUser(user: User, _options?: Configuration): Promise<void> {
         const result = this.api.createUser(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
 
@@ -219,6 +363,16 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
         const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
@@ -229,8 +383,28 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteUserWithHttpInfo(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
     public deleteUser(username: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteUser(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+        const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
 
@@ -250,6 +424,17 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+        const result = this.api.loginUserWithHttpInfo(username, password, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
     public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
         const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
@@ -259,8 +444,28 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.logoutUserWithHttpInfo(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
     public logoutUser(_options?: Configuration): Promise<void> {
         const result = this.api.logoutUser(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -436,14 +436,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPet(response: ResponseContext): Promise<Pet > {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -455,7 +455,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -468,7 +468,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePet(response: ResponseContext): Promise< void> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -476,7 +476,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -489,14 +489,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -508,7 +508,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -521,14 +521,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -540,7 +540,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -553,14 +553,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetById(response: ResponseContext): Promise<Pet > {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -588,14 +588,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePet(response: ResponseContext): Promise<Pet > {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -613,7 +613,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -626,7 +626,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithForm(response: ResponseContext): Promise< void> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -634,7 +634,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -647,14 +647,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,7 +663,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -436,14 +436,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -455,7 +455,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -468,7 +468,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -476,7 +476,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -489,14 +489,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -508,7 +508,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -521,14 +521,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -540,7 +540,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -553,14 +553,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -588,14 +588,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -613,7 +613,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -626,7 +626,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -634,7 +634,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -647,14 +647,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,7 +663,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrder(response: ResponseContext): Promise< void> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -186,14 +186,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -202,7 +202,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -215,14 +215,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderById(response: ResponseContext): Promise<Order > {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -237,7 +237,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -250,14 +250,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrder(response: ResponseContext): Promise<Order > {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -269,7 +269,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -162,7 +162,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -173,7 +173,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -186,14 +186,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -202,7 +202,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -215,14 +215,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -237,7 +237,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -250,14 +250,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -269,7 +269,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUser(response: ResponseContext): Promise< void> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -382,7 +382,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -403,7 +403,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -416,7 +416,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -424,7 +424,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -437,7 +437,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUser(response: ResponseContext): Promise< void> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -448,7 +448,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -461,14 +461,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByName(response: ResponseContext): Promise<User > {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -483,7 +483,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -496,14 +496,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUser(response: ResponseContext): Promise<string > {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -515,7 +515,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -528,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUser(response: ResponseContext): Promise< void> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -536,7 +536,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -549,7 +549,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUser(response: ResponseContext): Promise< void> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -560,7 +560,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {canConsumeForm, isCodeInRange} from '../util';
@@ -374,7 +374,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -382,7 +382,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -395,7 +395,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -403,7 +403,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -416,7 +416,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -424,7 +424,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -437,7 +437,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -448,7 +448,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -461,14 +461,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -483,7 +483,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -496,14 +496,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -515,7 +515,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -528,7 +528,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -536,7 +536,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -549,7 +549,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -560,7 +560,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -238,7 +238,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -237,3 +237,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,8 +125,26 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param param the request object
+     */
     public addPet(param: PetApiAddPetRequest, options?: Configuration): Promise<Pet> {
         return this.api.addPet(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param param the request object
+     */
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
     /**
@@ -143,8 +161,26 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param param the request object
+     */
     public findPetsByStatus(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<Array<Pet>> {
         return this.api.findPetsByStatus(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param param the request object
+     */
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
     /**
@@ -161,8 +197,26 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param param the request object
+     */
     public getPetById(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<Pet> {
         return this.api.getPetById(param.petId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param param the request object
+     */
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
     /**
@@ -179,8 +233,26 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param param the request object
+     */
     public updatePetWithForm(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<void> {
         return this.api.updatePetWithForm(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param param the request object
+     */
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
     /**
@@ -239,8 +311,26 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param param the request object
+     */
     public deleteOrder(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<void> {
         return this.api.deleteOrder(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     * @param param the request object
+     */
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
     /**
@@ -257,8 +347,26 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param param the request object
+     */
     public getOrderById(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<Order> {
         return this.api.getOrderById(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param param the request object
+     */
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
     /**
@@ -365,8 +473,26 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param param the request object
+     */
     public createUser(param: UserApiCreateUserRequest, options?: Configuration): Promise<void> {
         return this.api.createUser(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
     /**
@@ -383,8 +509,26 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
     public createUsersWithListInput(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<void> {
         return this.api.createUsersWithListInput(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param param the request object
+     */
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
     /**
@@ -401,8 +545,26 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+        return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param param the request object
+     */
     public getUserByName(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<User> {
         return this.api.getUserByName(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param param the request object
+     */
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+        return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
     /**
@@ -419,8 +581,26 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.logoutUserWithHttpInfo( options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     * @param param the request object
+     */
     public logoutUser(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<void> {
         return this.api.logoutUser( options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param param the request object
+     */
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,7 +125,7 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
-    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -143,7 +143,7 @@ export class ObjectPetApi {
      * Deletes a pet
      * @param param the request object
      */
-    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
@@ -161,7 +161,7 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
-    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
     }
 
@@ -179,7 +179,7 @@ export class ObjectPetApi {
      * Finds Pets by tags
      * @param param the request object
      */
-    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
@@ -197,7 +197,7 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
-    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
     }
 
@@ -215,7 +215,7 @@ export class ObjectPetApi {
      * Update an existing pet
      * @param param the request object
      */
-    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -233,7 +233,7 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
-    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
     }
 
@@ -251,7 +251,7 @@ export class ObjectPetApi {
      * uploads an image
      * @param param the request object
      */
-    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
@@ -311,7 +311,7 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
-    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -329,7 +329,7 @@ export class ObjectStoreApi {
      * Returns pet inventories by status
      * @param param the request object
      */
-    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
@@ -347,7 +347,7 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
-    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -365,7 +365,7 @@ export class ObjectStoreApi {
      * Place an order for a pet
      * @param param the request object
      */
-    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
@@ -473,7 +473,7 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
-    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -491,7 +491,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -509,7 +509,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -527,7 +527,7 @@ export class ObjectUserApi {
      * Delete user
      * @param param the request object
      */
-    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -545,7 +545,7 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
-    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<HttpInfo<User>> {
         return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -563,7 +563,7 @@ export class ObjectUserApi {
      * Logs user into the system
      * @param param the request object
      */
-    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<HttpInfo<string>> {
         return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
@@ -581,7 +581,7 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
-    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.logoutUserWithHttpInfo( options).toPromise();
     }
 
@@ -599,7 +599,7 @@ export class ObjectUserApi {
      * Updated user
      * @param param the request object
      */
-    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -55,7 +55,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -64,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -90,7 +90,7 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -98,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -123,7 +123,7 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -131,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -156,7 +156,7 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -164,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -189,7 +189,7 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
-        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -197,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -222,7 +222,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -232,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -259,7 +259,7 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
-        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -269,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -296,7 +296,7 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
-        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -322,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -347,14 +347,14 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
-        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -378,7 +378,7 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
-        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -386,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -411,7 +411,7 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
-        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
     /**
@@ -419,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -444,7 +444,7 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
-        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
 }
@@ -470,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -495,7 +495,7 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, _options?: Configuration): Observable<void> {
-        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -503,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -528,7 +528,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -536,7 +536,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -561,7 +561,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -569,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -594,7 +594,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, _options?: Configuration): Observable<void> {
-        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -602,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -627,7 +627,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, _options?: Configuration): Observable<User> {
-        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<User>) => apiResponse.data));
     }
 
     /**
@@ -636,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -662,14 +662,14 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
-        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -693,7 +693,7 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(_options?: Configuration): Observable<void> {
-        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -702,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -728,7 +728,7 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
-        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -45,8 +45,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -55,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -70,8 +79,18 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -79,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -94,8 +113,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatus(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatusWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -103,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -118,8 +146,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTags(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTagsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -127,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -142,8 +179,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -151,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -166,8 +212,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -177,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -192,8 +247,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithForm(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithFormWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -203,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -218,8 +284,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFile(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFileWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -245,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -260,15 +337,24 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -283,8 +369,16 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventory(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventoryWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -292,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -307,8 +401,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
     /**
@@ -316,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -331,8 +434,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
 }
@@ -358,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, _options?: Configuration): Observable<void> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -373,8 +485,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -382,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -397,7 +518,7 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInputWithHttpInfo(rsp)));
             }));
     }
 
@@ -406,7 +527,16 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -421,8 +551,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInputWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -430,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -445,8 +584,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -454,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -469,8 +617,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByName(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByNameWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
     }
 
     /**
@@ -479,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -494,15 +651,25 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUser(_options?: Configuration): Observable<void> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -517,8 +684,16 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
+    public logoutUser(_options?: Configuration): Observable<void> {
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -527,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -542,8 +717,18 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,8 +26,29 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.addPetWithHttpInfo(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
     public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
         const result = this.api.addPet(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -47,8 +68,28 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
         const result = this.api.findPetsByStatus(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
 
@@ -67,8 +108,28 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.getPetByIdWithHttpInfo(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
     public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
         const result = this.api.getPetById(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
 
@@ -89,8 +150,32 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -130,8 +215,27 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
     public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteOrder(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
 
@@ -149,8 +253,28 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
     public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
         const result = this.api.getOrderById(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
 
@@ -188,8 +312,28 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUserWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
     public createUser(user: User, _options?: Configuration): Promise<void> {
         const result = this.api.createUser(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
 
@@ -208,6 +352,16 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
         const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
@@ -218,8 +372,28 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteUserWithHttpInfo(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
     public deleteUser(username: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteUser(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+        const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
 
@@ -239,6 +413,17 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+        const result = this.api.loginUserWithHttpInfo(username, password, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
     public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
         const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
@@ -248,8 +433,28 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.logoutUserWithHttpInfo(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
     public logoutUser(_options?: Configuration): Promise<void> {
         const result = this.api.logoutUser(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,7 +26,7 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.addPetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -47,7 +47,7 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
@@ -68,7 +68,7 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
         return result.toPromise();
     }
@@ -88,7 +88,7 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
@@ -108,7 +108,7 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.getPetByIdWithHttpInfo(petId, _options);
         return result.toPromise();
     }
@@ -128,7 +128,7 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -150,7 +150,7 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
         return result.toPromise();
     }
@@ -174,7 +174,7 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
@@ -215,7 +215,7 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -234,7 +234,7 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -253,7 +253,7 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -273,7 +273,7 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
@@ -312,7 +312,7 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUserWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -332,7 +332,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -352,7 +352,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -372,7 +372,7 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteUserWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -392,7 +392,7 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<User>> {
         const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -413,7 +413,7 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.loginUserWithHttpInfo(username, password, _options);
         return result.toPromise();
     }
@@ -433,7 +433,7 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.logoutUserWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -453,7 +453,7 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -438,14 +438,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -457,7 +457,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -470,7 +470,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -478,7 +478,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -491,14 +491,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -510,7 +510,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -523,14 +523,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -542,7 +542,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -555,14 +555,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -577,7 +577,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -590,14 +590,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -615,7 +615,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -628,7 +628,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -636,7 +636,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -649,14 +649,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<HttpInfo<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -665,7 +665,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -438,14 +438,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to addPet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async addPet(response: ResponseContext): Promise<Pet > {
+     public async addPetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -457,7 +457,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -470,7 +470,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to deletePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deletePet(response: ResponseContext): Promise< void> {
+     public async deletePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined, response.headers);
@@ -478,7 +478,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -491,14 +491,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByStatus
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByStatus(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByStatusWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined, response.headers);
@@ -510,7 +510,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -523,14 +523,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to findPetsByTags
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async findPetsByTags(response: ResponseContext): Promise<Array<Pet> > {
+     public async findPetsByTagsWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Array<Pet> >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Array<Pet> = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined, response.headers);
@@ -542,7 +542,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Array<Pet>", ""
             ) as Array<Pet>;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -555,14 +555,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to getPetById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getPetById(response: ResponseContext): Promise<Pet > {
+     public async getPetByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -577,7 +577,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -590,14 +590,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePet
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePet(response: ResponseContext): Promise<Pet > {
+     public async updatePetWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Pet >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Pet = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -615,7 +615,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Pet", ""
             ) as Pet;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -628,7 +628,7 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to updatePetWithForm
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updatePetWithForm(response: ResponseContext): Promise< void> {
+     public async updatePetWithFormWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined, response.headers);
@@ -636,7 +636,7 @@ export class PetApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -649,14 +649,14 @@ export class PetApiResponseProcessor {
      * @params response Response returned by the server for a request to uploadFile
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async uploadFile(response: ResponseContext): Promise<ApiResponse > {
+     public async uploadFileWithHttpInfo(response: ResponseContext): Promise<ApiResponse<ApiResponse >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: ApiResponse = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -665,7 +665,7 @@ export class PetApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ApiResponse", ""
             ) as ApiResponse;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -164,7 +164,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -175,7 +175,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -188,14 +188,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<HttpInfo<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -204,7 +204,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -217,14 +217,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -239,7 +239,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -252,14 +252,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<HttpInfo<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -271,7 +271,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -164,7 +164,7 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteOrder(response: ResponseContext): Promise< void> {
+     public async deleteOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -175,7 +175,7 @@ export class StoreApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -188,14 +188,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getInventory
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getInventory(response: ResponseContext): Promise<{ [key: string]: number; } > {
+     public async getInventoryWithHttpInfo(response: ResponseContext): Promise<ApiResponse<{ [key: string]: number; } >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: { [key: string]: number; } = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -204,7 +204,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "{ [key: string]: number; }", "int32"
             ) as { [key: string]: number; };
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -217,14 +217,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to getOrderById
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getOrderById(response: ResponseContext): Promise<Order > {
+     public async getOrderByIdWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined, response.headers);
@@ -239,7 +239,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -252,14 +252,14 @@ export class StoreApiResponseProcessor {
      * @params response Response returned by the server for a request to placeOrder
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async placeOrder(response: ResponseContext): Promise<Order > {
+     public async placeOrderWithHttpInfo(response: ResponseContext): Promise<ApiResponse<Order >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: Order = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined, response.headers);
@@ -271,7 +271,7 @@ export class StoreApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "Order", ""
             ) as Order;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, HttpInfo} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -376,7 +376,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -384,7 +384,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -397,7 +397,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -405,7 +405,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -418,7 +418,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -426,7 +426,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -439,7 +439,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -450,7 +450,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -463,14 +463,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<HttpInfo<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -485,7 +485,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -498,14 +498,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -517,7 +517,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -530,7 +530,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -538,7 +538,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -551,7 +551,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<HttpInfo< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -562,7 +562,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -1,7 +1,7 @@
 // TODO: better import syntax?
 import {BaseAPIRequestFactory, RequiredError, COLLECTION_FORMATS} from './baseapi';
 import {Configuration} from '../configuration';
-import {RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+import {RequestContext, HttpMethod, ResponseContext, HttpFile, ApiResponse} from '../http/http';
 import * as FormData from "form-data";
 import { URLSearchParams } from 'url';
 import {ObjectSerializer} from '../models/ObjectSerializer';
@@ -376,7 +376,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUser(response: ResponseContext): Promise< void> {
+     public async createUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -384,7 +384,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -397,7 +397,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithArrayInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithArrayInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -405,7 +405,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -418,7 +418,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to createUsersWithListInput
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async createUsersWithListInput(response: ResponseContext): Promise< void> {
+     public async createUsersWithListInputWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -426,7 +426,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -439,7 +439,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to deleteUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async deleteUser(response: ResponseContext): Promise< void> {
+     public async deleteUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -450,7 +450,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -463,14 +463,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to getUserByName
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async getUserByName(response: ResponseContext): Promise<User > {
+     public async getUserByNameWithHttpInfo(response: ResponseContext): Promise<ApiResponse<User >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: User = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined, response.headers);
@@ -485,7 +485,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "User", ""
             ) as User;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -498,14 +498,14 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to loginUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async loginUser(response: ResponseContext): Promise<string > {
+     public async loginUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse<string >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
             const body: string = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined, response.headers);
@@ -517,7 +517,7 @@ export class UserApiResponseProcessor {
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "string", ""
             ) as string;
-            return body;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, body);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -530,7 +530,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to logoutUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async logoutUser(response: ResponseContext): Promise< void> {
+     public async logoutUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined, response.headers);
@@ -538,7 +538,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
@@ -551,7 +551,7 @@ export class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to updateUser
      * @throws ApiException if the response code was not in [200, 299]
      */
-     public async updateUser(response: ResponseContext): Promise< void> {
+     public async updateUserWithHttpInfo(response: ResponseContext): Promise<ApiResponse< void>> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
             throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined, response.headers);
@@ -562,7 +562,7 @@ export class UserApiResponseProcessor {
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-            return;
+            return new ApiResponse(response.httpStatusCode, response.headers, response.body, undefined);
         }
 
         throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -234,3 +234,14 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
     }
   }
 }
+
+export class ApiResponse<T> extends ResponseContext {
+    public constructor(
+        public httpStatusCode: number,
+        public headers: { [key: string]: string },
+        public body: ResponseBody,
+        public data: T,
+    ) {
+        super(httpStatusCode, headers, body);
+    }
+}

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -235,7 +235,7 @@ export function wrapHttpLibrary(promiseHttpLibrary: PromiseHttpLibrary): HttpLib
   }
 }
 
-export class ApiResponse<T> extends ResponseContext {
+export class HttpInfo<T> extends ResponseContext {
     public constructor(
         public httpStatusCode: number,
         public headers: { [key: string]: string },

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,8 +125,26 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param param the request object
+     */
     public addPet(param: PetApiAddPetRequest, options?: Configuration): Promise<Pet> {
         return this.api.addPet(param.pet,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param param the request object
+     */
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
     /**
@@ -143,8 +161,26 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param param the request object
+     */
     public findPetsByStatus(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<Array<Pet>> {
         return this.api.findPetsByStatus(param.status,  options).toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param param the request object
+     */
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
     /**
@@ -161,8 +197,26 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param param the request object
+     */
     public getPetById(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<Pet> {
         return this.api.getPetById(param.petId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param param the request object
+     */
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+        return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
     /**
@@ -179,8 +233,26 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param param the request object
+     */
     public updatePetWithForm(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<void> {
         return this.api.updatePetWithForm(param.petId, param.name, param.status,  options).toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param param the request object
+     */
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
     /**
@@ -239,8 +311,26 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param param the request object
+     */
     public deleteOrder(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<void> {
         return this.api.deleteOrder(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     * @param param the request object
+     */
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
     /**
@@ -257,8 +347,26 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param param the request object
+     */
     public getOrderById(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<Order> {
         return this.api.getOrderById(param.orderId,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param param the request object
+     */
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+        return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
     /**
@@ -365,8 +473,26 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param param the request object
+     */
     public createUser(param: UserApiCreateUserRequest, options?: Configuration): Promise<void> {
         return this.api.createUser(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
     /**
@@ -383,8 +509,26 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param param the request object
+     */
     public createUsersWithListInput(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<void> {
         return this.api.createUsersWithListInput(param.user,  options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param param the request object
+     */
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
     /**
@@ -401,8 +545,26 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+        return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param param the request object
+     */
     public getUserByName(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<User> {
         return this.api.getUserByName(param.username,  options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param param the request object
+     */
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+        return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
     /**
@@ -419,8 +581,26 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.logoutUserWithHttpInfo( options).toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     * @param param the request object
+     */
     public logoutUser(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<void> {
         return this.api.logoutUser( options).toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param param the request object
+     */
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+        return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -125,7 +125,7 @@ export class ObjectPetApi {
      * Add a new pet to the store
      * @param param the request object
      */
-    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(param: PetApiAddPetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.addPetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -143,7 +143,7 @@ export class ObjectPetApi {
      * Deletes a pet
      * @param param the request object
      */
-    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(param: PetApiDeletePetRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deletePetWithHttpInfo(param.petId, param.apiKey,  options).toPromise();
     }
 
@@ -161,7 +161,7 @@ export class ObjectPetApi {
      * Finds Pets by status
      * @param param the request object
      */
-    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(param: PetApiFindPetsByStatusRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByStatusWithHttpInfo(param.status,  options).toPromise();
     }
 
@@ -179,7 +179,7 @@ export class ObjectPetApi {
      * Finds Pets by tags
      * @param param the request object
      */
-    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(param: PetApiFindPetsByTagsRequest, options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         return this.api.findPetsByTagsWithHttpInfo(param.tags,  options).toPromise();
     }
 
@@ -197,7 +197,7 @@ export class ObjectPetApi {
      * Find pet by ID
      * @param param the request object
      */
-    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(param: PetApiGetPetByIdRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.getPetByIdWithHttpInfo(param.petId,  options).toPromise();
     }
 
@@ -215,7 +215,7 @@ export class ObjectPetApi {
      * Update an existing pet
      * @param param the request object
      */
-    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(param: PetApiUpdatePetRequest, options?: Configuration): Promise<HttpInfo<Pet>> {
         return this.api.updatePetWithHttpInfo(param.pet,  options).toPromise();
     }
 
@@ -233,7 +233,7 @@ export class ObjectPetApi {
      * Updates a pet in the store with form data
      * @param param the request object
      */
-    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(param: PetApiUpdatePetWithFormRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updatePetWithFormWithHttpInfo(param.petId, param.name, param.status,  options).toPromise();
     }
 
@@ -251,7 +251,7 @@ export class ObjectPetApi {
      * uploads an image
      * @param param the request object
      */
-    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(param: PetApiUploadFileRequest, options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         return this.api.uploadFileWithHttpInfo(param.petId, param.additionalMetadata, param.file,  options).toPromise();
     }
 
@@ -311,7 +311,7 @@ export class ObjectStoreApi {
      * Delete purchase order by ID
      * @param param the request object
      */
-    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(param: StoreApiDeleteOrderRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteOrderWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -329,7 +329,7 @@ export class ObjectStoreApi {
      * Returns pet inventories by status
      * @param param the request object
      */
-    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(param: StoreApiGetInventoryRequest = {}, options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         return this.api.getInventoryWithHttpInfo( options).toPromise();
     }
 
@@ -347,7 +347,7 @@ export class ObjectStoreApi {
      * Find purchase order by ID
      * @param param the request object
      */
-    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(param: StoreApiGetOrderByIdRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.getOrderByIdWithHttpInfo(param.orderId,  options).toPromise();
     }
 
@@ -365,7 +365,7 @@ export class ObjectStoreApi {
      * Place an order for a pet
      * @param param the request object
      */
-    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(param: StoreApiPlaceOrderRequest, options?: Configuration): Promise<HttpInfo<Order>> {
         return this.api.placeOrderWithHttpInfo(param.order,  options).toPromise();
     }
 
@@ -473,7 +473,7 @@ export class ObjectUserApi {
      * Create user
      * @param param the request object
      */
-    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(param: UserApiCreateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUserWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -491,7 +491,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(param: UserApiCreateUsersWithArrayInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithArrayInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -509,7 +509,7 @@ export class ObjectUserApi {
      * Creates list of users with given input array
      * @param param the request object
      */
-    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(param: UserApiCreateUsersWithListInputRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.createUsersWithListInputWithHttpInfo(param.user,  options).toPromise();
     }
 
@@ -527,7 +527,7 @@ export class ObjectUserApi {
      * Delete user
      * @param param the request object
      */
-    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(param: UserApiDeleteUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.deleteUserWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -545,7 +545,7 @@ export class ObjectUserApi {
      * Get user by user name
      * @param param the request object
      */
-    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(param: UserApiGetUserByNameRequest, options?: Configuration): Promise<HttpInfo<User>> {
         return this.api.getUserByNameWithHttpInfo(param.username,  options).toPromise();
     }
 
@@ -563,7 +563,7 @@ export class ObjectUserApi {
      * Logs user into the system
      * @param param the request object
      */
-    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(param: UserApiLoginUserRequest, options?: Configuration): Promise<HttpInfo<string>> {
         return this.api.loginUserWithHttpInfo(param.username, param.password,  options).toPromise();
     }
 
@@ -581,7 +581,7 @@ export class ObjectUserApi {
      * Logs out current logged in user session
      * @param param the request object
      */
-    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(param: UserApiLogoutUserRequest = {}, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.logoutUserWithHttpInfo( options).toPromise();
     }
 
@@ -599,7 +599,7 @@ export class ObjectUserApi {
      * Updated user
      * @param param the request object
      */
-    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(param: UserApiUpdateUserRequest, options?: Configuration): Promise<HttpInfo<void>> {
         return this.api.updateUserWithHttpInfo(param.username, param.user,  options).toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -55,7 +55,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -64,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -90,7 +90,7 @@ export class ObservablePetApi {
      * @param apiKey 
      */
     public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -98,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -123,7 +123,7 @@ export class ObservablePetApi {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -131,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -156,7 +156,7 @@ export class ObservablePetApi {
      * @param tags Tags to filter by
      */
     public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
-        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: HttpInfo<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -164,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -189,7 +189,7 @@ export class ObservablePetApi {
      * @param petId ID of pet to return
      */
     public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
-        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -197,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -222,7 +222,7 @@ export class ObservablePetApi {
      * @param pet Pet object that needs to be added to the store
      */
     public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
-        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: HttpInfo<Pet>) => apiResponse.data));
     }
 
     /**
@@ -232,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -259,7 +259,7 @@ export class ObservablePetApi {
      * @param status Updated status of the pet
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
-        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -269,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -296,7 +296,7 @@ export class ObservablePetApi {
      * @param file file to upload
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
-        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: HttpInfo<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -322,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -347,14 +347,14 @@ export class ObservableStoreApi {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
-        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -378,7 +378,7 @@ export class ObservableStoreApi {
      * Returns pet inventories by status
      */
     public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
-        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -386,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -411,7 +411,7 @@ export class ObservableStoreApi {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
-        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
     /**
@@ -419,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -444,7 +444,7 @@ export class ObservableStoreApi {
      * @param order order placed for purchasing the pet
      */
     public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
-        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: HttpInfo<Order>) => apiResponse.data));
     }
 
 }
@@ -470,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -495,7 +495,7 @@ export class ObservableUserApi {
      * @param user Created user object
      */
     public createUser(user: User, _options?: Configuration): Observable<void> {
-        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -503,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -528,7 +528,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -536,7 +536,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -561,7 +561,7 @@ export class ObservableUserApi {
      * @param user List of user object
      */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
-        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -569,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -594,7 +594,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be deleted
      */
     public deleteUser(username: string, _options?: Configuration): Observable<void> {
-        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -602,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -627,7 +627,7 @@ export class ObservableUserApi {
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
     public getUserByName(username: string, _options?: Configuration): Observable<User> {
-        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: HttpInfo<User>) => apiResponse.data));
     }
 
     /**
@@ -636,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -662,14 +662,14 @@ export class ObservableUserApi {
      * @param password The password for login in clear text
      */
     public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
-        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: HttpInfo<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -693,7 +693,7 @@ export class ObservableUserApi {
      * Logs out current logged in user session
      */
     public logoutUser(_options?: Configuration): Observable<void> {
-        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
     /**
@@ -702,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -728,7 +728,7 @@ export class ObservableUserApi {
      * @param user Updated user object
      */
     public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
-        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: HttpInfo<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 import { Observable, of, from } from '../rxjsStub';
 import {mergeMap, map} from  '../rxjsStub';
@@ -30,7 +30,7 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
@@ -45,8 +45,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.addPetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.addPetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -55,7 +64,7 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
@@ -70,8 +79,18 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deletePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        return this.deletePetWithHttpInfo(petId, apiKey, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -79,7 +98,7 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
@@ -94,8 +113,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatus(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByStatusWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByStatusWithHttpInfo(status, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -103,7 +131,7 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<ApiResponse<Array<Pet>>> {
         const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
@@ -118,8 +146,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTags(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.findPetsByTagsWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        return this.findPetsByTagsWithHttpInfo(tags, _options).pipe(map((apiResponse: ApiResponse<Array<Pet>>) => apiResponse.data));
     }
 
     /**
@@ -127,7 +164,7 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
@@ -142,8 +179,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getPetByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        return this.getPetByIdWithHttpInfo(petId, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -151,7 +197,7 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<ApiResponse<Pet>> {
         const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
@@ -166,8 +212,17 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePet(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        return this.updatePetWithHttpInfo(pet, _options).pipe(map((apiResponse: ApiResponse<Pet>) => apiResponse.data));
     }
 
     /**
@@ -177,7 +232,7 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
@@ -192,8 +247,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithForm(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updatePetWithFormWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        return this.updatePetWithFormWithHttpInfo(petId, name, status, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -203,7 +269,7 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse<ApiResponse>> {
         const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
@@ -218,8 +284,19 @@ export class ObservablePetApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFile(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.uploadFileWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options).pipe(map((apiResponse: ApiResponse<ApiResponse>) => apiResponse.data));
     }
 
 }
@@ -245,7 +322,7 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
@@ -260,15 +337,24 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        return this.deleteOrderWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Observable<ApiResponse<{ [key: string]: number; }>> {
         const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
@@ -283,8 +369,16 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventory(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getInventoryWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        return this.getInventoryWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<{ [key: string]: number; }>) => apiResponse.data));
     }
 
     /**
@@ -292,7 +386,7 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
@@ -307,8 +401,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderById(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getOrderByIdWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        return this.getOrderByIdWithHttpInfo(orderId, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
     /**
@@ -316,7 +419,7 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<ApiResponse<Order>> {
         const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
@@ -331,8 +434,17 @@ export class ObservableStoreApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrder(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.placeOrderWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        return this.placeOrderWithHttpInfo(order, _options).pipe(map((apiResponse: ApiResponse<Order>) => apiResponse.data));
     }
 
 }
@@ -358,7 +470,7 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, _options?: Configuration): Observable<void> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
@@ -373,8 +485,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        return this.createUserWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -382,7 +503,7 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
@@ -397,7 +518,7 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithArrayInputWithHttpInfo(rsp)));
             }));
     }
 
@@ -406,7 +527,16 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithArrayInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
@@ -421,8 +551,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInput(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.createUsersWithListInputWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        return this.createUsersWithListInputWithHttpInfo(user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -430,7 +569,7 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
@@ -445,8 +584,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.deleteUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        return this.deleteUserWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -454,7 +602,7 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<ApiResponse<User>> {
         const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
@@ -469,8 +617,17 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByName(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.getUserByNameWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        return this.getUserByNameWithHttpInfo(username, _options).pipe(map((apiResponse: ApiResponse<User>) => apiResponse.data));
     }
 
     /**
@@ -479,7 +636,7 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<ApiResponse<string>> {
         const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
@@ -494,15 +651,25 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.loginUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        return this.loginUserWithHttpInfo(username, password, _options).pipe(map((apiResponse: ApiResponse<string>) => apiResponse.data));
     }
 
     /**
      * 
      * Logs out current logged in user session
      */
-    public logoutUser(_options?: Configuration): Observable<void> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
@@ -517,8 +684,16 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.logoutUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
+    public logoutUser(_options?: Configuration): Observable<void> {
+        return this.logoutUserWithHttpInfo(_options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
     /**
@@ -527,7 +702,7 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<ApiResponse<void>> {
         const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
@@ -542,8 +717,18 @@ export class ObservableUserApi {
                 for (let middleware of this.configuration.middleware) {
                     middlewarePostObservable = middlewarePostObservable.pipe(mergeMap((rsp: ResponseContext) => middleware.post(rsp)));
                 }
-                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUser(rsp)));
+                return middlewarePostObservable.pipe(map((rsp: ResponseContext) => this.responseProcessor.updateUserWithHttpInfo(rsp)));
             }));
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        return this.updateUserWithHttpInfo(username, user, _options).pipe(map((apiResponse: ApiResponse<void>) => apiResponse.data));
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,8 +26,29 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.addPetWithHttpInfo(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Add a new pet to the store
+     * @param pet Pet object that needs to be added to the store
+     */
     public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
         const result = this.api.addPet(pet, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Deletes a pet
+     * @param petId Pet id to delete
+     * @param apiKey 
+     */
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -47,8 +68,28 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple status values can be provided with comma separated strings
+     * Finds Pets by status
+     * @param status Status values that need to be considered for filter
+     */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
         const result = this.api.findPetsByStatus(status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * Finds Pets by tags
+     * @param tags Tags to filter by
+     */
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+        const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
 
@@ -67,8 +108,28 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.getPetByIdWithHttpInfo(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a single pet
+     * Find pet by ID
+     * @param petId ID of pet to return
+     */
     public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
         const result = this.api.getPetById(petId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Update an existing pet
+     * @param pet Pet object that needs to be added to the store
+     */
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+        const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
 
@@ -89,8 +150,32 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Updates a pet in the store with form data
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     */
     public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
         const result = this.api.updatePetWithForm(petId, name, status, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * uploads an image
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param file file to upload
+     */
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+        const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -130,8 +215,27 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * Delete purchase order by ID
+     * @param orderId ID of the order that needs to be deleted
+     */
     public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteOrder(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * Returns a map of status codes to quantities
+     * Returns pet inventories by status
+     */
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+        const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
 
@@ -149,8 +253,28 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     * Find purchase order by ID
+     * @param orderId ID of pet that needs to be fetched
+     */
     public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
         const result = this.api.getOrderById(orderId, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Place an order for a pet
+     * @param order order placed for purchasing the pet
+     */
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+        const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
 
@@ -188,8 +312,28 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUserWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Create user
+     * @param user Created user object
+     */
     public createUser(user: User, _options?: Configuration): Promise<void> {
         const result = this.api.createUser(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
 
@@ -208,6 +352,16 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Creates list of users with given input array
+     * @param user List of user object
+     */
     public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
         const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
@@ -218,8 +372,28 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.deleteUserWithHttpInfo(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Delete user
+     * @param username The name that needs to be deleted
+     */
     public deleteUser(username: string, _options?: Configuration): Promise<void> {
         const result = this.api.deleteUser(username, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Get user by user name
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     */
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+        const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
 
@@ -239,6 +413,17 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+        const result = this.api.loginUserWithHttpInfo(username, password, _options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs user into the system
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     */
     public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
         const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
@@ -248,8 +433,28 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.logoutUserWithHttpInfo(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * 
+     * Logs out current logged in user session
+     */
     public logoutUser(_options?: Configuration): Promise<void> {
         const result = this.api.logoutUser(_options);
+        return result.toPromise();
+    }
+
+    /**
+     * This can only be done by the logged in user.
+     * Updated user
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     */
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+        const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
@@ -1,4 +1,4 @@
-import { ResponseContext, RequestContext, HttpFile, ApiResponse } from '../http/http';
+import { ResponseContext, RequestContext, HttpFile, HttpInfo } from '../http/http';
 import { Configuration} from '../configuration'
 
 import { ApiResponse } from '../models/ApiResponse';
@@ -26,7 +26,7 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.addPetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -47,7 +47,7 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deletePetWithHttpInfo(petId, apiKey, _options);
         return result.toPromise();
     }
@@ -68,7 +68,7 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByStatusWithHttpInfo(status, _options);
         return result.toPromise();
     }
@@ -88,7 +88,7 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<ApiResponse<Array<Pet>>> {
+    public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Promise<HttpInfo<Array<Pet>>> {
         const result = this.api.findPetsByTagsWithHttpInfo(tags, _options);
         return result.toPromise();
     }
@@ -108,7 +108,7 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.getPetByIdWithHttpInfo(petId, _options);
         return result.toPromise();
     }
@@ -128,7 +128,7 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<ApiResponse<Pet>> {
+    public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Promise<HttpInfo<Pet>> {
         const result = this.api.updatePetWithHttpInfo(pet, _options);
         return result.toPromise();
     }
@@ -150,7 +150,7 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updatePetWithFormWithHttpInfo(petId, name, status, _options);
         return result.toPromise();
     }
@@ -174,7 +174,7 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse<ApiResponse>> {
+    public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<HttpInfo<ApiResponse>> {
         const result = this.api.uploadFileWithHttpInfo(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
@@ -215,7 +215,7 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteOrderWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -234,7 +234,7 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventoryWithHttpInfo(_options?: Configuration): Promise<ApiResponse<{ [key: string]: number; }>> {
+    public getInventoryWithHttpInfo(_options?: Configuration): Promise<HttpInfo<{ [key: string]: number; }>> {
         const result = this.api.getInventoryWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -253,7 +253,7 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.getOrderByIdWithHttpInfo(orderId, _options);
         return result.toPromise();
     }
@@ -273,7 +273,7 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<ApiResponse<Order>> {
+    public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Promise<HttpInfo<Order>> {
         const result = this.api.placeOrderWithHttpInfo(order, _options);
         return result.toPromise();
     }
@@ -312,7 +312,7 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUserWithHttpInfo(user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUserWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -332,7 +332,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithArrayInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -352,7 +352,7 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<ApiResponse<void>> {
+    public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.createUsersWithListInputWithHttpInfo(user, _options);
         return result.toPromise();
     }
@@ -372,7 +372,7 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<void>> {
+    public deleteUserWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.deleteUserWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -392,7 +392,7 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<ApiResponse<User>> {
+    public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Promise<HttpInfo<User>> {
         const result = this.api.getUserByNameWithHttpInfo(username, _options);
         return result.toPromise();
     }
@@ -413,7 +413,7 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<ApiResponse<string>> {
+    public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Promise<HttpInfo<string>> {
         const result = this.api.loginUserWithHttpInfo(username, password, _options);
         return result.toPromise();
     }
@@ -433,7 +433,7 @@ export class PromiseUserApi {
      * 
      * Logs out current logged in user session
      */
-    public logoutUserWithHttpInfo(_options?: Configuration): Promise<ApiResponse<void>> {
+    public logoutUserWithHttpInfo(_options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.logoutUserWithHttpInfo(_options);
         return result.toPromise();
     }
@@ -453,7 +453,7 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<ApiResponse<void>> {
+    public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Promise<HttpInfo<void>> {
         const result = this.api.updateUserWithHttpInfo(username, user, _options);
         return result.toPromise();
     }


### PR DESCRIPTION
Currently it is not possible to access response headers. Other generated clients solve this by allowing you to not only retrieve the parsed response but also a wrapper which includes the parsed response and the original request. This PR implements such a functionality in a non-destructive way.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
