### PR TITLE
[java-client][resteasy] fix multipart requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -33,6 +33,7 @@ import {{javaxPackage}}.ws.rs.client.Entity;
 import {{javaxPackage}}.ws.rs.client.Invocation;
 import {{javaxPackage}}.ws.rs.client.WebTarget;
 import {{javaxPackage}}.ws.rs.core.Form;
+import {{javaxPackage}}.ws.rs.core.GenericEntity;
 import {{javaxPackage}}.ws.rs.core.GenericType;
 import {{javaxPackage}}.ws.rs.core.MediaType;
 import {{javaxPackage}}.ws.rs.core.Response;
@@ -497,15 +498,16 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         if (param.getValue() instanceof File) {
           File file = (File) param.getValue();
           try {
-            multipart.addFormData(param.getValue().toString(),new FileInputStream(file),MediaType.APPLICATION_OCTET_STREAM_TYPE);
+            multipart.addFormData(param.getKey(),new FileInputStream(file),MediaType.APPLICATION_OCTET_STREAM_TYPE);
           } catch (FileNotFoundException e) {
             throw new ApiException("Could not serialize multipart/form-data "+e.getMessage());
           }
         } else {
-          multipart.addFormData(param.getValue().toString(),param.getValue().toString(),MediaType.APPLICATION_OCTET_STREAM_TYPE);
+          multipart.addFormData(param.getKey(),param.getValue().toString(),MediaType.APPLICATION_OCTET_STREAM_TYPE);
         }
       }
-      entity = Entity.entity(multipart.getFormData(), MediaType.MULTIPART_FORM_DATA_TYPE);
+      GenericEntity<MultipartFormDataOutput> genericEntity = new GenericEntity<MultipartFormDataOutput>(multipart) { };
+      entity = Entity.entity(genericEntity, MediaType.MULTIPART_FORM_DATA_TYPE);
     } else if (contentType.startsWith("application/x-www-form-urlencoded")) {
       Form form = new Form();
       for (Entry<String, Object> param: formParams.entrySet()) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
@@ -31,6 +31,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Form;
+import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -500,7 +501,8 @@ public class ApiClient extends JavaTimeFormatter {
           multipart.addFormData(param.getValue().toString(),param.getValue().toString(),MediaType.APPLICATION_OCTET_STREAM_TYPE);
         }
       }
-      entity = Entity.entity(multipart.getFormData(), MediaType.MULTIPART_FORM_DATA_TYPE);
+      GenericEntity<MultipartFormDataOutput> genericEntity = new GenericEntity<MultipartFormDataOutput>(multipart) { };
+      entity = Entity.entity(genericEntity, MediaType.MULTIPART_FORM_DATA_TYPE);
     } else if (contentType.startsWith("application/x-www-form-urlencoded")) {
       Form form = new Form();
       for (Entry<String, Object> param: formParams.entrySet()) {


### PR DESCRIPTION
This patch fixes two issues with the Resteasy generated client code. The first is the usage of a deprecated method, `getFormData`.  The fix for this issue was originally conceived by @peter-seitz.

The second issue was a problem in how the Content-Disposition header was being constructed.  If we had a file named `test.txt` and were uploading it to a field named `myFile`, the Content-Disposition header should look
like

```http
Content-Disposition: form-data; name="myFile"
```

Instead, the code was using the file's name (rather than the field name) in the name directive and the header looked like

```http
Content-Disposition: form-data; name="test.txt"
```

The Content-Disposition header can take an optional directive, filename, but I have not included that here as that directive is mostly useful for file downloads and not uploads.


Tagging @martin-mfg for technical committee visibility

Fixes #2054 

Testing:
1. Generate the client source files
```
mvn clean package -Dmaven.test.skip=true && java -jar ~/devel/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i modules/openapi-generator/src/test/resources/3_1/petstore.yaml -g java --additional-properties library=resteasy -o out/
```
3. I modified the `PetApiTest.java` file to add the following test
```patch
--- /tmp/PetApiTest.java	2023-09-05 11:47:55.600727343 -0400
+++ out/src/test/java/org/openapitools/client/api/PetApiTest.java	2023-09-05 11:48:57.546840819 -0400
@@ -22,10 +22,8 @@
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.io.*;
 
 /**
  * API tests for PetApi
@@ -168,16 +166,17 @@
      *          if the Api call fails
      */
     @Test
-    public void uploadFileTest() throws ApiException {
-        //
-        //Object petId = null;
-        //
-        //Object additionalMetadata = null;
-        //
-        //Object _file = null;
-        //
-        //ModelApiResponse response = api.uploadFile(petId, additionalMetadata, _file);
+    public void uploadFileTest() throws Exception {
+        int petId = 1;
+        String additionalMetadata = null;
+        File file = new File("test.txt");
+        if(!file.exists()){
+            file.createNewFile();
+        }
+        file.deleteOnExit();
 
-        // TODO: test validations
+        ModelApiResponse response = api.uploadFile(petId, additionalMetadata, file);
+
+        Assert.assertEquals((int)response.getCode(), 200);
     }
 }

   ```
4. Run the unit tests
```
cd out ; mvn clean test -Dtest='PetApiTest#uploadFileTest'
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
  # NOTE
  **Running these scripts led to some whitespace changes in files under `openapi3/client/petstore/python{-aiohttp}`.  I did not include those in this PR.  I can include those changes in a separate commit if desired, but they did not seem like relevant changes for this issue so I elected to exclude them to keep the project commit history clearer.**
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
