### PR TITLE
Fix indent lambda using \n as line break

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/IndentedLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/IndentedLambda.java
@@ -109,7 +109,8 @@ public class IndentedLambda implements Mustache.Lambda {
 
         String prefixedIndention = StringUtils.repeat(new String(Character.toChars(spaceCode)), prefixSpaceCount);
         StringBuilder sb = new StringBuilder();
-        String[] lines = text.split(System.lineSeparator());
+        // use \n instead of System.lineSeparator (e.g. \r\n in Windows) as templates use \n
+        String[] lines = text.split("\n");
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
             // Mustache will apply correct indentation to the first line of a template (to match declaration location).

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/IndentedLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/IndentedLambda.java
@@ -122,9 +122,9 @@ public class IndentedLambda implements Mustache.Lambda {
 
             sb.append(line);
 
-            // We've split on the system's line separator. We don't want to add an additional trailing line.
+            // We've split on \n. We don't want to add an additional trailing line.
             if (i < lines.length - 1) {
-                sb.append(System.lineSeparator());
+                sb.append("\n");
             }
         }
         writer.write(sb.toString());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
@@ -16,7 +16,7 @@ public class IndentedLambdaTest extends LambdaTest {
         // When & Then
         // IndentedLambda applies indentation from second line on of a template.
         test("first line" + lineSeparator + "    second line",
-                "{{#indented}}first line" + lineSeparator +"second line{{/indented}}", ctx);
+                "{{#indented}}first line" + lineSeparator + "second line{{/indented}}", ctx);
     }
 
     @Test
@@ -27,7 +27,7 @@ public class IndentedLambdaTest extends LambdaTest {
         // When & Then
         // IndentedLambda applies indentation from second line on of a template.
         test("first line" + lineSeparator + "        second line",
-                "{{#indented}}first line" + lineSeparator +"second line{{/indented}}", ctx);
+                "{{#indented}}first line" + lineSeparator + "second line{{/indented}}", ctx);
     }
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
@@ -6,13 +6,12 @@ import org.testng.annotations.Test;
 
 public class IndentedLambdaTest extends LambdaTest {
 
-    String lineSeparator = System.lineSeparator();
+    String lineSeparator = "\n";
 
     @Test
     public void defaultIndentTest() {
         // Given
         Map<String, Object> ctx = context("indented", new IndentedLambda());
-        String lineSeparator = System.lineSeparator();
 
         // When & Then
         // IndentedLambda applies indentation from second line on of a template.


### PR DESCRIPTION
Fix indent lambda using \n as line break as that's what the templates use

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
