### PR TITLE
[haskell-servant][haskell-yesod] Fix specialCharReplacements

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -114,12 +114,6 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         specialCharReplacements.put(">", "GreaterThan");
         specialCharReplacements.put("<", "LessThan");
 
-        // backslash and double quote need double the escapement for both Java and Haskell
-        specialCharReplacements.remove("\\");
-        specialCharReplacements.remove("\"");
-        specialCharReplacements.put("\\\\", "Back_Slash");
-        specialCharReplacements.put("\\\"", "Double_Quote");
-
         // set the output folder here
         outputFolder = "generated-code/haskell-servant";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
@@ -108,12 +108,6 @@ public class HaskellYesodServerCodegen extends DefaultCodegen implements Codegen
         specialCharReplacements.put(">", "GreaterThan");
         specialCharReplacements.put("<", "LessThan");
 
-        // backslash and double quote need double the escapement for both Java and Haskell
-        specialCharReplacements.remove("\\");
-        specialCharReplacements.remove("\"");
-        specialCharReplacements.put("\\\\", "Back_Slash");
-        specialCharReplacements.put("\\\"", "Double_Quote");
-
         outputFolder = "generated-code" + File.separator + "haskell-yesod";
         apiTemplateFiles.put("api.mustache", ".hs");
         apiTestTemplateFiles.put("api_test.mustache", ".hs");


### PR DESCRIPTION
`HaskellServantCodegen` and `HaskellYesodServerCodegen` modify `specialCharReplacements` by replacing its keys: backslash (`\`) with `\\` and `"` with `\"`.

It seems that those replacements were for using the keys in string literals in the `specialChars` table in the generated code. 
 I.e. we want to have `("\\", "Back_Slash")` instead of `("\", "Back_Slash")` and `("\"", "Double_Quote")` instead of `(""", "Double_Quote")` in the table below.

https://github.com/OpenAPITools/openapi-generator/blob/81c398e5304f411eb57814349841827c13b2a54e/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/Types.hs#L158-L196

However, modifying the keys causes the substitution of those characters in field names not to work, making generated code syntactically invalid. Suppose we have the following spec:

```yaml
openapi: 3.0.0
info:
  title: Test
  description: Test API
  version: 1.0.0
servers:
  - url: https://api.example.com/
    description: the server

paths:
  /hello:
    get:
      operationId: hello
      summary: "summary"
      description: "description."
      responses:
        "200":
          description: foo
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/HelloResponse'

components:
  schemas:
    HelloResponse:
      type: object
      properties:
        "\"":
          type: string
          description: double quote
        "\\":
          type: string
          description: backslash
      required:
        - "\""
        - "\\"
      description: description
```

Those generators generate the following data type definition, but `helloResponse"` and `helloResponse\` are invalid identifiers in Haskell.
```haskell
-- | description
data HelloResponse = HelloResponse
  { helloResponse" :: Text -- ^ double quote
  , helloResponse\ :: Text -- ^ backslash
  } deriving (Show, Eq, Generic, Data)
```

Since the `specialChars` table has already been removed in #16232, we can safely stop modifying the `specialCharReplacements`, thereby generated code for the above example become the following syntactically correct code.

```haskell
-- | description
data HelloResponse = HelloResponse
  { helloResponseDoubleQuote :: Text -- ^ double quote
  , helloResponseBackSlash :: Text -- ^ backslash
  } deriving (Show, Eq, Generic, Data)
```

I believe that this change maintains backward compatibility, as it only fixes cases where it has not been working (when field names contain backslashes or double quotes).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
