### PR TITLE
[PYTHON] generate code based on pydantic v2

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -7,7 +7,7 @@ chardet==4.0.0
 click==7.1.2
 dnspython==2.1.0
 email-validator==1.1.2
-fastapi==0.95.2
+fastapi==0.103.0
 graphene==2.1.8
 graphql-core==2.3.2
 graphql-relay==2.0.1
@@ -20,7 +20,7 @@ Jinja2==2.11.3
 MarkupSafe==2.0.1
 orjson==3.5.2
 promise==2.3
-pydantic==1.8.2
+pydantic==2.3.0
 python-dotenv==0.17.1
 python-multipart==0.0.5
 PyYAML==5.4.1

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -6,7 +6,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated{{#asyncio}}
 from typing import overload, Optional, Union, Awaitable{{/asyncio}}
 
@@ -46,7 +46,7 @@ class {{classname}}(object):
         ...
 
 {{/asyncio}}
-    @validate_arguments
+    @validate_call
     def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}{{#asyncio}}async_req: Optional[bool]=None, {{/asyncio}}**kwargs) -> {{#asyncio}}Union[{{{returnType}}}{{^returnType}}None{{/returnType}}, Awaitable[{{{returnType}}}{{^returnType}}None{{/returnType}}]]{{/asyncio}}{{^asyncio}}{{{returnType}}}{{^returnType}}None{{/returnType}}{{/asyncio}}:  # noqa: E501
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 
@@ -83,7 +83,7 @@ class {{classname}}(object):
 {{/asyncio}}
         return self.{{operationId}}_with_http_info({{#allParams}}{{paramName}}, {{/allParams}}**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> ApiResponse:  # noqa: E501
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 

--- a/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
@@ -29,8 +29,9 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         actual_instance: Any
     any_of_schemas: List[str] = Field({{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ANY_OF_SCHEMAS, const=True)
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 {{#discriminator}}
 
     discriminator_value_class_map = {

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -73,10 +73,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{/isEnum}}
 {{/vars}}
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
 {{#hasChildren}}
 {{#discriminator}}

--- a/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
@@ -12,8 +12,6 @@ import re  # noqa: F401
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-{{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ONE_OF_SCHEMAS = [{{#oneOf}}"{{.}}"{{^-last}}, {{/-last}}{{/oneOf}}]
-
 class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}):
     """
     {{{description}}}{{^description}}{{{classname}}}{{/description}}
@@ -26,10 +24,11 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         actual_instance: Union[{{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field({{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal[{{#oneOf}}"{{.}}"{{^-last}}, {{/-last}}{{/oneOf}}]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 {{#discriminator}}
 
     discriminator_value_class_map = {

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -24,7 +24,7 @@ tornado = ">=4.2,<5"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
 {{/hasHttpSignatureMethods}}
-pydantic = "^1.10.5, <2"
+pydantic = ">=2"
 aenum = ">=3.1.11"
 
 [tool.poetry.dev-dependencies]

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,7 +1,7 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
-pydantic >= 1.10.5, < 2
+pydantic >= 2
 aenum >= 3.1.11
 {{#asyncio}}
 aiohttp >= 3.0.0

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -29,7 +29,7 @@ REQUIRES = [
     "pem>=19.3.0",
     "pycryptodome>=3.9.0",
 {{/hasHttpSignatureMethods}}
-    "pydantic >= 1.10.5, < 2",
+    "pydantic >= 2",
     "aenum"
 ]
 

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBytes, StrictStr, conlist
@@ -47,7 +47,7 @@ class BodyApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def test_binary_gif(self, **kwargs) -> bytearray:  # noqa: E501
         """Test binary (gif) response body  # noqa: E501
 
@@ -74,7 +74,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_binary_gif_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_binary_gif_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_binary_gif_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Test binary (gif) response body  # noqa: E501
 
@@ -178,7 +178,7 @@ class BodyApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_body_application_octetstream_binary(self, body : Optional[Union[StrictBytes, StrictStr]] = None, **kwargs) -> str:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
@@ -207,7 +207,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_body_application_octetstream_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_body_application_octetstream_binary_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_application_octetstream_binary_with_http_info(self, body : Optional[Union[StrictBytes, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
@@ -329,7 +329,7 @@ class BodyApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_body_multipart_formdata_array_of_binary(self, files : conlist(Union[StrictBytes, StrictStr]), **kwargs) -> str:  # noqa: E501
         """Test array of binary in multipart mime  # noqa: E501
 
@@ -358,7 +358,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_body_multipart_formdata_array_of_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_body_multipart_formdata_array_of_binary_with_http_info(files, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_multipart_formdata_array_of_binary_with_http_info(self, files : conlist(Union[StrictBytes, StrictStr]), **kwargs) -> ApiResponse:  # noqa: E501
         """Test array of binary in multipart mime  # noqa: E501
 
@@ -476,7 +476,7 @@ class BodyApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_free_form_object_response_string(self, body : Annotated[Optional[Dict[str, Any]], Field(description="Free form object")] = None, **kwargs) -> str:  # noqa: E501
         """Test free form object  # noqa: E501
 
@@ -505,7 +505,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_echo_body_free_form_object_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_echo_body_free_form_object_response_string_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_free_form_object_response_string_with_http_info(self, body : Annotated[Optional[Dict[str, Any]], Field(description="Free form object")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test free form object  # noqa: E501
 
@@ -622,7 +622,7 @@ class BodyApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_pet(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> Pet:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
@@ -651,7 +651,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_echo_body_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_echo_body_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_pet_with_http_info(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
@@ -768,7 +768,7 @@ class BodyApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_pet_response_string(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> str:  # noqa: E501
         """Test empty response body  # noqa: E501
 
@@ -797,7 +797,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_echo_body_pet_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_echo_body_pet_response_string_with_http_info(pet, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_pet_response_string_with_http_info(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test empty response body  # noqa: E501
 
@@ -914,7 +914,7 @@ class BodyApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_tag_response_string(self, tag : Annotated[Optional[Tag], Field(description="Tag object")] = None, **kwargs) -> str:  # noqa: E501
         """Test empty json (request body)  # noqa: E501
 
@@ -943,7 +943,7 @@ class BodyApi(object):
             raise ValueError("Error! Please call the test_echo_body_tag_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_echo_body_tag_response_string_with_http_info(tag, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_echo_body_tag_response_string_with_http_info(self, tag : Annotated[Optional[Tag], Field(description="Tag object")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test empty json (request body)  # noqa: E501
 

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import StrictBool, StrictInt, StrictStr
@@ -45,7 +45,7 @@ class FormApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def test_form_integer_boolean_string(self, integer_form : Optional[StrictInt] = None, boolean_form : Optional[StrictBool] = None, string_form : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test form parameter(s)  # noqa: E501
 
@@ -78,7 +78,7 @@ class FormApi(object):
             raise ValueError("Error! Please call the test_form_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_form_integer_boolean_string_with_http_info(integer_form, boolean_form, string_form, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_form_integer_boolean_string_with_http_info(self, integer_form : Optional[StrictInt] = None, boolean_form : Optional[StrictBool] = None, string_form : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test form parameter(s)  # noqa: E501
 

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import StrictBool, StrictInt, StrictStr
@@ -45,7 +45,7 @@ class HeaderApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def test_header_integer_boolean_string(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
@@ -78,7 +78,7 @@ class HeaderApi(object):
             raise ValueError("Error! Please call the test_header_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_header_integer_boolean_string_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import StrictInt, StrictStr
@@ -43,7 +43,7 @@ class PathApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def tests_path_string_path_string_integer_path_integer(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> str:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
@@ -74,7 +74,7 @@ class PathApi(object):
             raise ValueError("Error! Please call the tests_path_string_path_string_integer_path_integer_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def tests_path_string_path_string_integer_path_integer_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> ApiResponse:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from datetime import date, datetime
@@ -50,7 +50,7 @@ class QueryApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def test_enum_ref_string(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -79,7 +79,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_enum_ref_string_with_http_info(enum_ref_string_query, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_enum_ref_string_with_http_info(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -189,7 +189,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_datetime_date_string(self, datetime_query : Optional[datetime] = None, date_query : Optional[date] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -222,7 +222,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_datetime_date_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_datetime_date_string_with_http_info(datetime_query, date_query, string_query, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[datetime] = None, date_query : Optional[date] = None, string_query : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -350,7 +350,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_integer_boolean_string(self, integer_query : Optional[StrictInt] = None, boolean_query : Optional[StrictBool] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -383,7 +383,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_integer_boolean_string_with_http_info(integer_query, boolean_query, string_query, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_integer_boolean_string_with_http_info(self, integer_query : Optional[StrictInt] = None, boolean_query : Optional[StrictBool] = None, string_query : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -505,7 +505,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_style_deep_object_explode_true_object(self, query_object : Optional[Pet] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -534,7 +534,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_style_deep_object_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_style_deep_object_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_style_deep_object_explode_true_object_with_http_info(self, query_object : Optional[Pet] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -644,7 +644,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_style_deep_object_explode_true_object_all_of(self, query_object : Optional[Any] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -673,7 +673,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_style_deep_object_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_style_deep_object_explode_true_object_all_of_with_http_info(self, query_object : Optional[Any] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -783,7 +783,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_style_form_explode_true_array_string(self, query_object : Optional[TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -812,7 +812,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_style_form_explode_true_array_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_style_form_explode_true_array_string_with_http_info(query_object, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_style_form_explode_true_array_string_with_http_info(self, query_object : Optional[TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -922,7 +922,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_style_form_explode_true_object(self, query_object : Optional[Pet] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -951,7 +951,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_style_form_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_style_form_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_style_form_explode_true_object_with_http_info(self, query_object : Optional[Pet] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -1061,7 +1061,7 @@ class QueryApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_style_form_explode_true_object_all_of(self, query_object : Optional[Any] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
@@ -1090,7 +1090,7 @@ class QueryApi(object):
             raise ValueError("Error! Please call the test_query_style_form_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_style_form_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_style_form_explode_true_object_all_of_with_http_info(self, query_object : Optional[Any] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 

--- a/samples/client/echo_api/python/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python/openapi_client/models/bird.py
@@ -30,10 +30,11 @@ class Bird(BaseModel):
     color: Optional[StrictStr] = None
     __properties = ["size", "color"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/category.py
+++ b/samples/client/echo_api/python/openapi_client/models/category.py
@@ -30,10 +30,11 @@ class Category(BaseModel):
     name: Optional[StrictStr] = None
     __properties = ["id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python/openapi_client/models/data_query.py
@@ -32,10 +32,11 @@ class DataQuery(Query):
     var_date: Optional[datetime] = Field(None, alias="date", description="A date")
     __properties = ["id", "outcomes", "suffix", "text", "date"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -48,10 +48,11 @@ class DefaultValue(BaseModel):
                 raise ValueError("each list item must be one of ('success', 'failure', 'unclassified')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
@@ -31,10 +31,11 @@ class NumberPropertiesOnly(BaseModel):
     double: Optional[Union[confloat(le=50.2, ge=0.8, strict=True), conint(le=50, ge=1, strict=True)]] = None
     __properties = ["number", "float", "double"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -46,10 +46,11 @@ class Pet(BaseModel):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/query.py
+++ b/samples/client/echo_api/python/openapi_client/models/query.py
@@ -41,10 +41,11 @@ class Query(BaseModel):
                 raise ValueError("each list item must be one of ('SUCCESS', 'FAILURE', 'SKIPPED')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python/openapi_client/models/tag.py
@@ -30,10 +30,11 @@ class Tag(BaseModel):
     name: Optional[StrictStr] = None
     __properties = ["id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -32,10 +32,11 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
     name: Optional[StrictStr] = None
     __properties = ["size", "color", "id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -29,10 +29,11 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
     values: Optional[conlist(StrictStr)] = None
     __properties = ["values"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.7"
 
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"
-pydantic = "^1.10.5, <2"
+pydantic = ">=2"
 aenum = ">=3.1.11"
 
 [tool.poetry.dev-dependencies]

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
-pydantic >= 1.10.5, < 2
+pydantic >= 2
 aenum >= 3.1.11

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -27,7 +27,7 @@ PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
-    "pydantic >= 1.10.5, < 2",
+    "pydantic >= 2",
     "aenum"
 ]
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -52,7 +52,7 @@ class AnotherFakeApi(object):
     def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
         """To test special tags  # noqa: E501
 
@@ -83,7 +83,7 @@ class AnotherFakeApi(object):
             kwargs['async_req'] = async_req
         return self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test special tags  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -50,7 +50,7 @@ class DefaultApi(object):
     def foo_get(self, async_req: Optional[bool]=True, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def foo_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[FooGetDefaultResponse, Awaitable[FooGetDefaultResponse]]:  # noqa: E501
         """foo_get  # noqa: E501
 
@@ -78,7 +78,7 @@ class DefaultApi(object):
             kwargs['async_req'] = async_req
         return self.foo_get_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def foo_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """foo_get  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -64,7 +64,7 @@ class FakeApi(object):
     def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test any type request body  # noqa: E501
 
@@ -94,7 +94,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test any type request body  # noqa: E501
 
@@ -212,7 +212,7 @@ class FakeApi(object):
     def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
@@ -242,7 +242,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
@@ -353,7 +353,7 @@ class FakeApi(object):
     def fake_health_get(self, async_req: Optional[bool]=True, **kwargs) -> HealthCheckResult:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_health_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[HealthCheckResult, Awaitable[HealthCheckResult]]:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
@@ -381,7 +381,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_health_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
@@ -492,7 +492,7 @@ class FakeApi(object):
     def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
@@ -526,7 +526,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
@@ -656,7 +656,7 @@ class FakeApi(object):
     def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> bool:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[bool, Awaitable[bool]]:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
@@ -687,7 +687,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
@@ -812,7 +812,7 @@ class FakeApi(object):
     def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> OuterComposite:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[OuterComposite, Awaitable[OuterComposite]]:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
@@ -843,7 +843,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
@@ -968,7 +968,7 @@ class FakeApi(object):
     def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> float:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[float, Awaitable[float]]:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
@@ -999,7 +999,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
@@ -1124,7 +1124,7 @@ class FakeApi(object):
     def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> str:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[str, Awaitable[str]]:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
@@ -1155,7 +1155,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
@@ -1280,7 +1280,7 @@ class FakeApi(object):
     def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], async_req: Optional[bool]=True, **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], async_req: Optional[bool]=None, **kwargs) -> Union[OuterObjectWithEnumProperty, Awaitable[OuterObjectWithEnumProperty]]:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
@@ -1311,7 +1311,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> ApiResponse:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
@@ -1436,7 +1436,7 @@ class FakeApi(object):
     def fake_return_list_of_objects(self, async_req: Optional[bool]=True, **kwargs) -> List[List[Tag]]:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_return_list_of_objects(self, async_req: Optional[bool]=None, **kwargs) -> Union[List[List[Tag]], Awaitable[List[List[Tag]]]]:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
@@ -1464,7 +1464,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_return_list_of_objects_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
@@ -1575,7 +1575,7 @@ class FakeApi(object):
     def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test uuid example  # noqa: E501
 
@@ -1605,7 +1605,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> ApiResponse:  # noqa: E501
         """test uuid example  # noqa: E501
 
@@ -1716,7 +1716,7 @@ class FakeApi(object):
     def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
@@ -1747,7 +1747,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
@@ -1871,7 +1871,7 @@ class FakeApi(object):
     def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
@@ -1902,7 +1902,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
@@ -2021,7 +2021,7 @@ class FakeApi(object):
     def test_body_with_query_params(self, query : StrictStr, user : User, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_body_with_query_params(self, query : StrictStr, user : User, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
@@ -2053,7 +2053,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
@@ -2177,7 +2177,7 @@ class FakeApi(object):
     def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
@@ -2208,7 +2208,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_client_model_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
@@ -2333,7 +2333,7 @@ class FakeApi(object):
     def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
@@ -2365,7 +2365,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
@@ -2485,7 +2485,7 @@ class FakeApi(object):
     def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
@@ -2544,7 +2544,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_endpoint_parameters_with_http_info(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
@@ -2747,7 +2747,7 @@ class FakeApi(object):
     def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
@@ -2788,7 +2788,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
@@ -2930,7 +2930,7 @@ class FakeApi(object):
     def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
@@ -2961,7 +2961,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
@@ -3080,7 +3080,7 @@ class FakeApi(object):
     def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
@@ -3113,7 +3113,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> ApiResponse:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
@@ -3238,7 +3238,7 @@ class FakeApi(object):
     def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
@@ -3281,7 +3281,7 @@ class FakeApi(object):
             kwargs['async_req'] = async_req
         return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_parameter_collection_format_with_http_info(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -52,7 +52,7 @@ class FakeClassnameTags123Api(object):
     def test_classname(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def test_classname(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
@@ -83,7 +83,7 @@ class FakeClassnameTags123Api(object):
             kwargs['async_req'] = async_req
         return self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_classname_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -55,7 +55,7 @@ class PetApi(object):
     def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
@@ -86,7 +86,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def add_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
@@ -205,7 +205,7 @@ class PetApi(object):
     def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
@@ -238,7 +238,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
@@ -356,7 +356,7 @@ class PetApi(object):
     def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], async_req: Optional[bool]=True, **kwargs) -> List[Pet]:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], async_req: Optional[bool]=None, **kwargs) -> Union[List[Pet], Awaitable[List[Pet]]]:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
@@ -387,7 +387,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_status_with_http_info(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> ApiResponse:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
@@ -507,7 +507,7 @@ class PetApi(object):
     def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], async_req: Optional[bool]=True, **kwargs) -> List[Pet]:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], async_req: Optional[bool]=None, **kwargs) -> Union[List[Pet], Awaitable[List[Pet]]]:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
@@ -538,7 +538,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_tags_with_http_info(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> ApiResponse:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
@@ -660,7 +660,7 @@ class PetApi(object):
     def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], async_req: Optional[bool]=True, **kwargs) -> Pet:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], async_req: Optional[bool]=None, **kwargs) -> Union[Pet, Awaitable[Pet]]:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
@@ -691,7 +691,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> ApiResponse:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
@@ -811,7 +811,7 @@ class PetApi(object):
     def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
@@ -842,7 +842,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def update_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
@@ -961,7 +961,7 @@ class PetApi(object):
     def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
@@ -996,7 +996,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
@@ -1127,7 +1127,7 @@ class PetApi(object):
     def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, async_req: Optional[bool]=True, **kwargs) -> ApiResponse:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[ApiResponse, Awaitable[ApiResponse]]:  # noqa: E501
         """uploads an image  # noqa: E501
 
@@ -1162,7 +1162,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def upload_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image  # noqa: E501
 
@@ -1299,7 +1299,7 @@ class PetApi(object):
     def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, async_req: Optional[bool]=True, **kwargs) -> ApiResponse:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[ApiResponse, Awaitable[ApiResponse]]:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 
@@ -1334,7 +1334,7 @@ class PetApi(object):
             kwargs['async_req'] = async_req
         return self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def upload_file_with_required_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -54,7 +54,7 @@ class StoreApi(object):
     def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
@@ -85,7 +85,7 @@ class StoreApi(object):
             kwargs['async_req'] = async_req
         return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
@@ -197,7 +197,7 @@ class StoreApi(object):
     def get_inventory(self, async_req: Optional[bool]=True, **kwargs) -> Dict[str, int]:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def get_inventory(self, async_req: Optional[bool]=None, **kwargs) -> Union[Dict[str, int], Awaitable[Dict[str, int]]]:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
@@ -226,7 +226,7 @@ class StoreApi(object):
             kwargs['async_req'] = async_req
         return self.get_inventory_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_inventory_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
@@ -338,7 +338,7 @@ class StoreApi(object):
     def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], async_req: Optional[bool]=True, **kwargs) -> Order:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], async_req: Optional[bool]=None, **kwargs) -> Union[Order, Awaitable[Order]]:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
@@ -369,7 +369,7 @@ class StoreApi(object):
             kwargs['async_req'] = async_req
         return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_order_by_id_with_http_info(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> ApiResponse:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
@@ -489,7 +489,7 @@ class StoreApi(object):
     def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], async_req: Optional[bool]=True, **kwargs) -> Order:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], async_req: Optional[bool]=None, **kwargs) -> Union[Order, Awaitable[Order]]:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
@@ -520,7 +520,7 @@ class StoreApi(object):
             kwargs['async_req'] = async_req
         return self.place_order_with_http_info(order, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def place_order_with_http_info(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> ApiResponse:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 from typing import overload, Optional, Union, Awaitable
 
@@ -52,7 +52,7 @@ class UserApi(object):
     def create_user(self, user : Annotated[User, Field(..., description="Created user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def create_user(self, user : Annotated[User, Field(..., description="Created user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Create user  # noqa: E501
 
@@ -83,7 +83,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.create_user_with_http_info(user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def create_user_with_http_info(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Create user  # noqa: E501
 
@@ -217,7 +217,7 @@ class UserApi(object):
     def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -248,7 +248,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def create_users_with_array_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -367,7 +367,7 @@ class UserApi(object):
     def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -398,7 +398,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def create_users_with_list_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -517,7 +517,7 @@ class UserApi(object):
     def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Delete user  # noqa: E501
 
@@ -548,7 +548,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete user  # noqa: E501
 
@@ -660,7 +660,7 @@ class UserApi(object):
     def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], async_req: Optional[bool]=True, **kwargs) -> User:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], async_req: Optional[bool]=None, **kwargs) -> Union[User, Awaitable[User]]:  # noqa: E501
         """Get user by user name  # noqa: E501
 
@@ -691,7 +691,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> ApiResponse:  # noqa: E501
         """Get user by user name  # noqa: E501
 
@@ -811,7 +811,7 @@ class UserApi(object):
     def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], async_req: Optional[bool]=True, **kwargs) -> str:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], async_req: Optional[bool]=None, **kwargs) -> Union[str, Awaitable[str]]:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
@@ -844,7 +844,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def login_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> ApiResponse:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
@@ -969,7 +969,7 @@ class UserApi(object):
     def logout_user(self, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def logout_user(self, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
@@ -998,7 +998,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.logout_user_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def logout_user_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
@@ -1104,7 +1104,7 @@ class UserApi(object):
     def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
         ...
 
-    @validate_arguments
+    @validate_call
     def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
         """Updated user  # noqa: E501
 
@@ -1137,7 +1137,7 @@ class UserApi(object):
             kwargs['async_req'] = async_req
         return self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def update_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Updated user  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesAnyType(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesClass(BaseModel):
     map_of_map_property: Optional[Dict[str, Dict[str, StrictStr]]] = None
     __properties = ["map_property", "map_of_map_property"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesObject(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -30,10 +30,11 @@ class AllOfWithSingleRef(BaseModel):
     single_ref_type: Optional[SingleRefType] = Field(None, alias="SingleRefType")
     __properties = ["username", "SingleRefType"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -29,10 +29,11 @@ class Animal(BaseModel):
     color: Optional[StrictStr] = 'red'
     __properties = ["className", "color"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'className'

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
@@ -42,8 +42,9 @@ class AnyOfColor(BaseModel):
         actual_instance: Any
     any_of_schemas: List[str] = Field(ANYOFCOLOR_ANY_OF_SCHEMAS, const=True)
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
@@ -42,8 +42,9 @@ class AnyOfPig(BaseModel):
         actual_instance: Any
     any_of_schemas: List[str] = Field(ANYOFPIG_ANY_OF_SCHEMAS, const=True)
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
@@ -30,10 +30,11 @@ class ApiResponse(BaseModel):
     message: Optional[StrictStr] = None
     __properties = ["code", "type", "message"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -29,10 +29,11 @@ class ArrayOfArrayOfModel(BaseModel):
     another_property: Optional[conlist(conlist(Tag))] = None
     __properties = ["another_property"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -28,10 +28,11 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
     array_array_number: Optional[conlist(conlist(float))] = Field(None, alias="ArrayArrayNumber")
     __properties = ["ArrayArrayNumber"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
@@ -28,10 +28,11 @@ class ArrayOfNumberOnly(BaseModel):
     array_number: Optional[conlist(float)] = Field(None, alias="ArrayNumber")
     __properties = ["ArrayNumber"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -31,10 +31,11 @@ class ArrayTest(BaseModel):
     array_array_of_model: Optional[conlist(conlist(ReadOnlyFirst))] = None
     __properties = ["array_of_string", "array_array_of_integer", "array_array_of_model"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
@@ -29,10 +29,11 @@ class BasquePig(BaseModel):
     color: StrictStr = Field(...)
     __properties = ["className", "color"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
@@ -33,10 +33,11 @@ class Capitalization(BaseModel):
     att_name: Optional[StrictStr] = Field(None, alias="ATT_NAME", description="Name of the pet ")
     __properties = ["smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
@@ -29,10 +29,11 @@ class Cat(Animal):
     declawed: Optional[StrictBool] = None
     __properties = ["className", "color", "declawed"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
@@ -29,10 +29,11 @@ class Category(BaseModel):
     name: StrictStr = Field(...)
     __properties = ["id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -29,10 +29,11 @@ class CircularReferenceModel(BaseModel):
     nested: Optional[FirstRef] = None
     __properties = ["size", "nested"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -28,10 +28,11 @@ class ClassModel(BaseModel):
     var_class: Optional[StrictStr] = Field(None, alias="_class")
     __properties = ["_class"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
@@ -28,10 +28,11 @@ class Client(BaseModel):
     client: Optional[StrictStr] = None
     __properties = ["client"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
@@ -23,8 +23,6 @@ from pydantic import BaseModel, Field, StrictStr, ValidationError, conint, conli
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-COLOR_ONE_OF_SCHEMAS = ["List[int]", "str"]
-
 class Color(BaseModel):
     """
     RGB array, RGBA array, or hex string.
@@ -39,10 +37,11 @@ class Color(BaseModel):
         actual_instance: Union[List[int], str]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(COLOR_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["List[int]", "str"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -30,10 +30,11 @@ class Creature(BaseModel):
     type: StrictStr = Field(...)
     __properties = ["info", "type"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
@@ -28,10 +28,11 @@ class CreatureInfo(BaseModel):
     name: StrictStr = Field(...)
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
@@ -29,10 +29,11 @@ class DanishPig(BaseModel):
     size: StrictInt = Field(...)
     __properties = ["className", "size"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
@@ -28,10 +28,11 @@ class DeprecatedObject(BaseModel):
     name: Optional[StrictStr] = None
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
@@ -29,10 +29,11 @@ class Dog(Animal):
     breed: Optional[StrictStr] = None
     __properties = ["className", "color", "breed"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -29,10 +29,11 @@ class DummyModel(BaseModel):
     self_ref: Optional[SelfReferenceModel] = None
     __properties = ["category", "self_ref"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
@@ -50,10 +50,11 @@ class EnumArrays(BaseModel):
                 raise ValueError("each list item must be one of ('fish', 'crab')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -87,10 +87,11 @@ class EnumTest(BaseModel):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -28,10 +28,11 @@ class File(BaseModel):
     source_uri: Optional[StrictStr] = Field(None, alias="sourceURI", description="Test capitalization")
     __properties = ["sourceURI"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -30,10 +30,11 @@ class FileSchemaTestClass(BaseModel):
     files: Optional[conlist(File)] = None
     __properties = ["file", "files"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -29,10 +29,11 @@ class FirstRef(BaseModel):
     self_ref: Optional[SecondRef] = None
     __properties = ["category", "self_ref"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
@@ -28,10 +28,11 @@ class Foo(BaseModel):
     bar: Optional[StrictStr] = 'bar'
     __properties = ["bar"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -29,10 +29,11 @@ class FooGetDefaultResponse(BaseModel):
     string: Optional[Foo] = None
     __properties = ["string"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -84,10 +84,11 @@ class FormatTest(BaseModel):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
@@ -29,10 +29,11 @@ class HasOnlyReadOnly(BaseModel):
     foo: Optional[StrictStr] = None
     __properties = ["bar", "foo"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -28,10 +28,11 @@ class HealthCheckResult(BaseModel):
     nullable_message: Optional[StrictStr] = Field(None, alias="NullableMessage")
     __properties = ["NullableMessage"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -28,10 +28,11 @@ class InnerDictWithProperty(BaseModel):
     a_property: Optional[Dict[str, Any]] = Field(None, alias="aProperty")
     __properties = ["aProperty"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
@@ -23,8 +23,6 @@ from pydantic import BaseModel, Field, StrictStr, ValidationError, conint, valid
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-INTORSTRING_ONE_OF_SCHEMAS = ["int", "str"]
-
 class IntOrString(BaseModel):
     """
     IntOrString
@@ -37,10 +35,11 @@ class IntOrString(BaseModel):
         actual_instance: Union[int, str]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(INTORSTRING_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["int", "str"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list.py
@@ -28,10 +28,11 @@ class List(BaseModel):
     var_123_list: Optional[StrictStr] = Field(None, alias="123-list")
     __properties = ["123-list"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -29,10 +29,11 @@ class MapOfArrayOfModel(BaseModel):
     shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(None, alias="shopIdToOrgOnlineLipMap")
     __properties = ["shopIdToOrgOnlineLipMap"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -41,10 +41,11 @@ class MapTest(BaseModel):
             raise ValueError("must be one of enum values ('UPPER', 'lower')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -31,10 +31,11 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     map: Optional[Dict[str, Animal]] = None
     __properties = ["uuid", "dateTime", "map"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -29,10 +29,11 @@ class Model200Response(BaseModel):
     var_class: Optional[StrictStr] = Field(None, alias="class")
     __properties = ["name", "class"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -28,10 +28,11 @@ class ModelReturn(BaseModel):
     var_return: Optional[StrictInt] = Field(None, alias="return")
     __properties = ["return"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -31,10 +31,11 @@ class Name(BaseModel):
     var_123_number: Optional[StrictInt] = Field(None, alias="123Number")
     __properties = ["name", "snake_case", "property", "123Number"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -41,10 +41,11 @@ class NullableClass(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -39,10 +39,11 @@ class NullableProperty(BaseModel):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
@@ -28,10 +28,11 @@ class NumberOnly(BaseModel):
     just_number: Optional[float] = Field(None, alias="JustNumber")
     __properties = ["JustNumber"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -28,10 +28,11 @@ class ObjectToTestAdditionalProperties(BaseModel):
     var_property: Optional[StrictBool] = Field(False, alias="property", description="Property")
     __properties = ["property"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -32,10 +32,11 @@ class ObjectWithDeprecatedFields(BaseModel):
     bars: Optional[conlist(StrictStr)] = None
     __properties = ["uuid", "id", "deprecatedRef", "bars"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
@@ -25,8 +25,6 @@ from petstore_api.models.enum_string2 import EnumString2
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-ONEOFENUMSTRING_ONE_OF_SCHEMAS = ["EnumString1", "EnumString2"]
-
 class OneOfEnumString(BaseModel):
     """
     oneOf enum strings
@@ -39,10 +37,11 @@ class OneOfEnumString(BaseModel):
         actual_instance: Union[EnumString1, EnumString2]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(ONEOFENUMSTRING_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["EnumString1", "EnumString2"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
@@ -43,10 +43,11 @@ class Order(BaseModel):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
@@ -30,10 +30,11 @@ class OuterComposite(BaseModel):
     my_boolean: Optional[StrictBool] = None
     __properties = ["my_number", "my_string", "my_boolean"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -31,10 +31,11 @@ class OuterObjectWithEnumProperty(BaseModel):
     value: OuterEnumInteger = Field(...)
     __properties = ["str_value", "value"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -29,10 +29,11 @@ class Parent(BaseModel):
     optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(None, alias="optionalDict")
     __properties = ["optionalDict"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -29,10 +29,11 @@ class ParentWithOptionalDict(BaseModel):
     optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(None, alias="optionalDict")
     __properties = ["optionalDict"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -45,10 +45,11 @@ class Pet(BaseModel):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
@@ -25,8 +25,6 @@ from petstore_api.models.danish_pig import DanishPig
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-PIG_ONE_OF_SCHEMAS = ["BasquePig", "DanishPig"]
-
 class Pig(BaseModel):
     """
     Pig
@@ -39,10 +37,11 @@ class Pig(BaseModel):
         actual_instance: Union[BasquePig, DanishPig]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(PIG_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["BasquePig", "DanishPig"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     discriminator_value_class_map = {
     }

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
@@ -30,10 +30,11 @@ class PropertyNameCollision(BaseModel):
     type_: Optional[StrictStr] = None
     __properties = ["_type", "type", "type_"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
@@ -29,10 +29,11 @@ class ReadOnlyFirst(BaseModel):
     baz: Optional[StrictStr] = None
     __properties = ["bar", "baz"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -29,10 +29,11 @@ class SecondRef(BaseModel):
     circular_ref: Optional[CircularReferenceModel] = None
     __properties = ["category", "circular_ref"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -29,10 +29,11 @@ class SelfReferenceModel(BaseModel):
     nested: Optional[DummyModel] = None
     __properties = ["size", "nested"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
@@ -28,10 +28,11 @@ class SpecialModelName(BaseModel):
     special_property_name: Optional[StrictInt] = Field(None, alias="$special[property.name]")
     __properties = ["$special[property.name]"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
@@ -41,10 +41,11 @@ class SpecialName(BaseModel):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
@@ -29,10 +29,11 @@ class Tag(BaseModel):
     name: Optional[StrictStr] = None
     __properties = ["id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
@@ -28,10 +28,11 @@ class Tiger(BaseModel):
     skill: Optional[StrictStr] = None
     __properties = ["skill"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
@@ -35,10 +35,11 @@ class User(BaseModel):
     user_status: Optional[StrictInt] = Field(None, alias="userStatus", description="User Status")
     __properties = ["id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -32,10 +32,11 @@ class WithNestedOneOf(BaseModel):
     nested_oneof_enum_string: Optional[OneOfEnumString] = None
     __properties = ["size", "nested_pig", "nested_oneof_enum_string"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -17,7 +17,7 @@ python-dateutil = ">=2.8.2"
 aiohttp = ">= 3.8.4"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
-pydantic = "^1.10.5, <2"
+pydantic = ">=2"
 aenum = ">=3.1.11"
 
 [tool.poetry.dev-dependencies]

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
-pydantic >= 1.10.5, < 2
+pydantic >= 2
 aenum >= 3.1.11
 aiohttp >= 3.0.0

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "aiohttp >= 3.0.0",
     "pem>=19.3.0",
     "pycryptodome>=3.9.0",
-    "pydantic >= 1.10.5, < 2",
+    "pydantic >= 2",
     "aenum"
 ]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field
@@ -43,7 +43,7 @@ class AnotherFakeApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test special tags  # noqa: E501
 
@@ -72,7 +72,7 @@ class AnotherFakeApi(object):
             raise ValueError("Error! Please call the call_123_test_special_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test special tags  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from petstore_api.models.foo_get_default_response import FooGetDefaultResponse
@@ -41,7 +41,7 @@ class DefaultApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def foo_get(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
         """foo_get  # noqa: E501
 
@@ -67,7 +67,7 @@ class DefaultApi(object):
             raise ValueError("Error! Please call the foo_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.foo_get_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def foo_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """foo_get  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from datetime import date, datetime
@@ -55,7 +55,7 @@ class FakeApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> None:  # noqa: E501
         """test any type request body  # noqa: E501
 
@@ -83,7 +83,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_any_type_request_body_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test any type request body  # noqa: E501
 
@@ -193,7 +193,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> None:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
@@ -221,7 +221,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_enum_ref_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
@@ -324,7 +324,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_health_get(self, **kwargs) -> HealthCheckResult:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
@@ -350,7 +350,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_health_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_health_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
@@ -453,7 +453,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
@@ -485,7 +485,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_http_signature_test_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
@@ -607,7 +607,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
@@ -636,7 +636,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_outer_boolean_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
@@ -753,7 +753,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
@@ -782,7 +782,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_outer_composite_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
@@ -899,7 +899,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_outer_number_serialize(self, body : Annotated[Optional[StrictFloat], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
@@ -928,7 +928,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_outer_number_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[StrictFloat], Field(description="Input number as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
@@ -1045,7 +1045,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
@@ -1074,7 +1074,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_outer_string_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
@@ -1191,7 +1191,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
@@ -1220,7 +1220,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_property_enum_integer_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> ApiResponse:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
@@ -1337,7 +1337,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_return_list_of_objects(self, **kwargs) -> List[List[Tag]]:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
@@ -1363,7 +1363,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_return_list_of_objects_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_return_list_of_objects_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
@@ -1466,7 +1466,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> None:  # noqa: E501
         """test uuid example  # noqa: E501
 
@@ -1494,7 +1494,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the fake_uuid_example_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> ApiResponse:  # noqa: E501
         """test uuid example  # noqa: E501
 
@@ -1597,7 +1597,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> None:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
@@ -1626,7 +1626,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_body_with_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
@@ -1742,7 +1742,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
@@ -1771,7 +1771,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_body_with_file_schema_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
@@ -1882,7 +1882,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_body_with_query_params(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
@@ -1912,7 +1912,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_body_with_query_params_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
@@ -2028,7 +2028,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
@@ -2057,7 +2057,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_client_model_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_client_model_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
@@ -2174,7 +2174,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
@@ -2204,7 +2204,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_date_time_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
@@ -2316,7 +2316,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1, strict=True), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8, strict=True), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6, strict=True)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
@@ -2373,7 +2373,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_endpoint_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_endpoint_parameters_with_http_info(self, number : Annotated[confloat(le=543.2, ge=32.1, strict=True), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8, strict=True), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6, strict=True)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
@@ -2568,7 +2568,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
@@ -2607,7 +2607,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_group_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
@@ -2741,7 +2741,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> None:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
@@ -2770,7 +2770,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_inline_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
@@ -2881,7 +2881,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> None:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
@@ -2912,7 +2912,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_json_form_data_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> ApiResponse:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
@@ -3029,7 +3029,7 @@ class FakeApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
@@ -3070,7 +3070,7 @@ class FakeApi(object):
             raise ValueError("Error! Please call the test_query_parameter_collection_format_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_query_parameter_collection_format_with_http_info(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field
@@ -43,7 +43,7 @@ class FakeClassnameTags123Api(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def test_classname(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
@@ -72,7 +72,7 @@ class FakeClassnameTags123Api(object):
             raise ValueError("Error! Please call the test_classname_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def test_classname_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBytes, StrictInt, StrictStr, conlist, validator
@@ -46,7 +46,7 @@ class PetApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
@@ -75,7 +75,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the add_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def add_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
@@ -186,7 +186,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
@@ -217,7 +217,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the delete_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
@@ -327,7 +327,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
@@ -356,7 +356,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the find_pets_by_status_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_status_with_http_info(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> ApiResponse:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
@@ -468,7 +468,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
@@ -497,7 +497,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the find_pets_by_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def find_pets_by_tags_with_http_info(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> ApiResponse:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
@@ -611,7 +611,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
@@ -640,7 +640,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the get_pet_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> ApiResponse:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
@@ -752,7 +752,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
@@ -781,7 +781,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the update_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def update_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
@@ -892,7 +892,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
@@ -925,7 +925,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the update_pet_with_form_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
@@ -1048,7 +1048,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image  # noqa: E501
 
@@ -1081,7 +1081,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the upload_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def upload_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image  # noqa: E501
 
@@ -1210,7 +1210,7 @@ class PetApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 
@@ -1243,7 +1243,7 @@ class PetApi(object):
             raise ValueError("Error! Please call the upload_file_with_required_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def upload_file_with_required_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr, conint
@@ -45,7 +45,7 @@ class StoreApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
@@ -74,7 +74,7 @@ class StoreApi(object):
             raise ValueError("Error! Please call the delete_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
@@ -178,7 +178,7 @@ class StoreApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def get_inventory(self, **kwargs) -> Dict[str, int]:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
@@ -205,7 +205,7 @@ class StoreApi(object):
             raise ValueError("Error! Please call the get_inventory_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.get_inventory_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_inventory_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
@@ -309,7 +309,7 @@ class StoreApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
@@ -338,7 +338,7 @@ class StoreApi(object):
             raise ValueError("Error! Please call the get_order_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_order_by_id_with_http_info(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> ApiResponse:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
@@ -450,7 +450,7 @@ class StoreApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
@@ -479,7 +479,7 @@ class StoreApi(object):
             raise ValueError("Error! Please call the place_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.place_order_with_http_info(order, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def place_order_with_http_info(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> ApiResponse:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -16,7 +16,7 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+from pydantic import validate_call, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr, conlist
@@ -43,7 +43,7 @@ class UserApi(object):
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @validate_arguments
+    @validate_call
     def create_user(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> None:  # noqa: E501
         """Create user  # noqa: E501
 
@@ -72,7 +72,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the create_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.create_user_with_http_info(user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def create_user_with_http_info(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Create user  # noqa: E501
 
@@ -198,7 +198,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -227,7 +227,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the create_users_with_array_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def create_users_with_array_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -338,7 +338,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -367,7 +367,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the create_users_with_list_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def create_users_with_list_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
@@ -478,7 +478,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete user  # noqa: E501
 
@@ -507,7 +507,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the delete_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete user  # noqa: E501
 
@@ -611,7 +611,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
         """Get user by user name  # noqa: E501
 
@@ -640,7 +640,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the get_user_by_name_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> ApiResponse:  # noqa: E501
         """Get user by user name  # noqa: E501
 
@@ -752,7 +752,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
@@ -783,7 +783,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the login_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def login_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> ApiResponse:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
@@ -900,7 +900,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def logout_user(self, **kwargs) -> None:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
@@ -927,7 +927,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the logout_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.logout_user_with_http_info(**kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def logout_user_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
@@ -1025,7 +1025,7 @@ class UserApi(object):
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @validate_arguments
+    @validate_call
     def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> None:  # noqa: E501
         """Updated user  # noqa: E501
 
@@ -1056,7 +1056,7 @@ class UserApi(object):
             raise ValueError("Error! Please call the update_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
         return self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
 
-    @validate_arguments
+    @validate_call
     def update_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Updated user  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesAnyType(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -30,10 +30,11 @@ class AdditionalPropertiesClass(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["map_property", "map_of_map_property"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesObject(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
@@ -29,10 +29,11 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
@@ -31,10 +31,11 @@ class AllOfWithSingleRef(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["username", "SingleRefType"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -30,10 +30,11 @@ class Animal(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'className'

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
@@ -42,8 +42,9 @@ class AnyOfColor(BaseModel):
         actual_instance: Any
     any_of_schemas: List[str] = Field(ANYOFCOLOR_ANY_OF_SCHEMAS, const=True)
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
@@ -42,8 +42,9 @@ class AnyOfPig(BaseModel):
         actual_instance: Any
     any_of_schemas: List[str] = Field(ANYOFPIG_ANY_OF_SCHEMAS, const=True)
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/api_response.py
@@ -31,10 +31,11 @@ class ApiResponse(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["code", "type", "message"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -30,10 +30,11 @@ class ArrayOfArrayOfModel(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["another_property"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
@@ -29,10 +29,11 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["ArrayArrayNumber"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
@@ -29,10 +29,11 @@ class ArrayOfNumberOnly(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["ArrayNumber"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -32,10 +32,11 @@ class ArrayTest(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["array_of_string", "array_array_of_integer", "array_array_of_model"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
@@ -30,10 +30,11 @@ class BasquePig(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
@@ -34,10 +34,11 @@ class Capitalization(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
@@ -30,10 +30,11 @@ class Cat(Animal):
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color", "declawed"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/category.py
@@ -30,10 +30,11 @@ class Category(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
@@ -30,10 +30,11 @@ class CircularReferenceModel(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["size", "nested"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
@@ -29,10 +29,11 @@ class ClassModel(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["_class"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/client.py
@@ -29,10 +29,11 @@ class Client(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["client"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/color.py
@@ -23,8 +23,6 @@ from pydantic import BaseModel, Field, StrictStr, ValidationError, conint, conli
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-COLOR_ONE_OF_SCHEMAS = ["List[int]", "str"]
-
 class Color(BaseModel):
     """
     RGB array, RGBA array, or hex string.
@@ -39,10 +37,11 @@ class Color(BaseModel):
         actual_instance: Union[List[int], str]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(COLOR_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["List[int]", "str"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
@@ -31,10 +31,11 @@ class Creature(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["info", "type"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
@@ -29,10 +29,11 @@ class CreatureInfo(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
@@ -30,10 +30,11 @@ class DanishPig(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "size"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
@@ -29,10 +29,11 @@ class DeprecatedObject(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
@@ -30,10 +30,11 @@ class Dog(Animal):
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color", "breed"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
@@ -30,10 +30,11 @@ class DummyModel(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["category", "self_ref"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -51,10 +51,11 @@ class EnumArrays(BaseModel):
                 raise ValueError("each list item must be one of ('fish', 'crab')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -88,10 +88,11 @@ class EnumTest(BaseModel):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file.py
@@ -29,10 +29,11 @@ class File(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["sourceURI"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
@@ -31,10 +31,11 @@ class FileSchemaTestClass(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["file", "files"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
@@ -30,10 +30,11 @@ class FirstRef(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["category", "self_ref"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
@@ -29,10 +29,11 @@ class Foo(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["bar"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
@@ -30,10 +30,11 @@ class FooGetDefaultResponse(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["string"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -85,10 +85,11 @@ class FormatTest(BaseModel):
             raise ValueError(r"must validate the regular expression /^image_\d{1,3}$/i")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
@@ -30,10 +30,11 @@ class HasOnlyReadOnly(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["bar", "foo"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
@@ -29,10 +29,11 @@ class HealthCheckResult(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["NullableMessage"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
@@ -29,10 +29,11 @@ class InnerDictWithProperty(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["aProperty"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
@@ -23,8 +23,6 @@ from pydantic import BaseModel, Field, StrictStr, ValidationError, conint, valid
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-INTORSTRING_ONE_OF_SCHEMAS = ["int", "str"]
-
 class IntOrString(BaseModel):
     """
     IntOrString
@@ -37,10 +35,11 @@ class IntOrString(BaseModel):
         actual_instance: Union[int, str]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(INTORSTRING_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["int", "str"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/list.py
@@ -29,10 +29,11 @@ class List(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["123-list"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -30,10 +30,11 @@ class MapOfArrayOfModel(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["shopIdToOrgOnlineLipMap"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
@@ -42,10 +42,11 @@ class MapTest(BaseModel):
             raise ValueError("must be one of enum values ('UPPER', 'lower')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -32,10 +32,11 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["uuid", "dateTime", "map"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
@@ -30,10 +30,11 @@ class Model200Response(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name", "class"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
@@ -29,10 +29,11 @@ class ModelReturn(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["return"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/name.py
@@ -32,10 +32,11 @@ class Name(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["name", "snake_case", "property", "123Number"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -41,10 +41,11 @@ class NullableClass(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -40,10 +40,11 @@ class NullableProperty(BaseModel):
             raise ValueError(r"must validate the regular expression /^[A-Z].*/")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
@@ -29,10 +29,11 @@ class NumberOnly(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["JustNumber"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
@@ -29,10 +29,11 @@ class ObjectToTestAdditionalProperties(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["property"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
@@ -33,10 +33,11 @@ class ObjectWithDeprecatedFields(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["uuid", "id", "deprecatedRef", "bars"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
@@ -25,8 +25,6 @@ from petstore_api.models.enum_string2 import EnumString2
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-ONEOFENUMSTRING_ONE_OF_SCHEMAS = ["EnumString1", "EnumString2"]
-
 class OneOfEnumString(BaseModel):
     """
     oneOf enum strings
@@ -39,10 +37,11 @@ class OneOfEnumString(BaseModel):
         actual_instance: Union[EnumString1, EnumString2]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(ONEOFENUMSTRING_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["EnumString1", "EnumString2"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/order.py
@@ -44,10 +44,11 @@ class Order(BaseModel):
             raise ValueError("must be one of enum values ('placed', 'approved', 'delivered')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
@@ -31,10 +31,11 @@ class OuterComposite(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["my_number", "my_string", "my_boolean"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
@@ -32,10 +32,11 @@ class OuterObjectWithEnumProperty(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["str_value", "value"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -30,10 +30,11 @@ class Parent(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["optionalDict"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -30,10 +30,11 @@ class ParentWithOptionalDict(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["optionalDict"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
@@ -46,10 +46,11 @@ class Pet(BaseModel):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
@@ -25,8 +25,6 @@ from petstore_api.models.danish_pig import DanishPig
 from typing import Union, Any, List, TYPE_CHECKING
 from pydantic import StrictStr, Field
 
-PIG_ONE_OF_SCHEMAS = ["BasquePig", "DanishPig"]
-
 class Pig(BaseModel):
     """
     Pig
@@ -39,10 +37,11 @@ class Pig(BaseModel):
         actual_instance: Union[BasquePig, DanishPig]
     else:
         actual_instance: Any
-    one_of_schemas: List[str] = Field(PIG_ONE_OF_SCHEMAS, const=True)
+    one_of_schemas: List[str] = Literal["BasquePig", "DanishPig"]
 
-    class Config:
-        validate_assignment = True
+    model_config = {
+        "validate_assignment": True,
+    }
 
     discriminator_value_class_map = {
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
@@ -31,10 +31,11 @@ class PropertyNameCollision(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["_type", "type", "type_"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
@@ -30,10 +30,11 @@ class ReadOnlyFirst(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["bar", "baz"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
@@ -30,10 +30,11 @@ class SecondRef(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["category", "circular_ref"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
@@ -30,10 +30,11 @@ class SelfReferenceModel(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["size", "nested"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
@@ -29,10 +29,11 @@ class SpecialModelName(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["$special[property.name]"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
@@ -42,10 +42,11 @@ class SpecialName(BaseModel):
             raise ValueError("must be one of enum values ('available', 'pending', 'sold')")
         return value
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
@@ -30,10 +30,11 @@ class Tag(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "name"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
@@ -29,10 +29,11 @@ class Tiger(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["skill"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/user.py
@@ -36,10 +36,11 @@ class User(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
@@ -33,10 +33,11 @@ class WithNestedOneOf(BaseModel):
     additional_properties: Dict[str, Any] = {}
     __properties = ["size", "nested_pig", "nested_oneof_enum_string"]
 
-    class Config:
-        """Pydantic configuration"""
-        allow_population_by_field_name = True
-        validate_assignment = True
+    """Pydantic configuration"""
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True,
+    }
 
     def to_str(self) -> str:
         """Returns the string representation of the model using alias"""

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -16,7 +16,7 @@ urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
-pydantic = "^1.10.5, <2"
+pydantic = ">=2"
 aenum = ">=3.1.11"
 
 [tool.poetry.dev-dependencies]

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
-pydantic >= 1.10.5, < 2
+pydantic >= 2
 aenum >= 3.1.11

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     "python-dateutil",
     "pem>=19.3.0",
     "pycryptodome>=3.9.0",
-    "pydantic >= 1.10.5, < 2",
+    "pydantic >= 2",
     "aenum"
 ]
 

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -7,7 +7,7 @@ chardet==4.0.0
 click==7.1.2
 dnspython==2.1.0
 email-validator==1.1.2
-fastapi==0.95.2
+fastapi==0.103.0
 graphene==2.1.8
 graphql-core==2.3.2
 graphql-relay==2.0.1
@@ -20,7 +20,7 @@ Jinja2==2.11.3
 MarkupSafe==2.0.1
 orjson==3.5.2
 promise==2.3
-pydantic==1.8.2
+pydantic==2.3.0
 python-dotenv==0.17.1
 python-multipart==0.0.5
 PyYAML==5.4.1


### PR DESCRIPTION
In order to generate python clients with support for pydantic v2, some small adjustments are needed to the model templates.
This PR implements the changes, alongside a version update for pydantic in the various requirements lists

fixes https://github.com/OpenAPITools/openapi-generator/issues/16468

@spacether (2019/11) [❤️](https://github.com/sponsors/spacether/) @krjakbrjak (2023/02)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

