### PR TITLE
[typescript] fix: allow 'additionalProperties: true' at top level

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -502,14 +502,7 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
 
     @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
-
-        Object addPropsObj = schema.getAdditionalProperties();
-
-        if (addPropsObj instanceof Boolean){
-            codegenModel.isAdditionalPropertiesTrue = true;
-        }else{
-            codegenModel.additionalPropertiesType = getTypeDeclaration((Schema) addPropsObj);
-        }
+        codegenModel.additionalPropertiesType = getSchemaType(ModelUtils.getAdditionalProperties(schema));
         addImport(codegenModel, codegenModel.additionalPropertiesType);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -502,7 +502,14 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
 
     @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
-        codegenModel.additionalPropertiesType = getTypeDeclaration((Schema) schema.getAdditionalProperties());
+
+        Object addPropsObj = schema.getAdditionalProperties();
+
+        if (addPropsObj instanceof Boolean){
+            codegenModel.isAdditionalPropertiesTrue = true;
+        }else{
+            codegenModel.additionalPropertiesType = getTypeDeclaration((Schema) addPropsObj);
+        }
         addImport(codegenModel, codegenModel.additionalPropertiesType);
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I was getting the following error

```
Exception in thread "main" java.lang.RuntimeException: Could not process model 'AvatarizationBatchParameters'.Please make sure that your schema is correct!
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:529)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:950)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:511)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
Caused by: java.lang.ClassCastException: class java.lang.Boolean cannot be cast to class io.swagger.v3.oas.models.media.Schema (java.lang.Boolean is in module java.base of loader 'bootstrap'; io.swagger.v3.oas.models.media.Schema is in unnamed module of loader 'app')
	at org.openapitools.codegen.languages.TypeScriptClientCodegen.addAdditionPropertiesToCodeGenModel(TypeScriptClientCodegen.java:505)
	at org.openapitools.codegen.DefaultCodegen.updateModelForObject(DefaultCodegen.java:2893)
	at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:3111)
	at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1329)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:524)
	... 4 more
```
	
when having the following OpenAPI schema

```
"AvatarizationBatchParameters": {
        "title": "AvatarizationBatchParameters",
        "required": ["training_dataset_id"],
        "type": "object",
        "properties": {
          "training_dataset_id": {
            "title": "Training Dataset Id",
            "type": "string",
            "format": "uuid"
          },
        },
        "additionalProperties": true
      },
```

where we have `additionalProperties: true` at the top level which is a valid spec it seems.


This is related to https://github.com/OpenAPITools/openapi-generator/pull/13003, but it had `additionalProperties` that was nested.

Also related is the following issue, but is not specific to `typescript`:
https://github.com/OpenAPITools/openapi-generator/issues/9282


The fix was simply to conform to how all the other typescript generators do it, e.g. `TypeScriptAxiosClientCodegen.java`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
