### PR TITLE
Fix cast exception when handling example/default of UUID/Long type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -287,10 +287,8 @@ public class ExampleGenerator {
             return "https://openapi-generator.tech";
         } else if (ModelUtils.isStringSchema(property)) {
             LOGGER.debug("String property");
-            String defaultValue = String.valueOf(property.getDefault());
-            if (defaultValue != null && !defaultValue.isEmpty()) {
-                LOGGER.debug("Default value found: '{}'", defaultValue);
-                return defaultValue;
+            if (property.getDefault() != null) {
+                return String.valueOf(property.getDefault());
             }
             List<String> enumValues = property.getEnum();
             if (enumValues != null && !enumValues.isEmpty()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -287,7 +287,7 @@ public class ExampleGenerator {
             return "https://openapi-generator.tech";
         } else if (ModelUtils.isStringSchema(property)) {
             LOGGER.debug("String property");
-            String defaultValue = (String) property.getDefault();
+            String defaultValue = String.valueOf(property.getDefault());
             if (defaultValue != null && !defaultValue.isEmpty()) {
                 LOGGER.debug("Default value found: '{}'", defaultValue);
                 return defaultValue;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
@@ -262,7 +262,7 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
             return "null";
         } else if (ModelUtils.isStringSchema(p)) {
             if (p.getDefault() != null) {
-                String _default = (String) p.getDefault();
+                String _default = String.valueOf(p.getDefault());
                 if (p.getEnum() == null) {
                     return "\"" + escapeText(_default) + "\"";
                 } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -1133,5 +1133,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.F_SHARP; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.F_SHARP;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -795,7 +795,7 @@ public abstract class AbstractFSharpCodegen extends DefaultCodegen implements Co
             }
         } else if (ModelUtils.isStringSchema(p)) {
             if (p.getDefault() != null) {
-                String _default = (String) p.getDefault();
+                String _default = String.valueOf(p.getDefault());
                 if (p.getEnum() == null) {
                     return "\"" + _default + "\"";
                 } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -353,7 +353,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
         // correct "&#39;"s into "'"s after toString()
         if (ModelUtils.isStringSchema(schema) && schema.getDefault() != null && !ModelUtils.isDateSchema(schema) && !ModelUtils.isDateTimeSchema(schema)) {
-            example = (String) schema.getDefault();
+            example = String.valueOf(schema.getDefault());
         }
 
         if (StringUtils.isNotBlank(example) && !"null".equals(example)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
@@ -233,7 +233,7 @@ public class ApexClientCodegen extends AbstractApexCodegen {
             // true => "true", false => "false", null => "null"
             out = String.valueOf(p.getDefault());
         } else if (ModelUtils.isLongSchema(p)) {
-            if (p.getDefault() != null ) {
+            if (p.getDefault() != null) {
                 Long def = Long.parseLong(String.valueOf(p.getDefault()));
                 out = def == null ? out : def + "L";
             }
@@ -315,7 +315,7 @@ public class ApexClientCodegen extends AbstractApexCodegen {
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
 
         supportingFiles.add(new SupportingFile("README_ant.mustache", "README.md")
-            .doNotOverwrite());
+                .doNotOverwrite());
 
     }
 
@@ -325,10 +325,12 @@ public class ApexClientCodegen extends AbstractApexCodegen {
         supportingFiles.add(new SupportingFile("sfdx-project.json.mustache", "sfdx-project.json"));
 
         supportingFiles.add(new SupportingFile("README_sfdx.mustache", "README.md")
-            .doNotOverwrite());
+                .doNotOverwrite());
 
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.APEX; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.APEX;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
@@ -233,8 +233,10 @@ public class ApexClientCodegen extends AbstractApexCodegen {
             // true => "true", false => "false", null => "null"
             out = String.valueOf(p.getDefault());
         } else if (ModelUtils.isLongSchema(p)) {
-            Long def = (Long) p.getDefault();
-            out = def == null ? out : def + "L";
+            if (p.getDefault() != null ) {
+                Long def = Long.parseLong(String.valueOf(p.getDefault()));
+                out = def == null ? out : def + "L";
+            }
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
             String s = inner == null ? "Object" : getTypeDeclaration(inner);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -939,5 +939,7 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.C; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.C;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -235,9 +235,9 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         }
 
         if (allowableValues.containsKey("values")) {
-            List<String> values = (List<String>) allowableValues.get("values");
-            for (String value : values) {
-                value = prefix + "_" + value;
+            List<Object> values = (List<Object>) allowableValues.get("values");
+            for (Object value : values) {
+                value = prefix + "_" + String.valueOf(value);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -435,7 +435,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
             }
         } else if (ModelUtils.isStringSchema(p)) {
             if (p.getDefault() != null) {
-                if (Pattern.compile("\r\n|\r|\n").matcher((String) p.getDefault()).find())
+                if (Pattern.compile("\r\n|\r|\n").matcher(String.valueOf(p.getDefault())).find())
                     return "'''" + p.getDefault() + "'''";
                 else
                     return "'" + p.getDefault() + "'";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1236,7 +1236,7 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             }
         } else if (ModelUtils.isStringSchema(p)) {
             if (p.getDefault() != null) {
-                defaultValue = "\"" + (String) p.getDefault() + "\".to_string()";
+                defaultValue = "\"" + String.valueOf(p.getDefault()) + "\".to_string()";
             }
         }
         if ((defaultValue != null) && (ModelUtils.isNullable(p)))

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SwiftCombineClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SwiftCombineClientCodegen.java
@@ -396,9 +396,9 @@ public class SwiftCombineClientCodegen extends DefaultCodegen implements Codegen
         if (p.getEnum() != null && !p.getEnum().isEmpty()) {
             if (p.getDefault() != null) {
                 if (ModelUtils.isStringSchema(p)) {
-                    return "." + toEnumVarName(escapeText((String) p.getDefault()), p.getType());
+                    return "." + toEnumVarName(escapeText(String.valueOf(p.getDefault())), p.getType());
                 } else {
-                    return "." + toEnumVarName(escapeText(p.getDefault().toString()), p.getType());
+                    return "." + toEnumVarName(escapeText(String.valueOf(p.getDefault())), p.getType());
                 }
             }
         }
@@ -412,9 +412,9 @@ public class SwiftCombineClientCodegen extends DefaultCodegen implements Codegen
                 long epochMicro = TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + (instant.get(ChronoField.MICRO_OF_SECOND));
                 return "Date(timeIntervalSince1970: " + String.valueOf(epochMicro) + ".0 / 1_000_000)";
             } else if (ModelUtils.isUUIDSchema(p)) {
-                return "\"" + escapeText(p.getDefault().toString()) + "\"";
+                return "\"" + escapeText(String.valueOf(p.getDefault())) + "\"";
             } else if (ModelUtils.isStringSchema(p)) {
-                return "\"" + escapeText((String) p.getDefault()) + "\"";
+                return "\"" + escapeText(String.valueOf(p.getDefault())) + "\"";
             }
             // TODO: Handle more cases from `ModelUtils`, such as Date
         }


### PR DESCRIPTION
- Fix cast exception when handling example/default of UUID/Long type
- tested impacted generator to confirm all the fix

FYI @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
