### PR TITLE
Fix spring scope property

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/oauth2ClientProperties.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/oauth2ClientProperties.mustache
@@ -2,7 +2,7 @@
 {{#isOAuth}}
 spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}.enabled=false
 spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}.client-id=set-{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}-client-id
-{{#scopes}}{{#-first}}spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}.scopes={{/-first}}{{scope}}{{^-last}},{{/-last}}{{/scopes}}
+{{#scopes}}{{#-first}}spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}.scope={{/-first}}{{scope}}{{^-last}},{{/-last}}{{/scopes}}
     {{#isCode}}
 spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}.redirect-uri=set-{{{name}}}{{#lambda.pascalcase}}{{{flow}}}{{/lambda.pascalcase}}-redirect-uri

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/resources/oauth2-client.properties
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/resources/oauth2-client.properties
@@ -1,5 +1,5 @@
 spring.security.oauth2.client.registration.petstoreAuthImplicit.enabled=false
 spring.security.oauth2.client.registration.petstoreAuthImplicit.client-id=set-petstoreAuthImplicit-client-id
-spring.security.oauth2.client.registration.petstoreAuthImplicit.scopes=write:pets,read:pets
+spring.security.oauth2.client.registration.petstoreAuthImplicit.scope=write:pets,read:pets
 spring.security.oauth2.client.registration.petstoreAuthImplicit.authorization-grant-type=implicit
 spring.security.oauth2.client.provider.petstoreAuthImplicit.authorization-uri=http://petstore.swagger.io/api/oauth/dialog

--- a/samples/client/petstore/spring-cloud/src/main/resources/oauth2-client.properties
+++ b/samples/client/petstore/spring-cloud/src/main/resources/oauth2-client.properties
@@ -1,5 +1,5 @@
 spring.security.oauth2.client.registration.petstoreAuthImplicit.enabled=false
 spring.security.oauth2.client.registration.petstoreAuthImplicit.client-id=set-petstoreAuthImplicit-client-id
-spring.security.oauth2.client.registration.petstoreAuthImplicit.scopes=write:pets,read:pets
+spring.security.oauth2.client.registration.petstoreAuthImplicit.scope=write:pets,read:pets
 spring.security.oauth2.client.registration.petstoreAuthImplicit.authorization-grant-type=implicit
 spring.security.oauth2.client.provider.petstoreAuthImplicit.authorization-uri=http://petstore.swagger.io/api/oauth/dialog

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/resources/oauth2-client.properties
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/resources/oauth2-client.properties
@@ -1,5 +1,5 @@
 spring.security.oauth2.client.registration.petstoreAuthImplicit.enabled=false
 spring.security.oauth2.client.registration.petstoreAuthImplicit.client-id=set-petstoreAuthImplicit-client-id
-spring.security.oauth2.client.registration.petstoreAuthImplicit.scopes=write:pets,read:pets
+spring.security.oauth2.client.registration.petstoreAuthImplicit.scope=write:pets,read:pets
 spring.security.oauth2.client.registration.petstoreAuthImplicit.authorization-grant-type=implicit
 spring.security.oauth2.client.provider.petstoreAuthImplicit.authorization-uri=http://petstore.swagger.io/api/oauth/dialog

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/resources/oauth2-client.properties
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/resources/oauth2-client.properties
@@ -1,5 +1,5 @@
 spring.security.oauth2.client.registration.petstoreAuthImplicit.enabled=false
 spring.security.oauth2.client.registration.petstoreAuthImplicit.client-id=set-petstoreAuthImplicit-client-id
-spring.security.oauth2.client.registration.petstoreAuthImplicit.scopes=write:pets,read:pets
+spring.security.oauth2.client.registration.petstoreAuthImplicit.scope=write:pets,read:pets
 spring.security.oauth2.client.registration.petstoreAuthImplicit.authorization-grant-type=implicit
 spring.security.oauth2.client.provider.petstoreAuthImplicit.authorization-uri=http://petstore.swagger.io/api/oauth/dialog

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/resources/oauth2-client.properties
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/resources/oauth2-client.properties
@@ -1,5 +1,5 @@
 spring.security.oauth2.client.registration.petstoreAuthImplicit.enabled=false
 spring.security.oauth2.client.registration.petstoreAuthImplicit.client-id=set-petstoreAuthImplicit-client-id
-spring.security.oauth2.client.registration.petstoreAuthImplicit.scopes=write:pets,read:pets
+spring.security.oauth2.client.registration.petstoreAuthImplicit.scope=write:pets,read:pets
 spring.security.oauth2.client.registration.petstoreAuthImplicit.authorization-grant-type=implicit
 spring.security.oauth2.client.provider.petstoreAuthImplicit.authorization-uri=http://petstore.swagger.io/api/oauth/dialog

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/resources/oauth2-client.properties
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/resources/oauth2-client.properties
@@ -1,5 +1,5 @@
 spring.security.oauth2.client.registration.petstoreAuthImplicit.enabled=false
 spring.security.oauth2.client.registration.petstoreAuthImplicit.client-id=set-petstoreAuthImplicit-client-id
-spring.security.oauth2.client.registration.petstoreAuthImplicit.scopes=write:pets,read:pets
+spring.security.oauth2.client.registration.petstoreAuthImplicit.scope=write:pets,read:pets
 spring.security.oauth2.client.registration.petstoreAuthImplicit.authorization-grant-type=implicit
 spring.security.oauth2.client.provider.petstoreAuthImplicit.authorization-uri=http://petstore.swagger.io/api/oauth/dialog


### PR DESCRIPTION
The scopes property is incorrect and is not read when starting.

This PR fixes the wrong property

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master'
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09)
