### PR TITLE
[PHP] convert data to string before giving it to preg_match

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -449,7 +449,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
         {{/minimum}}
         {{#pattern}}
-        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(!preg_match("{{{pattern}}}", ${{name}}))) {
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(!preg_match("{{{pattern}}}", ObjectSerializer::toString(${{name}})))) {
             throw new \InvalidArgumentException("invalid value for \${{name}} when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
         }
         {{/pattern}}

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -718,7 +718,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable string cannot be null');
         }
 
-        if ((!preg_match("/[a-z]/i", $string))) {
+        if ((!preg_match("/[a-z]/i", ObjectSerializer::toString($string)))) {
             throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
         }
 
@@ -919,7 +919,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
         }
 
-        if ((!preg_match("/^\\d{10}$/", $pattern_with_digits))) {
+        if ((!preg_match("/^\\d{10}$/", ObjectSerializer::toString($pattern_with_digits)))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
         }
 
@@ -951,7 +951,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
         }
 
-        if ((!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
+        if ((!preg_match("/^image_\\d{1,3}$/i", ObjectSerializer::toString($pattern_with_digits_and_delimiter)))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
         }
 

--- a/samples/client/petstore/php/psr-18/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/FormatTest.php
@@ -718,7 +718,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable string cannot be null');
         }
 
-        if ((!preg_match("/[a-z]/i", $string))) {
+        if ((!preg_match("/[a-z]/i", ObjectSerializer::toString($string)))) {
             throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
         }
 
@@ -919,7 +919,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
         }
 
-        if ((!preg_match("/^\\d{10}$/", $pattern_with_digits))) {
+        if ((!preg_match("/^\\d{10}$/", ObjectSerializer::toString($pattern_with_digits)))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
         }
 
@@ -951,7 +951,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
         }
 
-        if ((!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
+        if ((!preg_match("/^image_\\d{1,3}$/i", ObjectSerializer::toString($pattern_with_digits_and_delimiter)))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
         }
 


### PR DESCRIPTION
Properties like
```
        lastModifiedDateTime:
          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
          type: string
          description: Date and time the item was last modified. Read-only.
          format: date-time
          readOnly: true
```

generate this kind of code:

```
    /**
     * Sets last_modified_date_time
     *
     * @param \DateTime|null $last_modified_date_time Date and time the item was last modified. Read-only.
     *
     * @return self
     */
    public function setLastModifiedDateTime($last_modified_date_time)
    {
        if (is_null($last_modified_date_time)) {
            throw new \InvalidArgumentException('non-nullable last_modified_date_time cannot be null');
        }
         if ((!preg_match("/^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$/", $last_modified_date_time))) {
              throw new \InvalidArgumentException("invalid value for \$last_modified_date_time when calling Drive., must conform to the pattern /^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$/.");
         }
....
```

so `preg_match` receives a `DateTime` objects and fails with `Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, DateTime given`

To avoid that call `ObjectSerializer::toString`, which takes a value and turns it into a string. If it's a string, pass through unchanged If it's a datetime object, format it in ISO8601 If it's a boolean, convert it to "true" or "false".

CC @jebentier @dkarlovi  @mandrean  @jfastnacht @ybelenko @renepardon

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
