### PR TITLE
Change default value of 'pathParamsAsVariables' config option

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -35,7 +35,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
     public static final String FOLDER_STRATEGY_DEFAULT_VALUE = "Tags";
     // Select whether to create Postman variables for path templates
     public static final String PATH_PARAMS_AS_VARIABLES = "pathParamsAsVariables";
-    public static final Boolean PATH_PARAMS_AS_VARIABLES_DEFAULT_VALUE = true;
+    public static final Boolean PATH_PARAMS_AS_VARIABLES_DEFAULT_VALUE = false;
 
     public static final String POSTMAN_FILE_DEFAULT_VALUE = "postman.json";
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -130,6 +130,7 @@ public class PostmanCollectionCodegenTest {
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("postman-collection")
                 .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
+                .addAdditionalProperty(PostmanCollectionCodegen.PATH_PARAMS_AS_VARIABLES, true)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -165,6 +166,7 @@ public class PostmanCollectionCodegenTest {
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("postman-collection")
                 .setInputSpec("src/test/resources/3_0/postman-collection/BasicVariablesInExample.yaml")
+                .addAdditionalProperty(PostmanCollectionCodegen.PATH_PARAMS_AS_VARIABLES, true)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -197,6 +199,7 @@ public class PostmanCollectionCodegenTest {
                 .setGeneratorName("postman-collection")
                 .addAdditionalProperty(PostmanCollectionCodegen.POSTMAN_VARIABLES, false)
                 .setInputSpec("src/test/resources/3_0/postman-collection/BasicVariablesInExample.yaml")
+                .addAdditionalProperty(PostmanCollectionCodegen.PATH_PARAMS_AS_VARIABLES, true)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -224,7 +227,6 @@ public class PostmanCollectionCodegenTest {
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("postman-collection")
-                .addAdditionalProperty(PostmanCollectionCodegen.PATH_PARAMS_AS_VARIABLES, false)
                 .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
@@ -277,6 +279,7 @@ public class PostmanCollectionCodegenTest {
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("postman-collection")
                 .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
+                .addAdditionalProperty(PostmanCollectionCodegen.PATH_PARAMS_AS_VARIABLES, true)
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -13,7 +13,7 @@
 	            "name": "default",
 	            "item": [
 	                        {
-    "name": "/users/{{userId}} (DEPRECATED)",
+    "name": "/users/{userId} (DEPRECATED)",
                 "description": "Update the information of an existing user.",
                  "item": [
                             {
@@ -52,13 +52,13 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{baseUrl}}/users/{{userId}}",
+                                        "raw": "{{baseUrl}}/users/{userId}",
                                         "host": [
                                             "{{baseUrl}}"
                                         ],
                                         "path": [
                                             "users",
-                                            "{{userId}}"
+                                            "{userId}"
                                         ],
                                         "variable": [
                                             {
@@ -81,7 +81,7 @@
 	            "name": "advanced",
 	            "item": [
 	                        {
-    "name": "/groups/{{groupId}}",
+    "name": "/groups/{groupId}",
                 "description": "Get group of users",
                  "item": [
                             {
@@ -105,13 +105,13 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{baseUrl}}/groups/{{groupId}}",
+                                        "raw": "{{baseUrl}}/groups/{groupId}",
                                         "host": [
                                             "{{baseUrl}}"
                                         ],
                                         "path": [
                                             "groups",
-                                            "{{groupId}}"
+                                            "{groupId}"
                                         ],
                                         "variable": [
                                             {
@@ -129,7 +129,7 @@
                             ]
                         },
 	                        {
-    "name": "/users/{{userId}}",
+    "name": "/users/{userId}",
                 "description": "Retrieve the information of the user with the matching user ID.",
                  "item": [
                             {
@@ -163,13 +163,13 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{baseUrl}}/users/{{userId}}",
+                                        "raw": "{{baseUrl}}/users/{userId}",
                                         "host": [
                                             "{{baseUrl}}"
                                         ],
                                         "path": [
                                             "users",
-                                            "{{userId}}"
+                                            "{userId}"
                                         ],
                                         "variable": [
                                             {
@@ -329,19 +329,9 @@
 			"type": "string"
 		},
 		{
-			"key": "groupId",
-			"value": "1",
-			"type": "number"
-		},
-		{
 			"key": "port",
 			"value": "5000",
 			"type": "string"
-		},
-		{
-			"key": "userId",
-			"value": "",
-			"type": "number"
 		}
 	]
 }


### PR DESCRIPTION
Path parameters are often modified by developers using the collection (ie to test different scenarios), therefore creating those path parameters as Postman (global) variables does not make much sense.

This PR changes the default value of the configuration `pathParamsAsVariables` to skip (by default) the path parameters. Developers can still decide to enable this behavior setting the property to true.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 