### PR TITLE
[python] Allow clients to define TLS Server name (SNI) (aiohttp)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -47,6 +47,8 @@ class RESTClientObject(object):
                 configuration.cert_file, keyfile=configuration.key_file
             )
 
+        self.server_hostname = configuration.tls_server_name
+
         if not configuration.verify_ssl:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
@@ -121,6 +123,9 @@ class RESTClientObject(object):
 
         if query_params:
             args["url"] += '?' + urlencode(query_params)
+
+        if self.server_hostname:
+            args["server_hostname"] = self.server_hostname
 
         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
         if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -57,6 +57,8 @@ class RESTClientObject(object):
                 configuration.cert_file, keyfile=configuration.key_file
             )
 
+        self.server_hostname = configuration.tls_server_name
+
         if not configuration.verify_ssl:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
@@ -131,6 +133,9 @@ class RESTClientObject(object):
 
         if query_params:
             args["url"] += '?' + urlencode(query_params)
+
+        if self.server_hostname:
+            args["server_hostname"] = self.server_hostname
 
         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
         if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:


### PR DESCRIPTION
This configures the same as in #15283 but for the aiohttp backend.


Waiting for one of the following upstream aiohttp pull request to be merged before marking this pull request as ready:

* https://github.com/aio-libs/aiohttp/pull/7541 (aiohttp 4.0.x)
* https://github.com/aio-libs/aiohttp/pull/7543 (aiohttp 3.9.x)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
