### PR TITLE
Fix scalatra on Windows

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalatraServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalatraServerCodegen.java
@@ -200,6 +200,6 @@ public class ScalatraServerCodegen extends AbstractScalaCodegen implements Codeg
     }
 
     private String sourceFolderByPackage(String packageName) {
-        return sourceFolder + File.separator + packageName.replaceAll("[.]", File.separator);
+        return sourceFolder + File.separator + packageName.replace('.', File.separatorChar);
     }
 }


### PR DESCRIPTION
Using the **scalatra** generator on Windows crashes OpenAPI Generator with `java.lang.IllegalArgumentException: character to be escaped is missing`. This PR fixes that.

`File.separator` returns a single backslash on Windows, which is not a valid value for `replaceAll`.

To guard against similar problems, I could add a unit test that simply invokes each existing generator on a small input spec. Just to ensure the generator runs without crashes. This would then automatically be checked by the [windows workflow](https://github.com/OpenAPITools/openapi-generator/blob/master/.github/workflows/windows.yaml) (and others as well).
Let me know if that would be helpful.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
   @clasnake (2017/07), @jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04) @fish86 (2023/06)