### PR TITLE
python: ignore long lines for model descriptions

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -12,7 +12,7 @@ import json
 
 class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}):
     """
-    {{{description}}}{{^description}}{{{classname}}}{{/description}}
+    {{#description}}{{{description}}}  # noqa: E501{{/description}}{{^description}}{{{classname}}}{{/description}}
     """
 {{#vars}}
     {{name}}: {{{vendorExtensions.x-py-typing}}}

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -25,7 +25,7 @@ from openapi_client.models.string_enum_ref import StringEnumRef
 
 class DefaultValue(BaseModel):
     """
-    to test the default value of properties
+    to test the default value of properties  # noqa: E501
     """
     array_string_enum_ref_default: Optional[conlist(StringEnumRef)] = None
     array_string_enum_default: Optional[conlist(StrictStr)] = None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictStr
 
 class ClassModel(BaseModel):
     """
-    Model for testing model with \"_class\" property
+    Model for testing model with \"_class\" property  # noqa: E501
     """
     var_class: Optional[StrictStr] = Field(None, alias="_class")
     __properties = ["_class"]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictStr
 
 class File(BaseModel):
     """
-    Must be named `File` for test.
+    Must be named `File` for test.  # noqa: E501
     """
     source_uri: Optional[StrictStr] = Field(None, alias="sourceURI", description="Test capitalization")
     __properties = ["sourceURI"]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictStr
 
 class HealthCheckResult(BaseModel):
     """
-    Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
+    Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.  # noqa: E501
     """
     nullable_message: Optional[StrictStr] = Field(None, alias="NullableMessage")
     __properties = ["NullableMessage"]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 class Model200Response(BaseModel):
     """
-    Model for testing model name starting with number
+    Model for testing model name starting with number  # noqa: E501
     """
     name: Optional[StrictInt] = None
     var_class: Optional[StrictStr] = Field(None, alias="class")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictInt
 
 class ModelReturn(BaseModel):
     """
-    Model for testing reserved words
+    Model for testing reserved words  # noqa: E501
     """
     var_return: Optional[StrictInt] = Field(None, alias="return")
     __properties = ["return"]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 class Name(BaseModel):
     """
-    Model for testing model name same as property name
+    Model for testing model name same as property name  # noqa: E501
     """
     name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictBool
 
 class ObjectToTestAdditionalProperties(BaseModel):
     """
-    Minimal object
+    Minimal object  # noqa: E501
     """
     var_property: Optional[StrictBool] = Field(False, alias="property", description="Property")
     __properties = ["property"]

--- a/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictStr
 
 class ClassModel(BaseModel):
     """
-    Model for testing model with \"_class\" property
+    Model for testing model with \"_class\" property  # noqa: E501
     """
     var_class: Optional[StrictStr] = Field(None, alias="_class")
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictStr
 
 class File(BaseModel):
     """
-    Must be named `File` for test.
+    Must be named `File` for test.  # noqa: E501
     """
     source_uri: Optional[StrictStr] = Field(None, alias="sourceURI", description="Test capitalization")
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictStr
 
 class HealthCheckResult(BaseModel):
     """
-    Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
+    Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.  # noqa: E501
     """
     nullable_message: Optional[StrictStr] = Field(None, alias="NullableMessage")
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 class Model200Response(BaseModel):
     """
-    Model for testing model name starting with number
+    Model for testing model name starting with number  # noqa: E501
     """
     name: Optional[StrictInt] = None
     var_class: Optional[StrictStr] = Field(None, alias="class")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictInt
 
 class ModelReturn(BaseModel):
     """
-    Model for testing reserved words
+    Model for testing reserved words  # noqa: E501
     """
     var_return: Optional[StrictInt] = Field(None, alias="return")
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/name.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 class Name(BaseModel):
     """
-    Model for testing model name same as property name
+    Model for testing model name same as property name  # noqa: E501
     """
     name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, StrictBool
 
 class ObjectToTestAdditionalProperties(BaseModel):
     """
-    Minimal object
+    Minimal object  # noqa: E501
     """
     var_property: Optional[StrictBool] = Field(False, alias="property", description="Property")
     additional_properties: Dict[str, Any] = {}


### PR DESCRIPTION
Descriptions can easily exceed line-length limits because they are often extracted from doc/comments strings, which may use unexpected formatting.

Python doc strings, in particular, are likely to use newlines, which mustache does not preserve, causing descriptions to be condensed to a single line.
