### PR TITLE
Fix slash in php generator's doc & config

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/BackSlashLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/BackSlashLambda.java
@@ -40,6 +40,7 @@ import static org.openapitools.codegen.utils.StringUtils.underscore;
 public class BackSlashLambda implements Mustache.Lambda {
     @Override
     public void execute(Template.Fragment fragment, Writer writer) throws IOException {
-        writer.write(fragment.execute().replace("/", "\\"));
+        writer.write(fragment.execute()
+                .replace("/", "\\"));
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/ForwardSlashLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/ForwardSlashLambda.java
@@ -40,6 +40,9 @@ import static org.openapitools.codegen.utils.StringUtils.underscore;
 public class ForwardSlashLambda implements Mustache.Lambda {
     @Override
     public void execute(Template.Fragment fragment, Writer writer) throws IOException {
-        writer.write(fragment.execute().replace("\\", "/"));
+        writer.write(fragment.execute()
+                .replace("\\/", "/")
+                .replace("\\", "/")
+                .replace("//", "/"));
     }
 }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
@@ -196,17 +196,17 @@ No model defined in this package
 {{#authMethods}}
 {{#isBasicBasic}}
 ### Security schema `{{name}}`
-> Important! To make Basic authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\BasicAuthenticator](./src/Auth/BasicAuthenticator.php) class.
+> Important! To make Basic authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{#lambda.forwardslash}}{{authSrcPath}}{{/lambda.forwardslash}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\BasicAuthenticator](./src/Auth/BasicAuthenticator.php) class.
 
 {{/isBasicBasic}}
 {{#isApiKey}}
 ### Security schema `{{name}}`
-> Important! To make ApiKey authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\ApiKeyAuthenticator](./src/Auth/ApiKeyAuthenticator.php) class.
+> Important! To make ApiKey authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{#lambda.forwardslash}}{{authSrcPath}}{{/lambda.forwardslash}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\ApiKeyAuthenticator](./src/Auth/ApiKeyAuthenticator.php) class.
 
 {{/isApiKey}}
 {{#isOAuth}}
 ### Security schema `{{name}}`
-> Important! To make OAuth authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{authSrcPath}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\OAuthAuthenticator](./src/Auth/OAuthAuthenticator.php) class.
+> Important! To make OAuth authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{#lambda.forwardslash}}{{authSrcPath}}{{/lambda.forwardslash}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\OAuthAuthenticator](./src/Auth/OAuthAuthenticator.php) class.
 
 Scope list:
 {{#scopes}}

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/phpunit.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/phpunit.xml.mustache
@@ -2,9 +2,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" beStrictAboutTestsThatDoNotTestAnything="false" stopOnFailure="false">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">{{apiSrcPath}}</directory>
+      <directory suffix=".php">{{#lambda.forwardslash}}{{apiSrcPath}}{{/lambda.forwardslash}}</directory>
       <file>./{{srcBasePath}}/BaseModel.php</file>
-      <directory suffix=".php">{{modelSrcPath}}</directory>
+      <directory suffix=".php">{{#lambda.forwardslash}}{{modelSrcPath}}{{/lambda.forwardslash}}</directory>
     </include>
   </coverage>
   <testsuites>

--- a/modules/openapi-generator/src/main/resources/php-symfony/testing/phpunit.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/testing/phpunit.xml.mustache
@@ -9,9 +9,9 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <coverage processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">{{apiSrcPath}}</directory>
-            <directory suffix=".php">{{modelSrcPath}}</directory>
-            <directory suffix=".php">{{controllerSrcPath}}</directory>
+            <directory suffix=".php">{{#lambda.forwardslash}}{{apiSrcPath}}{{/lambda.forwardslash}}</directory>
+            <directory suffix=".php">{{#lambda.forwardslash}}{{modelSrcPath}}{{/lambda.forwardslash}}</directory>
+            <directory suffix=".php">{{#lambda.forwardslash}}{{controllerSrcPath}}{{/lambda.forwardslash}}</directory>
         </include>
     </coverage>
     <testsuites>

--- a/modules/openapi-generator/src/main/resources/php/phpunit.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/php/phpunit.xml.mustache
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">{{apiSrcPath}}</directory>
-      <directory suffix=".php">{{modelSrcPath}}</directory>
+      <directory suffix=".php">{{#lambda.forwardslash}}{{apiSrcPath}}{{/lambda.forwardslash}}</directory>
+      <directory suffix=".php">{{#lambda.forwardslash}}{{modelSrcPath}}{{/lambda.forwardslash}}</directory>
     </include>
   </coverage>
   <testsuites>


### PR DESCRIPTION
Fix slash in php generator's doc & config

Without this fix, using the generator in Windows will generate
```diff
--- a/samples/client/petstore/php/OpenAPIClient-php/phpunit.xml.dist
+++ b/samples/client/petstore/php/OpenAPIClient-php/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="tr
ue" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./lib/Api</directory>
-      <directory suffix=".php">./lib/Model</directory>
+      <directory suffix=".php">./lib\/Api</directory>
+      <directory suffix=".php">./lib\/Model</directory>
     </include>
   </coverage>
   <testsuites>
```


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


FYI 
@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ybelenko (2018/07), @renepardon (2018/12)
