### PR TITLE
Fix selection of unnecessary form parameter models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6905,6 +6905,13 @@ public class DefaultCodegen implements CodegenConfig {
         LOGGER.debug("debugging fromRequestBodyToFormParameters= {}", body);
         Schema schema = ModelUtils.getSchemaFromRequestBody(body);
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+        if(ModelUtils.isMapSchema(schema)) {
+            LOGGER.error("Form parameters with additionalProperties are not supported by OpenAPI Generator. Please report the issue to https://github.com/openapitools/openapi-generator if you need help.");
+        }
+        if(ModelUtils.isArraySchema(schema)) {
+            LOGGER.error("Array form parameters are not supported by OpenAPI Generator. Please report the issue to https://github.com/openapitools/openapi-generator if you need help.");
+        }
+
         List<String> allRequired = new ArrayList<>();
         Map<String, Schema> properties = new LinkedHashMap<>();
         // this traverses a composed schema and extracts all properties in each schema into properties
@@ -6920,10 +6927,6 @@ public class DefaultCodegen implements CodegenConfig {
                 // value => property schema
                 String propertyName = entry.getKey();
                 Schema propertySchema = entry.getValue();
-                if (ModelUtils.isMapSchema(propertySchema)) {
-                    LOGGER.error("Map of form parameters not supported. Please report the issue to https://github.com/openapitools/openapi-generator if you need help.");
-                    continue;
-                }
                 codegenParameter = fromFormProperty(propertyName, propertySchema, imports);
 
                 // Set 'required' flag defined in the schema element

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -367,7 +367,7 @@ public class ModelUtils {
         Map<String, Schema> properties = schema.getProperties();
         if (properties != null) {
             for (Schema property : properties.values()) {
-                visitSchema(openAPI, property, mimeType, visitedSchemas, visitor);
+                visitSchema(openAPI, property, null, visitedSchemas, visitor);
             }
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -114,6 +114,14 @@ public class ModelUtilsTest {
     }
 
     @Test
+    public void testNestedFormParameter() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/nestedFormParameter.yaml");
+        List<String> unusedSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);
+        Assert.assertEquals(unusedSchemas.size(), 1);
+        Assert.assertTrue(unusedSchemas.contains("OuterObject"), "contains 'OuterObject'");
+    }
+
+    @Test
     public void testNoComponentsSection() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/ping.yaml");
         List<String> unusedSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);

--- a/modules/openapi-generator/src/test/resources/2_0/nestedFormParameter.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/nestedFormParameter.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  title: dummy
+  version: dummy
+paths:
+  /property:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      parameters:
+        - in: body
+          name: body
+          schema:
+              $ref: '#/definitions/OuterObject'
+      responses:
+        '200':
+          description: dummy
+definitions:
+  InnerObject:
+    type: object
+    properties:
+      innerProperty:
+        type: string
+  OuterObject:
+    type: object
+    properties:
+      outerProperty:
+        $ref: '#/definitions/InnerObject'


### PR DESCRIPTION
fix #12036, fix #14461, fix #14681, fix #10254, which all report the same problem. Possibly there are more such issues.

## Problem
For `application/x-www-form-urlencoded` and `multipart/form-data` parameters, the model class of the form parameter is not needed and thus (correctly) not generated. But if the form parameter has any property with a non-primitive type, a model class for this property *is* needed and should be generated. But it is currently not generated.

## Solution
The filtering of form model classes happens in `ModelUtils.getSchemasUsedOnlyInFormParam`. This method uses `visitOpenAPI` to iterate through all models. It then skips generation of all models for which the associated mime-type `t` is always `application/x-www-form-urlencoded` or `multipart/form-data`.
So to fix the described problem, I changed the internals of `visitOpenAPI` to set `t` to a mime-type only for those models that are used by a *parameter*, but not for those models that are used as *properties* of parameters.
This does not have any side effects on callers of `visitOpenAPI` other than `getSchemasUsedOnlyInFormParam`. Because the other two callers of `visitOpenAPI` do not use the value of the mime-type `t` in any way.

## Test Inputs
[This gist](https://gist.github.com/martin-mfg/2829d5390bf638ce6cd27aea103a733a) contains a simple OpenAPI v3 spec that demonstrates the described problem, as well as a v2 spec that does the same.

## Questions
- [This comment](https://github.com/OpenAPITools/openapi-generator/issues/405#issuecomment-405808009) sounds to me like there are cases where the changes of my PR are not preferable. I didn't find such a use case though. If I missed something, please let me know.

- While working on this issue I noticed that  OpenAPI Generator doesn't support MapSchemas and ArraySchemas for `application/x-www-form-urlencoded` and `multipart/form-data` parameters. Because [DefaultCodegen.fromRequestBodyToFormParameters](https://github.com/OpenAPITools/openapi-generator/blob/ec835fbd948cf1223c1d899c2859019cef4653a9/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L6903C35-L6903C66) doesn't support them. This method contains a warning for MapSchemas:  
  ```java
  if (ModelUtils.isMapSchema(propertySchema)) {
	  LOGGER.error("Map of form parameters not supported. Please report the issue to https://github.com/openapitools/openapi-generator if you need help.");
	continue;
  }
  ```
  Although this warning is triggered if a *property* of the form parameter is of type MapSchema, I think it was intended to be triggered if the form parameter itself is of type MapSchema. I could fix this and also add a similar warning for ArraySchema. Would that make sense?

---------------

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)