### PR TITLE
[csharp] JsonConverter.mustache - fix propertyName variable conflict

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -66,9 +66,9 @@
 
                 if (utf8JsonReaderDiscriminator.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderDiscriminator.CurrentDepth - 1)
                 {
-                    string{{nrt?}} propertyName = utf8JsonReaderDiscriminator.GetString();
+                    string{{nrt?}} __jsonPropertyName__ = utf8JsonReaderDiscriminator.GetString();
                     utf8JsonReaderDiscriminator.Read();
-                    if (propertyName{{nrt?}}.Equals("{{propertyBaseName}}"){{#nrt}} ?? false{{/nrt}})
+                    if (__jsonPropertyName__{{nrt?}}.Equals("{{propertyBaseName}}"){{#nrt}} ?? false{{/nrt}})
                     {
                         string{{nrt?}} discriminator = utf8JsonReaderDiscriminator.GetString();
                         {{#mappedModels}}
@@ -156,10 +156,10 @@
 
                 if (utf8JsonReader.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReader.CurrentDepth - 1)
                 {
-                    string{{nrt?}} propertyName = utf8JsonReader.GetString();
+                    string{{nrt?}} __jsonPropertyName__ = utf8JsonReader.GetString();
                     utf8JsonReader.Read();
 
-                    switch (propertyName)
+                    switch (__jsonPropertyName__)
                     {
                         {{#allVars}}
                         case "{{baseName}}":


### PR DESCRIPTION
Obfuscate ```propertyName``` variable to rarely used ```__jsonPropertyName__```, this fixes issue I came across, that if one of the variables contained in ```{{#allVars}}``` (mustache variable) is named "**propertyName**" ( - one of the properties in the model is actually named "**propertyName**" - ) then the generator would generate a conflicting variable with the same name ([see line 41](https://github.com/OpenAPITools/openapi-generator/blob/778a53a4069cf522cfbe8c045b8bf65671a394e8/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache#L41C15-L41C15)) which in turn prevents compiling the code.

While the above is a simple fix for this instance, speaking of this issue, I'd say that there are possibly more scenarios that could potentially cause similar conflicts, for example, the variables generated for ```{{#oneOf}}``` might potentially have the same name as vars in ```{{#allVars}}```, thus c# cannot compile.

For that reason, maybe a better solution might be to follow a convention to never generate a variable name based solely on provided mustache variables, but instead prefix generated variables with some context. For example instead of just using ```{{name}}``` for vars generated for {{#allVars}}, we can use ```CODEGEN__allVars__{{name}}```, then for the ```{{#oneOf}}``` vars you'd use ```CODEGEN__oneOf__{{name}}```.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
