### PR TITLE
Fix slash in python aiohttp files

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-aiohttp/conftest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/conftest.mustache
@@ -11,8 +11,12 @@ def client(loop, aiohttp_client):
     options = {
         "swagger_ui": True
         }
-    specification_dir = os.path.join(os.path.dirname(__file__), '..',{{#pythonSrcRoot}}
-                                     "{{{.}}}",{{/pythonSrcRoot}}
+    specification_dir = os.path.join(os.path.dirname(__file__), '..',
+                                     {{#lambda.forwardslash}}
+                                     {{#pythonSrcRoot}}
+                                     "{{{.}}}",
+                                     {{/pythonSrcRoot}}
+                                     {{/lambda.forwardslash}}
                                      '{{packageName}}',
                                      'openapi')
     app = connexion.AioHttpApp(__name__, specification_dir=specification_dir,

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/setup.mustache
@@ -27,9 +27,13 @@ setup(
     url="{{packageUrl}}",
     keywords=["OpenAPI", "{{appName}}"],
     install_requires=REQUIRES,
-    packages=find_packages({{#pythonSrcRoot}}"{{{.}}}"{{/pythonSrcRoot}}),{{#pythonSrcRoot}}
-    package_dir={"": "{{{.}}}"},{{/pythonSrcRoot}}
-    package_data={'': ['{{#pythonSrcRoot}}{{{.}}}/{{/pythonSrcRoot}}openapi/openapi.yaml']},
+    packages=find_packages({{#lambda.forwardslash}}{{#pythonSrcRoot}}"{{{.}}}"{{/pythonSrcRoot}}){{/lambda.forwardslash}},
+    {{#lambda.forwardslash}}
+    {{#pythonSrcRoot}}
+    package_dir={"": "{{{.}}}"},
+    {{/pythonSrcRoot}}
+    {{/lambda.forwardslash}}
+    package_data={'': ['{{#lambda.forwardslash}}{{#pythonSrcRoot}}{{{.}}}/{{/pythonSrcRoot}}{{/lambda.forwardslash}}openapi/openapi.yaml']},
     include_package_data=True,
     entry_points={
         'console_scripts': ['{{packageName}}={{packageName}}.__main__:main']},

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/tox.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/tox.mustache
@@ -8,4 +8,4 @@ deps=-r{toxinidir}/requirements.txt
 	 {toxinidir}
 
 commands=
-   {{^useNose}}pytest --cov={{{pythonSrcRoot}}}{{{packageName}}}{{/useNose}}{{#useNose}}nosetests{{/useNose}}
+   {{^useNose}}pytest --cov={{#lambda.forwardslash}}{{{pythonSrcRoot}}}{{/lambda.forwardslash}}{{{packageName}}}{{/useNose}}{{#useNose}}nosetests{{/useNose}}

--- a/samples/server/petstore/python-aiohttp-srclayout/setup.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=REQUIRES,
     packages=find_packages("src/"),
     package_dir={"": "src/"},
-    package_data={'': ['src//openapi/openapi.yaml']},
+    package_data={'': ['src/openapi/openapi.yaml']},
     include_package_data=True,
     entry_points={
         'console_scripts': ['openapi_server=openapi_server.__main__:main']},


### PR DESCRIPTION
Fix slash in python aiohttp files.

Before the fix when generating the samples on Windows,

```diff
$ git diff
diff --git a/samples/server/petstore/python-aiohttp-srclayout/setup.py b/samples/server/petstore/python-aiohttp-srclayout/setup.py
index 5cfff33cdbe..abc1aeb12a0 100644
--- a/samples/server/petstore/python-aiohttp-srclayout/setup.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/setup.py
@@ -27,9 +27,9 @@ setup(
     url="",
     keywords=["OpenAPI", "OpenAPI Petstore"],
     install_requires=REQUIRES,
-    packages=find_packages("src/"),
-    package_dir={"": "src/"},
-    package_data={'': ['src//openapi/openapi.yaml']},
+    packages=find_packages("src\"),
+    package_dir={"": "src\"},
+    package_data={'': ['src\/openapi/openapi.yaml']},
     include_package_data=True,
     entry_points={
         'console_scripts': ['openapi_server=openapi_server.__main__:main']},
diff --git a/samples/server/petstore/python-aiohttp-srclayout/tests/conftest.py b/samples/server/petstore/python-aiohttp-srclayout/tests/conftest.py
index 578bf18e982..63ba2f413d1 100644
--- a/samples/server/petstore/python-aiohttp-srclayout/tests/conftest.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/tests/conftest.py
@@ -12,7 +12,7 @@ def client(loop, aiohttp_client):
         "swagger_ui": True
         }
     specification_dir = os.path.join(os.path.dirname(__file__), '..',
-                                     "src/",
+                                     "src\",
                                      'openapi_server',
                                      'openapi')
     app = connexion.AioHttpApp(__name__, specification_dir=specification_dir,
diff --git a/samples/server/petstore/python-aiohttp-srclayout/tox.ini b/samples/server/petstore/python-aiohttp-srclayout/tox.ini
index 25d12bb84c0..3d847999b3c 100644
--- a/samples/server/petstore/python-aiohttp-srclayout/tox.ini
+++ b/samples/server/petstore/python-aiohttp-srclayout/tox.ini
@@ -8,4 +8,4 @@ deps=-r{toxinidir}/requirements.txt
         {toxinidir}

 commands=
-   pytest --cov=src/openapi_server
+   pytest --cov=src\openapi_server

```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @krjakbrjak (2023/02)
