### PR TITLE
[Spring] fix nullable map properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -148,13 +148,13 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
     {{#openApiNullable}}
     if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent(){{/isNullable}}) {
-      this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}}{{#isNullable}}){{/isNullable}};
+      this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}HashMap{{/uniqueItems}}<>(){{/defaultValue}}{{#isNullable}}){{/isNullable}};
     }
     this.{{name}}{{#isNullable}}.get(){{/isNullable}}.put(key, {{name}}Item);
     {{/openApiNullable}}
     {{^openApiNullable}}
     if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}HashMap{{/uniqueItems}}<>(){{/defaultValue}};
     }
     this.{{name}}.put(key, {{name}}Item);
     {{/openApiNullable}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -65,7 +65,7 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   {{#isContainer}}
   {{#useBeanValidation}}@Valid{{/useBeanValidation}}
   {{#openApiNullable}}
-  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
   {{/openApiNullable}}
   {{^openApiNullable}}
   private {{>nullableDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
@@ -79,7 +79,7 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   {{/isDateTime}}
   {{#openApiNullable}}
-  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
   {{/openApiNullable}}
   {{^openApiNullable}}
   private {{>nullableDataType}} {{name}}{{#isNullable}} = null{{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
@@ -146,10 +146,18 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   {{#isMap}}
 
   public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#openApiNullable}}
+    if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent(){{/isNullable}}) {
+      this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}}{{#isNullable}}){{/isNullable}};
+    }
+    this.{{name}}{{#isNullable}}.get(){{/isNullable}}.put(key, {{name}}Item);
+    {{/openApiNullable}}
+    {{^openApiNullable}}
     if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
     }
     this.{{name}}.put(key, {{name}}Item);
+    {{/openApiNullable}}
     return this;
   }
   {{/isMap}}

--- a/modules/openapi-generator/src/test/resources/3_0/spring/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -2051,3 +2051,11 @@ components:
           type: string
         property name with spaces:
           type: string
+    NullableMapProperty:
+      type: object
+      properties:
+        languageValues:
+          nullable: true
+          type: object
+          additionalProperties:
+            type: string

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/model/Pet.java
@@ -32,7 +32,7 @@ public class Pet {
 
   private Category category;
 
-  private JsonNullable<String> name = JsonNullable.undefined();
+  private JsonNullable<String> name = JsonNullable.<String>undefined();
 
   @Deprecated
   @Valid

--- a/samples/client/petstore/spring-http-interface-reactive/.openapi-generator/FILES
+++ b/samples/client/petstore/spring-http-interface-reactive/.openapi-generator/FILES
@@ -41,6 +41,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -52,7 +52,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -25,16 +25,16 @@ import jakarta.annotation.Generated;
 public class ContainerDefaultValue {
 
   
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   
   private List<String> requiredArray = new ArrayList<>();
 
   
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,105 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import jakarta.validation.constraints.NotNull;
+
+
+import java.util.*;
+import jakarta.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/spring-http-interface/.openapi-generator/FILES
+++ b/samples/client/petstore/spring-http-interface/.openapi-generator/FILES
@@ -40,6 +40,7 @@ src/main/java/org/openapitools/model/MapTestDto.java
 src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
 src/main/java/org/openapitools/model/Model200ResponseDto.java
 src/main/java/org/openapitools/model/NameDto.java
+src/main/java/org/openapitools/model/NullableMapPropertyDto.java
 src/main/java/org/openapitools/model/NumberOnlyDto.java
 src/main/java/org/openapitools/model/OrderDto.java
 src/main/java/org/openapitools/model/OuterCompositeDto.java

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -54,7 +54,7 @@ public class AdditionalPropertiesClassDto {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -27,16 +27,16 @@ import jakarta.annotation.Generated;
 public class ContainerDefaultValueDto {
 
   
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   
   private List<String> requiredArray = new ArrayList<>();
 
   
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto nullableArray(List<String> nullableArray) {
     this.nullableArray = JsonNullable.of(nullableArray);

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -1,0 +1,107 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import jakarta.validation.constraints.NotNull;
+
+
+import java.util.*;
+import jakarta.annotation.Generated;
+
+/**
+ * NullableMapPropertyDto
+ */
+
+@JsonTypeName("NullableMapProperty")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapPropertyDto {
+
+  
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapPropertyDto putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapPropertyDto nullableMapProperty = (NullableMapPropertyDto) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapPropertyDto {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/.openapi-generator/FILES
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/.openapi-generator/FILES
@@ -40,6 +40,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -54,7 +54,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,16 +27,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue nullableArray(List<String> nullableArray) {
     this.nullableArray = JsonNullable.of(nullableArray);

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,108 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @Schema(name = "languageValues", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/openapi3/server/petstore/springboot-delegate/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot-delegate/.openapi-generator/FILES
@@ -58,6 +58,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -54,7 +54,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,16 +27,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,108 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @Schema(name = "languageValues", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -54,7 +54,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,16 +27,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,108 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @Schema(name = "languageValues", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/.openapi-generator/FILES
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/.openapi-generator/FILES
@@ -41,6 +41,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -54,7 +54,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -27,16 +27,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,108 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @Schema(name = "languageValues", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/model/ObjectWithUniqueItems.java
@@ -32,13 +32,13 @@ import javax.annotation.Generated;
 public class ObjectWithUniqueItems {
 
   @Valid
-  private JsonNullable<Set<String>> nullSet = JsonNullable.undefined();
+  private JsonNullable<Set<String>> nullSet = JsonNullable.<Set<String>>undefined();
 
   @Valid
   private Set<String> notNullSet;
 
   @Valid
-  private JsonNullable<List<String>> nullList = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullList = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> notNullList;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,94 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.Map;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private Map<String, String> languageValues;
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = languageValues;
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null) {
+      this.languageValues = new HashMap<>();
+    }
+    this.languageValues.put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public Map<String, String> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(Map<String, String> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return Objects.equals(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(languageValues);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-beanvalidation/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-beanvalidation/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-delegate-j8/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-delegate-j8/.openapi-generator/FILES
@@ -58,6 +58,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-delegate/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-delegate/.openapi-generator/FILES
@@ -58,6 +58,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-implicitHeaders/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-implicitHeaders/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/.openapi-generator/FILES
@@ -57,6 +57,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-reactive/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-reactive/.openapi-generator/FILES
@@ -57,6 +57,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-useoptional/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-useoptional/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/ModelList.java
 src/main/java/org/openapitools/model/ModelReturn.java
 src/main/java/org/openapitools/model/Name.java
+src/main/java/org/openapitools/model/NullableMapProperty.java
 src/main/java/org/openapitools/model/NumberOnly.java
 src/main/java/org/openapitools/model/Order.java
 src/main/java/org/openapitools/model/OuterComposite.java

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -55,7 +55,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ContainerDefaultValue.java
@@ -28,16 +28,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NullableMapProperty.java
@@ -1,0 +1,109 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot-virtualan/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot-virtualan/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
 src/main/java/org/openapitools/virtualan/model/ModelList.java
 src/main/java/org/openapitools/virtualan/model/ModelReturn.java
 src/main/java/org/openapitools/virtualan/model/Name.java
+src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
 src/main/java/org/openapitools/virtualan/model/NumberOnly.java
 src/main/java/org/openapitools/virtualan/model/Order.java
 src/main/java/org/openapitools/virtualan/model/OuterComposite.java

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
@@ -54,7 +54,7 @@ public class AdditionalPropertiesClass {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ContainerDefaultValue.java
@@ -27,16 +27,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValue {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValue() {
     super();

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NullableMapProperty.java
@@ -1,0 +1,108 @@
+package org.openapitools.virtualan.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapProperty
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapProperty {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapProperty languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapProperty putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @Schema(name = "languageValues", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapProperty nullableMapProperty = (NullableMapProperty) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapProperty {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
@@ -2186,6 +2186,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/server/petstore/springboot/.openapi-generator/FILES
+++ b/samples/server/petstore/springboot/.openapi-generator/FILES
@@ -51,6 +51,7 @@ src/main/java/org/openapitools/model/MapTestDto.java
 src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClassDto.java
 src/main/java/org/openapitools/model/Model200ResponseDto.java
 src/main/java/org/openapitools/model/NameDto.java
+src/main/java/org/openapitools/model/NullableMapPropertyDto.java
 src/main/java/org/openapitools/model/NumberOnlyDto.java
 src/main/java/org/openapitools/model/OrderDto.java
 src/main/java/org/openapitools/model/OuterCompositeDto.java

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClassDto.java
@@ -57,7 +57,7 @@ public class AdditionalPropertiesClassDto {
 
   private Object anytype1;
 
-  private JsonNullable<Object> anytype2 = JsonNullable.undefined();
+  private JsonNullable<Object> anytype2 = JsonNullable.<Object>undefined();
 
   private Object anytype3;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ContainerDefaultValueDto.java
@@ -30,16 +30,16 @@ import javax.annotation.Generated;
 public class ContainerDefaultValueDto {
 
   @Valid
-  private JsonNullable<List<String>> nullableArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArray = JsonNullable.<List<String>>undefined();
 
   @Valid
-  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableRequiredArray = JsonNullable.<List<String>>undefined();
 
   @Valid
   private List<String> requiredArray = new ArrayList<>();
 
   @Valid
-  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.undefined();
+  private JsonNullable<List<String>> nullableArrayWithDefault = JsonNullable.<List<String>>undefined();
 
   public ContainerDefaultValueDto() {
     super();

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NullableMapPropertyDto.java
@@ -1,0 +1,111 @@
+package org.openapitools.model;
+
+import java.net.URI;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.util.NoSuchElementException;
+import org.openapitools.jackson.nullable.JsonNullable;
+import java.time.OffsetDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+
+import java.util.*;
+import javax.annotation.Generated;
+
+/**
+ * NullableMapPropertyDto
+ */
+
+@JsonTypeName("NullableMapProperty")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class NullableMapPropertyDto {
+
+  @Valid
+  private JsonNullable<Map<String, String>> languageValues = JsonNullable.<Map<String, String>>undefined();
+
+  public NullableMapPropertyDto languageValues(Map<String, String> languageValues) {
+    this.languageValues = JsonNullable.of(languageValues);
+    return this;
+  }
+
+  public NullableMapPropertyDto putLanguageValuesItem(String key, String languageValuesItem) {
+    if (this.languageValues == null || !this.languageValues.isPresent()) {
+      this.languageValues = JsonNullable.of(new HashMap<>());
+    }
+    this.languageValues.get().put(key, languageValuesItem);
+    return this;
+  }
+
+  /**
+   * Get languageValues
+   * @return languageValues
+  */
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("languageValues")
+  public JsonNullable<Map<String, String>> getLanguageValues() {
+    return languageValues;
+  }
+
+  public void setLanguageValues(JsonNullable<Map<String, String>> languageValues) {
+    this.languageValues = languageValues;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NullableMapPropertyDto nullableMapProperty = (NullableMapPropertyDto) o;
+    return equalsNullable(this.languageValues, nullableMapProperty.languageValues);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hashCodeNullable(languageValues));
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NullableMapPropertyDto {\n");
+    sb.append("    languageValues: ").append(toIndentedString(languageValues)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/server/petstore/springboot/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot/src/main/resources/openapi.yaml
@@ -2178,6 +2178,14 @@ components:
         property name with spaces:
           type: string
       type: object
+    NullableMapProperty:
+      properties:
+        languageValues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+      type: object
     updatePetWithForm_request:
       properties:
         name:


### PR DESCRIPTION
- fix nullable map properties
- add tests
- to close https://github.com/OpenAPITools/openapi-generator/issues/16519



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)
