### PR TITLE
Add omitGradleWrapper option to kotlin-server code generator

### DIFF
--- a/docs/generators/kotlin-server.md
+++ b/docs/generators/kotlin-server.md
@@ -34,6 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |interfaceOnly|Whether to generate only API interface stubs without the server files. This option is currently supported only when using jaxrs-spec library.| |false|
 |library|library template (sub-template)|<dl><dt>**ktor**</dt><dd>ktor framework</dd><dt>**jaxrs-spec**</dt><dd>JAX-RS spec only</dd></dl>|ktor|
 |modelMutable|Create mutable models| |false|
+|omitGradleWrapper|Whether to omit Gradle wrapper for creating a sub project.| |false|
 |packageName|Generated artifact package name.| |org.openapitools.server|
 |parcelizeModels|toggle &quot;@Parcelize&quot; for generated models| |null|
 |returnResponse|Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true. This option is currently supported only when using jaxrs-spec library.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -50,6 +50,7 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
     private boolean useCoroutines = false;
     private boolean useMutiny = false;
     private boolean returnResponse = false;
+    private boolean omitGradleWrapper = false;
 
     // This is here to potentially warn the user when an option is not supported by the target framework.
     private Map<String, List<String>> optionsSupportedPerFramework = new ImmutableMap.Builder<String, List<String>>()
@@ -60,7 +61,8 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                     Constants.CORS,
                     Constants.COMPRESSION,
                     Constants.RESOURCES,
-                    Constants.METRICS
+                    Constants.METRICS,
+                    Constants.OMIT_GRADLE_WRAPPER
             ))
             .put(Constants.JAXRS_SPEC, Arrays.asList(
                     USE_BEANVALIDATION,
@@ -132,6 +134,7 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
         addSwitch(Constants.USE_COROUTINES, Constants.USE_COROUTINES_DESC, useCoroutines);
         addSwitch(Constants.USE_MUTINY, Constants.USE_MUTINY_DESC, useMutiny);
         addSwitch(Constants.RETURN_RESPONSE, Constants.RETURN_RESPONSE_DESC, returnResponse);
+        addSwitch(Constants.OMIT_GRADLE_WRAPPER, Constants.OMIT_GRADLE_WRAPPER_DESC, omitGradleWrapper);
         addSwitch(USE_JAKARTA_EE, Constants.USE_JAKARTA_EE_DESC, useJakartaEe);
     }
 
@@ -181,6 +184,14 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
 
     public Boolean getResourcesFeatureEnabled() {
         return resourcesFeatureEnabled;
+    }
+
+    public boolean getOmitGradleWrapper() {
+        return omitGradleWrapper;
+    }
+
+    public void setOmitGradleWrapper(boolean omitGradleWrapper) {
+        this.omitGradleWrapper = omitGradleWrapper;
     }
 
     public void setResourcesFeatureEnabled(Boolean resourcesFeatureEnabled) {
@@ -245,6 +256,10 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
 
         if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
             setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));
+        }
+
+        if (additionalProperties.containsKey(Constants.OMIT_GRADLE_WRAPPER)) {
+            setOmitGradleWrapper(Boolean.parseBoolean(additionalProperties.get(Constants.OMIT_GRADLE_WRAPPER).toString()));
         }
 
         writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
@@ -360,6 +375,8 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
         public static final String USE_JAKARTA_EE_DESC = "whether to use Jakarta EE namespace instead of javax";
         public static final String USE_MUTINY = "useMutiny";
         public static final String USE_MUTINY_DESC = "Whether to use Mutiny (should not be used with useCoroutines). This option is currently supported only when using jaxrs-spec library.";
+        public static final String OMIT_GRADLE_WRAPPER = "omitGradleWrapper";
+        public static final String OMIT_GRADLE_WRAPPER_DESC = "Whether to omit Gradle wrapper for creating a sub project.";
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/build.gradle.mustache
@@ -2,7 +2,7 @@ group "{{groupId}}"
 version "{{artifactVersion}}"
 
 wrapper {
-    gradleVersion = "6.9"
+    gradleVersion = '6.9'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -1,10 +1,12 @@
 group "{{groupId}}"
 version "{{artifactVersion}}"
+{{^omitGradleWrapper}}
 
 wrapper {
     gradleVersion = "7.4.2"
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
+{{/omitGradleWrapper}}
 
 buildscript {
     ext.kotlin_version = "1.7.20"

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -2,7 +2,7 @@ group "org.openapitools"
 version "1.0.0"
 
 wrapper {
-    gradleVersion = "7.4.2"
+    gradleVersion = '7.5'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 


### PR DESCRIPTION
The added option removes the wrapper part of build.gradle, enabling the generated project to be used as a sub project. The same option from kotlin client was used as reference for this change.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
