### PR TITLE
[java][native] Add tests for oneOf form parameters

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -83,6 +83,40 @@ paths:
             text/plain:
               schema:
                 type: string
+  # form parameter tests for oneOf schema
+  /form/oneof:
+    post:
+      tags:
+        - form
+      summary: Test form parameter(s) for oneOf schema
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              oneOf:
+                - type: object
+                  properties:
+                    form1:
+                      type: string
+                    form2:
+                      type: integer
+                - type: object
+                  properties:
+                    form3:
+                      type: string
+                    form4:
+                      type: boolean
+                - $ref: '#/components/schemas/Tag'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
   # header parameter tests
   /header/integer/boolean/string:
     get:

--- a/samples/client/echo_api/csharp-restsharp/README.md
+++ b/samples/client/echo_api/csharp-restsharp/README.md
@@ -120,6 +120,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**TestEchoBodyPetResponseString**](docs/BodyApi.md#testechobodypetresponsestring) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**TestEchoBodyTagResponseString**](docs/BodyApi.md#testechobodytagresponsestring) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**TestFormIntegerBooleanString**](docs/FormApi.md#testformintegerbooleanstring) | **POST** /form/integer/boolean/string | Test form parameter(s)
+*FormApi* | [**TestFormOneof**](docs/FormApi.md#testformoneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *HeaderApi* | [**TestHeaderIntegerBooleanString**](docs/HeaderApi.md#testheaderintegerbooleanstring) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**TestsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testspathstringpathstringintegerpathinteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
 *QueryApi* | [**TestEnumRefString**](docs/QueryApi.md#testenumrefstring) | **GET** /query/enum_ref_string | Test query parameter(s)

--- a/samples/client/echo_api/csharp-restsharp/api/openapi.yaml
+++ b/samples/client/echo_api/csharp-restsharp/api/openapi.yaml
@@ -59,6 +59,25 @@ paths:
       summary: Test form parameter(s)
       tags:
       - form
+  /form/oneof:
+    post:
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/test_form_oneof_request'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test form parameter(s) for oneOf schema
+      tags:
+      - form
   /header/integer/boolean/string:
     get:
       description: Test header parameter(s)
@@ -641,6 +660,26 @@ components:
           type: boolean
         string_form:
           type: string
+      type: object
+    test_form_oneof_request_oneOf:
+      properties:
+        form1:
+          type: string
+        form2:
+          type: integer
+      type: object
+    test_form_oneof_request_oneOf_1:
+      properties:
+        form3:
+          type: string
+        form4:
+          type: boolean
+      type: object
+    test_form_oneof_request:
+      oneOf:
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf'
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf_1'
+      - $ref: '#/components/schemas/Tag'
       type: object
     test_query_style_form_explode_true_array_string_query_object_parameter:
       properties:

--- a/samples/client/echo_api/csharp-restsharp/docs/FormApi.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/FormApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 | Method | HTTP request | Description |
 |--------|--------------|-------------|
 | [**TestFormIntegerBooleanString**](FormApi.md#testformintegerbooleanstring) | **POST** /form/integer/boolean/string | Test form parameter(s) |
+| [**TestFormOneof**](FormApi.md#testformoneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema |
 
 <a id="testformintegerbooleanstring"></a>
 # **TestFormIntegerBooleanString**
@@ -79,6 +80,107 @@ catch (ApiException e)
 | **integerForm** | **int?** |  | [optional]  |
 | **booleanForm** | **bool?** |  | [optional]  |
 | **stringForm** | **string?** |  | [optional]  |
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="testformoneof"></a>
+# **TestFormOneof**
+> string TestFormOneof (string? form1 = null, int? form2 = null, string? form3 = null, bool? form4 = null, long? id = null, string? name = null)
+
+Test form parameter(s) for oneOf schema
+
+Test form parameter(s) for oneOf schema
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class TestFormOneofExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://localhost:3000";
+            var apiInstance = new FormApi(config);
+            var form1 = "form1_example";  // string? |  (optional) 
+            var form2 = 56;  // int? |  (optional) 
+            var form3 = "form3_example";  // string? |  (optional) 
+            var form4 = true;  // bool? |  (optional) 
+            var id = 789L;  // long? |  (optional) 
+            var name = "name_example";  // string? |  (optional) 
+
+            try
+            {
+                // Test form parameter(s) for oneOf schema
+                string result = apiInstance.TestFormOneof(form1, form2, form3, form4, id, name);
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling FormApi.TestFormOneof: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the TestFormOneofWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    // Test form parameter(s) for oneOf schema
+    ApiResponse<string> response = apiInstance.TestFormOneofWithHttpInfo(form1, form2, form3, form4, id, name);
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling FormApi.TestFormOneofWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+|------|------|-------------|-------|
+| **form1** | **string?** |  | [optional]  |
+| **form2** | **int?** |  | [optional]  |
+| **form3** | **string?** |  | [optional]  |
+| **form4** | **bool?** |  | [optional]  |
+| **id** | **long?** |  | [optional]  |
+| **name** | **string?** |  | [optional]  |
 
 ### Return type
 

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/FormApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/FormApi.cs
@@ -53,6 +53,39 @@ namespace Org.OpenAPITools.Api
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
         ApiResponse<string> TestFormIntegerBooleanStringWithHttpInfo(int? integerForm = default(int?), bool? booleanForm = default(bool?), string? stringForm = default(string?), int operationIndex = 0);
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <remarks>
+        /// Test form parameter(s) for oneOf schema
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        string TestFormOneof(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0);
+
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <remarks>
+        /// Test form parameter(s) for oneOf schema
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> TestFormOneofWithHttpInfo(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -91,6 +124,41 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
         System.Threading.Tasks.Task<ApiResponse<string>> TestFormIntegerBooleanStringWithHttpInfoAsync(int? integerForm = default(int?), bool? booleanForm = default(bool?), string? stringForm = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <remarks>
+        /// Test form parameter(s) for oneOf schema
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> TestFormOneofAsync(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <remarks>
+        /// Test form parameter(s) for oneOf schema
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> TestFormOneofWithHttpInfoAsync(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -366,6 +434,206 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestFormIntegerBooleanString", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        public string TestFormOneof(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestFormOneofWithHttpInfo(form1, form2, form3, form4, id, name);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> TestFormOneofWithHttpInfo(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+                "application/x-www-form-urlencoded"
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "text/plain"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+            if (form1 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form1", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form1)); // form parameter
+            }
+            if (form2 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form2", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form2)); // form parameter
+            }
+            if (form3 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form3", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form3)); // form parameter
+            }
+            if (form4 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form4", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form4)); // form parameter
+            }
+            if (id != null)
+            {
+                localVarRequestOptions.FormParameters.Add("id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(id)); // form parameter
+            }
+            if (name != null)
+            {
+                localVarRequestOptions.FormParameters.Add("name", Org.OpenAPITools.Client.ClientUtils.ParameterToString(name)); // form parameter
+            }
+
+            localVarRequestOptions.Operation = "FormApi.TestFormOneof";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Post<string>("/form/oneof", localVarRequestOptions, this.Configuration);
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("TestFormOneof", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> TestFormOneofAsync(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestFormOneofWithHttpInfoAsync(form1, form2, form3, form4, id, name, operationIndex, cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        /// Test form parameter(s) for oneOf schema Test form parameter(s) for oneOf schema
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="form1"> (optional)</param>
+        /// <param name="form2"> (optional)</param>
+        /// <param name="form3"> (optional)</param>
+        /// <param name="form4"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestFormOneofWithHttpInfoAsync(string? form1 = default(string?), int? form2 = default(int?), string? form3 = default(string?), bool? form4 = default(bool?), long? id = default(long?), string? name = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+                "application/x-www-form-urlencoded"
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "text/plain"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+            if (form1 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form1", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form1)); // form parameter
+            }
+            if (form2 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form2", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form2)); // form parameter
+            }
+            if (form3 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form3", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form3)); // form parameter
+            }
+            if (form4 != null)
+            {
+                localVarRequestOptions.FormParameters.Add("form4", Org.OpenAPITools.Client.ClientUtils.ParameterToString(form4)); // form parameter
+            }
+            if (id != null)
+            {
+                localVarRequestOptions.FormParameters.Add("id", Org.OpenAPITools.Client.ClientUtils.ParameterToString(id)); // form parameter
+            }
+            if (name != null)
+            {
+                localVarRequestOptions.FormParameters.Add("name", Org.OpenAPITools.Client.ClientUtils.ParameterToString(name)); // form parameter
+            }
+
+            localVarRequestOptions.Operation = "FormApi.TestFormOneof";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = await this.AsynchronousClient.PostAsync<string>("/form/oneof", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("TestFormOneof", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -113,6 +113,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
+*FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
 *QueryApi* | [**testEnumRefString**](docs/QueryApi.md#testEnumRefString) | **GET** /query/enum_ref_string | Test query parameter(s)

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -62,6 +62,27 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
+  /form/oneof:
+    post:
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/test_form_oneof_request'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test form parameter(s) for oneOf schema
+      tags:
+      - form
+      x-content-type: application/x-www-form-urlencoded
+      x-accepts: text/plain
   /header/integer/boolean/string:
     get:
       description: Test header parameter(s)
@@ -666,6 +687,26 @@ components:
           type: boolean
         string_form:
           type: string
+      type: object
+    test_form_oneof_request_oneOf:
+      properties:
+        form1:
+          type: string
+        form2:
+          type: integer
+      type: object
+    test_form_oneof_request_oneOf_1:
+      properties:
+        form3:
+          type: string
+        form4:
+          type: boolean
+      type: object
+    test_form_oneof_request:
+      oneOf:
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf'
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf_1'
+      - $ref: '#/components/schemas/Tag'
       type: object
     test_query_style_form_explode_true_array_string_query_object_parameter:
       properties:

--- a/samples/client/echo_api/java/apache-httpclient/docs/FormApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/FormApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
 | [**testFormIntegerBooleanString**](FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s) |
+| [**testFormOneof**](FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema |
 
 
 
@@ -57,6 +58,82 @@ public class Example {
 | **integerForm** | **Integer**|  | [optional] |
 | **booleanForm** | **Boolean**|  | [optional] |
 | **stringForm** | **String**|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testFormOneof
+
+> String testFormOneof(form1, form2, form3, form4, id, name)
+
+Test form parameter(s) for oneOf schema
+
+Test form parameter(s) for oneOf schema
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FormApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        FormApi apiInstance = new FormApi(defaultClient);
+        String form1 = "form1_example"; // String | 
+        Integer form2 = 56; // Integer | 
+        String form3 = "form3_example"; // String | 
+        Boolean form4 = true; // Boolean | 
+        Long id = 56L; // Long | 
+        String name = "name_example"; // String | 
+        try {
+            String result = apiInstance.testFormOneof(form1, form2, form3, form4, id, name);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FormApi#testFormOneof");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **form1** | **String**|  | [optional] |
+| **form2** | **Integer**|  | [optional] |
+| **form3** | **String**|  | [optional] |
+| **form4** | **Boolean**|  | [optional] |
+| **id** | **Long**|  | [optional] |
+| **name** | **String**|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/FormApi.java
@@ -129,4 +129,95 @@ if (stringForm != null)
     );
   }
 
+  /**
+   * Test form parameter(s) for oneOf schema
+   * Test form parameter(s) for oneOf schema
+   * @param form1  (optional)
+   * @param form2  (optional)
+   * @param form3  (optional)
+   * @param form4  (optional)
+   * @param id  (optional)
+   * @param name  (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testFormOneof(String form1, Integer form2, String form3, Boolean form4, Long id, String name) throws ApiException {
+    return this.testFormOneof(form1, form2, form3, form4, id, name, Collections.emptyMap());
+  }
+
+
+  /**
+   * Test form parameter(s) for oneOf schema
+   * Test form parameter(s) for oneOf schema
+   * @param form1  (optional)
+   * @param form2  (optional)
+   * @param form3  (optional)
+   * @param form4  (optional)
+   * @param id  (optional)
+   * @param name  (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testFormOneof(String form1, Integer form2, String form3, Boolean form4, Long id, String name, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/form/oneof";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    if (form1 != null)
+      localVarFormParams.put("form1", form1);
+if (form2 != null)
+      localVarFormParams.put("form2", form2);
+if (form3 != null)
+      localVarFormParams.put("form3", form3);
+if (form4 != null)
+      localVarFormParams.put("form4", form4);
+if (id != null)
+      localVarFormParams.put("id", id);
+if (name != null)
+      localVarFormParams.put("name", name);
+
+    final String[] localVarAccepts = {
+      "text/plain"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/x-www-form-urlencoded"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    TypeReference<String> localVarReturnType = new TypeReference<String>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
 }

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -62,6 +62,27 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
+  /form/oneof:
+    post:
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/test_form_oneof_request'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test form parameter(s) for oneOf schema
+      tags:
+      - form
+      x-content-type: application/x-www-form-urlencoded
+      x-accepts: text/plain
   /header/integer/boolean/string:
     get:
       description: Test header parameter(s)
@@ -666,6 +687,26 @@ components:
           type: boolean
         string_form:
           type: string
+      type: object
+    test_form_oneof_request_oneOf:
+      properties:
+        form1:
+          type: string
+        form2:
+          type: integer
+      type: object
+    test_form_oneof_request_oneOf_1:
+      properties:
+        form3:
+          type: string
+        form4:
+          type: boolean
+      type: object
+    test_form_oneof_request:
+      oneOf:
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf'
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf_1'
+      - $ref: '#/components/schemas/Tag'
       type: object
     test_query_style_form_explode_true_array_string_query_object_parameter:
       properties:

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/FormApi.java
@@ -47,4 +47,43 @@ public interface FormApi extends ApiClient.Api {
   ApiResponse<String> testFormIntegerBooleanStringWithHttpInfo(@Param("integer_form") Integer integerForm, @Param("boolean_form") Boolean booleanForm, @Param("string_form") String stringForm);
 
 
+
+  /**
+   * Test form parameter(s) for oneOf schema
+   * Test form parameter(s) for oneOf schema
+   * @param form1  (optional)
+   * @param form2  (optional)
+   * @param form3  (optional)
+   * @param form4  (optional)
+   * @param id  (optional)
+   * @param name  (optional)
+   * @return String
+   */
+  @RequestLine("POST /form/oneof")
+  @Headers({
+    "Content-Type: application/x-www-form-urlencoded",
+    "Accept: text/plain",
+  })
+  String testFormOneof(@Param("form1") String form1, @Param("form2") Integer form2, @Param("form3") String form3, @Param("form4") Boolean form4, @Param("id") Long id, @Param("name") String name);
+
+  /**
+   * Test form parameter(s) for oneOf schema
+   * Similar to <code>testFormOneof</code> but it also returns the http response headers .
+   * Test form parameter(s) for oneOf schema
+   * @param form1  (optional)
+   * @param form2  (optional)
+   * @param form3  (optional)
+   * @param form4  (optional)
+   * @param id  (optional)
+   * @param name  (optional)
+   * @return A ApiResponse that wraps the response boyd and the http headers.
+   */
+  @RequestLine("POST /form/oneof")
+  @Headers({
+    "Content-Type: application/x-www-form-urlencoded",
+    "Accept: text/plain",
+  })
+  ApiResponse<String> testFormOneofWithHttpInfo(@Param("form1") String form1, @Param("form2") Integer form2, @Param("form3") String form3, @Param("form4") Boolean form4, @Param("id") Long id, @Param("name") String name);
+
+
 }

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -120,6 +120,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyTagResponseStringWithHttpInfo**](docs/BodyApi.md#testEchoBodyTagResponseStringWithHttpInfo) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormIntegerBooleanStringWithHttpInfo**](docs/FormApi.md#testFormIntegerBooleanStringWithHttpInfo) | **POST** /form/integer/boolean/string | Test form parameter(s)
+*FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
+*FormApi* | [**testFormOneofWithHttpInfo**](docs/FormApi.md#testFormOneofWithHttpInfo) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *HeaderApi* | [**testHeaderIntegerBooleanStringWithHttpInfo**](docs/HeaderApi.md#testHeaderIntegerBooleanStringWithHttpInfo) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -62,6 +62,27 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
+  /form/oneof:
+    post:
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/test_form_oneof_request'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test form parameter(s) for oneOf schema
+      tags:
+      - form
+      x-content-type: application/x-www-form-urlencoded
+      x-accepts: text/plain
   /header/integer/boolean/string:
     get:
       description: Test header parameter(s)
@@ -666,6 +687,26 @@ components:
           type: boolean
         string_form:
           type: string
+      type: object
+    test_form_oneof_request_oneOf:
+      properties:
+        form1:
+          type: string
+        form2:
+          type: integer
+      type: object
+    test_form_oneof_request_oneOf_1:
+      properties:
+        form3:
+          type: string
+        form4:
+          type: boolean
+      type: object
+    test_form_oneof_request:
+      oneOf:
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf'
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf_1'
+      - $ref: '#/components/schemas/Tag'
       type: object
     test_query_style_form_explode_true_array_string_query_object_parameter:
       properties:

--- a/samples/client/echo_api/java/native/docs/FormApi.md
+++ b/samples/client/echo_api/java/native/docs/FormApi.md
@@ -6,6 +6,8 @@ All URIs are relative to *http://localhost:3000*
 |------------- | ------------- | -------------|
 | [**testFormIntegerBooleanString**](FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s) |
 | [**testFormIntegerBooleanStringWithHttpInfo**](FormApi.md#testFormIntegerBooleanStringWithHttpInfo) | **POST** /form/integer/boolean/string | Test form parameter(s) |
+| [**testFormOneof**](FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema |
+| [**testFormOneofWithHttpInfo**](FormApi.md#testFormOneofWithHttpInfo) | **POST** /form/oneof | Test form parameter(s) for oneOf schema |
 
 
 
@@ -130,6 +132,160 @@ public class Example {
 | **integerForm** | **Integer**|  | [optional] |
 | **booleanForm** | **Boolean**|  | [optional] |
 | **stringForm** | **String**|  | [optional] |
+
+### Return type
+
+ApiResponse<**String**>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testFormOneof
+
+> String testFormOneof(form1, form2, form3, form4, id, name)
+
+Test form parameter(s) for oneOf schema
+
+Test form parameter(s) for oneOf schema
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FormApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        FormApi apiInstance = new FormApi(defaultClient);
+        String form1 = "form1_example"; // String | 
+        Integer form2 = 56; // Integer | 
+        String form3 = "form3_example"; // String | 
+        Boolean form4 = true; // Boolean | 
+        Long id = 56L; // Long | 
+        String name = "name_example"; // String | 
+        try {
+            String result = apiInstance.testFormOneof(form1, form2, form3, form4, id, name);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FormApi#testFormOneof");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **form1** | **String**|  | [optional] |
+| **form2** | **Integer**|  | [optional] |
+| **form3** | **String**|  | [optional] |
+| **form4** | **Boolean**|  | [optional] |
+| **id** | **Long**|  | [optional] |
+| **name** | **String**|  | [optional] |
+
+### Return type
+
+**String**
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testFormOneofWithHttpInfo
+
+> ApiResponse<String> testFormOneof testFormOneofWithHttpInfo(form1, form2, form3, form4, id, name)
+
+Test form parameter(s) for oneOf schema
+
+Test form parameter(s) for oneOf schema
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FormApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        FormApi apiInstance = new FormApi(defaultClient);
+        String form1 = "form1_example"; // String | 
+        Integer form2 = 56; // Integer | 
+        String form3 = "form3_example"; // String | 
+        Boolean form4 = true; // Boolean | 
+        Long id = 56L; // Long | 
+        String name = "name_example"; // String | 
+        try {
+            ApiResponse<String> response = apiInstance.testFormOneofWithHttpInfo(form1, form2, form3, form4, id, name);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FormApi#testFormOneof");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **form1** | **String**|  | [optional] |
+| **form2** | **Integer**|  | [optional] |
+| **form3** | **String**|  | [optional] |
+| **form4** | **Boolean**|  | [optional] |
+| **id** | **Long**|  | [optional] |
+| **name** | **String**|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/FormApi.java
@@ -185,4 +185,118 @@ public class FormApi {
     }
     return localVarRequestBuilder;
   }
+  /**
+   * Test form parameter(s) for oneOf schema
+   * Test form parameter(s) for oneOf schema
+   * @param form1  (optional)
+   * @param form2  (optional)
+   * @param form3  (optional)
+   * @param form4  (optional)
+   * @param id  (optional)
+   * @param name  (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testFormOneof(String form1, Integer form2, String form3, Boolean form4, Long id, String name) throws ApiException {
+    ApiResponse<String> localVarResponse = testFormOneofWithHttpInfo(form1, form2, form3, form4, id, name);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test form parameter(s) for oneOf schema
+   * Test form parameter(s) for oneOf schema
+   * @param form1  (optional)
+   * @param form2  (optional)
+   * @param form3  (optional)
+   * @param form4  (optional)
+   * @param id  (optional)
+   * @param name  (optional)
+   * @return ApiResponse&lt;String&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<String> testFormOneofWithHttpInfo(String form1, Integer form2, String form3, Boolean form4, Long id, String name) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testFormOneofRequestBuilder(form1, form2, form3, form4, id, name);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testFormOneof", localVarResponse);
+        }
+        // for plain text response
+        if (localVarResponse.headers().map().containsKey("Content-Type") &&
+                "text/plain".equalsIgnoreCase(localVarResponse.headers().map().get("Content-Type").get(0).split(";")[0].trim())) {
+          java.util.Scanner s = new java.util.Scanner(localVarResponse.body()).useDelimiter("\\A");
+          String responseBodyText = s.hasNext() ? s.next() : "";
+          return new ApiResponse<String>(
+                  localVarResponse.statusCode(),
+                  localVarResponse.headers().map(),
+                  responseBodyText
+          );
+        } else {
+            throw new RuntimeException("Error! The response Content-Type is supposed to be `text/plain` but it's not: " + localVarResponse);
+        }
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testFormOneofRequestBuilder(String form1, Integer form2, String form3, Boolean form4, Long id, String name) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/form/oneof";
+
+    localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+
+    localVarRequestBuilder.header("Accept", "text/plain");
+
+    List<NameValuePair> formValues = new ArrayList<>();
+    if (form1 != null) {
+        formValues.add(new BasicNameValuePair("form1", form1.toString()));
+    }
+    if (form2 != null) {
+        formValues.add(new BasicNameValuePair("form2", form2.toString()));
+    }
+    if (form3 != null) {
+        formValues.add(new BasicNameValuePair("form3", form3.toString()));
+    }
+    if (form4 != null) {
+        formValues.add(new BasicNameValuePair("form4", form4.toString()));
+    }
+    if (id != null) {
+        formValues.add(new BasicNameValuePair("id", id.toString()));
+    }
+    if (name != null) {
+        formValues.add(new BasicNameValuePair("name", name.toString()));
+    }
+    HttpEntity entity = new UrlEncodedFormEntity(formValues, java.nio.charset.StandardCharsets.UTF_8);
+    ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
+    try {
+        entity.writeTo(formOutputStream);
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
+    localVarRequestBuilder
+        .header("Content-Type", entity.getContentType().getValue())
+        .method("POST", HttpRequest.BodyPublishers
+            .ofInputStream(() -> new ByteArrayInputStream(formOutputStream.toByteArray())));
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
 }

--- a/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/CustomTest.java
+++ b/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/CustomTest.java
@@ -285,6 +285,18 @@ public class CustomTest {
     }
 
     @Test
+    public void testFormOneOf() throws ApiException {
+        String form1 = "form1_example"; // String | 
+        Integer form2 = 56; // Integer | 
+        String form3 = "form3  example"; // String | 
+        Boolean form4 = true;
+        String response = formApi.testFormOneof(form1, form2, form3, form4, null, null);
+        org.openapitools.client.EchoServerResponseParser p = new org.openapitools.client.EchoServerResponseParser(response);
+        Assert.assertEquals("/form/oneof", p.path);
+        Assert.assertEquals("3c\nform1=form1_example&form2=56&form3=form3++example&form4=true\n0\n\n", p.body);
+    }
+
+    @Test
     public void testBodyMultipartFormdataArrayOfBinary() throws ApiException {
         File file1 = Objects.requireNonNull(getFile("Hello"));
         File file2 = Objects.requireNonNull(getFile("World"));

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -120,6 +120,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
+*FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
 *QueryApi* | [**testEnumRefString**](docs/QueryApi.md#testEnumRefString) | **GET** /query/enum_ref_string | Test query parameter(s)

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -62,6 +62,27 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
+  /form/oneof:
+    post:
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/test_form_oneof_request'
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test form parameter(s) for oneOf schema
+      tags:
+      - form
+      x-content-type: application/x-www-form-urlencoded
+      x-accepts: text/plain
   /header/integer/boolean/string:
     get:
       description: Test header parameter(s)
@@ -666,6 +687,26 @@ components:
           type: boolean
         string_form:
           type: string
+      type: object
+    test_form_oneof_request_oneOf:
+      properties:
+        form1:
+          type: string
+        form2:
+          type: integer
+      type: object
+    test_form_oneof_request_oneOf_1:
+      properties:
+        form3:
+          type: string
+        form4:
+          type: boolean
+      type: object
+    test_form_oneof_request:
+      oneOf:
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf'
+      - $ref: '#/components/schemas/test_form_oneof_request_oneOf_1'
+      - $ref: '#/components/schemas/Tag'
       type: object
     test_query_style_form_explode_true_array_string_query_object_parameter:
       properties:

--- a/samples/client/echo_api/java/okhttp-gson/docs/FormApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/FormApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
 | [**testFormIntegerBooleanString**](FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s) |
+| [**testFormOneof**](FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema |
 
 
 <a id="testFormIntegerBooleanString"></a>
@@ -54,6 +55,78 @@ public class Example {
 | **integerForm** | **Integer**|  | [optional] |
 | **booleanForm** | **Boolean**|  | [optional] |
 | **stringForm** | **String**|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+<a id="testFormOneof"></a>
+# **testFormOneof**
+> String testFormOneof(form1, form2, form3, form4, id, name)
+
+Test form parameter(s) for oneOf schema
+
+Test form parameter(s) for oneOf schema
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FormApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:3000");
+
+    FormApi apiInstance = new FormApi(defaultClient);
+    String form1 = "form1_example"; // String | 
+    Integer form2 = 56; // Integer | 
+    String form3 = "form3_example"; // String | 
+    Boolean form4 = true; // Boolean | 
+    Long id = 56L; // Long | 
+    String name = "name_example"; // String | 
+    try {
+      String result = apiInstance.testFormOneof(form1, form2, form3, form4, id, name);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FormApi#testFormOneof");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **form1** | **String**|  | [optional] |
+| **form2** | **Integer**|  | [optional] |
+| **form3** | **String**|  | [optional] |
+| **form4** | **Boolean**|  | [optional] |
+| **id** | **Long**|  | [optional] |
+| **name** | **String**|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/FormApi.java
@@ -209,4 +209,166 @@ public class FormApi {
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+    /**
+     * Build call for testFormOneof
+     * @param form1  (optional)
+     * @param form2  (optional)
+     * @param form3  (optional)
+     * @param form4  (optional)
+     * @param id  (optional)
+     * @param name  (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testFormOneofCall(String form1, Integer form2, String form3, Boolean form4, Long id, String name, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/form/oneof";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (form1 != null) {
+            localVarFormParams.put("form1", form1);
+        }
+
+        if (form2 != null) {
+            localVarFormParams.put("form2", form2);
+        }
+
+        if (form3 != null) {
+            localVarFormParams.put("form3", form3);
+        }
+
+        if (form4 != null) {
+            localVarFormParams.put("form4", form4);
+        }
+
+        if (id != null) {
+            localVarFormParams.put("id", id);
+        }
+
+        if (name != null) {
+            localVarFormParams.put("name", name);
+        }
+
+        final String[] localVarAccepts = {
+            "text/plain"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/x-www-form-urlencoded"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testFormOneofValidateBeforeCall(String form1, Integer form2, String form3, Boolean form4, Long id, String name, final ApiCallback _callback) throws ApiException {
+        return testFormOneofCall(form1, form2, form3, form4, id, name, _callback);
+
+    }
+
+    /**
+     * Test form parameter(s) for oneOf schema
+     * Test form parameter(s) for oneOf schema
+     * @param form1  (optional)
+     * @param form2  (optional)
+     * @param form3  (optional)
+     * @param form4  (optional)
+     * @param id  (optional)
+     * @param name  (optional)
+     * @return String
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public String testFormOneof(String form1, Integer form2, String form3, Boolean form4, Long id, String name) throws ApiException {
+        ApiResponse<String> localVarResp = testFormOneofWithHttpInfo(form1, form2, form3, form4, id, name);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Test form parameter(s) for oneOf schema
+     * Test form parameter(s) for oneOf schema
+     * @param form1  (optional)
+     * @param form2  (optional)
+     * @param form3  (optional)
+     * @param form4  (optional)
+     * @param id  (optional)
+     * @param name  (optional)
+     * @return ApiResponse&lt;String&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<String> testFormOneofWithHttpInfo(String form1, Integer form2, String form3, Boolean form4, Long id, String name) throws ApiException {
+        okhttp3.Call localVarCall = testFormOneofValidateBeforeCall(form1, form2, form3, form4, id, name, null);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Test form parameter(s) for oneOf schema (asynchronously)
+     * Test form parameter(s) for oneOf schema
+     * @param form1  (optional)
+     * @param form2  (optional)
+     * @param form3  (optional)
+     * @param form4  (optional)
+     * @param id  (optional)
+     * @param name  (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testFormOneofAsync(String form1, Integer form2, String form3, Boolean form4, Long id, String name, final ApiCallback<String> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testFormOneofValidateBeforeCall(form1, form2, form3, form4, id, name, _callback);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
 }

--- a/samples/client/echo_api/python/README.md
+++ b/samples/client/echo_api/python/README.md
@@ -92,6 +92,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
+*FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *HeaderApi* | [**test_header_integer_boolean_string**](docs/HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
 *PathApi* | [**tests_path_string_path_string_integer_path_integer**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
 *QueryApi* | [**test_enum_ref_string**](docs/QueryApi.md#test_enum_ref_string) | **GET** /query/enum_ref_string | Test query parameter(s)

--- a/samples/client/echo_api/python/docs/FormApi.md
+++ b/samples/client/echo_api/python/docs/FormApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *http://localhost:3000*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**test_form_integer_boolean_string**](FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
+[**test_form_oneof**](FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 
 
 # **test_form_integer_boolean_string**
@@ -56,6 +57,82 @@ Name | Type | Description  | Notes
  **integer_form** | **int**|  | [optional] 
  **boolean_form** | **bool**|  | [optional] 
  **string_form** | **str**|  | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_form_oneof**
+> str test_form_oneof(form1=form1, form2=form2, form3=form3, form4=form4, id=id, name=name)
+
+Test form parameter(s) for oneOf schema
+
+Test form parameter(s) for oneOf schema
+
+### Example
+
+```python
+import time
+import os
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.FormApi(api_client)
+    form1 = 'form1_example' # str |  (optional)
+    form2 = 56 # int |  (optional)
+    form3 = 'form3_example' # str |  (optional)
+    form4 = True # bool |  (optional)
+    id = 56 # int |  (optional)
+    name = 'name_example' # str |  (optional)
+
+    try:
+        # Test form parameter(s) for oneOf schema
+        api_response = api_instance.test_form_oneof(form1=form1, form2=form2, form3=form3, form4=form4, id=id, name=name)
+        print("The response of FormApi->test_form_oneof:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling FormApi->test_form_oneof: %s\n" % e)
+```
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **form1** | **str**|  | [optional] 
+ **form2** | **int**|  | [optional] 
+ **form3** | **str**|  | [optional] 
+ **form4** | **bool**|  | [optional] 
+ **id** | **int**|  | [optional] 
+ **name** | **str**|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -207,3 +207,190 @@ class FormApi:
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
+    def test_form_oneof(self, form1 : Optional[StrictStr] = None, form2 : Optional[StrictInt] = None, form3 : Optional[StrictStr] = None, form4 : Optional[StrictBool] = None, id : Optional[StrictInt] = None, name : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
+        """Test form parameter(s) for oneOf schema  # noqa: E501
+
+        Test form parameter(s) for oneOf schema  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_form_oneof(form1, form2, form3, form4, id, name, async_req=True)
+        >>> result = thread.get()
+
+        :param form1:
+        :type form1: str
+        :param form2:
+        :type form2: int
+        :param form3:
+        :type form3: str
+        :param form4:
+        :type form4: bool
+        :param id:
+        :type id: int
+        :param name:
+        :type name: str
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _request_timeout: timeout setting for this request.
+               If one number provided, it will be total request
+               timeout. It can also be a pair (tuple) of
+               (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: str
+        """
+        kwargs['_return_http_data_only'] = True
+        if '_preload_content' in kwargs:
+            message = "Error! Please call the test_form_oneof_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            raise ValueError(message)
+        return self.test_form_oneof_with_http_info(form1, form2, form3, form4, id, name, **kwargs)  # noqa: E501
+
+    @validate_arguments
+    def test_form_oneof_with_http_info(self, form1 : Optional[StrictStr] = None, form2 : Optional[StrictInt] = None, form3 : Optional[StrictStr] = None, form4 : Optional[StrictBool] = None, id : Optional[StrictInt] = None, name : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+        """Test form parameter(s) for oneOf schema  # noqa: E501
+
+        Test form parameter(s) for oneOf schema  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_form_oneof_with_http_info(form1, form2, form3, form4, id, name, async_req=True)
+        >>> result = thread.get()
+
+        :param form1:
+        :type form1: str
+        :param form2:
+        :type form2: int
+        :param form3:
+        :type form3: str
+        :param form4:
+        :type form4: bool
+        :param id:
+        :type id: int
+        :param name:
+        :type name: str
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the ApiResponse.data will
+                                 be set to none and raw_data will store the
+                                 HTTP response body without reading/decoding.
+                                 Default is True.
+        :type _preload_content: bool, optional
+        :param _return_http_data_only: response data instead of ApiResponse
+                                       object with status code, headers, etc
+        :type _return_http_data_only: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+            'form1',
+            'form2',
+            'form3',
+            'form4',
+            'id',
+            'name'
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_form_oneof" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        if _params['form1']:
+            _form_params.append(('form1', _params['form1']))
+
+        if _params['form2']:
+            _form_params.append(('form2', _params['form2']))
+
+        if _params['form3']:
+            _form_params.append(('form3', _params['form3']))
+
+        if _params['form4']:
+            _form_params.append(('form4', _params['form4']))
+
+        if _params['id']:
+            _form_params.append(('id', _params['id']))
+
+        if _params['name']:
+            _form_params.append(('name', _params['name']))
+
+        # process the body parameter
+        _body_params = None
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['text/plain'])  # noqa: E501
+
+        # set the HTTP header `Content-Type`
+        _content_types_list = _params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/x-www-form-urlencoded']))
+        if _content_types_list:
+                _header_params['Content-Type'] = _content_types_list
+
+        # authentication setting
+        _auth_settings = []  # noqa: E501
+
+        _response_types_map = {
+            '200': "str",
+        }
+
+        return self.api_client.call_api(
+            '/form/oneof', 'POST',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))


### PR DESCRIPTION
add tests for oneOf form parameters in Java native client

<!-- Please check the completed items below -->
### PR checklist
 
- [x]  Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
