### PR TITLE
Fix model name being a type in TS abstract codegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -512,9 +512,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
     @Override
     public String toParamName(String name) {
-        // obtain the name from nameMapping directly if provided
-        if (nameMapping.containsKey(name)) {
-            return nameMapping.get(name);
+        // obtain the name from parameterNameMapping directly if provided
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
         }
 
         name = sanitizeName(name, "[^\\w$]");
@@ -557,6 +557,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
     @Override
     public String toModelName(final String name) {
+        // obtain the name from modelNameMapping directly if provided
+        if (modelNameMapping.containsKey(name)) {
+            return modelNameMapping.get(name);
+        }
+
         String fullModelName = name;
         fullModelName = addPrefix(fullModelName, modelNamePrefix);
         fullModelName = addSuffix(fullModelName, modelNameSuffix);
@@ -630,6 +635,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         } else if (ModelUtils.isBinarySchema(p)) {
             return "ArrayBuffer";
         }
+
         return super.getTypeDeclaration(p);
     }
 
@@ -754,6 +760,17 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
     @Override
     public String getSchemaType(Schema p) {
+        // check if $ref is a model and modelNameMapping is used
+        if (StringUtils.isNotBlank(p.get$ref())) {
+            Schema unaliasSchema = unaliasSchema(p);
+            Schema actualSchema = ModelUtils.getReferencedSchema(openAPI, unaliasSchema);
+            String modelName = ModelUtils.getSimpleRef(unaliasSchema.get$ref());
+
+            if (ModelUtils.isModel(actualSchema) && modelNameMapping.containsKey(modelName)) {
+                return toModelName(modelNameMapping.get(modelName));
+            }
+        }
+
         String openAPIType = super.getSchemaType(p);
         String type = null;
         if (ModelUtils.isComposedSchema(p)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -313,4 +313,35 @@ public class TypeScriptAngularClientCodegenTest {
                 "export type Token = ExpressionToken | StringToken"
         );
     }
+
+    @Test
+    public void testModelNameMappings() throws Exception {
+        final String specPath = "src/test/resources/2_0/issue_8289.json";
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TypeScriptAngularClientCodegen.TAGGED_UNIONS, "true");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        Map<String, String> modelNames = new HashMap<>();
+        modelNames.put("File", "SystemFile");
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setModelNameMappings(modelNames)
+                .setGeneratorName("typescript-angular")
+                .setInputSpec(specPath)
+                .setAdditionalProperties(properties)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+
+        Generator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        TestUtils.assertFileContains(
+                Paths.get(output + "/model/folder.ts"),
+                "files?: Array<SystemFile>;" // ensure it's an array of SystemFile (not Any)
+        );
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -226,10 +226,10 @@ public class TypeScriptAngularClientCodegenTest {
 
         final String modelName = "FooResponse__links";
         final Schema schema = new Schema()
-            .name(modelName)
-            .description("an inline model with name previously prefixed with underscore")
-            .addRequiredItem("self")
-            .addProperty("self", new StringSchema());
+                .name(modelName)
+                .description("an inline model with name previously prefixed with underscore")
+                .addRequiredItem("self")
+                .addProperty("self", new StringSchema());
 
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("test", schema);
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/resources/2_0/issue_8289.json
+++ b/modules/openapi-generator/src/test/resources/2_0/issue_8289.json
@@ -1,0 +1,33 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test swagger",
+    "version": "0.1.0"
+  },
+  "definitions": {
+    "File": {
+      "title": "File",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Folder": {
+      "title": "Folder",
+      "type": "object",
+      "properties": {
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/File"
+          }
+        }
+      }
+    }
+  },
+  "paths": {},
+  "host": "localhost:3000",
+  "schemes": ["http"]
+}


### PR DESCRIPTION
- Fix model name being a type in TS abstract codegen by using modelNameMappings option
- to fix https://github.com/OpenAPITools/openapi-generator/issues/9289
- tested locally to confirm the fix
```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g typescript-fetch -i /tmp/a.json -o /tmp/ts2/ --model-name-mappings File=SystemFile
```

will add a test later

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
