### PR TITLE
[kotlin-multiplatform] Fixed build error when setting formdata in array

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -42,7 +42,14 @@ import kotlinx.serialization.encoding.*
             {{#isMultipart}}
             formData {
                 {{#formParams}}
+                {{#isArray}}
+                {{{paramName}}}?.onEach {
+                    append("{{{baseName}}}[]", it)
+                }
+                {{/isArray}}
+                {{^isArray}}
                 {{{paramName}}}?.apply { append("{{{baseName}}}", {{{paramName}}}) }
+                {{/isArray}}
                 {{/formParams}}
             }
             {{/isMultipart}}

--- a/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -81,7 +81,9 @@ open class DefaultApi(
                 fn1?.apply { append("fn1", fn1) }
                 fn2?.apply { append("fn2", fn2) }
                 fn3?.apply { append("fn3", fn3) }
-                fn4?.apply { append("fn4", fn4) }
+                fn4?.onEach {
+                    append("fn4[]", it)
+                }
             }
 
         val localVariableQuery = mutableMapOf<String, List<String>>()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
