### PR TITLE
[Go] return errors that happen while unmarshalling objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -404,9 +404,13 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{#isMap}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
-		*o = {{{classname}}}(var{{{classname}}})
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+
+	if err != nil {
+		return err
 	}
+
+	*o = {{{classname}}}(var{{{classname}}})
 
 	additionalProperties := make(map[string]interface{})
 
@@ -423,9 +427,13 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{^parent}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
-		*o = {{{classname}}}(var{{{classname}}})
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+
+	if err != nil {
+		return err
 	}
+
+	*o = {{{classname}}}(var{{{classname}}})
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesAnyType) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesAnyType) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesAnyType := _AdditionalPropertiesAnyType{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesAnyType); err == nil {
-		*o = AdditionalPropertiesAnyType(varAdditionalPropertiesAnyType)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesAnyType)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesAnyType(varAdditionalPropertiesAnyType)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesArray) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesArray) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesArray := _AdditionalPropertiesArray{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesArray); err == nil {
-		*o = AdditionalPropertiesArray(varAdditionalPropertiesArray)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesArray)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesArray(varAdditionalPropertiesArray)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesBoolean) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesBoolean) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesBoolean := _AdditionalPropertiesBoolean{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesBoolean); err == nil {
-		*o = AdditionalPropertiesBoolean(varAdditionalPropertiesBoolean)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesBoolean)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesBoolean(varAdditionalPropertiesBoolean)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesInteger) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesInteger) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesInteger := _AdditionalPropertiesInteger{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesInteger); err == nil {
-		*o = AdditionalPropertiesInteger(varAdditionalPropertiesInteger)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesInteger)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesInteger(varAdditionalPropertiesInteger)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesNumber) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesNumber) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesNumber := _AdditionalPropertiesNumber{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesNumber); err == nil {
-		*o = AdditionalPropertiesNumber(varAdditionalPropertiesNumber)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesNumber)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesNumber(varAdditionalPropertiesNumber)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesObject) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesObject) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesObject := _AdditionalPropertiesObject{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesObject); err == nil {
-		*o = AdditionalPropertiesObject(varAdditionalPropertiesObject)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesObject)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesObject(varAdditionalPropertiesObject)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
@@ -98,9 +98,13 @@ func (o AdditionalPropertiesString) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesString) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesString := _AdditionalPropertiesString{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesString); err == nil {
-		*o = AdditionalPropertiesString(varAdditionalPropertiesString)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesString)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesString(varAdditionalPropertiesString)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
@@ -134,9 +134,13 @@ func (o Model200Response) ToMap() (map[string]interface{}, error) {
 func (o *Model200Response) UnmarshalJSON(bytes []byte) (err error) {
 	varModel200Response := _Model200Response{}
 
-	if err = json.Unmarshal(bytes, &varModel200Response); err == nil {
-		*o = Model200Response(varModel200Response)
+	err = json.Unmarshal(bytes, &varModel200Response)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Model200Response(varModel200Response)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
@@ -98,9 +98,13 @@ func (o FooGetDefaultResponse) ToMap() (map[string]interface{}, error) {
 func (o *FooGetDefaultResponse) UnmarshalJSON(bytes []byte) (err error) {
 	varFooGetDefaultResponse := _FooGetDefaultResponse{}
 
-	if err = json.Unmarshal(bytes, &varFooGetDefaultResponse); err == nil {
-		*o = FooGetDefaultResponse(varFooGetDefaultResponse)
+	err = json.Unmarshal(bytes, &varFooGetDefaultResponse)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FooGetDefaultResponse(varFooGetDefaultResponse)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
@@ -98,9 +98,13 @@ func (o SpecialModelName) ToMap() (map[string]interface{}, error) {
 func (o *SpecialModelName) UnmarshalJSON(bytes []byte) (err error) {
 	varSpecialModelName := _SpecialModelName{}
 
-	if err = json.Unmarshal(bytes, &varSpecialModelName); err == nil {
-		*o = SpecialModelName(varSpecialModelName)
+	err = json.Unmarshal(bytes, &varSpecialModelName)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpecialModelName(varSpecialModelName)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
@@ -134,9 +134,13 @@ func (o AdditionalPropertiesClass) ToMap() (map[string]interface{}, error) {
 func (o *AdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
 	varAdditionalPropertiesClass := _AdditionalPropertiesClass{}
 
-	if err = json.Unmarshal(bytes, &varAdditionalPropertiesClass); err == nil {
-		*o = AdditionalPropertiesClass(varAdditionalPropertiesClass)
+	err = json.Unmarshal(bytes, &varAdditionalPropertiesClass)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AdditionalPropertiesClass(varAdditionalPropertiesClass)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types.go
@@ -99,9 +99,13 @@ func (o AllOfPrimitiveTypes) ToMap() (map[string]interface{}, error) {
 func (o *AllOfPrimitiveTypes) UnmarshalJSON(bytes []byte) (err error) {
 	varAllOfPrimitiveTypes := _AllOfPrimitiveTypes{}
 
-	if err = json.Unmarshal(bytes, &varAllOfPrimitiveTypes); err == nil {
-		*o = AllOfPrimitiveTypes(varAllOfPrimitiveTypes)
+	err = json.Unmarshal(bytes, &varAllOfPrimitiveTypes)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AllOfPrimitiveTypes(varAllOfPrimitiveTypes)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -129,9 +129,13 @@ func (o Animal) ToMap() (map[string]interface{}, error) {
 func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
 	varAnimal := _Animal{}
 
-	if err = json.Unmarshal(bytes, &varAnimal); err == nil {
-		*o = Animal(varAnimal)
+	err = json.Unmarshal(bytes, &varAnimal)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Animal(varAnimal)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
@@ -170,9 +170,13 @@ func (o ApiResponse) ToMap() (map[string]interface{}, error) {
 func (o *ApiResponse) UnmarshalJSON(bytes []byte) (err error) {
 	varApiResponse := _ApiResponse{}
 
-	if err = json.Unmarshal(bytes, &varApiResponse); err == nil {
-		*o = ApiResponse(varApiResponse)
+	err = json.Unmarshal(bytes, &varApiResponse)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ApiResponse(varApiResponse)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
@@ -98,9 +98,13 @@ func (o Apple) ToMap() (map[string]interface{}, error) {
 func (o *Apple) UnmarshalJSON(bytes []byte) (err error) {
 	varApple := _Apple{}
 
-	if err = json.Unmarshal(bytes, &varApple); err == nil {
-		*o = Apple(varApple)
+	err = json.Unmarshal(bytes, &varApple)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Apple(varApple)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -125,9 +125,13 @@ func (o AppleReq) ToMap() (map[string]interface{}, error) {
 func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
 	varAppleReq := _AppleReq{}
 
-	if err = json.Unmarshal(bytes, &varAppleReq); err == nil {
-		*o = AppleReq(varAppleReq)
+	err = json.Unmarshal(bytes, &varAppleReq)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AppleReq(varAppleReq)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
@@ -98,9 +98,13 @@ func (o ArrayOfArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 func (o *ArrayOfArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
 	varArrayOfArrayOfNumberOnly := _ArrayOfArrayOfNumberOnly{}
 
-	if err = json.Unmarshal(bytes, &varArrayOfArrayOfNumberOnly); err == nil {
-		*o = ArrayOfArrayOfNumberOnly(varArrayOfArrayOfNumberOnly)
+	err = json.Unmarshal(bytes, &varArrayOfArrayOfNumberOnly)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ArrayOfArrayOfNumberOnly(varArrayOfArrayOfNumberOnly)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
@@ -98,9 +98,13 @@ func (o ArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 func (o *ArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
 	varArrayOfNumberOnly := _ArrayOfNumberOnly{}
 
-	if err = json.Unmarshal(bytes, &varArrayOfNumberOnly); err == nil {
-		*o = ArrayOfNumberOnly(varArrayOfNumberOnly)
+	err = json.Unmarshal(bytes, &varArrayOfNumberOnly)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ArrayOfNumberOnly(varArrayOfNumberOnly)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
@@ -170,9 +170,13 @@ func (o ArrayTest) ToMap() (map[string]interface{}, error) {
 func (o *ArrayTest) UnmarshalJSON(bytes []byte) (err error) {
 	varArrayTest := _ArrayTest{}
 
-	if err = json.Unmarshal(bytes, &varArrayTest); err == nil {
-		*o = ArrayTest(varArrayTest)
+	err = json.Unmarshal(bytes, &varArrayTest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ArrayTest(varArrayTest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
@@ -98,9 +98,13 @@ func (o Banana) ToMap() (map[string]interface{}, error) {
 func (o *Banana) UnmarshalJSON(bytes []byte) (err error) {
 	varBanana := _Banana{}
 
-	if err = json.Unmarshal(bytes, &varBanana); err == nil {
-		*o = Banana(varBanana)
+	err = json.Unmarshal(bytes, &varBanana)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Banana(varBanana)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -125,9 +125,13 @@ func (o BananaReq) ToMap() (map[string]interface{}, error) {
 func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
 	varBananaReq := _BananaReq{}
 
-	if err = json.Unmarshal(bytes, &varBananaReq); err == nil {
-		*o = BananaReq(varBananaReq)
+	err = json.Unmarshal(bytes, &varBananaReq)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BananaReq(varBananaReq)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
@@ -279,9 +279,13 @@ func (o Capitalization) ToMap() (map[string]interface{}, error) {
 func (o *Capitalization) UnmarshalJSON(bytes []byte) (err error) {
 	varCapitalization := _Capitalization{}
 
-	if err = json.Unmarshal(bytes, &varCapitalization); err == nil {
-		*o = Capitalization(varCapitalization)
+	err = json.Unmarshal(bytes, &varCapitalization)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Capitalization(varCapitalization)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -127,9 +127,13 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 	varCategory := _Category{}
 
-	if err = json.Unmarshal(bytes, &varCategory); err == nil {
-		*o = Category(varCategory)
+	err = json.Unmarshal(bytes, &varCategory)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Category(varCategory)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
@@ -98,9 +98,13 @@ func (o ClassModel) ToMap() (map[string]interface{}, error) {
 func (o *ClassModel) UnmarshalJSON(bytes []byte) (err error) {
 	varClassModel := _ClassModel{}
 
-	if err = json.Unmarshal(bytes, &varClassModel); err == nil {
-		*o = ClassModel(varClassModel)
+	err = json.Unmarshal(bytes, &varClassModel)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ClassModel(varClassModel)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_client.go
@@ -98,9 +98,13 @@ func (o Client) ToMap() (map[string]interface{}, error) {
 func (o *Client) UnmarshalJSON(bytes []byte) (err error) {
 	varClient := _Client{}
 
-	if err = json.Unmarshal(bytes, &varClient); err == nil {
-		*o = Client(varClient)
+	err = json.Unmarshal(bytes, &varClient)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Client(varClient)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
@@ -90,9 +90,13 @@ func (o DuplicatedPropParent) ToMap() (map[string]interface{}, error) {
 func (o *DuplicatedPropParent) UnmarshalJSON(bytes []byte) (err error) {
 	varDuplicatedPropParent := _DuplicatedPropParent{}
 
-	if err = json.Unmarshal(bytes, &varDuplicatedPropParent); err == nil {
-		*o = DuplicatedPropParent(varDuplicatedPropParent)
+	err = json.Unmarshal(bytes, &varDuplicatedPropParent)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DuplicatedPropParent(varDuplicatedPropParent)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -134,9 +134,13 @@ func (o EnumArrays) ToMap() (map[string]interface{}, error) {
 func (o *EnumArrays) UnmarshalJSON(bytes []byte) (err error) {
 	varEnumArrays := _EnumArrays{}
 
-	if err = json.Unmarshal(bytes, &varEnumArrays); err == nil {
-		*o = EnumArrays(varEnumArrays)
+	err = json.Unmarshal(bytes, &varEnumArrays)
+
+	if err != nil {
+		return err
 	}
+
+	*o = EnumArrays(varEnumArrays)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -359,9 +359,13 @@ func (o EnumTest) ToMap() (map[string]interface{}, error) {
 func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
 	varEnumTest := _EnumTest{}
 
-	if err = json.Unmarshal(bytes, &varEnumTest); err == nil {
-		*o = EnumTest(varEnumTest)
+	err = json.Unmarshal(bytes, &varEnumTest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = EnumTest(varEnumTest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file.go
@@ -99,9 +99,13 @@ func (o File) ToMap() (map[string]interface{}, error) {
 func (o *File) UnmarshalJSON(bytes []byte) (err error) {
 	varFile := _File{}
 
-	if err = json.Unmarshal(bytes, &varFile); err == nil {
-		*o = File(varFile)
+	err = json.Unmarshal(bytes, &varFile)
+
+	if err != nil {
+		return err
 	}
+
+	*o = File(varFile)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
@@ -134,9 +134,13 @@ func (o FileSchemaTestClass) ToMap() (map[string]interface{}, error) {
 func (o *FileSchemaTestClass) UnmarshalJSON(bytes []byte) (err error) {
 	varFileSchemaTestClass := _FileSchemaTestClass{}
 
-	if err = json.Unmarshal(bytes, &varFileSchemaTestClass); err == nil {
-		*o = FileSchemaTestClass(varFileSchemaTestClass)
+	err = json.Unmarshal(bytes, &varFileSchemaTestClass)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FileSchemaTestClass(varFileSchemaTestClass)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
@@ -102,9 +102,13 @@ func (o Foo) ToMap() (map[string]interface{}, error) {
 func (o *Foo) UnmarshalJSON(bytes []byte) (err error) {
 	varFoo := _Foo{}
 
-	if err = json.Unmarshal(bytes, &varFoo); err == nil {
-		*o = Foo(varFoo)
+	err = json.Unmarshal(bytes, &varFoo)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Foo(varFoo)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -570,9 +570,13 @@ func (o FormatTest) ToMap() (map[string]interface{}, error) {
 func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
 	varFormatTest := _FormatTest{}
 
-	if err = json.Unmarshal(bytes, &varFormatTest); err == nil {
-		*o = FormatTest(varFormatTest)
+	err = json.Unmarshal(bytes, &varFormatTest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FormatTest(varFormatTest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -134,9 +134,13 @@ func (o HasOnlyReadOnly) ToMap() (map[string]interface{}, error) {
 func (o *HasOnlyReadOnly) UnmarshalJSON(bytes []byte) (err error) {
 	varHasOnlyReadOnly := _HasOnlyReadOnly{}
 
-	if err = json.Unmarshal(bytes, &varHasOnlyReadOnly); err == nil {
-		*o = HasOnlyReadOnly(varHasOnlyReadOnly)
+	err = json.Unmarshal(bytes, &varHasOnlyReadOnly)
+
+	if err != nil {
+		return err
 	}
+
+	*o = HasOnlyReadOnly(varHasOnlyReadOnly)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
@@ -108,9 +108,13 @@ func (o HealthCheckResult) ToMap() (map[string]interface{}, error) {
 func (o *HealthCheckResult) UnmarshalJSON(bytes []byte) (err error) {
 	varHealthCheckResult := _HealthCheckResult{}
 
-	if err = json.Unmarshal(bytes, &varHealthCheckResult); err == nil {
-		*o = HealthCheckResult(varHealthCheckResult)
+	err = json.Unmarshal(bytes, &varHealthCheckResult)
+
+	if err != nil {
+		return err
 	}
+
+	*o = HealthCheckResult(varHealthCheckResult)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_list.go
@@ -98,9 +98,13 @@ func (o List) ToMap() (map[string]interface{}, error) {
 func (o *List) UnmarshalJSON(bytes []byte) (err error) {
 	varList := _List{}
 
-	if err = json.Unmarshal(bytes, &varList); err == nil {
-		*o = List(varList)
+	err = json.Unmarshal(bytes, &varList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = List(varList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
@@ -100,9 +100,13 @@ func (o MapOfFileTest) ToMap() (map[string]interface{}, error) {
 func (o *MapOfFileTest) UnmarshalJSON(bytes []byte) (err error) {
 	varMapOfFileTest := _MapOfFileTest{}
 
-	if err = json.Unmarshal(bytes, &varMapOfFileTest); err == nil {
-		*o = MapOfFileTest(varMapOfFileTest)
+	err = json.Unmarshal(bytes, &varMapOfFileTest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MapOfFileTest(varMapOfFileTest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
@@ -206,9 +206,13 @@ func (o MapTest) ToMap() (map[string]interface{}, error) {
 func (o *MapTest) UnmarshalJSON(bytes []byte) (err error) {
 	varMapTest := _MapTest{}
 
-	if err = json.Unmarshal(bytes, &varMapTest); err == nil {
-		*o = MapTest(varMapTest)
+	err = json.Unmarshal(bytes, &varMapTest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MapTest(varMapTest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -171,9 +171,13 @@ func (o MixedPropertiesAndAdditionalPropertiesClass) ToMap() (map[string]interfa
 func (o *MixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
 	varMixedPropertiesAndAdditionalPropertiesClass := _MixedPropertiesAndAdditionalPropertiesClass{}
 
-	if err = json.Unmarshal(bytes, &varMixedPropertiesAndAdditionalPropertiesClass); err == nil {
-		*o = MixedPropertiesAndAdditionalPropertiesClass(varMixedPropertiesAndAdditionalPropertiesClass)
+	err = json.Unmarshal(bytes, &varMixedPropertiesAndAdditionalPropertiesClass)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MixedPropertiesAndAdditionalPropertiesClass(varMixedPropertiesAndAdditionalPropertiesClass)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -197,9 +197,13 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
 	varName := _Name{}
 
-	if err = json.Unmarshal(bytes, &varName); err == nil {
-		*o = Name(varName)
+	err = json.Unmarshal(bytes, &varName)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Name(varName)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
@@ -108,9 +108,13 @@ func (o NullableAllOf) ToMap() (map[string]interface{}, error) {
 func (o *NullableAllOf) UnmarshalJSON(bytes []byte) (err error) {
 	varNullableAllOf := _NullableAllOf{}
 
-	if err = json.Unmarshal(bytes, &varNullableAllOf); err == nil {
-		*o = NullableAllOf(varNullableAllOf)
+	err = json.Unmarshal(bytes, &varNullableAllOf)
+
+	if err != nil {
+		return err
 	}
+
+	*o = NullableAllOf(varNullableAllOf)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
@@ -98,9 +98,13 @@ func (o NullableAllOfChild) ToMap() (map[string]interface{}, error) {
 func (o *NullableAllOfChild) UnmarshalJSON(bytes []byte) (err error) {
 	varNullableAllOfChild := _NullableAllOfChild{}
 
-	if err = json.Unmarshal(bytes, &varNullableAllOfChild); err == nil {
-		*o = NullableAllOfChild(varNullableAllOfChild)
+	err = json.Unmarshal(bytes, &varNullableAllOfChild)
+
+	if err != nil {
+		return err
 	}
+
+	*o = NullableAllOfChild(varNullableAllOfChild)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
@@ -32,7 +32,10 @@ type NullableClass struct {
 	ObjectNullableProp map[string]map[string]interface{} `json:"object_nullable_prop,omitempty"`
 	ObjectAndItemsNullableProp map[string]map[string]interface{} `json:"object_and_items_nullable_prop,omitempty"`
 	ObjectItemsNullable map[string]map[string]interface{} `json:"object_items_nullable,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _NullableClass NullableClass
 
 // NewNullableClass instantiates a new NullableClass object
 // This constructor will assign default values to properties that have it defined,
@@ -549,7 +552,44 @@ func (o NullableClass) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ObjectItemsNullable) {
 		toSerialize["object_items_nullable"] = o.ObjectItemsNullable
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *NullableClass) UnmarshalJSON(bytes []byte) (err error) {
+	varNullableClass := _NullableClass{}
+
+	err = json.Unmarshal(bytes, &varNullableClass)
+
+	if err != nil {
+		return err
+	}
+
+	*o = NullableClass(varNullableClass)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "integer_prop")
+		delete(additionalProperties, "number_prop")
+		delete(additionalProperties, "boolean_prop")
+		delete(additionalProperties, "string_prop")
+		delete(additionalProperties, "date_prop")
+		delete(additionalProperties, "datetime_prop")
+		delete(additionalProperties, "array_nullable_prop")
+		delete(additionalProperties, "array_and_items_nullable_prop")
+		delete(additionalProperties, "array_items_nullable")
+		delete(additionalProperties, "object_nullable_prop")
+		delete(additionalProperties, "object_and_items_nullable_prop")
+		delete(additionalProperties, "object_items_nullable")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableNullableClass struct {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
@@ -32,10 +32,7 @@ type NullableClass struct {
 	ObjectNullableProp map[string]map[string]interface{} `json:"object_nullable_prop,omitempty"`
 	ObjectAndItemsNullableProp map[string]map[string]interface{} `json:"object_and_items_nullable_prop,omitempty"`
 	ObjectItemsNullable map[string]map[string]interface{} `json:"object_items_nullable,omitempty"`
-	AdditionalProperties map[string]interface{}
 }
-
-type _NullableClass NullableClass
 
 // NewNullableClass instantiates a new NullableClass object
 // This constructor will assign default values to properties that have it defined,
@@ -552,40 +549,7 @@ func (o NullableClass) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ObjectItemsNullable) {
 		toSerialize["object_items_nullable"] = o.ObjectItemsNullable
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return toSerialize, nil
-}
-
-func (o *NullableClass) UnmarshalJSON(bytes []byte) (err error) {
-	varNullableClass := _NullableClass{}
-
-	if err = json.Unmarshal(bytes, &varNullableClass); err == nil {
-		*o = NullableClass(varNullableClass)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "integer_prop")
-		delete(additionalProperties, "number_prop")
-		delete(additionalProperties, "boolean_prop")
-		delete(additionalProperties, "string_prop")
-		delete(additionalProperties, "date_prop")
-		delete(additionalProperties, "datetime_prop")
-		delete(additionalProperties, "array_nullable_prop")
-		delete(additionalProperties, "array_and_items_nullable_prop")
-		delete(additionalProperties, "array_items_nullable")
-		delete(additionalProperties, "object_nullable_prop")
-		delete(additionalProperties, "object_and_items_nullable_prop")
-		delete(additionalProperties, "object_items_nullable")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }
 
 type NullableNullableClass struct {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
@@ -98,9 +98,13 @@ func (o NumberOnly) ToMap() (map[string]interface{}, error) {
 func (o *NumberOnly) UnmarshalJSON(bytes []byte) (err error) {
 	varNumberOnly := _NumberOnly{}
 
-	if err = json.Unmarshal(bytes, &varNumberOnly); err == nil {
-		*o = NumberOnly(varNumberOnly)
+	err = json.Unmarshal(bytes, &varNumberOnly)
+
+	if err != nil {
+		return err
 	}
+
+	*o = NumberOnly(varNumberOnly)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
@@ -98,9 +98,13 @@ func (o OneOfPrimitiveTypeChild) ToMap() (map[string]interface{}, error) {
 func (o *OneOfPrimitiveTypeChild) UnmarshalJSON(bytes []byte) (err error) {
 	varOneOfPrimitiveTypeChild := _OneOfPrimitiveTypeChild{}
 
-	if err = json.Unmarshal(bytes, &varOneOfPrimitiveTypeChild); err == nil {
-		*o = OneOfPrimitiveTypeChild(varOneOfPrimitiveTypeChild)
+	err = json.Unmarshal(bytes, &varOneOfPrimitiveTypeChild)
+
+	if err != nil {
+		return err
 	}
+
+	*o = OneOfPrimitiveTypeChild(varOneOfPrimitiveTypeChild)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_order.go
@@ -284,9 +284,13 @@ func (o Order) ToMap() (map[string]interface{}, error) {
 func (o *Order) UnmarshalJSON(bytes []byte) (err error) {
 	varOrder := _Order{}
 
-	if err = json.Unmarshal(bytes, &varOrder); err == nil {
-		*o = Order(varOrder)
+	err = json.Unmarshal(bytes, &varOrder)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Order(varOrder)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
@@ -170,9 +170,13 @@ func (o OuterComposite) ToMap() (map[string]interface{}, error) {
 func (o *OuterComposite) UnmarshalJSON(bytes []byte) (err error) {
 	varOuterComposite := _OuterComposite{}
 
-	if err = json.Unmarshal(bytes, &varOuterComposite); err == nil {
-		*o = OuterComposite(varOuterComposite)
+	err = json.Unmarshal(bytes, &varOuterComposite)
+
+	if err != nil {
+		return err
 	}
+
+	*o = OuterComposite(varOuterComposite)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -265,9 +265,13 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 	varPet := _Pet{}
 
-	if err = json.Unmarshal(bytes, &varPet); err == nil {
-		*o = Pet(varPet)
+	err = json.Unmarshal(bytes, &varPet)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Pet(varPet)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_property_name_mapping.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_property_name_mapping.go
@@ -19,10 +19,10 @@ var _ MappedNullable = &PropertyNameMapping{}
 
 // PropertyNameMapping struct for PropertyNameMapping
 type PropertyNameMapping struct {
-	HttpDebugOperation *string `json:"http_debug_operation,omitempty"`
-	Type *string `json:"_type,omitempty"`
+	HTTPDebugOperation *string `json:"http_debug_operation,omitempty"`
+	UnderscoreType *string `json:"_type,omitempty"`
 	Type *string `json:"type,omitempty"`
-	Type *string `json:"type_,omitempty"`
+	TypeWithUnderscore *string `json:"type_,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -45,36 +45,68 @@ func NewPropertyNameMappingWithDefaults() *PropertyNameMapping {
 	return &this
 }
 
-// GetHttpDebugOperation returns the HttpDebugOperation field value if set, zero value otherwise.
-func (o *PropertyNameMapping) GetHttpDebugOperation() string {
-	if o == nil || IsNil(o.HttpDebugOperation) {
+// GetHTTPDebugOperation returns the HTTPDebugOperation field value if set, zero value otherwise.
+func (o *PropertyNameMapping) GetHTTPDebugOperation() string {
+	if o == nil || IsNil(o.HTTPDebugOperation) {
 		var ret string
 		return ret
 	}
-	return *o.HttpDebugOperation
+	return *o.HTTPDebugOperation
 }
 
-// GetHttpDebugOperationOk returns a tuple with the HttpDebugOperation field value if set, nil otherwise
+// GetHTTPDebugOperationOk returns a tuple with the HTTPDebugOperation field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PropertyNameMapping) GetHttpDebugOperationOk() (*string, bool) {
-	if o == nil || IsNil(o.HttpDebugOperation) {
+func (o *PropertyNameMapping) GetHTTPDebugOperationOk() (*string, bool) {
+	if o == nil || IsNil(o.HTTPDebugOperation) {
 		return nil, false
 	}
-	return o.HttpDebugOperation, true
+	return o.HTTPDebugOperation, true
 }
 
-// HasHttpDebugOperation returns a boolean if a field has been set.
-func (o *PropertyNameMapping) HasHttpDebugOperation() bool {
-	if o != nil && !IsNil(o.HttpDebugOperation) {
+// HasHTTPDebugOperation returns a boolean if a field has been set.
+func (o *PropertyNameMapping) HasHTTPDebugOperation() bool {
+	if o != nil && !IsNil(o.HTTPDebugOperation) {
 		return true
 	}
 
 	return false
 }
 
-// SetHttpDebugOperation gets a reference to the given string and assigns it to the HttpDebugOperation field.
-func (o *PropertyNameMapping) SetHttpDebugOperation(v string) {
-	o.HttpDebugOperation = &v
+// SetHTTPDebugOperation gets a reference to the given string and assigns it to the HTTPDebugOperation field.
+func (o *PropertyNameMapping) SetHTTPDebugOperation(v string) {
+	o.HTTPDebugOperation = &v
+}
+
+// GetUnderscoreType returns the UnderscoreType field value if set, zero value otherwise.
+func (o *PropertyNameMapping) GetUnderscoreType() string {
+	if o == nil || IsNil(o.UnderscoreType) {
+		var ret string
+		return ret
+	}
+	return *o.UnderscoreType
+}
+
+// GetUnderscoreTypeOk returns a tuple with the UnderscoreType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PropertyNameMapping) GetUnderscoreTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.UnderscoreType) {
+		return nil, false
+	}
+	return o.UnderscoreType, true
+}
+
+// HasUnderscoreType returns a boolean if a field has been set.
+func (o *PropertyNameMapping) HasUnderscoreType() bool {
+	if o != nil && !IsNil(o.UnderscoreType) {
+		return true
+	}
+
+	return false
+}
+
+// SetUnderscoreType gets a reference to the given string and assigns it to the UnderscoreType field.
+func (o *PropertyNameMapping) SetUnderscoreType(v string) {
+	o.UnderscoreType = &v
 }
 
 // GetType returns the Type field value if set, zero value otherwise.
@@ -109,68 +141,36 @@ func (o *PropertyNameMapping) SetType(v string) {
 	o.Type = &v
 }
 
-// GetType returns the Type field value if set, zero value otherwise.
-func (o *PropertyNameMapping) GetType() string {
-	if o == nil || IsNil(o.Type) {
+// GetTypeWithUnderscore returns the TypeWithUnderscore field value if set, zero value otherwise.
+func (o *PropertyNameMapping) GetTypeWithUnderscore() string {
+	if o == nil || IsNil(o.TypeWithUnderscore) {
 		var ret string
 		return ret
 	}
-	return *o.Type
+	return *o.TypeWithUnderscore
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
+// GetTypeWithUnderscoreOk returns a tuple with the TypeWithUnderscore field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PropertyNameMapping) GetTypeOk() (*string, bool) {
-	if o == nil || IsNil(o.Type) {
+func (o *PropertyNameMapping) GetTypeWithUnderscoreOk() (*string, bool) {
+	if o == nil || IsNil(o.TypeWithUnderscore) {
 		return nil, false
 	}
-	return o.Type, true
+	return o.TypeWithUnderscore, true
 }
 
-// HasType returns a boolean if a field has been set.
-func (o *PropertyNameMapping) HasType() bool {
-	if o != nil && !IsNil(o.Type) {
+// HasTypeWithUnderscore returns a boolean if a field has been set.
+func (o *PropertyNameMapping) HasTypeWithUnderscore() bool {
+	if o != nil && !IsNil(o.TypeWithUnderscore) {
 		return true
 	}
 
 	return false
 }
 
-// SetType gets a reference to the given string and assigns it to the Type field.
-func (o *PropertyNameMapping) SetType(v string) {
-	o.Type = &v
-}
-
-// GetType returns the Type field value if set, zero value otherwise.
-func (o *PropertyNameMapping) GetType() string {
-	if o == nil || IsNil(o.Type) {
-		var ret string
-		return ret
-	}
-	return *o.Type
-}
-
-// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *PropertyNameMapping) GetTypeOk() (*string, bool) {
-	if o == nil || IsNil(o.Type) {
-		return nil, false
-	}
-	return o.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (o *PropertyNameMapping) HasType() bool {
-	if o != nil && !IsNil(o.Type) {
-		return true
-	}
-
-	return false
-}
-
-// SetType gets a reference to the given string and assigns it to the Type field.
-func (o *PropertyNameMapping) SetType(v string) {
-	o.Type = &v
+// SetTypeWithUnderscore gets a reference to the given string and assigns it to the TypeWithUnderscore field.
+func (o *PropertyNameMapping) SetTypeWithUnderscore(v string) {
+	o.TypeWithUnderscore = &v
 }
 
 func (o PropertyNameMapping) MarshalJSON() ([]byte, error) {
@@ -183,17 +183,17 @@ func (o PropertyNameMapping) MarshalJSON() ([]byte, error) {
 
 func (o PropertyNameMapping) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.HttpDebugOperation) {
-		toSerialize["http_debug_operation"] = o.HttpDebugOperation
+	if !IsNil(o.HTTPDebugOperation) {
+		toSerialize["http_debug_operation"] = o.HTTPDebugOperation
 	}
-	if !IsNil(o.Type) {
-		toSerialize["_type"] = o.Type
+	if !IsNil(o.UnderscoreType) {
+		toSerialize["_type"] = o.UnderscoreType
 	}
 	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
-	if !IsNil(o.Type) {
-		toSerialize["type_"] = o.Type
+	if !IsNil(o.TypeWithUnderscore) {
+		toSerialize["type_"] = o.TypeWithUnderscore
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_property_name_mapping.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_property_name_mapping.go
@@ -19,10 +19,10 @@ var _ MappedNullable = &PropertyNameMapping{}
 
 // PropertyNameMapping struct for PropertyNameMapping
 type PropertyNameMapping struct {
-	HTTPDebugOperation *string `json:"http_debug_operation,omitempty"`
-	UnderscoreType *string `json:"_type,omitempty"`
+	HttpDebugOperation *string `json:"http_debug_operation,omitempty"`
+	Type *string `json:"_type,omitempty"`
 	Type *string `json:"type,omitempty"`
-	TypeWithUnderscore *string `json:"type_,omitempty"`
+	Type *string `json:"type_,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -45,68 +45,36 @@ func NewPropertyNameMappingWithDefaults() *PropertyNameMapping {
 	return &this
 }
 
-// GetHTTPDebugOperation returns the HTTPDebugOperation field value if set, zero value otherwise.
-func (o *PropertyNameMapping) GetHTTPDebugOperation() string {
-	if o == nil || IsNil(o.HTTPDebugOperation) {
+// GetHttpDebugOperation returns the HttpDebugOperation field value if set, zero value otherwise.
+func (o *PropertyNameMapping) GetHttpDebugOperation() string {
+	if o == nil || IsNil(o.HttpDebugOperation) {
 		var ret string
 		return ret
 	}
-	return *o.HTTPDebugOperation
+	return *o.HttpDebugOperation
 }
 
-// GetHTTPDebugOperationOk returns a tuple with the HTTPDebugOperation field value if set, nil otherwise
+// GetHttpDebugOperationOk returns a tuple with the HttpDebugOperation field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PropertyNameMapping) GetHTTPDebugOperationOk() (*string, bool) {
-	if o == nil || IsNil(o.HTTPDebugOperation) {
+func (o *PropertyNameMapping) GetHttpDebugOperationOk() (*string, bool) {
+	if o == nil || IsNil(o.HttpDebugOperation) {
 		return nil, false
 	}
-	return o.HTTPDebugOperation, true
+	return o.HttpDebugOperation, true
 }
 
-// HasHTTPDebugOperation returns a boolean if a field has been set.
-func (o *PropertyNameMapping) HasHTTPDebugOperation() bool {
-	if o != nil && !IsNil(o.HTTPDebugOperation) {
+// HasHttpDebugOperation returns a boolean if a field has been set.
+func (o *PropertyNameMapping) HasHttpDebugOperation() bool {
+	if o != nil && !IsNil(o.HttpDebugOperation) {
 		return true
 	}
 
 	return false
 }
 
-// SetHTTPDebugOperation gets a reference to the given string and assigns it to the HTTPDebugOperation field.
-func (o *PropertyNameMapping) SetHTTPDebugOperation(v string) {
-	o.HTTPDebugOperation = &v
-}
-
-// GetUnderscoreType returns the UnderscoreType field value if set, zero value otherwise.
-func (o *PropertyNameMapping) GetUnderscoreType() string {
-	if o == nil || IsNil(o.UnderscoreType) {
-		var ret string
-		return ret
-	}
-	return *o.UnderscoreType
-}
-
-// GetUnderscoreTypeOk returns a tuple with the UnderscoreType field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *PropertyNameMapping) GetUnderscoreTypeOk() (*string, bool) {
-	if o == nil || IsNil(o.UnderscoreType) {
-		return nil, false
-	}
-	return o.UnderscoreType, true
-}
-
-// HasUnderscoreType returns a boolean if a field has been set.
-func (o *PropertyNameMapping) HasUnderscoreType() bool {
-	if o != nil && !IsNil(o.UnderscoreType) {
-		return true
-	}
-
-	return false
-}
-
-// SetUnderscoreType gets a reference to the given string and assigns it to the UnderscoreType field.
-func (o *PropertyNameMapping) SetUnderscoreType(v string) {
-	o.UnderscoreType = &v
+// SetHttpDebugOperation gets a reference to the given string and assigns it to the HttpDebugOperation field.
+func (o *PropertyNameMapping) SetHttpDebugOperation(v string) {
+	o.HttpDebugOperation = &v
 }
 
 // GetType returns the Type field value if set, zero value otherwise.
@@ -141,36 +109,68 @@ func (o *PropertyNameMapping) SetType(v string) {
 	o.Type = &v
 }
 
-// GetTypeWithUnderscore returns the TypeWithUnderscore field value if set, zero value otherwise.
-func (o *PropertyNameMapping) GetTypeWithUnderscore() string {
-	if o == nil || IsNil(o.TypeWithUnderscore) {
+// GetType returns the Type field value if set, zero value otherwise.
+func (o *PropertyNameMapping) GetType() string {
+	if o == nil || IsNil(o.Type) {
 		var ret string
 		return ret
 	}
-	return *o.TypeWithUnderscore
+	return *o.Type
 }
 
-// GetTypeWithUnderscoreOk returns a tuple with the TypeWithUnderscore field value if set, nil otherwise
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PropertyNameMapping) GetTypeWithUnderscoreOk() (*string, bool) {
-	if o == nil || IsNil(o.TypeWithUnderscore) {
+func (o *PropertyNameMapping) GetTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.Type) {
 		return nil, false
 	}
-	return o.TypeWithUnderscore, true
+	return o.Type, true
 }
 
-// HasTypeWithUnderscore returns a boolean if a field has been set.
-func (o *PropertyNameMapping) HasTypeWithUnderscore() bool {
-	if o != nil && !IsNil(o.TypeWithUnderscore) {
+// HasType returns a boolean if a field has been set.
+func (o *PropertyNameMapping) HasType() bool {
+	if o != nil && !IsNil(o.Type) {
 		return true
 	}
 
 	return false
 }
 
-// SetTypeWithUnderscore gets a reference to the given string and assigns it to the TypeWithUnderscore field.
-func (o *PropertyNameMapping) SetTypeWithUnderscore(v string) {
-	o.TypeWithUnderscore = &v
+// SetType gets a reference to the given string and assigns it to the Type field.
+func (o *PropertyNameMapping) SetType(v string) {
+	o.Type = &v
+}
+
+// GetType returns the Type field value if set, zero value otherwise.
+func (o *PropertyNameMapping) GetType() string {
+	if o == nil || IsNil(o.Type) {
+		var ret string
+		return ret
+	}
+	return *o.Type
+}
+
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PropertyNameMapping) GetTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.Type) {
+		return nil, false
+	}
+	return o.Type, true
+}
+
+// HasType returns a boolean if a field has been set.
+func (o *PropertyNameMapping) HasType() bool {
+	if o != nil && !IsNil(o.Type) {
+		return true
+	}
+
+	return false
+}
+
+// SetType gets a reference to the given string and assigns it to the Type field.
+func (o *PropertyNameMapping) SetType(v string) {
+	o.Type = &v
 }
 
 func (o PropertyNameMapping) MarshalJSON() ([]byte, error) {
@@ -183,17 +183,17 @@ func (o PropertyNameMapping) MarshalJSON() ([]byte, error) {
 
 func (o PropertyNameMapping) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.HTTPDebugOperation) {
-		toSerialize["http_debug_operation"] = o.HTTPDebugOperation
+	if !IsNil(o.HttpDebugOperation) {
+		toSerialize["http_debug_operation"] = o.HttpDebugOperation
 	}
-	if !IsNil(o.UnderscoreType) {
-		toSerialize["_type"] = o.UnderscoreType
+	if !IsNil(o.Type) {
+		toSerialize["_type"] = o.Type
 	}
 	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
-	if !IsNil(o.TypeWithUnderscore) {
-		toSerialize["type_"] = o.TypeWithUnderscore
+	if !IsNil(o.Type) {
+		toSerialize["type_"] = o.Type
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -206,9 +206,13 @@ func (o PropertyNameMapping) ToMap() (map[string]interface{}, error) {
 func (o *PropertyNameMapping) UnmarshalJSON(bytes []byte) (err error) {
 	varPropertyNameMapping := _PropertyNameMapping{}
 
-	if err = json.Unmarshal(bytes, &varPropertyNameMapping); err == nil {
-		*o = PropertyNameMapping(varPropertyNameMapping)
+	err = json.Unmarshal(bytes, &varPropertyNameMapping)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PropertyNameMapping(varPropertyNameMapping)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
@@ -134,9 +134,13 @@ func (o ReadOnlyFirst) ToMap() (map[string]interface{}, error) {
 func (o *ReadOnlyFirst) UnmarshalJSON(bytes []byte) (err error) {
 	varReadOnlyFirst := _ReadOnlyFirst{}
 
-	if err = json.Unmarshal(bytes, &varReadOnlyFirst); err == nil {
-		*o = ReadOnlyFirst(varReadOnlyFirst)
+	err = json.Unmarshal(bytes, &varReadOnlyFirst)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ReadOnlyFirst(varReadOnlyFirst)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
@@ -326,9 +326,13 @@ func (o ReadOnlyWithDefault) ToMap() (map[string]interface{}, error) {
 func (o *ReadOnlyWithDefault) UnmarshalJSON(bytes []byte) (err error) {
 	varReadOnlyWithDefault := _ReadOnlyWithDefault{}
 
-	if err = json.Unmarshal(bytes, &varReadOnlyWithDefault); err == nil {
-		*o = ReadOnlyWithDefault(varReadOnlyWithDefault)
+	err = json.Unmarshal(bytes, &varReadOnlyWithDefault)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ReadOnlyWithDefault(varReadOnlyWithDefault)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_return.go
@@ -98,9 +98,13 @@ func (o Return) ToMap() (map[string]interface{}, error) {
 func (o *Return) UnmarshalJSON(bytes []byte) (err error) {
 	varReturn := _Return{}
 
-	if err = json.Unmarshal(bytes, &varReturn); err == nil {
-		*o = Return(varReturn)
+	err = json.Unmarshal(bytes, &varReturn)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Return(varReturn)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
@@ -134,9 +134,13 @@ func (o Tag) ToMap() (map[string]interface{}, error) {
 func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
 	varTag := _Tag{}
 
-	if err = json.Unmarshal(bytes, &varTag); err == nil {
-		*o = Tag(varTag)
+	err = json.Unmarshal(bytes, &varTag)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Tag(varTag)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_user.go
@@ -502,9 +502,13 @@ func (o User) ToMap() (map[string]interface{}, error) {
 func (o *User) UnmarshalJSON(bytes []byte) (err error) {
 	varUser := _User{}
 
-	if err = json.Unmarshal(bytes, &varUser); err == nil {
-		*o = User(varUser)
+	err = json.Unmarshal(bytes, &varUser)
+
+	if err != nil {
+		return err
 	}
+
+	*o = User(varUser)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -161,9 +161,13 @@ func (o Whale) ToMap() (map[string]interface{}, error) {
 func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
 	varWhale := _Whale{}
 
-	if err = json.Unmarshal(bytes, &varWhale); err == nil {
-		*o = Whale(varWhale)
+	err = json.Unmarshal(bytes, &varWhale)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Whale(varWhale)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -125,9 +125,13 @@ func (o Zebra) ToMap() (map[string]interface{}, error) {
 func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
 	varZebra := _Zebra{}
 
-	if err = json.Unmarshal(bytes, &varZebra); err == nil {
-		*o = Zebra(varZebra)
+	err = json.Unmarshal(bytes, &varZebra)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Zebra(varZebra)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/samples/openapi3/client/petstore/go/store_api_test.go
+++ b/samples/openapi3/client/petstore/go/store_api_test.go
@@ -24,7 +24,7 @@ func TestPlaceOrder(t *testing.T) {
 		// Skip parsing time error due to error in Petstore Test Server
 		// https://github.com/OpenAPITools/openapi-generator/issues/1292
 		if regexp.
-			MustCompile(`^parsing time.+cannot parse "\+0000"" as "Z07:00"$`).
+			MustCompile(`as "Z07:00"$`).
 			MatchString(err.Error()) {
 			t.Log("Skipping error for parsing time with `+0000` UTC offset as Petstore Test Server does not return valid RFC 3339 datetime")
 		} else {


### PR DESCRIPTION
This updates the Go client templates so that the `UnmarshalJSON` function for a model always returns errors that occur during unmarshalling.

Given the following spec (pseudocode, not necessarily a fully-valid spec):

```yaml
components:
  schemas:
    ItemType:
      type: string
      enum:
        - foo
        - bar
        - baz
    Item:
      type: object
      properties:
        type:
          $ref: '#/ItemType'
```

and the following JSON for an Item:
```json
{
  "type": "invalid"
}
```

The generated Go model should throw an error in `UnmarshalJSON` because the value of the `type` field does not match the spec.


cc/ Go committe: @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
