### PR TITLE
[ruby] Not symbolize header param keys to allow the usage of underscore ("_") character

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -17,6 +17,8 @@
 
 package org.openapitools.codegen.languages;
 
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
 import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
@@ -30,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -286,6 +290,18 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 .doNotOverwrite());
         supportingFiles.add(new SupportingFile("api_client_spec.mustache", specFolder, "api_client_spec.rb")
                 .doNotOverwrite());
+
+        // add lambda to convert a symbol to a string if an underscore is included (e.g. :'user_uuid' => 'user_uuid')
+        additionalProperties.put("lambdaFixHeaderKey", new Mustache.Lambda() {
+            @Override
+            public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+                String content = fragment.execute();
+                if (content.contains("_")) {
+                    content = content.substring(1);
+                }
+                writer.write(content);
+            }
+        });
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -199,12 +199,12 @@ module {{moduleName}}
       {{/hasConsumes}}
       {{#headerParams}}
       {{#required}}
-      header_params['{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
+      header_params[{{#lambdaFixHeaderKey}}:'{{{baseName}}}'{{/lambdaFixHeaderKey}}] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
       {{/required}}
       {{/headerParams}}
       {{#headerParams}}
       {{^required}}
-      header_params['{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
+      header_params[{{#lambdaFixHeaderKey}}:'{{{baseName}}}'{{/lambdaFixHeaderKey}}] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
       {{/required}}
       {{/headerParams}}
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -199,12 +199,12 @@ module {{moduleName}}
       {{/hasConsumes}}
       {{#headerParams}}
       {{#required}}
-      header_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
+      header_params['{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
       {{/required}}
       {{/headerParams}}
       {{#headerParams}}
       {{^required}}
-      header_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
+      header_params['{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
       {{/required}}
       {{/headerParams}}
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/fake_api.rb
@@ -168,7 +168,7 @@ module Petstore
       if !content_type.nil?
           header_params['Content-Type'] = content_type
       end
-      header_params[:'header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
+      header_params['header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -1031,8 +1031,8 @@ module Petstore
       if !content_type.nil?
           header_params['Content-Type'] = content_type
       end
-      header_params[:'enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
-      header_params[:'enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
+      header_params['enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
+      header_params['enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -1122,8 +1122,8 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'required_boolean_group'] = required_boolean_group
-      header_params[:'boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
+      header_params['required_boolean_group'] = required_boolean_group
+      header_params['boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-autoload/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/api/pet_api.rb
@@ -118,7 +118,7 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
+      header_params['api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -168,7 +168,7 @@ module Petstore
       if !content_type.nil?
           header_params['Content-Type'] = content_type
       end
-      header_params[:'header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
+      header_params['header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -1031,8 +1031,8 @@ module Petstore
       if !content_type.nil?
           header_params['Content-Type'] = content_type
       end
-      header_params[:'enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
-      header_params[:'enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
+      header_params['enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
+      header_params['enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -1122,8 +1122,8 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'required_boolean_group'] = required_boolean_group
-      header_params[:'boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
+      header_params['required_boolean_group'] = required_boolean_group
+      header_params['boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/pet_api.rb
@@ -118,7 +118,7 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
+      header_params['api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -168,7 +168,7 @@ module Petstore
       if !content_type.nil?
           header_params['Content-Type'] = content_type
       end
-      header_params[:'header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
+      header_params['header_1'] = opts[:'header_1'] if !opts[:'header_1'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -562,8 +562,8 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'_type'] = underscore_type
-      header_params[:'type_'] = type_with_underscore
+      header_params['_type'] = underscore_type
+      header_params['type_'] = type_with_underscore
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -1112,8 +1112,8 @@ module Petstore
       if !content_type.nil?
           header_params['Content-Type'] = content_type
       end
-      header_params[:'enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
-      header_params[:'enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
+      header_params['enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
+      header_params['enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -1203,8 +1203,8 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'required_boolean_group'] = required_boolean_group
-      header_params[:'boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
+      header_params['required_boolean_group'] = required_boolean_group
+      header_params['boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -118,7 +118,7 @@ module Petstore
 
       # header parameters
       header_params = opts[:header_params] || {}
-      header_params[:'api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
+      header_params['api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}


### PR DESCRIPTION
Faraday replaces the underscore ("_") character with hyphen ("-") if a header param key is symbol:
https://github.com/lostisland/faraday/blob/v2.7.10/lib/faraday/utils/headers.rb#L44-L46

e.g. `user_uuid` => `User-Uuid`

I understand that the underscore ("_") character can be problematic (https://httpwg.org/specs/rfc9110.html#rfc.section.16.3.2.1) but still I think there are some cases we want to use the underscore ("_") character in header param keys.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 