### PR TITLE
[php-nextgen] Use PHP 8.1 backed enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -79,12 +79,10 @@ class ObjectSerializer
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
                     if ($value !== null && !in_array($openAPIType, [{{&primitives}}], true)) {
-                        $callable = [$openAPIType, 'getAllowableEnumValues'];
-                        if (is_callable($callable)) {
-                            /** array $callable */
-                            $allowedEnumTypes = $callable();
-                            if (!in_array($value, $allowedEnumTypes, true)) {
-                                $imploded = implode("', '", $allowedEnumTypes);
+                        if ($openAPIType instanceof \BackedEnum) {
+                            $data = $openAPIType::tryFrom($data);
+                            if ($data === null) {
+                                $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
                                 throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
                             }
                         }
@@ -488,9 +486,10 @@ class ObjectSerializer
         }
 
 
-        if (method_exists($class, 'getAllowableEnumValues')) {
-            if (!in_array($data, $class::getAllowableEnumValues(), true)) {
-                $imploded = implode("', '", $class::getAllowableEnumValues());
+        if ($class instanceof \BackedEnum) {
+            $data = $class::tryFrom($data);
+            if ($data === null) {
+                $imploded = implode("', '", array_map(fn($case) => $case->value, $class::cases()));
                 throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }
             return $data;

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_enum.mustache
@@ -1,28 +1,9 @@
-class {{classname}}
+enum {{classname}}: {{vendorExtensions.x-php-enum-type}}
 {
-    /**
-     * Possible values of this enum
-     */
     {{#allowableValues}}
     {{#enumVars}}
-    public const {{^isString}}NUMBER_{{/isString}}{{{name}}} = {{{value}}};
+    case {{^isString}}NUMBER_{{/isString}}{{{name}}} = {{{value}}};
 
     {{/enumVars}}
     {{/allowableValues}}
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            {{#allowableValues}}
-            {{#enumVars}}
-            self::{{^isString}}NUMBER_{{/isString}}{{{name}}}{{^-last}},
-            {{/-last}}
-            {{/enumVars}}
-            {{/allowableValues}}
-
-        ];
-    }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumClass.php
@@ -37,29 +37,14 @@ use \OpenAPI\Client\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-class EnumClass
+enum EnumClass: string
 {
-    /**
-     * Possible values of this enum
-     */
-    public const ABC = '_abc';
+    case ABC = '_abc';
 
-    public const EFG = '-efg';
+    case EFG = '-efg';
 
-    public const XYZ = '(xyz)';
+    case XYZ = '(xyz)';
 
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            self::ABC,
-            self::EFG,
-            self::XYZ
-        ];
-    }
 }
 
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
@@ -37,29 +37,14 @@ use \OpenAPI\Client\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-class OuterEnum
+enum OuterEnum: string
 {
-    /**
-     * Possible values of this enum
-     */
-    public const PLACED = 'placed';
+    case PLACED = 'placed';
 
-    public const APPROVED = 'approved';
+    case APPROVED = 'approved';
 
-    public const DELIVERED = 'delivered';
+    case DELIVERED = 'delivered';
 
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            self::PLACED,
-            self::APPROVED,
-            self::DELIVERED
-        ];
-    }
 }
 
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
@@ -37,29 +37,14 @@ use \OpenAPI\Client\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-class OuterEnumDefaultValue
+enum OuterEnumDefaultValue: string
 {
-    /**
-     * Possible values of this enum
-     */
-    public const PLACED = 'placed';
+    case PLACED = 'placed';
 
-    public const APPROVED = 'approved';
+    case APPROVED = 'approved';
 
-    public const DELIVERED = 'delivered';
+    case DELIVERED = 'delivered';
 
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            self::PLACED,
-            self::APPROVED,
-            self::DELIVERED
-        ];
-    }
 }
 
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumInteger.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumInteger.php
@@ -37,29 +37,14 @@ use \OpenAPI\Client\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-class OuterEnumInteger
+enum OuterEnumInteger: int
 {
-    /**
-     * Possible values of this enum
-     */
-    public const NUMBER_0 = 0;
+    case NUMBER_0 = 0;
 
-    public const NUMBER_1 = 1;
+    case NUMBER_1 = 1;
 
-    public const NUMBER_2 = 2;
+    case NUMBER_2 = 2;
 
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            self::NUMBER_0,
-            self::NUMBER_1,
-            self::NUMBER_2
-        ];
-    }
 }
 
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumIntegerDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumIntegerDefaultValue.php
@@ -37,29 +37,14 @@ use \OpenAPI\Client\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-class OuterEnumIntegerDefaultValue
+enum OuterEnumIntegerDefaultValue: int
 {
-    /**
-     * Possible values of this enum
-     */
-    public const NUMBER_0 = 0;
+    case NUMBER_0 = 0;
 
-    public const NUMBER_1 = 1;
+    case NUMBER_1 = 1;
 
-    public const NUMBER_2 = 2;
+    case NUMBER_2 = 2;
 
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            self::NUMBER_0,
-            self::NUMBER_1,
-            self::NUMBER_2
-        ];
-    }
 }
 
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SingleRefType.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SingleRefType.php
@@ -37,26 +37,12 @@ use \OpenAPI\Client\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
  */
-class SingleRefType
+enum SingleRefType: string
 {
-    /**
-     * Possible values of this enum
-     */
-    public const ADMIN = 'admin';
+    case ADMIN = 'admin';
 
-    public const USER = 'user';
+    case USER = 'user';
 
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public static function getAllowableEnumValues()
-    {
-        return [
-            self::ADMIN,
-            self::USER
-        ];
-    }
 }
 
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -88,12 +88,10 @@ class ObjectSerializer
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
                     if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
-                        $callable = [$openAPIType, 'getAllowableEnumValues'];
-                        if (is_callable($callable)) {
-                            /** array $callable */
-                            $allowedEnumTypes = $callable();
-                            if (!in_array($value, $allowedEnumTypes, true)) {
-                                $imploded = implode("', '", $allowedEnumTypes);
+                        if ($openAPIType instanceof \BackedEnum) {
+                            $data = $openAPIType::tryFrom($data);
+                            if ($data === null) {
+                                $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
                                 throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
                             }
                         }
@@ -497,9 +495,10 @@ class ObjectSerializer
         }
 
 
-        if (method_exists($class, 'getAllowableEnumValues')) {
-            if (!in_array($data, $class::getAllowableEnumValues(), true)) {
-                $imploded = implode("', '", $class::getAllowableEnumValues());
+        if ($class instanceof \BackedEnum) {
+            $data = $class::tryFrom($data);
+            if ($data === null) {
+                $imploded = implode("', '", array_map(fn($case) => $case->value, $class::cases()));
                 throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }
             return $data;


### PR DESCRIPTION
In the PHP generator, enums are implemented by creating a class that stores the enum values in static properties.
This results in weird type hints where these enums are used since the PHPDoc type specifies the class, but the actual values are the values of these properties.

PHP 8.1 adds backed enums which allow us to implement this correctly with less confusing type hints and better developer ergonomics.

Since backed enums need to declare the backing type, I introduced the vendor extension x-php-enum-type.
This follows the same principle as how a similar problem was solved [in the python generator](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java#L995).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon