### PR TITLE
Update kotlin client dependencies to newer versions

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -9,7 +9,7 @@ wrapper {
 {{/omitGradleWrapper}}
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     {{#jvm-ktor}}
     ext.ktor_version = '2.1.3'
     {{/jvm-ktor}}
@@ -99,13 +99,13 @@ dependencies {
     {{#moshi}}
     {{^moshiCodeGen}}
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     {{/moshiCodeGen}}
     {{#moshiCodeGen}}
-    implementation "com.squareup.moshi:moshi:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"
+    implementation "com.squareup.moshi:moshi:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.14.0"
     {{/moshiCodeGen}}
     {{/moshi}}
     {{#gson}}
@@ -113,8 +113,8 @@ dependencies {
     {{/gson}}
     {{#jackson}}
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
     {{/jackson}}
     {{#kotlinx_serialization}}
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
@@ -135,14 +135,14 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:3.12.13"
     {{/jvm-okhttp3}}
     {{#jvm-okhttp4}}
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     {{/jvm-okhttp4}}
     {{#jvm-spring-webclient}}
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     {{/jvm-spring-webclient}}
     {{#threetenbp}}
-    implementation "org.threeten:threetenbp:1.5.1"
+    implementation "org.threeten:threetenbp:1.6.8"
     {{/threetenbp}}
     {{#jvm-retrofit2}}
     {{#hasOAuthMethods}}

--- a/samples/client/petstore/kotlin-allOff-discriminator/build.gradle
+++ b/samples/client/petstore/kotlin-allOff-discriminator/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     implementation "com.squareup.okhttp3:okhttp:3.12.13"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     implementation "com.squareup.okhttp3:okhttp:3.12.13"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.9.0'
 
     repositories {
@@ -32,8 +32,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"

--- a/samples/client/petstore/kotlin-enum-default-value/build.gradle
+++ b/samples/client/petstore/kotlin-enum-default-value/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,6 +31,6 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.google.code.gson:gson:2.9.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jackson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -34,7 +34,7 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.ktor_version = '2.1.3'
 
     repositories {

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.ktor_version = '2.1.3'
 
     repositories {
@@ -32,8 +32,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
     implementation "io.ktor:ktor-client-jackson:$ktor_version"

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.ktor_version = '2.1.3'
 
     repositories {

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -32,6 +32,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "com.google.code.gson:gson:2.9.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "2.7.12"
     ext.reactor_version = "3.5.6"
 
@@ -33,8 +33,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "3.1.0"
     ext.reactor_version = "3.5.6"
 
@@ -39,8 +39,8 @@ kotlin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.3.3"
 
     repositories {

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.3.3"
 
     repositories {
@@ -33,8 +33,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.3.3"
 
     repositories {
@@ -32,8 +32,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.3.3"
 
     repositories {
@@ -32,8 +32,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-modelMutable/build.gradle
+++ b/samples/client/petstore/kotlin-modelMutable/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,9 +31,9 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.squareup.moshi:moshi:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     implementation "com.squareup.okhttp3:okhttp:3.12.13"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.9.0'
 
     repositories {

--- a/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.9.0'
     ext.rxJava3Version = '3.0.12'
 
@@ -33,8 +33,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
     implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
     implementation "io.reactivex.rxjava3:rxjava:$rxJava3Version"

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.9.0'
 
     repositories {
@@ -32,8 +32,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
     implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,9 +31,9 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
-    implementation "org.threeten:threetenbp:1.5.1"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "org.threeten:threetenbp:1.6.8"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-uppercase-enum/build.gradle
+++ b/samples/client/petstore/kotlin-uppercase-enum/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -33,7 +33,7 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
 

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,8 +31,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.13.0"
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
+    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.okhttp3:okhttp:4.11.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }


### PR DESCRIPTION
Update kotlin client dependencies to newer versions

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)
