### PR TITLE
[csharp][generichost] Only one JsonConstructor

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -15,7 +15,6 @@
         {{#allVars}}
         /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}</param>
         {{/allVars}}
-        [JsonConstructor]
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}({{#lambda.joinWithComma}}{{{dataType}}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}  {{#model.composedSchemas.anyOf}}{{{dataType}}}{{>NullConditionalProperty}} {{#lambda.camelcase_param}}{{baseType}}{{/lambda.camelcase_param}}  {{/model.composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{#parentModel.composedSchemas.oneOf}}{{#lambda.camelcase_param}}{{parent}}{{/lambda.camelcase_param}}.{{#lambda.titlecase}}{{baseType}}{{/lambda.titlecase}}  {{/parentModel.composedSchemas.oneOf}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}
@@ -47,7 +46,9 @@
         {{#allVars}}
         /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}</param>
         {{/allVars}}
+        {{^composedSchemas.anyOf}}
         [JsonConstructor]
+        {{/composedSchemas.anyOf}}
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}({{#lambda.joinWithComma}}{{#composedSchemas.anyOf}}{{{name}}}{{>NullConditionalProperty}} {{#lambda.camelcase_param}}{{baseType}}{{/lambda.camelcase_param}}  {{/composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Fruit.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="apple"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
             Apple = apple;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
             Banana = banana;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -34,7 +34,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
         /// </summary>
         /// <param name="appleReq"></param>
-        [JsonConstructor]
         public FruitReq(AppleReq appleReq)
         {
             AppleReq = appleReq;
@@ -45,7 +44,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
         /// </summary>
         /// <param name="bananaReq"></param>
-        [JsonConstructor]
         public FruitReq(BananaReq bananaReq)
         {
             BananaReq = bananaReq;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -36,7 +36,6 @@ namespace Org.OpenAPITools.Model
         /// <param name="apple"></param>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public GmFruit(Apple? apple, Banana? banana, string color)
         {
             Apple = apple;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Mammal.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="whale"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Whale whale, string className)
         {
             Whale = whale;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="zebra"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Zebra zebra, string className)
         {
             Zebra = zebra;
@@ -61,7 +59,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="pig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Pig pig, string className)
         {
             Pig = pig;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public NullableShape(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public NullableShape(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -34,7 +34,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
         /// <param name="varString"></param>
-        [JsonConstructor]
         internal OneOfString(string varString)
         {
             VarString = varString;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Pig.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="basquePig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Pig(BasquePig basquePig, string className)
         {
             BasquePig = basquePig;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="danishPig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Pig(DanishPig danishPig, string className)
         {
             DanishPig = danishPig;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -34,7 +34,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varBool"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(bool varBool)
         {
             VarBool = varBool;
@@ -45,7 +44,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varString"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(string varString)
         {
             VarString = varString;
@@ -56,7 +54,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varObject"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(Object varObject)
         {
             VarObject = varObject;
@@ -67,7 +64,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="list"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(List<string> list)
         {
             List = list;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="simpleQuadrilateral"></param>
         /// <param name="quadrilateralType">quadrilateralType</param>
-        [JsonConstructor]
         public Quadrilateral(SimpleQuadrilateral simpleQuadrilateral, string quadrilateralType)
         {
             SimpleQuadrilateral = simpleQuadrilateral;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="complexQuadrilateral"></param>
         /// <param name="quadrilateralType">quadrilateralType</param>
-        [JsonConstructor]
         public Quadrilateral(ComplexQuadrilateral complexQuadrilateral, string quadrilateralType)
         {
             ComplexQuadrilateral = complexQuadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Shape.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public Shape(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public Shape(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public ShapeOrNull(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public ShapeOrNull(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/Model/Triangle.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="equilateralTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(EquilateralTriangle equilateralTriangle, string triangleType)
         {
             EquilateralTriangle = equilateralTriangle;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="isoscelesTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(IsoscelesTriangle isoscelesTriangle, string triangleType)
         {
             IsoscelesTriangle = isoscelesTriangle;
@@ -61,7 +59,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="scaleneTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(ScaleneTriangle scaleneTriangle, string triangleType)
         {
             ScaleneTriangle = scaleneTriangle;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Fruit.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="apple"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
             Apple = apple;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
             Banana = banana;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
         /// </summary>
         /// <param name="appleReq"></param>
-        [JsonConstructor]
         public FruitReq(AppleReq appleReq)
         {
             AppleReq = appleReq;
@@ -43,7 +42,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
         /// </summary>
         /// <param name="bananaReq"></param>
-        [JsonConstructor]
         public FruitReq(BananaReq bananaReq)
         {
             BananaReq = bananaReq;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -34,7 +34,6 @@ namespace Org.OpenAPITools.Model
         /// <param name="apple"></param>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public GmFruit(Apple apple, Banana banana, string color)
         {
             Apple = apple;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Mammal.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="whale"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Whale whale, string className)
         {
             Whale = whale;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="zebra"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Zebra zebra, string className)
         {
             Zebra = zebra;
@@ -59,7 +57,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="pig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Pig pig, string className)
         {
             Pig = pig;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public NullableShape(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public NullableShape(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
         /// <param name="varString"></param>
-        [JsonConstructor]
         internal OneOfString(string varString)
         {
             VarString = varString;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Pig.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="basquePig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Pig(BasquePig basquePig, string className)
         {
             BasquePig = basquePig;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="danishPig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Pig(DanishPig danishPig, string className)
         {
             DanishPig = danishPig;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varBool"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(bool varBool)
         {
             VarBool = varBool;
@@ -43,7 +42,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varString"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(string varString)
         {
             VarString = varString;
@@ -54,7 +52,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varObject"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(Object varObject)
         {
             VarObject = varObject;
@@ -65,7 +62,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="list"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(List<string> list)
         {
             List = list;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="simpleQuadrilateral"></param>
         /// <param name="quadrilateralType">quadrilateralType</param>
-        [JsonConstructor]
         public Quadrilateral(SimpleQuadrilateral simpleQuadrilateral, string quadrilateralType)
         {
             SimpleQuadrilateral = simpleQuadrilateral;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="complexQuadrilateral"></param>
         /// <param name="quadrilateralType">quadrilateralType</param>
-        [JsonConstructor]
         public Quadrilateral(ComplexQuadrilateral complexQuadrilateral, string quadrilateralType)
         {
             ComplexQuadrilateral = complexQuadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public Shape(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public Shape(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public ShapeOrNull(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public ShapeOrNull(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/Model/Triangle.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="equilateralTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(EquilateralTriangle equilateralTriangle, string triangleType)
         {
             EquilateralTriangle = equilateralTriangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="isoscelesTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(IsoscelesTriangle isoscelesTriangle, string triangleType)
         {
             IsoscelesTriangle = isoscelesTriangle;
@@ -59,7 +57,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="scaleneTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(ScaleneTriangle scaleneTriangle, string triangleType)
         {
             ScaleneTriangle = scaleneTriangle;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -36,7 +36,6 @@ namespace Org.OpenAPITools.Model
         /// <param name="apple"></param>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Apple? apple, Banana? banana, string color)
         {
             Apple = apple;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -35,7 +35,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="apple"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
             Apple = apple;
@@ -48,7 +47,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
             Banana = banana;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Fruit.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="apple"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Apple apple, string color)
         {
             Apple = apple;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public Fruit(Banana banana, string color)
         {
             Banana = banana;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
         /// </summary>
         /// <param name="appleReq"></param>
-        [JsonConstructor]
         public FruitReq(AppleReq appleReq)
         {
             AppleReq = appleReq;
@@ -43,7 +42,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
         /// </summary>
         /// <param name="bananaReq"></param>
-        [JsonConstructor]
         public FruitReq(BananaReq bananaReq)
         {
             BananaReq = bananaReq;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -34,7 +34,6 @@ namespace Org.OpenAPITools.Model
         /// <param name="apple"></param>
         /// <param name="banana"></param>
         /// <param name="color">color</param>
-        [JsonConstructor]
         public GmFruit(Apple apple, Banana banana, string color)
         {
             Apple = apple;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Mammal.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="whale"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Whale whale, string className)
         {
             Whale = whale;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="zebra"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Zebra zebra, string className)
         {
             Zebra = zebra;
@@ -59,7 +57,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="pig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Mammal(Pig pig, string className)
         {
             Pig = pig;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public NullableShape(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public NullableShape(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
         /// <param name="varString"></param>
-        [JsonConstructor]
         internal OneOfString(string varString)
         {
             VarString = varString;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Pig.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="basquePig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Pig(BasquePig basquePig, string className)
         {
             BasquePig = basquePig;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="danishPig"></param>
         /// <param name="className">className</param>
-        [JsonConstructor]
         public Pig(DanishPig danishPig, string className)
         {
             DanishPig = danishPig;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -32,7 +32,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varBool"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(bool varBool)
         {
             VarBool = varBool;
@@ -43,7 +42,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varString"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(string varString)
         {
             VarString = varString;
@@ -54,7 +52,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="varObject"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(Object varObject)
         {
             VarObject = varObject;
@@ -65,7 +62,6 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
         /// <param name="list"></param>
-        [JsonConstructor]
         internal PolymorphicProperty(List<string> list)
         {
             List = list;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="simpleQuadrilateral"></param>
         /// <param name="quadrilateralType">quadrilateralType</param>
-        [JsonConstructor]
         public Quadrilateral(SimpleQuadrilateral simpleQuadrilateral, string quadrilateralType)
         {
             SimpleQuadrilateral = simpleQuadrilateral;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="complexQuadrilateral"></param>
         /// <param name="quadrilateralType">quadrilateralType</param>
-        [JsonConstructor]
         public Quadrilateral(ComplexQuadrilateral complexQuadrilateral, string quadrilateralType)
         {
             ComplexQuadrilateral = complexQuadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public Shape(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public Shape(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="triangle"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public ShapeOrNull(Triangle triangle, string shapeType)
         {
             Triangle = triangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="quadrilateral"></param>
         /// <param name="shapeType">shapeType</param>
-        [JsonConstructor]
         public ShapeOrNull(Quadrilateral quadrilateral, string shapeType)
         {
             Quadrilateral = quadrilateral;

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/Model/Triangle.cs
@@ -33,7 +33,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="equilateralTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(EquilateralTriangle equilateralTriangle, string triangleType)
         {
             EquilateralTriangle = equilateralTriangle;
@@ -46,7 +45,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="isoscelesTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(IsoscelesTriangle isoscelesTriangle, string triangleType)
         {
             IsoscelesTriangle = isoscelesTriangle;
@@ -59,7 +57,6 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="scaleneTriangle"></param>
         /// <param name="triangleType">triangleType</param>
-        [JsonConstructor]
         public Triangle(ScaleneTriangle scaleneTriangle, string triangleType)
         {
             ScaleneTriangle = scaleneTriangle;


### PR DESCRIPTION
The JsonConstructor attribute may only be on one constructor. This change avoids using it on composed classes because there is more than one constructor.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
