### PR TITLE
[Dart/CSharp/Python] replace File.separator with slash

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -60,8 +60,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     protected boolean useEnumExtension = false;
     protected String sourceFolder = "src";
     protected String libPath = "lib" + File.separator;
-    protected String apiDocPath = "doc" + File.separator;
-    protected String modelDocPath = "doc" + File.separator;
+    protected String apiDocPath = "doc/";
+    protected String modelDocPath = "doc/";
     protected String apiTestPath = "test" + File.separator;
     protected String modelTestPath = "test" + File.separator;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -99,8 +99,8 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     protected String packageGuid = "{" + java.util.UUID.randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
     protected String clientPackage = "Client";
     protected String authFolder = "Auth";
-    protected String apiDocPath = "docs" + File.separator;
-    protected String modelDocPath = "docs" + File.separator;
+    protected String apiDocPath = "docs/";
+    protected String modelDocPath = "docs/";
 
     // Defines TargetFrameworkVersion in csproj files
     protected String targetFramework = latestFramework.name;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -51,8 +51,8 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
     public static final String DATE_FORMAT = "dateFormat";
 
     protected String packageUrl;
-    protected String apiDocPath = "docs" + File.separator;
-    protected String modelDocPath = "docs" + File.separator;
+    protected String apiDocPath = "docs/";
+    protected String modelDocPath = "docs/";
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
     protected String datetimeFormat = "%Y-%m-%dT%H:%M:%S.%f%z";
     protected String dateFormat = "%Y-%m-%d";
@@ -236,8 +236,8 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
             // tests in <package>/test
             testFolder = packagePath() + File.separatorChar + testFolder;
             // api/model docs in <package>/docs
-            apiDocPath = packagePath() + File.separatorChar + apiDocPath;
-            modelDocPath = packagePath() + File.separatorChar + modelDocPath;
+            apiDocPath = packagePath() + "/" + apiDocPath;
+            modelDocPath = packagePath() + "/" + modelDocPath;
         }
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### overview

Fix for incorrect links in Windows-generated markdown.


I have conducted my own tests on Windows and have confirmed that only markdown files are affected.



```
$ git diff --name-only --cached
samples/client/echo_api/csharp-restsharp/README.md
samples/client/echo_api/python/README.md
samples/client/others/csharp-complex-files/README.md
samples/client/petstore/csharp-restsharp-name-parameter-mappings/README.md
samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/README.md
samples/client/petstore/csharp/OpenAPIClient-httpclient/README.md
samples/client/petstore/csharp/OpenAPIClient-net47/README.md
samples/client/petstore/csharp/OpenAPIClient-net48/README.md
samples/client/petstore/csharp/OpenAPIClient-net5.0/README.md
samples/client/petstore/csharp/OpenAPIClient/README.md
samples/client/petstore/csharp/OpenAPIClientCore/README.md
samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/README.md
samples/openapi3/client/petstore/dart-dio/oneof/README.md
samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/README.md
samples/openapi3/client/petstore/dart-dio/oneof_primitive/README.md
samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/README.md
samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
samples/openapi3/client/petstore/dart2/petstore_client_lib/README.md
samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
samples/openapi3/client/petstore/python-aiohttp/README.md
samples/openapi3/client/petstore/python/README.md
```

