### PR TITLE
Could org.openapitools:cxf-annotated-basepath:war:1.0.0 drop off redundant dependencies?

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -105,6 +105,28 @@
       <artifactId>swagger-jaxrs</artifactId>
       <scope>compile</scope>
       <version>${swagger-core-version}</version>
+       <exclusions>
+        <exclusion>
+          <artifactId>checker-compat-qual</artifactId>
+          <groupId>org.checkerframework</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jsr305</artifactId>
+          <groupId>com.google.code.findbugs</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jsr311-api</artifactId>
+          <groupId>javax.ws.rs</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>error_prone_annotations</artifactId>
+          <groupId>com.google.errorprone</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>j2objc-annotations</artifactId>
+          <groupId>com.google.j2objc</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -147,6 +169,60 @@
         <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         <version>${cxf-version}</version>
         <scope>compile</scope>
+         <exclusions>
+          <exclusion>
+            <artifactId>dtd-parser</artifactId>
+            <groupId>com.sun.xml.dtd-parser</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>stax-ex</artifactId>
+            <groupId>org.jvnet.staxex</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>ant-launcher</artifactId>
+            <groupId>org.apache.ant</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>javax.annotation-api</artifactId>
+            <groupId>javax.annotation</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>istack-commons-runtime</artifactId>
+            <groupId>com.sun.istack</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>FastInfoset</artifactId>
+            <groupId>com.sun.xml.fastinfoset</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>ant</artifactId>
+            <groupId>org.apache.ant</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>txw2</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>rngom</artifactId>
+            <groupId>com.sun.xml.bind.external</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jakarta.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>xsom</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>relaxng-datatype</artifactId>
+            <groupId>com.sun.xml.bind.external</groupId>
+          </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>org.apache.cxf</groupId>
@@ -165,6 +241,12 @@
         <artifactId>cxf-rt-wsdl</artifactId>
         <version>${cxf-version}</version>
         <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>asm</artifactId>
+            <groupId>org.ow2.asm</groupId>
+          </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -189,11 +271,6 @@
         <artifactId>jakarta.annotation-api</artifactId>
         <version>${jakarta-annotation-version}</version>
         <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>2.10.13</version>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/126549527/230752549-87727e9c-bc4c-4461-adc8-8ccd7a086ed1.png)
![image](https://user-images.githubusercontent.com/126549527/230752551-e35378ef-d475-4d0f-bb6b-7e6bb9d556a6.png)
![image](https://user-images.githubusercontent.com/126549527/230752554-fc3da0dd-20de-45d4-a17e-dd1f5250141a.png)
![image](https://user-images.githubusercontent.com/126549527/230752557-d1578e43-b93a-4b35-a05d-3b870fcd4555.png)
![image](https://user-images.githubusercontent.com/126549527/230752560-1f194294-51ff-42ee-ae7c-ad3f3e098304.png)
![image](https://user-images.githubusercontent.com/126549527/230752563-3be0845c-e65d-4129-aa2d-a66e5ba7e8ca.png)

Hi, I found that **_org.openapitools:cxf-annotated-basepath:war:1.0.0_**’s pom file introduced **_68_** dependencies. However, among them, **_20_** libraries (**_29%_** have not been used by your project), the redundant dependencies are listed below. 

More seriously,**_19_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）. 

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.
 
This PR **_org.openapitools:cxf-annotated-basepath:war:1.0.0_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
          joda-time:joda-time:2.10.13:compile [629 KB]
#### Redundant indirect dependencies:
         com.sun.xml.dtd-parser:dtd-parser:1.4.1:compile [61 KB]
         org.jvnet.staxex:stax-ex:1.8.1:compile [37 KB]
         org.apache.ant:ant-launcher:1.10.5:compile [18 KB]
         javax.annotation:javax.annotation-api:1.3:compile [25 KB]
         com.sun.istack:istack-commons-runtime:3.0.8:compile [26 KB]
         org.checkerframework:checker-compat-qual:2.5.2:compile [5 KB]
         com.google.code.findbugs:jsr305:3.0.2:compile [19 KB]
         jakarta.xml.bind:jakarta.xml.bind-api:2.3.2:compile [112 KB]
         com.sun.xml.fastinfoset:FastInfoset:1.2.16:compile [309 KB]
         javax.ws.rs:jsr311-api:1.1.1:compile [45 KB]
         org.apache.ant:ant:1.10.5:compile [2 MB]
         org.glassfish.jaxb:txw2:2.3.2:compile [70 KB]
         com.sun.xml.bind.external:rngom:2.3.2:compile [308 KB]
         com.google.errorprone:error_prone_annotations:2.2.0:compile [13 KB]
         com.google.j2objc:j2objc-annotations:1.1:compile [8 KB]
         org.ow2.asm:asm:7.0:compile [111 KB]
         jakarta.activation:jakarta.activation-api:1.2.1:compile [43 KB]
         org.glassfish.jaxb:xsom:2.3.2:compile [405 KB]
         com.sun.xml.bind.external:relaxng-datatype:2.3.2:compile [19 KB] 
       

## Outdated dependencies
javax.annotation:javax.annotation-api:1.3 (**_2389_** days without maintenance) 
com.sun.xml.dtd-parser:dtd-parser:1.4.1 (**_1563_** days without maintenance)
jakarta.activation:jakarta.activation-api:1.2.2(**_1600_** days without maintenance)
com.sun.xml.fastinfoset:FastInfoset:1.2.16 (**_1564_** days without maintenance)
org.ow2.asm:asm:7.0 (**_1625_** days without maintenance)
org.glassfish.jaxb:txw2:2.3.2 (**_1558_** days without maintenance)
com.google.errorprone:error_prone_annotations:2.2.0 (**_1916_** days without maintenance)
javax.ws.rs:jsr311-api:1.1.1 (**_4884_** days without maintenance)
org.jvnet.staxex:stax-ex:1.8.1 (**_1564_** days without maintenance)
org.apache.ant:ant-launcher:1.10.5 (**_1734_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.1 (**_2271_** days without maintenance)
org.checkerframework:checker-compat-qual:2.5.2 (**_1772_** days without maintenance)
jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 (**_1564_** days without maintenance)
com.google.code.findbugs:jsr305:3.0.2 (**_2200_** days without maintenance)
org.apache.ant: ant:1.10.5 (**_1734_** days without maintenance)
com.sun.xml.bind.external:relaxng-datatype:2.3.2 (**_1564_** days without maintenance)
com.sun.xml.bind.external:rngom:2.3.2 (**_1564_** days without maintenance)
org.glassfish.jaxb:xsom:2.3.2 (**_1564_** days without maintenance)
com.sun.istack:istack-commons-runtime:3.0.8 (**_1564_** days without maintenance)
