### PR TITLE
Bug fix AWS4Auth to support query parameters and updated to use AWS SDK V2 from V1

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/AWS4Auth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/AWS4Auth.mustache
@@ -11,12 +11,14 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.List;
 
-import com.amazonaws.DefaultRequest;
-import com.amazonaws.auth.AWS4Signer;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.http.HttpMethodName;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
 
 import okio.Buffer;
 
@@ -28,11 +30,11 @@ public class AWS4Auth implements Authentication {
   private String service;
 
   public AWS4Auth() {
-    this.credentials = new AnonymousAWSCredentials();
+    this.credentials = AnonymousCredentialsProvider.create().resolveCredentials();
   }
 
   public void setCredentials(String accessKey, String secretKey) {
-    this.credentials = new BasicAWSCredentials(accessKey, secretKey);
+    this.credentials = AwsBasicCredentials.create(accessKey, secretKey);
   }
 
   public void setRegion(String region) {
@@ -44,28 +46,50 @@ public class AWS4Auth implements Authentication {
   }
 
   @Override
-  public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams,
-      String payload, String method, URI uri) throws ApiException {
+  public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams,
+      Map<String, String> cookieParams, String payload, String method, URI uri)
+      throws ApiException {
 
-    DefaultRequest<String> signableRequest = new DefaultRequest<>(this.service);
+    SdkHttpFullRequest.Builder requestBuilder =
+        SdkHttpFullRequest.builder().uri(uri).method(SdkHttpMethod.fromValue(method));
 
-    signableRequest.setContent(new ByteArrayInputStream(payload.getBytes()));
+    ContentStreamProvider provider = new ContentStreamProvider() {
+      @Override
+      public InputStream newStream() {
+        InputStream is = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+        return is;
+      }
+    };
 
-    signableRequest.setHttpMethod(HttpMethodName.valueOf(method));
-    URI targetUri = null;
-    try {
-      targetUri = new URI(uri.getScheme(), "", uri.getHost(), uri.getPort(), "", "", "");
-    } catch (URISyntaxException e) {
-      return;
+    requestBuilder = requestBuilder.contentStreamProvider(provider);
+
+    SdkHttpFullRequest signableRequest = sign(requestBuilder);
+
+    Map<String, String> headers = signableRequest.headers().entrySet().stream()
+        .collect(Collectors.toMap(s -> s.getKey(), e -> e.getValue().get(0)));
+
+    headerParams.putAll(headers);
+  }
+
+  /**
+   * AWS Signature Version 4 signing.
+   * 
+   * @param request {@link SdkHttpFullRequest.Builder}
+   * @return {@link SdkHttpFullRequest}
+   */
+  private SdkHttpFullRequest sign(final SdkHttpFullRequest.Builder request) {
+
+    SdkHttpFullRequest req = request.build();
+
+    if (this.service != null && this.region != null && this.credentials != null) {
+      Aws4SignerParams params = Aws4SignerParams.builder().signingName(this.service)
+          .signingRegion(Region.of(this.region)).awsCredentials(this.credentials).build();
+
+      Aws4Signer signer = Aws4Signer.create();
+
+      req = signer.sign(req, params);
     }
-    signableRequest.setEndpoint(targetUri);
-    signableRequest.setResourcePath(uri.getPath());
 
-    AWS4Signer signer = new AWS4Signer(false);
-    signer.setServiceName(this.service);
-    signer.setRegionName(this.region);
-    signer.sign(signableRequest, credentials);
-
-    headerParams.putAll(signableRequest.getHeaders());
+    return req;
   }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -378,9 +378,9 @@
 
         {{#withAWSV4Signature}}
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-signer</artifactId>
-            <version>1.12.349</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>2.20.120</version>
         </dependency>
         {{/withAWSV4Signature}}
         <dependency>

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/pom.xml
@@ -307,9 +307,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-signer</artifactId>
-            <version>1.12.349</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>2.20.120</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
Bug fix AWS4Auth to support query parameters and updated to use AWS SDK V2 from V1

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

To fix #16268 

The ./modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/AWS4Auth.mustache does not follow the AWS Sigv4 specification when it comes to Query parameters as per https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html. The causes all requests that have a query parameter to receive a 403 forbidden response.

I also updated the implementation to use the AWS SDK v2 instead of previous v1. 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 


@martin-mfg 
