### PR TITLE
python: use isinstance instead of type()

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -234,7 +234,7 @@ class ApiClient:
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and type(response_data.status) == int and 100 <= response_data.status <= 599:
+          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
               # if not found, look for '1XX', '2XX', etc.
               response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -227,7 +227,7 @@ class ApiClient:
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and type(response_data.status) == int and 100 <= response_data.status <= 599:
+          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
               # if not found, look for '1XX', '2XX', etc.
               response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -227,7 +227,7 @@ class ApiClient:
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and type(response_data.status) == int and 100 <= response_data.status <= 599:
+          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
               # if not found, look for '1XX', '2XX', etc.
               response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -226,7 +226,7 @@ class ApiClient:
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and type(response_data.status) == int and 100 <= response_data.status <= 599:
+          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
               # if not found, look for '1XX', '2XX', etc.
               response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 


### PR DESCRIPTION
Use of `isinstance` is preferred (and validated by common linters).
