### PR TITLE
[csharp] Improved regex support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -639,32 +639,30 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     }
 
     /*
-     * The pattern spec follows the Perl convention and style of modifiers. .NET
-     * does not support this syntax directly so we need to convert the pattern to a .NET compatible
-     * format and apply modifiers in a compatible way.
      * See https://msdn.microsoft.com/en-us/library/yd1hzczs(v=vs.110).aspx for .NET options.
      */
     public void postProcessPattern(String pattern, Map<String, Object> vendorExtensions) {
         if (pattern != null) {
-            int i = pattern.lastIndexOf('/');
+            int end = pattern.contains("/")
+                ? pattern.lastIndexOf('/')
+                : pattern.length();
 
-            //Must follow Perl /pattern/modifiers convention
-            if (pattern.charAt(0) != '/' || i < 2) {
-                throw new IllegalArgumentException("Pattern must follow the Perl "
-                        + "/pattern/modifiers convention. " + pattern + " is not valid.");
-            }
+            int start = pattern.startsWith("/")
+                ? 1
+                : 0;
 
-            String regex = pattern.substring(1, i).replace("'", "\'").replace("\"", "\"\"");
+            String regex = pattern.substring(start, end).replace("'", "\'").replace("\"", "\"\"");
             List<String> modifiers = new ArrayList<String>();
 
-            // perl requires an explicit modifier to be culture specific and .NET is the reverse.
             modifiers.add("CultureInvariant");
 
-            for (char c : pattern.substring(i).toCharArray()) {
+            for (char c : pattern.substring(end).toCharArray()) {
                 if (regexModifiers.containsKey(c)) {
                     String modifier = regexModifiers.get(c);
                     modifiers.add(modifier);
                 } else if (c == 'l') {
+                    // there does not appear to be an official l regex option
+                    // leaving it here as a way for users to opt out of culture invariant
                     modifiers.remove("CultureInvariant");
                 }
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -669,7 +669,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 } else if (c == 'l'){
                     modifiers.remove("CultureInvariant");
                 } else {
-                    vendorExtensions.put("x-unhandled-modifier-" + c, c);
+                    vendorExtensions.put("x-modifier-" + c, c);
                 }
             }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -639,7 +639,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         if (pattern != null) {
             // check if the pattern has any modifiers
             // gmiyuvsd - ecma modifiers
-            // l - legacy modifier provided by this libray, provides a way to opt out of culture invariant
+            // l - legacy modifier provided by this library, provides a way to opt out of culture invariant
             // nx - c# modifiers https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options
             Pattern hasModifiers = Pattern.compile(".*/[gmiyuvsdlnx]+$");
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -651,8 +651,6 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 ? 1
                 : 0;
 
-            String regex = pattern.substring(start, end).replace("'", "\'").replace("\"", "\"\"");
-
             Map<Character, String> optionsMap = new HashMap();
             optionsMap.put('i', "IgnoreCase");
             optionsMap.put('m', "Multiline");
@@ -673,6 +671,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 }
             }
 
+            String regex = pattern.substring(start, end).replace("'", "\'").replace("\"", "\"\"");
             vendorExtensions.put("x-regex", regex);
             vendorExtensions.put("x-modifiers", modifiers);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -643,9 +644,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
      */
     public void postProcessPattern(String pattern, Map<String, Object> vendorExtensions) {
         if (pattern != null) {
-            int end = pattern.contains("/")
+            // check if the pattern has any ECMA modifiers
+            // there does not appear to be an official l regex option
+            // leaving this legacy option here as a way for users to opt out of culture invariant
+            Pattern hasModifiers = Pattern.compile(".*/[gmisxuUl]+$");
+
+            int end = hasModifiers.matcher(pattern).find()
                 ? pattern.lastIndexOf('/')
-                : pattern.length();
+                : pattern.length() - 1;
 
             int start = pattern.startsWith("/")
                 ? 1
@@ -661,8 +667,6 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                     String modifier = regexModifiers.get(c);
                     modifiers.add(modifier);
                 } else if (c == 'l') {
-                    // there does not appear to be an official l regex option
-                    // leaving it here as a way for users to opt out of culture invariant
                     modifiers.remove("CultureInvariant");
                 }
             }

--- a/modules/openapi-generator/src/main/resources/csharp/validatable.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/validatable.mustache
@@ -97,24 +97,32 @@
             {{#vendorExtensions.x-is-value-type}}
             {{#isNullable}}
             if (this.{{{name}}} != null){
+                {{#lambda.trimTrailingWhiteSpace}}
                 {{#lambda.indent4}}
                 {{>ValidateRegex}}
                 {{/lambda.indent4}}
+
+                {{/lambda.trimTrailingWhiteSpace}}
             }
 
             {{/isNullable}}
             {{^isNullable}}
+            {{#lambda.trimTrailingWhiteSpace}}
             {{#lambda.indent3}}
             {{>ValidateRegex}}
-
             {{/lambda.indent3}}
+
+            {{/lambda.trimTrailingWhiteSpace}}
             {{/isNullable}}
             {{/vendorExtensions.x-is-value-type}}
             {{^vendorExtensions.x-is-value-type}}
             if (this.{{{name}}} != null) {
+                {{#lambda.trimTrailingWhiteSpace}}
                 {{#lambda.indent4}}
                 {{>ValidateRegex}}
                 {{/lambda.indent4}}
+
+                {{/lambda.trimTrailingWhiteSpace}}
             }
 
             {{/vendorExtensions.x-is-value-type}}

--- a/modules/openapi-generator/src/test/resources/3_0/csharp/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/csharp/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1979,6 +1979,9 @@ components:
         origin:
           type: string
           pattern: /^[A-Z\s]*$/i
+        color_code:
+          type: string
+          pattern: ^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$
       nullable: true
     banana:
       type: object

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Apple.cs
@@ -188,7 +188,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -196,7 +197,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,7 +37,8 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this._Cultivar = cultivar;
             if (this.Cultivar != null)
@@ -48,6 +49,11 @@ namespace Org.OpenAPITools.Model
             if (this.Origin != null)
             {
                 this._flagOrigin = true;
+            }
+            this._ColorCode = colorCode;
+            if (this.ColorCode != null)
+            {
+                this._flagColorCode = true;
             }
             this.AdditionalProperties = new Dictionary<string, object>();
         }
@@ -101,6 +107,30 @@ namespace Org.OpenAPITools.Model
             return _flagOrigin;
         }
         /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode
+        {
+            get{ return _ColorCode;}
+            set
+            {
+                _ColorCode = value;
+                _flagColorCode = true;
+            }
+        }
+        private string _ColorCode;
+        private bool _flagColorCode;
+
+        /// <summary>
+        /// Returns false as ColorCode should not be serialized given that it's read-only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeColorCode()
+        {
+            return _flagColorCode;
+        }
+        /// <summary>
         /// Gets or Sets additional properties
         /// </summary>
         [JsonExtensionData]
@@ -116,6 +146,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -167,6 +198,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 if (this.AdditionalProperties != null)
                 {
                     hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
@@ -197,6 +232,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -837,7 +837,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -857,7 +858,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -865,7 +867,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -873,7 +876,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -258,7 +258,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-manual-tests/OpenAPIClient-generichost-manual-tests/UnitTest1.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-manual-tests/OpenAPIClient-generichost-manual-tests/UnitTest1.cs
@@ -47,7 +47,7 @@ namespace OpenAPIClient_generichost_manual_tests
         [TestMethod]
         public void Apple()
         {
-            Apple apple = new("cultivar", "origin");
+            Apple apple = new("#000000", "cultivar", "origin");
             string appleJson = JsonSerializer.Serialize(apple, _jsonSerializerOptions);
             Apple? apple2 = JsonSerializer.Deserialize<Apple>(appleJson, _jsonSerializerOptions);
             Assert.IsTrue(apple2 != null && apple.Cultivar.Equals(apple2.Cultivar) && apple.Origin.Equals(apple2.Origin));
@@ -81,7 +81,7 @@ namespace OpenAPIClient_generichost_manual_tests
         [TestMethod]
         public void GmFruit()
         {
-            Apple apple = new("cultivar", "origin");
+            Apple apple = new("#000000", "cultivar", "origin");
             Banana banana = new(10);
             GmFruit gmFruit = new(apple, banana, "yellow");
             string gmFruitJson = JsonSerializer.Serialize(gmFruit, _jsonSerializerOptions);

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/models/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/models/Apple.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**ColorCode** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
@@ -91,7 +91,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -99,7 +100,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Apple.cs
@@ -33,17 +33,25 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
+        /// <param name="colorCode">colorCode</param>
         /// <param name="cultivar">cultivar</param>
         /// <param name="origin">origin</param>
         [JsonConstructor]
-        public Apple(string cultivar, string origin)
+        public Apple(string colorCode, string cultivar, string origin)
         {
+            ColorCode = colorCode;
             Cultivar = cultivar;
             Origin = origin;
             OnCreated();
         }
 
         partial void OnCreated();
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [JsonPropertyName("color_code")]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets Cultivar
@@ -71,6 +79,7 @@ namespace Org.OpenAPITools.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class Apple {\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
@@ -85,6 +94,15 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
+                }
+            }
+
             if (this.Cultivar != null) {
                 // Cultivar (string) pattern
                 Regex regexCultivar = new Regex(@"^[a-zA-Z\s]*$", RegexOptions.CultureInvariant);
@@ -129,6 +147,7 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
+            string? colorCode = default;
             string? cultivar = default;
             string? origin = default;
 
@@ -147,6 +166,9 @@ namespace Org.OpenAPITools.Model
 
                     switch (propertyName)
                     {
+                        case "color_code":
+                            colorCode = utf8JsonReader.GetString();
+                            break;
                         case "cultivar":
                             cultivar = utf8JsonReader.GetString();
                             break;
@@ -159,13 +181,16 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
+            if (colorCode == null)
+                throw new ArgumentNullException(nameof(colorCode), "Property is required for class Apple.");
+
             if (cultivar == null)
                 throw new ArgumentNullException(nameof(cultivar), "Property is required for class Apple.");
 
             if (origin == null)
                 throw new ArgumentNullException(nameof(origin), "Property is required for class Apple.");
 
-            return new Apple(cultivar, origin);
+            return new Apple(colorCode, cultivar, origin);
         }
 
         /// <summary>
@@ -192,6 +217,7 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(ref Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
+            writer.WriteString("color_code", apple.ColorCode);
             writer.WriteString("cultivar", apple.Cultivar);
             writer.WriteString("origin", apple.Origin);
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -322,7 +322,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigits != null) {
                 // PatternWithDigits (string) pattern
@@ -330,7 +331,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -338,7 +340,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.VarString != null) {
                 // VarString (string) pattern
@@ -346,7 +349,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // UnsignedInteger (uint) maximum
             if (this.UnsignedInteger > (uint)200)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -108,7 +108,8 @@ namespace Org.OpenAPITools.Model
             if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-            }            yield break;
+            }
+            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/models/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/models/Apple.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**ColorCode** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -31,17 +31,25 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
+        /// <param name="colorCode">colorCode</param>
         /// <param name="cultivar">cultivar</param>
         /// <param name="origin">origin</param>
         [JsonConstructor]
-        public Apple(string cultivar, string origin)
+        public Apple(string colorCode, string cultivar, string origin)
         {
+            ColorCode = colorCode;
             Cultivar = cultivar;
             Origin = origin;
             OnCreated();
         }
 
         partial void OnCreated();
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [JsonPropertyName("color_code")]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets Cultivar
@@ -69,6 +77,7 @@ namespace Org.OpenAPITools.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class Apple {\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
@@ -83,6 +92,15 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
+                }
+            }
+
             if (this.Cultivar != null) {
                 // Cultivar (string) pattern
                 Regex regexCultivar = new Regex(@"^[a-zA-Z\s]*$", RegexOptions.CultureInvariant);
@@ -127,6 +145,7 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
+            string colorCode = default;
             string cultivar = default;
             string origin = default;
 
@@ -145,6 +164,9 @@ namespace Org.OpenAPITools.Model
 
                     switch (propertyName)
                     {
+                        case "color_code":
+                            colorCode = utf8JsonReader.GetString();
+                            break;
                         case "cultivar":
                             cultivar = utf8JsonReader.GetString();
                             break;
@@ -157,13 +179,16 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
+            if (colorCode == null)
+                throw new ArgumentNullException(nameof(colorCode), "Property is required for class Apple.");
+
             if (cultivar == null)
                 throw new ArgumentNullException(nameof(cultivar), "Property is required for class Apple.");
 
             if (origin == null)
                 throw new ArgumentNullException(nameof(origin), "Property is required for class Apple.");
 
-            return new Apple(cultivar, origin);
+            return new Apple(colorCode, cultivar, origin);
         }
 
         /// <summary>
@@ -190,6 +215,7 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(ref Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
+            writer.WriteString("color_code", apple.ColorCode);
             writer.WriteString("cultivar", apple.Cultivar);
             writer.WriteString("origin", apple.Origin);
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -89,7 +89,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -97,7 +98,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -320,7 +320,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigits != null) {
                 // PatternWithDigits (string) pattern
@@ -328,7 +329,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -336,7 +338,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.VarString != null) {
                 // VarString (string) pattern
@@ -344,7 +347,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // UnsignedInteger (uint) maximum
             if (this.UnsignedInteger > (uint)200)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -106,7 +106,8 @@ namespace Org.OpenAPITools.Model
             if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-            }            yield break;
+            }
+            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/models/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/models/Apple.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**ColorCode** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -31,17 +31,25 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
         /// </summary>
+        /// <param name="colorCode">colorCode</param>
         /// <param name="cultivar">cultivar</param>
         /// <param name="origin">origin</param>
         [JsonConstructor]
-        public Apple(string cultivar, string origin)
+        public Apple(string colorCode, string cultivar, string origin)
         {
+            ColorCode = colorCode;
             Cultivar = cultivar;
             Origin = origin;
             OnCreated();
         }
 
         partial void OnCreated();
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [JsonPropertyName("color_code")]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets Cultivar
@@ -69,6 +77,7 @@ namespace Org.OpenAPITools.Model
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class Apple {\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
@@ -83,6 +92,15 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
+                }
+            }
+
             if (this.Cultivar != null) {
                 // Cultivar (string) pattern
                 Regex regexCultivar = new Regex(@"^[a-zA-Z\s]*$", RegexOptions.CultureInvariant);
@@ -127,6 +145,7 @@ namespace Org.OpenAPITools.Model
 
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
+            string colorCode = default;
             string cultivar = default;
             string origin = default;
 
@@ -145,6 +164,9 @@ namespace Org.OpenAPITools.Model
 
                     switch (propertyName)
                     {
+                        case "color_code":
+                            colorCode = utf8JsonReader.GetString();
+                            break;
                         case "cultivar":
                             cultivar = utf8JsonReader.GetString();
                             break;
@@ -157,13 +179,16 @@ namespace Org.OpenAPITools.Model
                 }
             }
 
+            if (colorCode == null)
+                throw new ArgumentNullException(nameof(colorCode), "Property is required for class Apple.");
+
             if (cultivar == null)
                 throw new ArgumentNullException(nameof(cultivar), "Property is required for class Apple.");
 
             if (origin == null)
                 throw new ArgumentNullException(nameof(origin), "Property is required for class Apple.");
 
-            return new Apple(cultivar, origin);
+            return new Apple(colorCode, cultivar, origin);
         }
 
         /// <summary>
@@ -190,6 +215,7 @@ namespace Org.OpenAPITools.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(ref Utf8JsonWriter writer, Apple apple, JsonSerializerOptions jsonSerializerOptions)
         {
+            writer.WriteString("color_code", apple.ColorCode);
             writer.WriteString("cultivar", apple.Cultivar);
             writer.WriteString("origin", apple.Origin);
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -89,7 +89,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -97,7 +98,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -320,7 +320,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigits != null) {
                 // PatternWithDigits (string) pattern
@@ -328,7 +329,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -336,7 +338,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.VarString != null) {
                 // VarString (string) pattern
@@ -344,7 +347,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // UnsignedInteger (uint) maximum
             if (this.UnsignedInteger > (uint)200)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -106,7 +106,8 @@ namespace Org.OpenAPITools.Model
             if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-            }            yield break;
+            }
+            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Apple.cs
@@ -38,10 +38,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 
@@ -56,6 +58,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
         public string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -73,6 +81,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -124,6 +133,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 if (this.AdditionalProperties != null)
                 {
                     hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
@@ -154,6 +167,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Apple.cs
@@ -145,7 +145,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -153,7 +154,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -436,7 +436,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -456,7 +457,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -464,7 +466,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -472,7 +475,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -171,7 +171,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Apple.cs
@@ -144,7 +144,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -152,7 +153,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,10 +37,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 
@@ -55,6 +57,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
         public string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -72,6 +80,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -123,6 +132,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 if (this.AdditionalProperties != null)
                 {
                     hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
@@ -153,6 +166,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -435,7 +435,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -455,7 +456,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -463,7 +465,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -471,7 +474,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -170,7 +170,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Apple.cs
@@ -144,7 +144,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -152,7 +153,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,10 +37,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 
@@ -55,6 +57,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
         public string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -72,6 +80,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -123,6 +132,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 if (this.AdditionalProperties != null)
                 {
                     hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
@@ -153,6 +166,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -435,7 +435,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -455,7 +456,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -463,7 +465,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -471,7 +474,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -170,7 +170,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -144,7 +144,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -152,7 +153,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,10 +37,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 
@@ -55,6 +57,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
         public string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -72,6 +80,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -123,6 +132,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 if (this.AdditionalProperties != null)
                 {
                     hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
@@ -153,6 +166,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -435,7 +435,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -455,7 +456,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -463,7 +465,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -471,7 +474,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -170,7 +170,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Apple.cs
@@ -35,10 +35,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
         }
 
         /// <summary>
@@ -54,6 +56,12 @@ namespace Org.OpenAPITools.Model
         public string Origin { get; set; }
 
         /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -63,6 +71,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,6 +116,11 @@ namespace Org.OpenAPITools.Model
                     this.Origin == input.Origin ||
                     (this.Origin != null &&
                     this.Origin.Equals(input.Origin))
+                ) && 
+                (
+                    this.ColorCode == input.ColorCode ||
+                    (this.ColorCode != null &&
+                    this.ColorCode.Equals(input.ColorCode))
                 );
         }
 
@@ -126,6 +140,10 @@ namespace Org.OpenAPITools.Model
                 if (this.Origin != null)
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
+                }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
                 }
                 return hashCode;
             }

--- a/samples/client/petstore/csharp/OpenAPIClient/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClient/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Apple.cs
@@ -144,7 +144,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -152,7 +153,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,10 +37,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 
@@ -55,6 +57,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
         public string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -72,6 +80,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -123,6 +132,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 if (this.AdditionalProperties != null)
                 {
                     hashCode = (hashCode * 59) + this.AdditionalProperties.GetHashCode();
@@ -153,6 +166,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -435,7 +435,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -455,7 +456,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -463,7 +465,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -471,7 +474,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -170,7 +170,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClientCore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/api/openapi.yaml
@@ -1941,6 +1941,9 @@ components:
         origin:
           pattern: "/^[A-Z\\s]*$/i"
           type: string
+        color_code:
+          pattern: "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"
+          type: string
       type: object
     banana:
       properties:

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Apple.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Fruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/GmFruit.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **Color** | **string** |  | [optional] 
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
+**ColorCode** | **string** |  | [optional] 
 **LengthCm** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
@@ -132,7 +132,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Cultivar, must match a pattern of " + regexCultivar, new [] { "Cultivar" });
-                }            }
+                }
+            }
 
             if (this.Origin != null) {
                 // Origin (string) pattern
@@ -140,7 +141,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
@@ -37,10 +37,12 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
-        public Apple(string cultivar = default(string), string origin = default(string))
+        /// <param name="colorCode">colorCode.</param>
+        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
+            this.ColorCode = colorCode;
         }
 
         /// <summary>
@@ -56,6 +58,12 @@ namespace Org.OpenAPITools.Model
         public string Origin { get; set; }
 
         /// <summary>
+        /// Gets or Sets ColorCode
+        /// </summary>
+        [DataMember(Name = "color_code", EmitDefaultValue = false)]
+        public string ColorCode { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -65,6 +73,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("class Apple {\n");
             sb.Append("  Cultivar: ").Append(Cultivar).Append("\n");
             sb.Append("  Origin: ").Append(Origin).Append("\n");
+            sb.Append("  ColorCode: ").Append(ColorCode).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -115,6 +124,10 @@ namespace Org.OpenAPITools.Model
                 {
                     hashCode = (hashCode * 59) + this.Origin.GetHashCode();
                 }
+                if (this.ColorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.ColorCode.GetHashCode();
+                }
                 return hashCode;
             }
         }
@@ -141,6 +154,15 @@ namespace Org.OpenAPITools.Model
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Origin, must match a pattern of " + regexOrigin, new [] { "Origin" });
+                }
+            }
+
+            if (this.ColorCode != null) {
+                // ColorCode (string) pattern
+                Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
+                if (!regexColorCode.Match(this.ColorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ColorCode, must match a pattern of " + regexColorCode, new [] { "ColorCode" });
                 }
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -420,7 +420,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexVarString.Match(this.VarString).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarString, must match a pattern of " + regexVarString, new [] { "VarString" });
-                }            }
+                }
+            }
 
             // Password (string) maxLength
             if (this.Password != null && this.Password.Length > 64)
@@ -440,7 +441,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigits, must match a pattern of " + regexPatternWithDigits, new [] { "PatternWithDigits" });
-                }            }
+                }
+            }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
                 // PatternWithDigitsAndDelimiter (string) pattern
@@ -448,7 +450,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithDigitsAndDelimiter, must match a pattern of " + regexPatternWithDigitsAndDelimiter, new [] { "PatternWithDigitsAndDelimiter" });
-                }            }
+                }
+            }
 
             if (this.PatternWithBackslash != null) {
                 // PatternWithBackslash (string) pattern
@@ -456,7 +459,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for PatternWithBackslash, must match a pattern of " + regexPatternWithBackslash, new [] { "PatternWithBackslash" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -158,7 +158,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UuidWithPattern, must match a pattern of " + regexUuidWithPattern, new [] { "UuidWithPattern" });
-                }            }
+                }
+            }
 
             yield break;
         }

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Category.cs
@@ -129,7 +129,8 @@ namespace Org.OpenAPITools.Model
                 if (!regexName.Match(this.Name).Success)
                 {
                     yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Name, must match a pattern of " + regexName, new [] { "Name" });
-                }            }
+                }
+            }
 
             yield break;
         }


### PR DESCRIPTION
Trying to generate this spec https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json fails due to the pattern 

"pattern": "^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$"

It appears that the existing code and comments, this pattern is not in compliance with the OpenApi spec. I do not think that is accurate.  It appears that the correct flavor of regex is actually ECMA. Regardless, if you paste that regex into regex101 such as https://regex101.com/r/c62U8V/1 you can see the regex is valid regardless of the flavor used.

Here is some documentation that says ECMA is the correct flavor. 
https://spec.openapis.org/oas/v3.0.3#format:~:text=pattern%20(This%20string%20SHOULD%20be%20a%20valid%20regular%20expression%2C%20according%20to%20the%20Ecma%2D262%20Edition%205.1%20regular%20expression%20dialect)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
