### PR TITLE
[Ruby] Fix incorrect escaping of Ruby forward slashes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -205,6 +205,20 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
     }
 
     @Override
+    public String addRegularExpressionDelimiter(String pattern) {
+        if (StringUtils.isEmpty(pattern)) {
+            return pattern;
+        }
+
+        if (!pattern.matches("^/.*")) {
+            // Perform a negative lookbehind on each `/` to ensure that it is escaped.
+            return "/" + pattern.replaceAll("(?<!\\\\)\\/", "\\\\/") + "/";
+        }
+
+        return pattern;
+    }
+
+    @Override
     public String toParamName(String name) {
         // obtain the name from parameterNameMapping directly if provided
         if (parameterNameMapping.containsKey(name)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -712,4 +712,33 @@ public class RubyClientCodegenTest {
         Assert.assertFalse(cp2.required);
         Assert.assertEquals(cp2.dataType, "VerySpecialStringInRuby");
     }
+
+    @Test(description = "test regex patterns")
+    public void testRegularExpressionOpenAPISchemaVersion3() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_1517.yaml");
+        final RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        final String path = "/ping";
+        final Operation p = openAPI.getPaths().get(path).getGet();
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        // pattern_no_forward_slashes '^pattern$'
+        Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
+        // pattern_two_slashes '/^pattern$/'
+        Assert.assertEquals(op.allParams.get(1).pattern, "/^pattern$/");
+        // pattern_dont_escape_backslash '/^pattern\d{3}$/'
+        Assert.assertEquals(op.allParams.get(2).pattern, "/^pattern\\d{3}$/");
+        // pattern_dont_escape_escaped_forward_slash '/^pattern\/\d{3}$/'
+        Assert.assertEquals(op.allParams.get(3).pattern, "/^pattern\\/\\d{3}$/");
+        // pattern_escape_unescaped_forward_slash '^pattern/\d{3}$'
+        Assert.assertEquals(op.allParams.get(4).pattern, "/^pattern\\/\\d{3}$/");
+        // pattern_with_modifiers '/^pattern\d{3}$/i
+        Assert.assertEquals(op.allParams.get(5).pattern, "/^pattern\\d{3}$/i");
+        // not testing pattern_with_backslash_after_bracket '/^[\pattern\d{3}$/i'
+        // as "/^[\\pattern\\d{3}$/i" is invalid regex because [ is not escaped and there is no closing ]
+        // Assert.assertEquals(op.allParams.get(6).pattern, "/^[\\pattern\\d{3}$/i");
+        // alternation_with_forward_slash '/ax$|/bx$'
+        Assert.assertEquals(op.allParams.get(7).pattern, "/ax$|/bx$");
+        // patten_starts_ends_with_slash '/root/'
+        Assert.assertEquals(op.allParams.get(8).pattern, "/root/");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_1517.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_1517.yaml
@@ -50,6 +50,17 @@ paths:
           schema:
             type: string
             pattern: '/^[\pattern\d{3}$/i'
+        - name: alternation_with_forward_slash
+          in: header
+          schema:
+            type: string
+            pattern: '/ax$|/bx$'
+        - name: patten_starts_ends_with_slash
+          in: header
+          schema:
+            type: string
+            pattern: '/root/'
+            description: 'Should match only /root/ but not root'
 
       responses:
         '200':


### PR DESCRIPTION
Ruby regexs are always generated as match patterns enclosed in slash characters (i.e. using the `/pattern/` syntax). Regular expressions defined in the OpenAPI declaration via the `pattern` attribute follow [ECMA 262](https://262.ecma-international.org/5.1/#sec-15.10.1) which means they already include the correct escaping of forward slashes as far as Ruby is concerned.

The current Ruby codegen is incorrectly escaping all forward slashes, which ultimately causes the generated code to include additional incorrect escape sequences which cause the generated file to have an invalid syntax.

This commit ports the same fix introduced in https://github.com/OpenAPITools/openapi-generator/pull/1539 for the Python codegen, as both Ruby and Python use perl-flavored regular expressions so they behave in the same way when it comes to escaping forward slashes.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/5582.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

----

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
