### PR TITLE
[php-nextgen] Fix parent class check in ObjectSerializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -79,7 +79,7 @@ class ObjectSerializer
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
                     if ($value !== null && !in_array($openAPIType, [{{&primitives}}], true)) {
-                        if ($openAPIType instanceof \BackedEnum) {
+                        if (is_sublass_of($openAPIType, '\BackedEnum')) {
                             $data = $openAPIType::tryFrom($data);
                             if ($data === null) {
                                 $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
@@ -486,7 +486,7 @@ class ObjectSerializer
         }
 
 
-        if ($class instanceof \BackedEnum) {
+        if (is_subclass_of($class, '\BackedEnum')) {
             $data = $class::tryFrom($data);
             if ($data === null) {
                 $imploded = implode("', '", array_map(fn($case) => $case->value, $class::cases()));

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -88,7 +88,7 @@ class ObjectSerializer
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
                     if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
-                        if ($openAPIType instanceof \BackedEnum) {
+                        if (is_sublass_of($openAPIType, '\BackedEnum')) {
                             $data = $openAPIType::tryFrom($data);
                             if ($data === null) {
                                 $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
@@ -495,7 +495,7 @@ class ObjectSerializer
         }
 
 
-        if ($class instanceof \BackedEnum) {
+        if (is_subclass_of($class, '\BackedEnum')) {
             $data = $class::tryFrom($data);
             if ($data === null) {
                 $imploded = implode("', '", array_map(fn($case) => $case->value, $class::cases()));


### PR DESCRIPTION
In #16556 I updated the ObjectSerializer to work with the new PHP enums. Unfortunately I got a little confused and performed an instanceof check on the class string.
This PR fixes this by using [`is_subclass_of`](https://www.php.net/manual/en/function.is-subclass-of.php)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
