### PR TITLE
[php-nextgen] Set minimal PHP version to ^8.1

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/.travis.yml
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/.travis.yml
@@ -6,7 +6,7 @@ dist: jammy
 os:
   - linux
 php:
-  - 8.0
   - 8.1
+  - 8.2
 before_install: "composer install"
 script: "vendor/bin/phpunit"

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
@@ -1,7 +1,7 @@
 <?php
 /**
  * ApiException
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -1,7 +1,7 @@
 <?php
 /**
  * Configuration
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/HeaderSelector.mustache
@@ -1,7 +1,7 @@
 <?php
 /**
  * HeaderSelector
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ModelInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ModelInterface.mustache
@@ -2,7 +2,7 @@
 /**
  * ModelInterface
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{modelPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -2,7 +2,7 @@
 /**
  * ObjectSerializer
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/README.mustache
@@ -12,7 +12,7 @@ For more information, please visit [{{{infoUrl}}}]({{{infoUrl}}}).
 
 ### Requirements
 
-PHP 8.0 and later.
+PHP 8.1 and later.
 
 ### Composer
 

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -1,7 +1,7 @@
 <?php
 /**
  * {{classname}}
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api_test.mustache
@@ -1,7 +1,7 @@
 <?php
 /**
  * {{classname}}Test
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/composer.mustache
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
@@ -4,7 +4,7 @@
 /**
  * {{classname}}
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_test.mustache
@@ -4,7 +4,7 @@
 /**
  * {{classname}}Test
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  {{invokerPackage}}

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/.travis.yml
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/.travis.yml
@@ -6,7 +6,7 @@ dist: jammy
 os:
   - linux
 php:
-  - 8.0
   - 8.1
+  - 8.2
 before_install: "composer install"
 script: "vendor/bin/phpunit"

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/README.md
@@ -7,7 +7,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 
 ### Requirements
 
-PHP 8.0 and later.
+PHP 8.1 and later.
 
 ### Composer
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/composer.json
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * AnotherFakeApi
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * DefaultApi
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * FakeApi
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * FakeClassnameTags123Api
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * PetApi
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * StoreApi
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * UserApi
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * ApiException
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Configuration
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/HeaderSelector.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/HeaderSelector.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * HeaderSelector
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -2,7 +2,7 @@
 /**
  * AdditionalPropertiesClass
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -2,7 +2,7 @@
 /**
  * AllOfWithSingleRef
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -2,7 +2,7 @@
 /**
  * Animal
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -2,7 +2,7 @@
 /**
  * ApiResponse
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
@@ -2,7 +2,7 @@
 /**
  * ArrayOfArrayOfNumberOnly
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
@@ -2,7 +2,7 @@
 /**
  * ArrayOfNumberOnly
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -2,7 +2,7 @@
 /**
  * ArrayTest
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -2,7 +2,7 @@
 /**
  * Capitalization
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -2,7 +2,7 @@
 /**
  * Cat
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -2,7 +2,7 @@
 /**
  * Category
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
@@ -2,7 +2,7 @@
 /**
  * ClassModel
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
@@ -2,7 +2,7 @@
 /**
  * Client
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
@@ -2,7 +2,7 @@
 /**
  * DeprecatedObject
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -2,7 +2,7 @@
 /**
  * Dog
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -2,7 +2,7 @@
 /**
  * EnumArrays
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumClass.php
@@ -2,7 +2,7 @@
 /**
  * EnumClass
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -2,7 +2,7 @@
 /**
  * EnumTest
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -2,7 +2,7 @@
 /**
  * FakeBigDecimalMap200Response
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
@@ -2,7 +2,7 @@
 /**
  * File
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -2,7 +2,7 @@
 /**
  * FileSchemaTestClass
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
@@ -2,7 +2,7 @@
 /**
  * Foo
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
@@ -2,7 +2,7 @@
 /**
  * FooGetDefaultResponse
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -2,7 +2,7 @@
 /**
  * FormatTest
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -2,7 +2,7 @@
 /**
  * HasOnlyReadOnly
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
@@ -2,7 +2,7 @@
 /**
  * HealthCheckResult
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -2,7 +2,7 @@
 /**
  * MapTest
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -2,7 +2,7 @@
 /**
  * MixedPropertiesAndAdditionalPropertiesClass
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -2,7 +2,7 @@
 /**
  * Model200Response
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelInterface.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelInterface.php
@@ -2,7 +2,7 @@
 /**
  * ModelInterface
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client\Model

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
@@ -2,7 +2,7 @@
 /**
  * ModelList
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
@@ -2,7 +2,7 @@
 /**
  * ModelReturn
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -2,7 +2,7 @@
 /**
  * Name
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -2,7 +2,7 @@
 /**
  * NullableClass
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
@@ -2,7 +2,7 @@
 /**
  * NumberOnly
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -2,7 +2,7 @@
 /**
  * ObjectWithDeprecatedFields
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -2,7 +2,7 @@
 /**
  * Order
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -2,7 +2,7 @@
 /**
  * OuterComposite
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
@@ -2,7 +2,7 @@
 /**
  * OuterEnum
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
@@ -2,7 +2,7 @@
 /**
  * OuterEnumDefaultValue
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumInteger.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumInteger.php
@@ -2,7 +2,7 @@
 /**
  * OuterEnumInteger
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumIntegerDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumIntegerDefaultValue.php
@@ -2,7 +2,7 @@
 /**
  * OuterEnumIntegerDefaultValue
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
@@ -2,7 +2,7 @@
 /**
  * OuterObjectWithEnumProperty
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -2,7 +2,7 @@
 /**
  * Pet
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -2,7 +2,7 @@
 /**
  * ReadOnlyFirst
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SingleRefType.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SingleRefType.php
@@ -2,7 +2,7 @@
 /**
  * SingleRefType
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
@@ -2,7 +2,7 @@
 /**
  * SpecialModelName
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -2,7 +2,7 @@
 /**
  * Tag
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -2,7 +2,7 @@
 /**
  * User
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -2,7 +2,7 @@
 /**
  * ObjectSerializer
  *
- * PHP version 8.0
+ * PHP version 8.1
  *
  * @category Class
  * @package  OpenAPI\Client


### PR DESCRIPTION
This PR updates the minimal PHP version of the php-nextgen generator to ^8.1. This allows the generator to make use of backed enums, which I have already [implemented in a different branch](https://github.com/JulianVennen/openapi-generator/commit/0dfd65c42f1eeab5dcad708b0123a4cd3b023a56).

The target for this PR is master, since the php-nextgen generator was merged into master after the 7.0.0 release.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon