### PR TITLE
Elixir: fix broken connection token authorization middleware

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -284,7 +284,7 @@ defmodule {{moduleName}}.Connection do
   def authorization(token, scopes \\ @default_scopes)
 
   def authorization(token, _scopes) when is_binary(token) do
-    {Tesla.Middleware.Headers, ["authorization", token]}
+    {Tesla.Middleware.Headers, [{"authorization", token}]}
   end
 
   def authorization({module, function}, scopes) when is_atom(module) and is_atom(function) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
@@ -216,7 +216,7 @@ defmodule OpenapiPetstore.Connection do
   def authorization(token, scopes \\ @default_scopes)
 
   def authorization(token, _scopes) when is_binary(token) do
-    {Tesla.Middleware.Headers, ["authorization", token]}
+    {Tesla.Middleware.Headers, [{"authorization", token}]}
   end
 
   def authorization({module, function}, scopes) when is_atom(module) and is_atom(function) do


### PR DESCRIPTION
Correctly types the arguments for the Tesla.Middleware.Headers module on the token authorization. As you can see in [the example here](https://hexdocs.pm/tesla/Tesla.html#client/2) the Headers middleware options are a list of key-value pairs. 

This looks to be a regression introduced in https://github.com/OpenAPITools/openapi-generator/pull/12775 as a typo, as the stringdoc shows the correct structure.

Relevant issue https://github.com/ory/sdk/issues/285

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mrmstn