### PR TITLE
Add mapping features to C client generator

### DIFF
--- a/bin/configs/c.yaml
+++ b/bin/configs/c.yaml
@@ -2,3 +2,6 @@ generatorName: c
 outputDir: samples/client/petstore/c
 inputSpec: modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/C-libcurl
+modelNameMappings:
+  another_model: MappedModel
+  another_property: mappedProperty

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -559,6 +559,11 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toVarName(String name) {
+        // obtain the name from nameMapping directly if provided
+        if (nameMapping.containsKey(name)) {
+            return nameMapping.get(name);
+        }
+
         // sanitize name
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         // if it's all upper case, convert to lower case
@@ -578,6 +583,11 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toParamName(String name) {
+        // obtain the name from parameterNameMapping directly if provided
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
+        }
+
         // should be the same as variable name
         if (isReservedWord(name) || name.matches("^\\d.*")) {
             name = escapeReservedWord(name);
@@ -588,6 +598,11 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toModelName(String name) {
+        // obtain the name from modelNameMapping directly if provided
+        if (modelNameMapping.containsKey(name)) {
+            return modelNameMapping.get(name);
+        }
+
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         if (!StringUtils.isEmpty(modelNamePrefix)) {

--- a/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
@@ -715,3 +715,10 @@ definitions:
         type: string
       message:
         type: string
+  another_model:
+    description: to test mapping features
+    type: object
+    properties:
+      another_property:
+        type: integer
+        format: int32

--- a/samples/client/petstore/c/.openapi-generator/FILES
+++ b/samples/client/petstore/c/.openapi-generator/FILES
@@ -6,6 +6,7 @@ api/StoreAPI.c
 api/StoreAPI.h
 api/UserAPI.c
 api/UserAPI.h
+docs/MappedModel.md
 docs/PetAPI.md
 docs/StoreAPI.md
 docs/UserAPI.md
@@ -27,6 +28,8 @@ model/api_response.c
 model/api_response.h
 model/category.c
 model/category.h
+model/mapped_model.c
+model/mapped_model.h
 model/object.c
 model/object.h
 model/order.c

--- a/samples/client/petstore/c/README.md
+++ b/samples/client/petstore/c/README.md
@@ -89,6 +89,7 @@ Category | Method | HTTP request | Description
 
 ## Documentation for Models
 
+ - [MappedModel_t](docs/MappedModel.md)
  - [api_response_t](docs/api_response.md)
  - [category_t](docs/category.md)
  - [order_t](docs/order.md)

--- a/samples/client/petstore/c/docs/MappedModel.md
+++ b/samples/client/petstore/c/docs/MappedModel.md
@@ -1,0 +1,10 @@
+# MappedModel_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**another_property** | **int** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/model/mapped_model.c
+++ b/samples/client/petstore/c/model/mapped_model.c
@@ -1,0 +1,69 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "MappedModel.h"
+
+
+
+MappedModel_t *MappedModel_create(
+    int another_property
+    ) {
+    MappedModel_t *MappedModel_local_var = malloc(sizeof(MappedModel_t));
+    if (!MappedModel_local_var) {
+        return NULL;
+    }
+    MappedModel_local_var->another_property = another_property;
+
+    return MappedModel_local_var;
+}
+
+
+void MappedModel_free(MappedModel_t *MappedModel) {
+    if(NULL == MappedModel){
+        return ;
+    }
+    listEntry_t *listEntry;
+    free(MappedModel);
+}
+
+cJSON *MappedModel_convertToJSON(MappedModel_t *MappedModel) {
+    cJSON *item = cJSON_CreateObject();
+
+    // MappedModel->another_property
+    if(MappedModel->another_property) {
+    if(cJSON_AddNumberToObject(item, "another_property", MappedModel->another_property) == NULL) {
+    goto fail; //Numeric
+    }
+    }
+
+    return item;
+fail:
+    if (item) {
+        cJSON_Delete(item);
+    }
+    return NULL;
+}
+
+MappedModel_t *MappedModel_parseFromJSON(cJSON *MappedModelJSON){
+
+    MappedModel_t *MappedModel_local_var = NULL;
+
+    // MappedModel->another_property
+    cJSON *another_property = cJSON_GetObjectItemCaseSensitive(MappedModelJSON, "another_property");
+    if (another_property) { 
+    if(!cJSON_IsNumber(another_property))
+    {
+    goto end; //Numeric
+    }
+    }
+
+
+    MappedModel_local_var = MappedModel_create (
+        another_property ? another_property->valuedouble : 0
+        );
+
+    return MappedModel_local_var;
+end:
+    return NULL;
+
+}

--- a/samples/client/petstore/c/model/mapped_model.h
+++ b/samples/client/petstore/c/model/mapped_model.h
@@ -1,0 +1,37 @@
+/*
+ * MappedModel.h
+ *
+ * to test mapping features
+ */
+
+#ifndef _MappedModel_H_
+#define _MappedModel_H_
+
+#include <string.h>
+#include "../external/cJSON.h"
+#include "../include/list.h"
+#include "../include/keyValuePair.h"
+#include "../include/binary.h"
+
+typedef struct MappedModel_t MappedModel_t;
+
+
+
+
+typedef struct MappedModel_t {
+    int another_property; //numeric
+
+} MappedModel_t;
+
+MappedModel_t *MappedModel_create(
+    int another_property
+);
+
+void MappedModel_free(MappedModel_t *MappedModel);
+
+MappedModel_t *MappedModel_parseFromJSON(cJSON *MappedModelJSON);
+
+cJSON *MappedModel_convertToJSON(MappedModel_t *MappedModel);
+
+#endif /* _MappedModel_H_ */
+

--- a/samples/client/petstore/c/unit-test/test_mapped_model.c
+++ b/samples/client/petstore/c/unit-test/test_mapped_model.c
@@ -1,0 +1,58 @@
+#ifndef mapped_model_TEST
+#define mapped_model_TEST
+
+// the following is to include only the main from the first c file
+#ifndef TEST_MAIN
+#define TEST_MAIN
+#define mapped_model_MAIN
+#endif // TEST_MAIN
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include "../external/cJSON.h"
+
+#include "../model/mapped_model.h"
+MappedModel_t* instantiate_MappedModel(int include_optional);
+
+
+
+MappedModel_t* instantiate_MappedModel(int include_optional) {
+  MappedModel_t* MappedModel = NULL;
+  if (include_optional) {
+    MappedModel = MappedModel_create(
+      56
+    );
+  } else {
+    MappedModel = MappedModel_create(
+      56
+    );
+  }
+
+  return MappedModel;
+}
+
+
+#ifdef mapped_model_MAIN
+
+void test_MappedModel(int include_optional) {
+    MappedModel_t* MappedModel_1 = instantiate_MappedModel(include_optional);
+
+	cJSON* jsonMappedModel_1 = MappedModel_convertToJSON(MappedModel_1);
+	printf("MappedModel :\n%s\n", cJSON_Print(jsonMappedModel_1));
+	MappedModel_t* MappedModel_2 = MappedModel_parseFromJSON(jsonMappedModel_1);
+	cJSON* jsonMappedModel_2 = MappedModel_convertToJSON(MappedModel_2);
+	printf("repeating MappedModel:\n%s\n", cJSON_Print(jsonMappedModel_2));
+}
+
+int main() {
+  test_MappedModel(1);
+  test_MappedModel(0);
+
+  printf("Hello world \n");
+  return 0;
+}
+
+#endif // mapped_model_MAIN
+#endif // mapped_model_TEST


### PR DESCRIPTION
Add mapping features (property, parameter model names) to C client generator (we've added these features to many other generators)

Added a simple test

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc @zhemant (2018/11) @ityuhui (2019/12) @michelealbano (2020/03)
