### PR TITLE
add test to invoke each generator and catch simple crashes

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -1,6 +1,5 @@
 /*
  * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
- * Copyright 2018 SmartBear Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen;
+
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AllGeneratorsTest {
+
+    @Test
+    public void testEachWithPetstore() throws IOException {
+        for (final CodegenConfig codegenConfig : CodegenConfigLoader.getAll()) {
+            File output = Files.createTempDirectory("test").toFile();
+            output.deleteOnExit();
+
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName(codegenConfig.getName())
+                    .setInputSpec("src/test/resources/2_0/petstore.yaml")
+                    .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            DefaultGenerator generator = new DefaultGenerator();
+            List<File> files = generator.opts(clientOptInput).generate();
+
+            // Main intention of this test is to check that nothing crashes. Besides, we check here that
+            // at least 1 file is generated, besides the common ".openapi-generator-ignore", "FILES" and "VERSION" files.
+            Assert.assertTrue(files.size() >= 4);
+        }
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -35,7 +35,7 @@ public class AllGeneratorsTest {
 
             final CodegenConfigurator configurator = new CodegenConfigurator()
                     .setGeneratorName(codegenConfig.getName())
-                    .setInputSpec("src/test/resources/2_0/petstore.yaml")
+                    .setInputSpec("src/test/resources/3_0/petstore.yaml")
                     .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
             final ClientOptInput clientOptInput = configurator.toClientOptInput();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AllGeneratorsTest.java
@@ -24,9 +24,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class AllGeneratorsTest {
 


### PR DESCRIPTION
as discussed in https://github.com/OpenAPITools/openapi-generator/pull/16395#issuecomment-1692622328

Adding a unit test that simply invokes each existing generator on the petstore input spec. Just to ensure all generators run without crashes.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)