### PR TITLE
[python] Update github workflow, use debug instead of warning

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2747,14 +2747,14 @@ public class DefaultCodegen implements CodegenConfig {
 
                     if (composed.getAnyOf() != null) {
                         if (m.anyOf.contains(languageType)) {
-                            LOGGER.warn("{} (anyOf schema) already has `{}` defined and therefore it's skipped.", m.name, languageType);
+                            LOGGER.debug("{} (anyOf schema) already has `{}` defined and therefore it's skipped.", m.name, languageType);
                         } else {
                             m.anyOf.add(languageType);
 
                         }
                     } else if (composed.getOneOf() != null) {
                         if (m.oneOf.contains(languageType)) {
-                            LOGGER.warn("{} (oneOf schema) already has `{}` defined and therefore it's skipped.", m.name, languageType);
+                            LOGGER.debug("{} (oneOf schema) already has `{}` defined and therefore it's skipped.", m.name, languageType);
                         } else {
                             m.oneOf.add(languageType);
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -529,7 +529,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             }
             example += ")";
         } else {
-            LOGGER.warn("Type {} not handled properly in toExampleValue", schema.getType());
+            LOGGER.debug("Type {} not handled properly in toExampleValue", schema.getType());
         }
 
         if (ModelUtils.isStringSchema(schema)) {
@@ -591,7 +591,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             // type is a model class, e.g. User
             example = this.packageName + "." + type + "()";
         } else {
-            LOGGER.warn("Type {} not handled properly in setParameterExampleValue", type);
+            LOGGER.debug("Type {} not handled properly in setParameterExampleValue", type);
         }
 
         if (example == null) {

--- a/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
+++ b/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
@@ -27,6 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/modules/openapi-generator/src/main/resources/python/gitlab-ci.mustache
+++ b/modules/openapi-generator/src/main/resources/python/gitlab-ci.mustache
@@ -23,3 +23,9 @@ pytest-3.8:
 pytest-3.9:
   extends: .pytest
   image: python:3.9-alpine
+pytest-3.10:
+  extends: .pytest
+  image: python:3.10-alpine
+pytest-3.11:
+  extends: .pytest
+  image: python:3.11-alpine

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -6,3 +6,6 @@ aenum >= 3.1.11
 {{#asyncio}}
 aiohttp >= 3.0.0
 {{/asyncio}}
+{{#hasHttpSignatureMethods}}
+pycryptodome >= 3.9.0
+{{/hasHttpSignatureMethods}}

--- a/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
@@ -1,6 +1,3 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
-{{#hasHttpSignatureMethods}}
-pycryptodome>=3.9.0
-{{/hasHttpSignatureMethods}}

--- a/samples/client/echo_api/python/.github/workflows/python.yml
+++ b/samples/client/echo_api/python/.github/workflows/python.yml
@@ -26,6 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/samples/client/echo_api/python/.gitlab-ci.yml
+++ b/samples/client/echo_api/python/.gitlab-ci.yml
@@ -23,3 +23,9 @@ pytest-3.8:
 pytest-3.9:
   extends: .pytest
   image: python:3.9-alpine
+pytest-3.10:
+  extends: .pytest
+  image: python:3.10-alpine
+pytest-3.11:
+  extends: .pytest
+  image: python:3.11-alpine

--- a/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
@@ -26,6 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/samples/openapi3/client/petstore/python-aiohttp/.gitlab-ci.yml
+++ b/samples/openapi3/client/petstore/python-aiohttp/.gitlab-ci.yml
@@ -23,3 +23,9 @@ pytest-3.8:
 pytest-3.9:
   extends: .pytest
   image: python:3.9-alpine
+pytest-3.10:
+  extends: .pytest
+  image: python:3.10-alpine
+pytest-3.11:
+  extends: .pytest
+  image: python:3.11-alpine

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -4,3 +4,4 @@ urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11
 aiohttp >= 3.0.0
+pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
@@ -1,4 +1,3 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
-pycryptodome>=3.9.0

--- a/samples/openapi3/client/petstore/python/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python/.github/workflows/python.yml
@@ -26,6 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/samples/openapi3/client/petstore/python/.gitlab-ci.yml
+++ b/samples/openapi3/client/petstore/python/.gitlab-ci.yml
@@ -23,3 +23,9 @@ pytest-3.8:
 pytest-3.9:
   extends: .pytest
   image: python:3.9-alpine
+pytest-3.10:
+  extends: .pytest
+  image: python:3.10-alpine
+pytest-3.11:
+  extends: .pytest
+  image: python:3.11-alpine

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -3,3 +3,4 @@ setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11
+pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python/test-requirements.txt
@@ -1,4 +1,3 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
-pycryptodome>=3.9.0


### PR DESCRIPTION
-  Update github workflow, use debug instead of warning

FYI @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @krjakbrjak (2023/02)
